### PR TITLE
visp: 3.1.0-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4052,7 +4052,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.0.1-4
+      version: 3.1.0-2
     status: maintained
   visualization_tutorials:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.1.0-2`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `3.0.1-4`
