### PR TITLE
camera1394: 1.10.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -713,6 +713,21 @@ repositories:
       url: https://github.com/ros-perception/calibration.git
       version: hydro
     status: maintained
+  camera1394:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/camera1394.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/camera1394-release.git
+      version: 1.10.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/camera1394.git
+      version: master
+    status: maintained
   camera_info_manager_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394` to `1.10.1-0`:

- upstream repository: https://github.com/ros-drivers/camera1394.git
- release repository: https://github.com/ros-drivers-gbp/camera1394-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## camera1394

- No changes
