### PR TITLE
moveit_visual_tools: 3.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4873,7 +4873,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.3.0-0
+      version: 3.4.0-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.4.0-0`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `3.3.0-0`

## moveit_visual_tools

```
* Apply current MoveIt clang-format
* Various improvements needed while finishing planning thesis
* Fix greater than/less than issue in clearance check
* Ability to specify clearance for random state
* Small threading fixes
* imarker: Fix setToRandomState()
  imarker: Switch to std::makeshared
* Improve console output
* Contributors: Dave Coleman, Mike Lautman
```
