### PR TITLE
bus_server: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -686,6 +686,12 @@ repositories:
       url: https://github.com/voxel-dot-at/bta_tof_driver.git
       version: master
     status: maintained
+  bus_server:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/bus_server-release.git
+      version: 0.1.1-0
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bus_server` to `0.1.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/bus_server.git
- release repository: https://github.com/UbiquityRobotics-release/bus_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## bus_server

```
* Added minor travis stuff
* Contributors: Rohan Agrawal
```
