### PR TITLE
loki_robot: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4238,6 +4238,19 @@ repositories:
       url: https://github.com/easymov/log_server-release.git
       version: 0.1.4-1
     status: developed
+  loki_robot:
+    release:
+      packages:
+      - loki_bringup
+      - loki_demos
+      - loki_description
+      - loki_nav
+      - loki_robot
+      - loki_teleop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/loki_robot-release.git
+      version: 0.0.1-0
   look_at_pose:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `loki_robot` to `0.0.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/loki_robot.git
- release repository: https://github.com/UbiquityRobotics-release/loki_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## loki_bringup

```
* add loki_nav, fix cmake errors
* added launch files for base bringup
* Started cleaning out old stuff.  Added loki_rviz_local_costmap.
* Converted remaining .launch files to use ubiquity_launches as the package name.
* Change PID parameters for new firmware changes
* Got loki_description sub-directory to work.
* Renamed ros_arduino_bridge.launch to bringup.launch.
* Rearranched files into task based sub-directories.
* Contributors: Mark Johnston, Rohan Agrawal, Wayne C. Gramlich, Wayne Gramlich
```

## loki_demos

```
* mirror relevant parts of magni_demos to loki_demos
* Contributors: Rohan Agrawal
```

## loki_description

```
* fix urdf mesh refrences
* remove magni refs in loki_description
* install meshes as well
* added loki_description for urdf
* Started cleaning out old stuff.  Added loki_rviz_local_costmap.
* Converted remaining .launch files to use ubiquity_launches as the package name.
* Added camera_pose to loki.urdf file.
* Merge branch 'master' of https://github.com/UbiquityRobotics/loki_robot
* Added rviz_description.launch
* Missed description.launch
* Rearranched files into task based sub-directories.
* Contributors: Rohan Agrawal, Wayne C. Gramlich, Wayne Gramlich
```

## loki_nav

```
* add loki_nav, fix cmake errors
* Contributors: Rohan Agrawal
```

## loki_robot

```
* make metapackage pull in all the subpackages
  you need to use exec_depend on all the subpackages in the metapackage
  otherwise the installing the metapackage won't pull in the others
* remove old ur launch stuff, start moving to metapackage
  This is the first step in resolving issue #1 <https://github.com/UbiquityRobotics/loki_robot/issues/1>
* Scrubbed repository down to the README.md .
* Using format 2, added ubiquity_launches dependancy
* added loki_robot meta package
* Contributors: Rohan Agrawal, Wayne C. Gramlich
```

## loki_teleop

```
* add loki_nav, fix cmake errors
* depend on keyboard teleop to make sure it gets installed
* add teleop config to loki_teleop
* Contributors: Rohan Agrawal
```
