### PR TITLE
kobuki: 0.7.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3795,7 +3795,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.7.4-0
+      version: 0.7.5-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki` to `0.7.5-0`:

- upstream repository: https://github.com/yujinrobot/kobuki.git
- release repository: https://github.com/yujinrobot-release/kobuki-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.4-0`

## kobuki_auto_docking

```
* bugfix missing nav_msgs dependency
```
