### PR TITLE
baldor: 0.1.2-0 in 'indigo/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -871,15 +871,11 @@ repositories:
       version: 3.5.0-5
     status: maintained
   baldor:
-    doc:
-      type: git
-      url: https://github.com/crigroup/baldor.git
-      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/crigroup/baldor-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/crigroup/baldor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baldor` to `0.1.2-0`:

- upstream repository: https://github.com/crigroup/baldor.git
- release repository: https://github.com/crigroup/baldor-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.1-0`

## baldor

```
* Add function to estimate the transformation between two axes (#3)
* Contributors: fsuarez6
```