### PR TITLE
baldor: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -513,7 +513,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/crigroup/baldor-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/crigroup/baldor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `baldor` to `0.1.2-0`:

- upstream repository: https://github.com/crigroup/baldor.git
- release repository: https://github.com/crigroup/baldor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.1-0`

## baldor

```
* Add function to estimate the transformation between two axes (#3)
* Contributors: Francisco
```
