### PR TITLE
loki_base_node: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4238,6 +4238,12 @@ repositories:
       url: https://github.com/easymov/log_server-release.git
       version: 0.1.4-1
     status: developed
+  loki_base_node:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/loki_base_node-release.git
+      version: 0.2.0-0
   loki_robot:
     release:
       packages:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4237,7 +4237,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/loki_base_node-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
   loki_robot:
     release:
       packages:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -686,12 +686,6 @@ repositories:
       url: https://github.com/voxel-dot-at/bta_tof_driver.git
       version: master
     status: maintained
-  bus_server:
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/UbiquityRobotics-release/bus_server-release.git
-      version: 0.1.1-0
   calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `loki_base_node` to `0.2.1-0`:

- upstream repository: https://github.com/UbiquityRobotics/loki_base_node.git
- release repository: https://github.com/UbiquityRobotics-release/loki_base_node-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## loki_base_node

```
* change package name from bus_server to loki_base_node
* Contributors: Rohan Agrawal
```
