### PR TITLE
cost_map: 0.3.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1401,7 +1401,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/cost_map-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/stonier/cost_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cost_map` to `0.3.3-0`:

- upstream repository: https://github.com/stonier/cost_map.git
- release repository: https://github.com/stonier/cost_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.3.2-0`

## cost_map_core

```
* refactor for grid_map_core api changes (trivial)
```
