### PR TITLE
robot_localization: 2.5.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2570,7 +2570,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.5.0-0
+      version: 2.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.5.1-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.5.0-0`

## robot_localization

```
* Fixing CMakeLists
* Contributors: Tom Moore
```
