### PR TITLE
xpp: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11105,7 +11105,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.4-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.3-0`

## xpp

- No changes

## xpp_examples

```
* Merge pull request #3 from leggedrobotics/devel
  Fix xacro bug and remove terrain and optimization specific classes.
* renamed some launch files
* Contributors: Alexander W Winkler
```

## xpp_hyq

```
* Merge pull request #3 from leggedrobotics/devel
  Fix xacro bug and remove terrain and optimization specific classes.
* xpp_hyq: add --inorder when processing xacro files
  see http://wiki.ros.org/xacro#Processing_Order
* cleaned up formatting of xacro files
* removed unused xacro origin tag causing run failure
* Contributors: Alexander W Winkler
```

## xpp_msgs

```
* Merge pull request #3 from leggedrobotics/devel
  Fix xacro bug and remove terrain and optimization specific classes.
* removed optimization related topic names
* rename OptParameters.msg to more concise RobotParameters.msg
* removed UserCommand msg and terrain_builder class
* renamed some launch files
* Contributors: Alexander W Winkler
```

## xpp_quadrotor

- No changes

## xpp_states

- No changes

## xpp_vis

```
* Merge pull request #3 from leggedrobotics/devel
  Fix xacro bug and remove terrain and optimization specific classes.
* removed optimization related topic names
* rename OptParameters.msg to more concise RobotParameters.msg
* removed UserCommand msg and terrain_builder class
* use =default for empty c'tor/d'tor.
* [smell] removed quiet return function that gives no warning.
* Contributors: Alexander W Winkler
```
