### PR TITLE
pcdfilter_pa: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6084,6 +6084,11 @@ repositories:
       type: git
       url: https://github.com/peterweissig/ros_pcdfilter.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/peterweissig/ros_pcdfilter-release.git
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_pcdfilter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcdfilter_pa` to `1.2.0-0`:

- upstream repository: https://github.com/peterweissig/ros_pcdfilter.git
- release repository: https://github.com/peterweissig/ros_pcdfilter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## pcdfilter_pa

```
* bugfixed g++-warning (missing whitespace after the macro name)
* updated parameters (*.yaml and ...node_parameter.cpp)
* updated documentation
* 
  
    * changed api to new version of parameter_pa
    * added support for visual studio code
  
* Contributors: Peter Weissig
```
