### PR TITLE
pcdfilter_pa: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8951,7 +8951,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/peterweissig/ros_pcdfilter-release.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/peterweissig/ros_pcdfilter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcdfilter_pa` to `1.2.0-0`:

- upstream repository: https://github.com/peterweissig/ros_pcdfilter.git
- release repository: https://github.com/peterweissig/ros_pcdfilter-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.1.0-0`

## pcdfilter_pa

```
* bugfixed g++-warning (missing whitespace after the macro name)
* updated parameters (*.yaml and ...node_parameter.cpp)
* updated documentation
* 
  
    * changed api to new version of parameter_pa
    * added support for visual studio code
  
* Contributors: Peter Weissig
```
