### PR TITLE
jsk_common: 2.2.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5522,7 +5522,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.5-0
+      version: 2.2.6-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.6-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `2.2.5-0`

## dynamic_tf_publisher

- No changes

## image_view2

```
* image_view2: support kinetic (#1573 <https://github.com/jsk-ros-pkg/jsk_common/issues/1573>)
* image_view2: fix publish_mouse_event (#1564 <https://github.com/jsk-ros-pkg/jsk_common/issues/1564>)
* need to find pcl_ros for image_view2 (#1541 <https://github.com/jsk-ros-pkg/jsk_common/issues/1541>)
* Contributors: Eisoku Kuroiwa, Kei Okada, Yuki Furuta
```

## jsk_common

- No changes

## jsk_data

```
* jsk_data: download_data.py: ensure chmod downloaded data if possible (#1571 <https://github.com/jsk-ros-pkg/jsk_common/issues/1571>)
* jsk_data: download_data.py: Skip mkdir failures that can be caused by multiprocessing (#1553 <https://github.com/jsk-ros-pkg/jsk_common/issues/1553>)
* Fix data_collection_server (#1549 <https://github.com/jsk-ros-pkg/jsk_common/issues/1549>)
  * Sleep less time in data_collection_server.py
  * Return false response in data_collection_server
* Improve print information while download_data (#1536 <https://github.com/jsk-ros-pkg/jsk_common/issues/1536>)
* [jsk_data][download_data.py] chmod decompressed data (#1532 <https://github.com/jsk-ros-pkg/jsk_common/issues/1532>)
* Contributors: Kei Okada, Kentaro Wada, Yuki Furuta
```

## jsk_network_tools

```
* Fix warning about %d vs %lu in silverhammer_highspeed_internal_receiver (#1537 <https://github.com/jsk-ros-pkg/jsk_common/issues/1537>)
* Contributors: Kentaro Wada
```

## jsk_tilt_laser

- No changes

## jsk_tools

```
* [jsk_tools] add ROS param set test (#1535 <https://github.com/jsk-ros-pkg/jsk_common/issues/1535>)
* jsk_tools: fix sanity lib test (#1573 <https://github.com/jsk-ros-pkg/jsk_common/issues/1573>)
* update generate_deb_status_table.py (#1539 <https://github.com/jsk-ros-pkg/jsk_common/issues/1539>)
  * default rosdistro-to is lunar
  * use python-rosdistro to create DISTRS Dict
* Support network interface name convention from ubuntu 15.10 (#1561 <https://github.com/jsk-ros-pkg/jsk_common/issues/1561>)
  * Fixes https://github.com/jsk-ros-pkg/jsk_common/issues/1559c.f.: https://askubuntu.com/questions/702161/why-is-my-interface-now-wlp2s0-instead-of-wlan0
* Make TopicPublishedChecker run in parallel (#1546 <https://github.com/jsk-ros-pkg/jsk_common/issues/1546>)
  * Make TopicPublishedChecker multi-processable
* Fix undefined variable arg in rosview on bash (#1545 <https://github.com/jsk-ros-pkg/jsk_common/issues/1545>)
* Contributors: Kentaro Wada, Shingo Kitagawa, Yuki Furuta
```

## jsk_topic_tools

```
* jsk_topic_tools: stealth_relay_nodelet: support MessageEvent (#1572 <https://github.com/jsk-ros-pkg/jsk_common/issues/1572>)
* jsk_topic_tools: stealth_relay add options as dynamic_reconfigure (#1568 <https://github.com/jsk-ros-pkg/jsk_common/issues/1568>)
  * jsk_topic_tools: test_stealth_relay: disable updating dynamic reconfigure
  * jsk_topic_tools: test_stealth_relay: update timeout
  * jsk_topic_tools: stealth_relay: add deprecation warning
  * jsk_topic_tools: add options as dynamic_reconfigure
* jsk_topic_tools: connection_based_nodelet: fix typo in advertiseCamera (#1558 <https://github.com/jsk-ros-pkg/jsk_common/issues/1558>)
* jsk_topic_tools: add stealth_relay for silently subscribing topic (#1544 <https://github.com/jsk-ros-pkg/jsk_common/issues/1544>)
* Validate implementation of child class of ConnectionBasedTransport (#1556 <https://github.com/jsk-ros-pkg/jsk_common/issues/1556>)
  * Check if publishers exist to avoid implementation failures
  * Use ABCMeta to avoid unexpected usage of ConnectionBasedTransportSomeone use this class without any subscriptions,
  and in that case this class should not be used in general.
* Contributors: Kei Okada, Kentaro Wada, Yuki Furuta
```

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
