### PR TITLE
visualization_tutorials: 0.10.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10855,7 +10855,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.10.1-0
+      version: 0.10.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.2-0`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.10.1-0`

## interactive_marker_tutorials

```
* Normalized quaternions. (#40 <https://github.com/ros-visualization/visualization_tutorials//issues/40>)
* Contributors: dhood
```

## librviz_tutorial

```
* Unified find_package for Qt4 and Qt5. (#33 <https://github.com/ros-visualization/visualization_tutorials//issues/33>)
* Contributors: Robert Haschke, William Woodall
```

## rviz_plugin_tutorials

```
* Unified find_package for Qt4 and Qt5. (#33 <https://github.com/ros-visualization/visualization_tutorials//issues/33>)
* Contributors: Robert Haschke, William Woodall
```

## rviz_python_tutorial

- No changes

## visualization_marker_tutorials

- No changes

## visualization_tutorials

- No changes
