### PR TITLE
rviz: 1.12.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9050,7 +9050,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.14-0
+      version: 1.12.15-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.15-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.12.14-0`

## rviz

```
* Fixed Ogre crashes from invalid quaternions by normalizing them so they no longer need to be rejected. (#1179 <https://github.com/ros-visualization/rviz/issues/1179>)
* Restored processing of ROS messages containing invalid quaternions. (#1182 <https://github.com/ros-visualization/rviz/issues/1182>)
  Unnormalized quaternions in messages will generate warnings; previously they were rejected.
  Publishers of invalid quaternions should be updated to publish valid quaternions, as rviz will reject invalid quaternions in the future.
* Contributors: Robert Haschke, dhood
```
