### PR TITLE
graspit_tools: 1.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4053,7 +4053,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/graspit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `1.1.3-0`:

- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.1.2-0`

## grasp_planning_graspit

```
* Tested with current version of graspit
* Adaptation for graspit upstream merge
* Contributors: Jennifer Buehler
```

## grasp_planning_graspit_msgs

- No changes

## grasp_planning_graspit_ros

```
* Adaptation for graspit upstream merge
* Changed link/finger names for new jaco
* Contributors: Jennifer Buehler
```

## graspit_tools

- No changes

## jaco_graspit_sample

```
* Tested with current version of graspit
* Changed contact reference in jaco
* Adaptation for graspit upstream merge
* Contributors: Jennifer Buehler
```

## urdf2graspit

```
* Adaptation for graspit upstream merge
* Fixed bug for issue #19 <https://github.com/JenniferBuehler/graspit-pkgs/issues/19>
* Fixed problem with contact points in which names not accepted by SoName would then not be found in the MarkerSelector
* Fixed bug: transform to DH world frame in Urdf2Graspit.cpp
* Added urdf viewer launch file for jaco
* Rotation axis correction was the wrong way, now negate_joint_movement may not be necessary for some hands (or become necessary for others
* More testing changes
* Backup
* Fixed issue with thumb in allegro but still not displaying properly in GraspIt simulator
* Improved debugging abilities with viewer
* Fixed missing white spaces in XMLFuncs.cpp generation of inertia
* Catching case in urdf2graspit for hands with no inertial. Fixes #19 <https://github.com/JenniferBuehler/graspit-pkgs/issues/19>
* Changed link/finger names for new jaco
* Contributors: Jennifer Buehler
```
