### PR TITLE
Adding darknet_ros to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1546,6 +1546,25 @@ repositories:
       url: https://github.com/OTL/cv_camera.git
       version: master
     status: developed
+  darknet_ros:
+    doc:
+      type: git
+      url: https://github.com/leggedrobotics/darknet_ros
+      version: master
+    release:
+      packages:
+      - darknet_ros
+      - darknet_ros_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/leggedrobotics/darknet_ros-release.git
+      version: 1.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/leggedrobotics/darknet_ros.git
+      version: master
+    status: developed
   dataspeed_can:
     doc:
       type: hg

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1558,7 +1558,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/leggedrobotics/darknet_ros-release.git
-      version: 1.1.0-0
+      version: 1.1.2-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1549,7 +1549,7 @@ repositories:
   darknet_ros:
     doc:
       type: git
-      url: https://github.com/leggedrobotics/darknet_ros
+      url: https://github.com/leggedrobotics/darknet_ros.git
       version: master
     release:
       packages:


### PR DESCRIPTION
I'd like darknet_ros to be indexed and documented on ros.org.