### PR TITLE
urdf_tools: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15797,7 +15797,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/urdf-tools-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tools` to `1.0.2-0`:

- upstream repository: https://github.com/JenniferBuehler/urdf-tools-pkgs.git
- release repository: https://github.com/JenniferBuehler/urdf-tools-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.1-0`

## urdf2inventor

```
* Urdf2Inventor::convert() now accepts MeshRecursionParams so that it additional transforms can be handled per link
* Backup
* Backup before critical changes
* Some tidy up
* Can now use collision geometry instead of visual for meshes, though it still needs to be added as paramter
* Contributors: Jennifer Buehler
```

## urdf_processing_tools

- No changes

## urdf_transform

```
* Fixed error in joining fixed links
* Fixed rotation to z axis which was still going the wrong way. Some robots may now need parameter negate_joint_movement inverted
* Contributors: Jennifer Buehler
```

## urdf_traverser

```
* Fixed error in joining fixed links
* Fixed rotation to z axis which was still going the wrong way. Some robots may now need parameter negate_joint_movement inverted
* Some tidy up
* Contributors: Jennifer Buehler
```

## urdf_viewer

```
* Some tidy up
* Contributors: Jennifer Buehler
```
