### PR TITLE
moveit_helpers: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7235,7 +7235,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/moveit-pkgs-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/moveit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_helpers` to `1.0.1-0`:

- upstream repository: https://github.com/JenniferBuehler/moveit-pkgs.git
- release repository: https://github.com/JenniferBuehler/moveit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.0-0`

## moveit_controller_multidof

- No changes

## moveit_object_handling

```
* Update to support detachment of objects from robots with new MoveIt version
* Contributors: Jennifer Buehler
```

## moveit_planning_helper

- No changes
