### PR TITLE
gazebo_tools: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3693,7 +3693,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/gazebo-pkgs-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/gazebo-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_tools` to `1.0.2-0`:

- upstream repository: https://github.com/JenniferBuehler/gazebo-pkgs.git
- release repository: https://github.com/JenniferBuehler/gazebo-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.1-0`

## gazebo_grasp_plugin

```
* Merge branch jacknlliu-fix-c11-error
* fix build error with c++ 11
* Contributors: Jack Liu, Jennifer Buehler
```

## gazebo_test_tools

```
* Merge branch jacknlliu-fix-c11-error
* fix build error with c++ 11
* Contributors: Jack Liu, Jennifer Buehler
```

## gazebo_world_plugin_loader

```
* Merge branch jacknlliu-fix-c11-error
* fix build error with c++ 11
* Contributors: Jack Liu, Jennifer Buehler
```
