### PR TITLE
universal_robot: 1.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15726,7 +15726,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.1.10-1
+      version: 1.1.11-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.1.11-0`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.1.10-1`

## universal_robot

- No changes

## ur10_moveit_config

```
* Merge pull request #321 <https://github.com//ros-industrial/universal_robot/issues/321> from gavanderhoorn/bp_266_indigo-devel
  Backport #266 <https://github.com//ros-industrial/universal_robot/issues/266> to Indigo.
* Reduce longest valid segment fraction to accomodate non-limited version of the UR5 (#266 <https://github.com//ros-industrial/universal_robot/issues/266>)
* Contributors: G.A. vd. Hoorn, Scott Paulin
```

## ur3_moveit_config

```
* Merge pull request #321 <https://github.com//ros-industrial/universal_robot/issues/321> from gavanderhoorn/bp_266_indigo-devel
  Backport #266 <https://github.com//ros-industrial/universal_robot/issues/266> to Indigo.
* Reduce longest valid segment fraction to accomodate non-limited version of the UR5 (#266 <https://github.com//ros-industrial/universal_robot/issues/266>)
* Contributors: G.A. vd. Hoorn, Scott Paulin
```

## ur5_moveit_config

```
* Merge pull request #321 <https://github.com//ros-industrial/universal_robot/issues/321> from gavanderhoorn/bp_266_indigo-devel
  Backport #266 <https://github.com//ros-industrial/universal_robot/issues/266> to Indigo.
* Reduce longest valid segment fraction to accomodate non-limited version of the UR5 (#266 <https://github.com//ros-industrial/universal_robot/issues/266>)
* Contributors: G.A. vd. Hoorn, Scott Paulin
```

## ur_bringup

- No changes

## ur_description

```
* Merge pull request #320 <https://github.com//ros-industrial/universal_robot/issues/320> from gavanderhoorn/bp_268_indigo-devel
  Backport #268 <https://github.com//ros-industrial/universal_robot/issues/268> to Indigo
* Fix elbow joint limits (#268 <https://github.com//ros-industrial/universal_robot/issues/268>)
* Contributors: Beatriz Leon, G.A. vd. Hoorn
```

## ur_driver

- No changes

## ur_gazebo

- No changes

## ur_kinematics

- No changes

## ur_msgs

- No changes
