### PR TITLE
universal_robot: 1.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10445,7 +10445,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.2.1-0`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.2.0-0`

## universal_robot

- No changes

## ur10_moveit_config

```
* Reduce longest valid segment fraction to accomodate non-limited version of the UR5 (#266 <https://github.com//ros-industrial/universal_robot/issues/266>)
* Contributors: Scott Paulin
```

## ur3_moveit_config

```
* Reduce longest valid segment fraction to accomodate non-limited version of the UR5 (#266 <https://github.com//ros-industrial/universal_robot/issues/266>)
* Contributors: Scott Paulin
```

## ur5_moveit_config

```
* Reduce longest valid segment fraction to accomodate non-limited version of the UR5 (#266 <https://github.com//ros-industrial/universal_robot/issues/266>)
* Contributors: Scott Paulin
```

## ur_bringup

```
* Merge pull request #322 <https://github.com//ros-industrial/universal_robot/issues/322> from gavanderhoorn/use_robot_state_publisher
  driver: don't use deprecated robot_state binary.
* driver: don't use deprecated robot_state binary.
* Contributors: Felix Messmer, gavanderhoorn
```

## ur_description

```
* Merge pull request #329 <https://github.com//ros-industrial/universal_robot/issues/329> from tecnalia-medical-robotics/joint_limits
  Homogenize xacro macro arguments.
* Merge pull request #332 <https://github.com//ros-industrial/universal_robot/issues/332> from davetcoleman/kinetic_hw_iface_warning
  Remove UR3 ROS Control Hardware Interface warning
* Remove UR3 ROS Control Hardware Interface warning
* Extend changes to '_robot.urdf.xacro' variants as well.
* Homogenize xacro macro arguments.
  Joint limits for the limited version could be set using arguments for the UR10
  but not for the UR3 and UR5. Same lower and upper limit arguments are added to
  the UR3 and UR5 xacro macros.
* Fix elbow joint limits (#268 <https://github.com//ros-industrial/universal_robot/issues/268>)
* Remove warning 'redefining global property: pi' (Jade+) (#315 <https://github.com//ros-industrial/universal_robot/issues/315>)
* Contributors: Beatriz Leon, Dave Coleman, Felix Messmer, Miguel Prada
```

## ur_driver

- No changes

## ur_gazebo

- No changes

## ur_kinematics

```
* Merge pull request #303 <https://github.com//ros-industrial/universal_robot/issues/303> from marcoesposito1988/pr-urdf-pointer-type
  Updated urdf::ModelInterface pointer type for ROS Lunar
* Updated urdf::ModelInterface pointer type for ROS Lunar
* Contributors: G.A. vd. Hoorn, Marco Esposito
```

## ur_msgs

- No changes
