### PR TITLE
graspit_tools: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4053,7 +4053,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/JenniferBuehler/graspit-pkgs-release.git
-      version: 1.1.3-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/JenniferBuehler/graspit-pkgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graspit_tools` to `1.2.0-0`:

- upstream repository: https://github.com/JenniferBuehler/graspit-pkgs.git
- release repository: https://github.com/JenniferBuehler/graspit-pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.1.3-0`

## grasp_planning_graspit

```
* Update
* Contributors: Jennifer Buehler
```

## grasp_planning_graspit_msgs

- No changes

## grasp_planning_graspit_ros

- No changes

## graspit_tools

- No changes

## jaco_graspit_sample

```
* Added grasp messages as readable string
* Updated grasp messages for new jaco joint names
* Contributors: Jennifer Buehler
```

## urdf2graspit

- No changes
