### PR TITLE
remove alliance and rqt_alliance

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -235,9 +235,7 @@ repositories:
   alliance:
     release:
       packages:
-      - alliance
       - alliance_msgs
-      - rqt_alliance
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/adrianohrl/alliance-release.git


### PR DESCRIPTION
Due to failure to build on the buildfarm

Partial reversion of #16347 @adrianohrl 

Ticketed upstream at https://github.com/adrianohrl/alliance/issues/9