### PR TITLE
cob_extern: 0.6.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1094,7 +1094,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.12-0`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.11-0`

## cob_extern

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #89 <https://github.com/ipa320/cob_extern/issues/89> from ipa320/ipa-rmb-patch-1
  Changed maintainer
* Changed maintainer
* Contributors: Felix Messmer, Richard Bormann
```

## libconcorde_tsp_solver

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #91 <https://github.com/ipa320/cob_extern/issues/91> from ipa-rmb/indigo_dev
  fixed libqsopt and libconcorde_tsp_solver
* fixed libqsopt and libconcorde_tsp_solver
* Merge pull request #90 <https://github.com/ipa320/cob_extern/issues/90> from ipa-rmb/concorde-patch
  added missing binary in CMakeLists of libconcorde_tsp_solver
* changed PROGRAMS to FILES for installing concorde.a
* added missing binary in CMakeLists of libconcorde_tsp_solver
* Contributors: Felix Messmer, Richard Bormann, ipa-fez
```

## libdlib

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Contributors: Felix Messmer
```

## libntcan

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Contributors: Felix Messmer
```

## libpcan

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Contributors: Felix Messmer
```

## libphidgets

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Contributors: Felix Messmer
```

## libqsopt

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #91 <https://github.com/ipa320/cob_extern/issues/91> from ipa-rmb/indigo_dev
  fixed libqsopt and libconcorde_tsp_solver
* fixed libqsopt and libconcorde_tsp_solver
* Contributors: Felix Messmer, Richard Bormann
```

## opengm

```
* Merge pull request #92 <https://github.com/ipa320/cob_extern/issues/92> from ipa320/indigo_release_candidate
  Indigo release candidate
* Contributors: Felix Messmer
```
