### PR TITLE
cob_command_tools: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1707,7 +1707,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.6-0`

## cob_command_gui

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_command_tools

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #202 <https://github.com/ipa320/cob_command_tools/issues/202> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_dashboard

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #202 <https://github.com/ipa320/cob_command_tools/issues/202> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_helper_tools

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #213 <https://github.com/ipa320/cob_command_tools/issues/213> from ipa-fxm/no_recover_em_stop
  do not recover on em_stop
* do not recover on em_stop
* Merge pull request #212 <https://github.com/ipa320/cob_command_tools/issues/212> from ipa-fxm/enhance_auto_recover_logic
  enhance auto_recover logic
* enhance auto_recover logic
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm, ipa-uhr-mk
```

## cob_interactive_teleop

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #199 <https://github.com/ipa320/cob_command_tools/issues/199> from ipa320/ipa-rmb-patch-1
  Changed maintainer
* Changed maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_monitoring

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #214 <https://github.com/ipa320/cob_command_tools/issues/214> from ipa-fmw/fix/emstop_monitor
  [EM stop monitor] prevent emstop monitor from saying empty strings
* prevent emstop monitor from saying empty strings
* Merge pull request #211 <https://github.com/ipa320/cob_command_tools/issues/211> from ipa-fxm/enhance_em_sound_logic
  enhance emergency sound output
* enhance emergency sound output
* Merge pull request #208 <https://github.com/ipa320/cob_command_tools/issues/208> from ipa-fxm/allow_distinct_say_on_release
  allow distinct say on released
* allow distinct say on released
* Merge pull request #207 <https://github.com/ipa320/cob_command_tools/issues/207> from ipa-fxm/sound_emergency_stop_monitor
  Sound emergency stop monitor
* allow to configure battery monitor notifications
* allow to configure emergency stop notifications
* Merge pull request #200 <https://github.com/ipa320/cob_command_tools/issues/200> from ipa-fxm/configurable_ntp_monitor
  enhance ntp_monitor
* Merge pull request #202 <https://github.com/ipa320/cob_command_tools/issues/202> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* refactor ntp_monitor
* made ntp_monitor configurable via yaml
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, Richard Bormann, ipa-fxm, ipa-uhr-mk, mailto:robot@cob4-2
```

## cob_script_server

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #206 <https://github.com/ipa320/cob_command_tools/issues/206> from ipa-fmw/hotfix_cob_console
  [cob_console] hotfix for ipython shebang
* hotfix for cob_console ipython shebang
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm, ipa-uhr-mk
```

## cob_teleop

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #202 <https://github.com/ipa320/cob_command_tools/issues/202> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## generic_throttle

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #209 <https://github.com/ipa320/cob_command_tools/issues/209> from ipa-fxm/generic_throttle_private_param
  use private parameters for generic_throttle
* use private parameters for generic_throttle
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Benjamin Maidel, Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## service_tools

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #197 <https://github.com/ipa320/cob_command_tools/issues/197> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```
