### PR TITLE
cob_common: 0.6.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -985,7 +985,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.7-0
+      version: 0.6.8-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.8-0`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.7-0`

## cob_common

```
* Merge pull request #246 <https://github.com/ipa320/cob_common/issues/246> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #230 <https://github.com/ipa320/cob_common/issues/230> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #224 <https://github.com/ipa320/cob_common/issues/224> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_description

```
* Merge pull request #246 <https://github.com/ipa320/cob_common/issues/246> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #244 <https://github.com/ipa320/cob_common/issues/244> from ipa-fxm/fix_depth_registered
  adjust topic to real hardware
* adjust topic to real hardware
* Merge pull request #243 <https://github.com/ipa320/cob_common/issues/243> from ipa-fxm/fix/test_urdf_travis
  fix test_urdf for travis
* fix test_urdf for travis
* Merge pull request #240 <https://github.com/ipa320/cob_common/issues/240> from mgruhler/fix/test_urdf
  cob_common: fix test_urdf.py
* cob_common: fix test_urdf.py
  * fix check of return value from subprocess call
  * use 'rosrun xacro xacro' instead of 'rospack find xacro'/xacro as this does not work in kinetic anymore
  * clearer error output
* Merge pull request #237 <https://github.com/ipa320/cob_common/issues/237> from ipa-fxm/fix/s300-max-range
  sick_s300: adjust range_max
* sick_s300: adjust range_max
* Merge pull request #235 <https://github.com/ipa320/cob_common/issues/235> from ipa-fxm/cob4_tricycle
  cob4 tricycle
* allow tricycle_mode
* Merge pull request #236 <https://github.com/ipa320/cob_common/issues/236> from ipa-fxm/remove_use_old_joint_name
  remove obsolete argument use_old_joint_names
* remove obsolete argument use_old_joint_names
* Merge pull request #233 <https://github.com/ipa320/cob_common/issues/233> from ipa-fxm/fix_asus_coord_frames
  fix camera coord frames for all cameras for hw and sim
* adjust sick_3dcs according to hardware driver specs
* tweak inertia
* Update usb_cam.gazebo.xacro
* fix frames of sick_3dcs
* fix frames of usb_cam
* fix image color format
* fix coordinate frames for asus camera
* Merge pull request #230 <https://github.com/ipa320/cob_common/issues/230> from ipa-fxm/update_maintainer
  update maintainer
* add missing include
* update maintainer
* Merge pull request #224 <https://github.com/ipa320/cob_common/issues/224> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #227 <https://github.com/ipa320/cob_common/issues/227> from ipa-fxm/copy_cob4_arm
  copy cob4_arm description
* copy cob4_arm description
* Merge pull request #226 <https://github.com/ipa320/cob_common/issues/226> from ipa-fxm/zr300_unique_macro_names
  unique macro name for zr300
* unique macro name for zr300
* Merge pull request #225 <https://github.com/ipa320/cob_common/issues/225> from ipa-fmw/feature/zr300
  add zr300 cameras
* add zr300 urdfs
* use license apache 2.0
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, Matthias Gruhler, Richard Bormann, ipa-fmw, ipa-fxm, ipa-uhr-mk
```

## cob_msgs

```
* Merge pull request #246 <https://github.com/ipa320/cob_common/issues/246> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #230 <https://github.com/ipa320/cob_common/issues/230> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #224 <https://github.com/ipa320/cob_common/issues/224> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_srvs

```
* Merge pull request #246 <https://github.com/ipa320/cob_common/issues/246> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #224 <https://github.com/ipa320/cob_common/issues/224> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-uhr-mk
```

## raw_description

```
* Merge pull request #246 <https://github.com/ipa320/cob_common/issues/246> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #239 <https://github.com/ipa320/cob_common/issues/239> from ipa-fxm/indigo_dev_rmb
  corrected torso definition
* corrected torso definition
* Merge pull request #232 <https://github.com/ipa320/cob_common/issues/232> from bmagyar/simplify_raw_vacuum_gripper_collision_model
  Replace vacuum gripper collision mesh with bounding box
* Replace vacuum gripper collision mesh with bounding box
* Merge pull request #230 <https://github.com/ipa320/cob_common/issues/230> from ipa-fxm/update_maintainer
  update maintainer
* Merge pull request #231 <https://github.com/ipa320/cob_common/issues/231> from ipa-fxm/update_torso_raw3-1
  new torso raw3-1
* add new torso for raw3-1
* add powerball urdf
* update maintainer
* Merge pull request #224 <https://github.com/ipa320/cob_common/issues/224> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #229 <https://github.com/ipa320/cob_common/issues/229> from ipa-fxm/move_ur_arm
  move ur_arm to raw_description
* move ur_arm to raw_description
* use license apache 2.0
* Contributors: Bence Magyar, Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```
