### PR TITLE
cob_driver: 0.6.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1035,7 +1035,6 @@ repositories:
       - cob_driver
       - cob_elmo_homing
       - cob_generic_can
-      - cob_head_axis
       - cob_light
       - cob_mimic
       - cob_phidget_em_state
@@ -1052,7 +1051,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.11-0`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.10-0`

## cob_base_drive_chain

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_bms_driver

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #364 <https://github.com/ipa320/cob_driver/issues/364> from ipa-fxm/fake_bms_diagnostics
  use diagnostic updater in fake_bms
* use diagnostic updater in fake_bms
* Merge pull request #361 <https://github.com/ipa320/cob_driver/issues/361> from ipa-fxm/set_relative_remaining_capacity
  set relative remaining capacity
* set relative remaining capacity
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* change maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm, ipa-uhr-mk
```

## cob_camera_sensors

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Merge branch 'indigo_dev' of github.com:ipa320/cob_driver into feature/mimic_sim
* Merge pull request #351 <https://github.com/ipa320/cob_driver/issues/351> from mikaelarguedas/add_tinyxml_dependency
  add tinyxml to package.xml
* add tinyxml to package.xml
* Merge pull request #349 <https://github.com/ipa320/cob_driver/issues/349> from ipa320/ipa-rmb-patch-1
  Changed Maintainer
* Changed Maintainer
* Contributors: Benjamin Maidel, Felix Messmer, Mikael Arguedas, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_canopen_motor

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_driver

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #353 <https://github.com/ipa320/cob_driver/issues/353> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_elmo_homing

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* change maintainer
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_generic_can

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_light

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_mimic

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #359 <https://github.com/ipa320/cob_driver/issues/359> from ipa-bnm/fix/mimic
  [cob_mimic] use glx/opengl output for mimic
* use glx/opengl output for mimic, fixes mimic issue for 6th and 7th gen nuc
* Merge pull request #354 <https://github.com/ipa320/cob_driver/issues/354> from ipa-bnm/feature/mimic
  [Mimic] improvements
* Merge pull request #353 <https://github.com/ipa320/cob_driver/issues/353> from ipa-fxm/update_maintainer
  update maintainer
* Merge pull request #356 <https://github.com/ipa320/cob_driver/issues/356> from ipa-nhg/MimicPy
  HotFix: readded python node for mimic
* remove duplicated test_mimic.py install tag
* use the old driver
* readded python node for mimic
* do not start blinking timer on sleeping or falling_asleep requests
* added random mimics
* double check username
* update maintainer
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #352 <https://github.com/ipa320/cob_driver/issues/352> from ipa-bnm/feature/mimic_sim
  Do not run mimic in fullscreen if sim is enabled
* use license apache 2.0
* Merge branch 'indigo_dev' of github.com:ipa320/cob_driver into feature/mimic_sim
* no fullscreen if sim enabled
* Merge pull request #345 <https://github.com/ipa320/cob_driver/issues/345> from ipa-fxm/fix_mimic_permission
  guarantee unique copy destinations
* guarantee unique copy destinations
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-fxm, ipa-nhg, ipa-uhr-mk
```

## cob_phidget_em_state

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_phidget_power_state

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_phidgets

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_relayboard

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_scan_unifier

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #353 <https://github.com/ipa320/cob_driver/issues/353> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_sick_lms1xx

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_sick_s300

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #358 <https://github.com/ipa320/cob_driver/issues/358> from ipa-jba/fix/s300-max-range
  [cob_sick_s300] adjust range_max
* Merge pull request #357 <https://github.com/ipa320/cob_driver/issues/357> from ipa-jba/fix/remove-dead-code
  [cob_sick_s300] remove dead code
* remove dead code
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* cob_sick_s300: adjust range_max
* Contributors: Felix Messmer, ipa-fxm, ipa-mig, ipa-uhr-mk
```

## cob_sound

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #353 <https://github.com/ipa320/cob_driver/issues/353> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_undercarriage_ctrl

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_utilities

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_voltage_control

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #341 <https://github.com/ipa320/cob_driver/issues/341> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```
