### PR TITLE
cob_hand: 0.6.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1873,7 +1873,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_hand-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_hand.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_hand` to `0.6.3-0`:

- upstream repository: https://github.com/ipa320/cob_hand.git
- release repository: https://github.com/ipa320/cob_hand-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.2-0`

## cob_hand

```
* Merge pull request #19 <https://github.com/ipa320/cob_hand/issues/19> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #17 <https://github.com/ipa320/cob_hand/issues/17> from ipa-fxm/APACHE_license
  use license apache 2.0
* change maintainer
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_hand_bridge

```
* Merge pull request #19 <https://github.com/ipa320/cob_hand/issues/19> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #17 <https://github.com/ipa320/cob_hand/issues/17> from ipa-fxm/APACHE_license
  use license apache 2.0
* change maintainer
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```
