### PR TITLE
cob_perception_common: 0.6.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1202,7 +1202,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.6.11-0`:

- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.10-0`

## cob_3d_mapping_msgs

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* use license apache 2.0
* Contributors: ipa-fxm, ipa-uhr-mk
```

## cob_cam3d_throttle

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #86 <https://github.com/ipa320/cob_perception_common/issues/86> from mikaelarguedas/patch-1
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* use license apache 2.0
* Contributors: Mikael Arguedas, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_image_flip

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #87 <https://github.com/ipa320/cob_perception_common/issues/87> from ipa-fxm/fix/depend_pluginlib
  add missing dependency
* add missing dependency
* Merge pull request #86 <https://github.com/ipa320/cob_perception_common/issues/86> from mikaelarguedas/patch-1
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* use license apache 2.0
* Contributors: Mikael Arguedas, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_object_detection_msgs

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* use license apache 2.0
* Contributors: ipa-fxm, ipa-uhr-mk
```

## cob_object_detection_visualizer

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* Merge pull request #83 <https://github.com/ipa320/cob_perception_common/issues/83> from ipa-rmb/indigo_dev
  fixed typo in package.xml
* fixed typo in package.xml
* use license apache 2.0
* Merge pull request #82 <https://github.com/ipa320/cob_perception_common/issues/82> from ipa-rmb/indigo_dev
  bugfix for a warning
* bugfix for a warning
* Contributors: Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_perception_common

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* use license apache 2.0
* Contributors: ipa-fxm, ipa-uhr-mk
```

## cob_perception_msgs

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* use license apache 2.0
* Contributors: ipa-fxm, ipa-uhr-mk
```

## cob_vision_utils

```
* Merge remote-tracking branch 'origin/indigo_release_candidate' into indigo_dev
* use license apache 2.0
* Contributors: ipa-fxm, ipa-uhr-mk
```
