### PR TITLE
cob_robots: 0.6.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1224,7 +1224,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.7-1
+      version: 0.6.8-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.8-0`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.7-1`

## cob_bringup

```
* Merge pull request #744 <https://github.com/ipa320/cob_robots/issues/744> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #743 <https://github.com/ipa320/cob_robots/issues/743> from ipa-fxm/laser_range_filter
  introduce laser range filter
* introduce laser range filter
* Merge pull request #740 <https://github.com/ipa320/cob_robots/issues/740> from ipa-fxm/fix_cam3d_nodelet_namespaces
  fix nodelet and topic namespaces
* fix nodelet and topic namespaces
* Merge pull request #731 <https://github.com/ipa320/cob_robots/issues/731> from ipa-fxm/enhance_auto_recover_logic
  enhance auto_recover logic
* Merge pull request #733 <https://github.com/ipa320/cob_robots/issues/733> from ipa-fxm/add_cob4-16_uh
  add cob4-16 uh
* add cob4-16 uh
* enhance auto_recover logic
* Merge pull request #728 <https://github.com/ipa320/cob_robots/issues/728> from ipa-nhg/cob47-setup
  setup cob4-7
* setup cob4-7
* Merge pull request #725 <https://github.com/ipa320/cob_robots/issues/725> from ipa-fmw/cob4-11_add_light
  add light to cob4-11
* add light to cob4-11
* Merge pull request #723 <https://github.com/ipa320/cob_robots/issues/723> from ipa-fxm/move_cob4-2
  move cob4-2 to unity-robotics
* Merge pull request #722 <https://github.com/ipa320/cob_robots/issues/722> from ipa-mjp/uncomment_ur_arm
  uncomment ur arm
* move cob4-2 to unity-robotics
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into correct_torso_param
* uncomment ur_arm
* Merge pull request #720 <https://github.com/ipa320/cob_robots/issues/720> from ipa-fxm/fix_camera_coord_frames
  fix camera coord frames for all cameras and all robots for hw and sim
* fix frame_id
* fix image flip for 3dcs
* consistency for all robots
* fix frames for usb_camera and sick_3dcs
* add missing frames for asus
* add nodelet manager for simulation
* fix camera coord frames for asus and zr300 on cob4-7
* add static transforms for zr300
* remove serial number (only needed for multi-camera setup)
* fix torso zr300 camera
* add zr300 launch file
* use zr300 for torso_right camera
* Merge pull request #719 <https://github.com/ipa320/cob_robots/issues/719> from ipa-fxm/anon_machine_tag
  anon machine tags
* Merge pull request #716 <https://github.com/ipa320/cob_robots/issues/716> from ipa-fxm/spacenav_launch_args
  introduce launch args for parameters
* anon machine tags
* Merge pull request #717 <https://github.com/ipa320/cob_robots/issues/717> from ipa-fxm/ntp_monitor_toggle
  do not monitor ntp offset for base pcs
* do not monitor ntp offset for base pcs
* introduce launch args for parameters
* Merge pull request #698 <https://github.com/ipa320/cob_robots/issues/698> from ipa-fxm/add_ntp_monitor
  add ntp monitor
* Merge pull request #714 <https://github.com/ipa320/cob_robots/issues/714> from ipa-fxm/legacy_cleanup
  remove legacy stuff and cleanup dependencies
* remove legacy stuff and cleanup dependencies
* add ntp_server for additional pcs of cob4-10
* fix indentation
* add ntp monitor
* Merge pull request #708 <https://github.com/ipa320/cob_robots/issues/708> from ipa-fxm/feature/powerball_raw3-1
  Feature/powerball raw3 1
* Merge pull request #707 <https://github.com/ipa320/cob_robots/issues/707> from ipa-fxm/update_maintainer
  update maintainer
* Merge pull request #712 <https://github.com/ipa320/cob_robots/issues/712> from ipa-jba/feature/kinetic_raw
  single computer for raw, fix ports
* autoinit/autorecover launch file
* single computer for raw, fix ports
* Merge pull request #709 <https://github.com/ipa320/cob_robots/issues/709> from ipa-nhg/cob4-10
  Full configuration cob4-10
* harmonize configuration with current status
* support old mimic node
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_config/robots/cob4-8/script_server/command_gui_buttons.yaml
* Configuration for cob4-10
* setup cob4-10
* turn on twist control, corrected axis
* actuate powerball via canopen
* remove unavailable components
* Merge pull request #702 <https://github.com/ipa320/cob_robots/issues/702> from ipa-fez/feature/raw3-1-canopen
  Migrate raw3-1 base to canopen
* pass loosened stuck_detector parameters for all raws
* setup cob4-10
* Merge pull request #706 <https://github.com/ipa320/cob_robots/issues/706> from ipa-fmw/feature/docking
  use scan unified and laser filter for docking
* update maintainer
* Merge pull request #704 <https://github.com/ipa320/cob_robots/issues/704> from ipa-bnm/feature/mimic_sim
  Add sim argument to mimic launch
* use scan unified and laser filter for docking
* add sim argument to mimic launch
* Merge pull request #705 <https://github.com/ipa320/cob_robots/issues/705> from ipa-fmw/feature/mimic
  fix mimic vs sound issue
* fix typo
* fix mimic for all robots
* adapt mimic changes to all mimic robots
* fix mimic vs sound issue
* Merge pull request #686 <https://github.com/ipa320/cob_robots/issues/686> from ipa-fxm/APACHE_license
  use license apache 2.0
* change disable_stuck_detector to enable_stuck_detector
* add setting to disable stuck detector for raws and disable it for raw3-1
* tabs vs. spaces
* set proper can device for raw3-1 base
* WIP migration to canopen
* use license apache 2.0
* Contributors: Benjamin Maidel, Felix, Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, Richard Bormann, cob4-11, ipa-fmw, ipa-fxm, ipa-mjp, ipa-nhg, ipa-uhr-mk, raw3-1, mailto:rob@work robot, robot
```

## cob_default_robot_behavior

```
* Merge pull request #744 <https://github.com/ipa320/cob_robots/issues/744> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #733 <https://github.com/ipa320/cob_robots/issues/733> from ipa-fxm/add_cob4-16_uh
  add cob4-16 uh
* add cob4-16 uh
* Merge pull request #723 <https://github.com/ipa320/cob_robots/issues/723> from ipa-fxm/move_cob4-2
  move cob4-2 to unity-robotics
* move cob4-2 to unity-robotics
* Merge pull request #707 <https://github.com/ipa320/cob_robots/issues/707> from ipa-fxm/update_maintainer
  update maintainer
* Merge pull request #709 <https://github.com/ipa320/cob_robots/issues/709> from ipa-nhg/cob4-10
  Full configuration cob4-10
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_config/robots/cob4-8/script_server/command_gui_buttons.yaml
* setup cob4-10
* update maintainer
* Merge pull request #686 <https://github.com/ipa320/cob_robots/issues/686> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-fxm, ipa-nhg, ipa-uhr-mk
```

## cob_default_robot_config

```
* Merge pull request #744 <https://github.com/ipa320/cob_robots/issues/744> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #733 <https://github.com/ipa320/cob_robots/issues/733> from ipa-fxm/add_cob4-16_uh
  add cob4-16 uh
* add cob4-16 uh
* Merge pull request #728 <https://github.com/ipa320/cob_robots/issues/728> from ipa-nhg/cob47-setup
  setup cob4-7
* setup cob4-7
* Merge pull request #723 <https://github.com/ipa320/cob_robots/issues/723> from ipa-fxm/move_cob4-2
  move cob4-2 to unity-robotics
* move cob4-2 to unity-robotics
* Merge pull request #721 <https://github.com/ipa320/cob_robots/issues/721> from ipa-mjp/correct_torso_param
  Correct torso param
* change torso joint name
* Merge pull request #707 <https://github.com/ipa320/cob_robots/issues/707> from ipa-fxm/update_maintainer
  update maintainer
* Merge pull request #709 <https://github.com/ipa320/cob_robots/issues/709> from ipa-nhg/cob4-10
  Full configuration cob4-10
* harmonize configuration with current status
* Merge pull request #710 <https://github.com/ipa320/cob_robots/issues/710> from ipa-nhg/indigo_dev
  Add head positon buttons for cob4-8 command_gui
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_config/robots/cob4-8/script_server/command_gui_buttons.yaml
* add command_gui buttons for head - aalto
* setup cob4-10
* update maintainer
* Merge pull request #686 <https://github.com/ipa320/cob_robots/issues/686> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #701 <https://github.com/ipa320/cob_robots/issues/701> from ipa-fxm/config_cob4-8_aalto
  some fixes cob4-8
* some fixes cob4-8
* restore torso configs
* WIP migration to canopen
* use license apache 2.0
* Contributors: Benjamin Maidel, Felix, Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-cob4-8, ipa-fxm, ipa-mjp, ipa-nhg, ipa-uhr-mk
```

## cob_hardware_config

```
* Merge pull request #744 <https://github.com/ipa320/cob_robots/issues/744> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #743 <https://github.com/ipa320/cob_robots/issues/743> from ipa-fxm/laser_range_filter
  introduce laser range filter
* introduce laser range filter
* Merge pull request #742 <https://github.com/ipa320/cob_robots/issues/742> from ipa-fxm/adjust_ntp_thresholds
  adjust ntp thresholds
* adjust ntp thresholds
* Merge pull request #739 <https://github.com/ipa320/cob_robots/issues/739> from ipa-rmb/wheel-update
  updated homing digital input for wheel
* updated homing digital input for wheel
* Merge pull request #736 <https://github.com/ipa320/cob_robots/issues/736> from ipa-fmw/calibrate_cob4-7_base
  calibrate cob4-7 base
* calibrate cob4-7 base
* Merge pull request #735 <https://github.com/ipa320/cob_robots/issues/735> from ipa-fxm/indigo_dev_rmb
  corrected torso definition
* Added a clarifying comment which link is referred to
* Merge pull request #733 <https://github.com/ipa320/cob_robots/issues/733> from ipa-fxm/add_cob4-16_uh
  add cob4-16 uh
* corrected torso definition
* add cob4-16 uh
* Merge pull request #728 <https://github.com/ipa320/cob_robots/issues/728> from ipa-nhg/cob47-setup
  setup cob4-7
* update URDF to static head and sensorring
* setup cob4-7
* Merge pull request #727 <https://github.com/ipa320/cob_robots/issues/727> from ipa-fxm/remove_use_old_joint_name
  remove obsolete use_old_joint_names argument
* remove obsolete use_old_joint_names argument
* Merge pull request #726 <https://github.com/ipa320/cob_robots/issues/726> from ipa-bnm/cob4-7-homing-offsets
  use homing offsets from cob4-2 for cob4-7
* use homing offsets from cob4-2
* Merge pull request #725 <https://github.com/ipa320/cob_robots/issues/725> from ipa-fmw/cob4-11_add_light
  add light to cob4-11
* add light to cob4-11
* Merge pull request #723 <https://github.com/ipa320/cob_robots/issues/723> from ipa-fxm/move_cob4-2
  move cob4-2 to unity-robotics
* Merge pull request #722 <https://github.com/ipa320/cob_robots/issues/722> from ipa-mjp/uncomment_ur_arm
  uncomment ur arm
* move cob4-2 to unity-robotics
* Merge branch 'indigo_dev' of https://github.com/ipa320/cob_robots into correct_torso_param
* uncomment ur_arm
* Merge pull request #720 <https://github.com/ipa320/cob_robots/issues/720> from ipa-fxm/fix_camera_coord_frames
  fix camera coord frames for all cameras and all robots for hw and sim
* Merge pull request #721 <https://github.com/ipa320/cob_robots/issues/721> from ipa-mjp/correct_torso_param
  Correct torso param
* correct torso calibration param
* fix head_cam mount position
* fix image flip for 3dcs
* consistency for all robots
* fix frames for usb_camera and sick_3dcs
* fix camera coord frames for asus and zr300 on cob4-7
* finalize zr300 transformations
* use zr300 for torso_right camera
* Merge pull request #698 <https://github.com/ipa320/cob_robots/issues/698> from ipa-fxm/add_ntp_monitor
  add ntp monitor
* proper error threshold
* add ntp monitor
* Merge pull request #708 <https://github.com/ipa320/cob_robots/issues/708> from ipa-fxm/feature/powerball_raw3-1
  Feature/powerball raw3 1
* Merge pull request #707 <https://github.com/ipa320/cob_robots/issues/707> from ipa-fxm/update_maintainer
  update maintainer
* Merge pull request #712 <https://github.com/ipa320/cob_robots/issues/712> from ipa-jba/feature/kinetic_raw
  single computer for raw, fix ports
* ttyLED for LED
* single computer for raw, fix ports
* Merge pull request #709 <https://github.com/ipa320/cob_robots/issues/709> from ipa-nhg/cob4-10
  Full configuration cob4-10
* harmonize configuration with current status
* Merge pull request #711 <https://github.com/ipa320/cob_robots/issues/711> from ipa-bnm/fix/homing_offset
  reverted homing offsets for cob4-b7
* reverted homing offsets for cob4-b7
* unify arm driver configuration
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_config/robots/cob4-8/script_server/command_gui_buttons.yaml
* Configuration for cob4-10
* setup cob4-10
* turn on twist control, corrected axis
* actuate powerball via canopen
* adjust urdf
* remove unavailable components
* Merge pull request #702 <https://github.com/ipa320/cob_robots/issues/702> from ipa-fez/feature/raw3-1-canopen
  Migrate raw3-1 base to canopen
* setup cob4-10
* update maintainer
* Merge pull request #686 <https://github.com/ipa320/cob_robots/issues/686> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #694 <https://github.com/ipa320/cob_robots/issues/694> from ipa-fxm/use_cob4_arm
  use cob4_arm description
* Merge pull request #701 <https://github.com/ipa320/cob_robots/issues/701> from ipa-fxm/config_cob4-8_aalto
  some fixes cob4-8
* some fixes cob4-8
* Merge pull request #699 <https://github.com/ipa320/cob_robots/issues/699> from ipa-fxm/move_ur_arm
  move ur_arm to raw_description
* fix direction of left side wheels
* restore torso configs
* adjust motor configs based on deleted inis
* move ur_arm to raw_description
* WIP migration to canopen
* use cob4_arm description
* use license apache 2.0
* Contributors: Benjamin Maidel, Felix, Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, Richard Bormann, cob4-11, ipa-fmw, ipa-fxm, ipa-mjp, ipa-nhg, ipa-uhr-mk, raw3-1, mailto:rob@work robot
```

## cob_moveit_config

```
* Merge pull request #744 <https://github.com/ipa320/cob_robots/issues/744> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #733 <https://github.com/ipa320/cob_robots/issues/733> from ipa-fxm/add_cob4-16_uh
  add cob4-16 uh
* add cob4-16 uh
* Merge pull request #730 <https://github.com/ipa320/cob_robots/issues/730> from ipa-fxm/moveit_setup_assistant_xacro
  fix setup assistant jade xacro support
* Merge pull request #729 <https://github.com/ipa320/cob_robots/issues/729> from ipa-fxm/remove_add_robot_helper
  remove add_robot helper
* fix setup assistant jade xacro support
* remove add_robot helper
* Merge pull request #723 <https://github.com/ipa320/cob_robots/issues/723> from ipa-fxm/move_cob4-2
  move cob4-2 to unity-robotics
* move cob4-2 to unity-robotics
* Merge pull request #707 <https://github.com/ipa320/cob_robots/issues/707> from ipa-fxm/update_maintainer
  update maintainer
* Merge pull request #709 <https://github.com/ipa320/cob_robots/issues/709> from ipa-nhg/cob4-10
  Full configuration cob4-10
* harmonize configuration with current status
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_config/robots/cob4-8/script_server/command_gui_buttons.yaml
* setup cob4-10
* update maintainer
* Merge pull request #686 <https://github.com/ipa320/cob_robots/issues/686> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, Nadia Hammoudeh García, ipa-fxm, ipa-nhg, ipa-uhr-mk
```

## cob_robots

```
* Merge pull request #744 <https://github.com/ipa320/cob_robots/issues/744> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #707 <https://github.com/ipa320/cob_robots/issues/707> from ipa-fxm/update_maintainer
  update maintainer
* Merge github.com:ipa320/cob_robots into indigo_dev
  Conflicts:
  cob_default_robot_config/robots/cob4-8/script_server/command_gui_buttons.yaml
* update maintainer
* Merge pull request #686 <https://github.com/ipa320/cob_robots/issues/686> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-nhg, ipa-uhr-mk
```
