### PR TITLE
cob_simulation: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1999,7 +1999,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.9-0`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.8-0`

## cob_bringup_sim

```
* Merge pull request #160 <https://github.com/ipa320/cob_simulation/issues/160> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #156 <https://github.com/ipa320/cob_simulation/issues/156> from ipa-fxm/add_move_initialpose_mode
  add move_initialpose mode
* add move_initialpose mode
* Merge pull request #154 <https://github.com/ipa320/cob_simulation/issues/154> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #151 <https://github.com/ipa320/cob_simulation/issues/151> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_gazebo

```
* Merge pull request #160 <https://github.com/ipa320/cob_simulation/issues/160> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #154 <https://github.com/ipa320/cob_simulation/issues/154> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #151 <https://github.com/ipa320/cob_simulation/issues/151> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_gazebo_objects

```
* Merge pull request #160 <https://github.com/ipa320/cob_simulation/issues/160> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #151 <https://github.com/ipa320/cob_simulation/issues/151> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #153 <https://github.com/ipa320/cob_simulation/issues/153> from ipa-rmb/ipa-rmb-changed-maintainers
  Changed maintainers
* changed maintainers
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-uhr-mk
```

## cob_gazebo_worlds

```
* Merge pull request #160 <https://github.com/ipa320/cob_simulation/issues/160> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #157 <https://github.com/ipa320/cob_simulation/issues/157> from ipa-fxm/fix_tests_izs_campus
  add launch file for izs-campus
* add launch file for izs-campus
* Merge pull request #154 <https://github.com/ipa320/cob_simulation/issues/154> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #151 <https://github.com/ipa320/cob_simulation/issues/151> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_simulation

```
* Merge pull request #160 <https://github.com/ipa320/cob_simulation/issues/160> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #154 <https://github.com/ipa320/cob_simulation/issues/154> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #151 <https://github.com/ipa320/cob_simulation/issues/151> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #153 <https://github.com/ipa320/cob_simulation/issues/153> from ipa-rmb/ipa-rmb-changed-maintainers
  Changed maintainers
* changed maintainers
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```
