### PR TITLE
cob_substitute: 0.6.7-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2019,7 +2019,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.6-0
+      version: 0.6.7-1
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.7-1`:

- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.6-0`

## cob_docker_control

```
* Merge pull request #50 <https://github.com/ipa320/cob_substitute/issues/50> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #48 <https://github.com/ipa320/cob_substitute/issues/48> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #45 <https://github.com/ipa320/cob_substitute/issues/45> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_reflector_referencing

```
* Merge pull request #50 <https://github.com/ipa320/cob_substitute/issues/50> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #48 <https://github.com/ipa320/cob_substitute/issues/48> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #45 <https://github.com/ipa320/cob_substitute/issues/45> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_safety_controller

```
* Merge pull request #50 <https://github.com/ipa320/cob_substitute/issues/50> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #49 <https://github.com/ipa320/cob_substitute/issues/49> from ipa-fxm/fix_flexisoft_sim
  proper python dummy for flexisoft_sim
* proper python dummy for flexisoft_sim
* Merge pull request #48 <https://github.com/ipa320/cob_substitute/issues/48> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #45 <https://github.com/ipa320/cob_substitute/issues/45> from ipa-fxm/APACHE_license
  use license apache 2.0
* change maintainer
* Merge pull request #46 <https://github.com/ipa320/cob_substitute/issues/46> from ipa-fmw/remove/cob_relayboard
  remove cob_relayboard
* remove cob_relayboard
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm, ipa-uhr-mk
```

## cob_substitute

```
* Merge pull request #50 <https://github.com/ipa320/cob_substitute/issues/50> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #48 <https://github.com/ipa320/cob_substitute/issues/48> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #45 <https://github.com/ipa320/cob_substitute/issues/45> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```
