### PR TITLE
schunk_modular_robotics: 0.6.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9178,7 +9178,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.10-0`:

- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.9-0`

## schunk_description

```
* Merge pull request #198 <https://github.com/ipa320/schunk_modular_robotics/issues/198> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #197 <https://github.com/ipa320/schunk_modular_robotics/issues/197> from christian-rauch/mesh_face_orientation
  fix face orientation "Re-Orient all faces coherently"
* fix face orientation "Re-Orient all faces coherently"
* Merge pull request #196 <https://github.com/ipa320/schunk_modular_robotics/issues/196> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #191 <https://github.com/ipa320/schunk_modular_robotics/issues/191> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Christian Rauch, Felix Messmer, Florian Weisshardt, ipa-fxm
```

## schunk_libm5api

```
* Merge pull request #198 <https://github.com/ipa320/schunk_modular_robotics/issues/198> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #191 <https://github.com/ipa320/schunk_modular_robotics/issues/191> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm
```

## schunk_modular_robotics

```
* Merge pull request #198 <https://github.com/ipa320/schunk_modular_robotics/issues/198> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #196 <https://github.com/ipa320/schunk_modular_robotics/issues/196> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #191 <https://github.com/ipa320/schunk_modular_robotics/issues/191> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm
```

## schunk_powercube_chain

```
* Merge pull request #198 <https://github.com/ipa320/schunk_modular_robotics/issues/198> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #191 <https://github.com/ipa320/schunk_modular_robotics/issues/191> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm
```

## schunk_sdh

```
* Merge pull request #198 <https://github.com/ipa320/schunk_modular_robotics/issues/198> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #195 <https://github.com/ipa320/schunk_modular_robotics/issues/195> from christian-rauch/motor_power_switch
  Motor power switch
* Merge pull request #191 <https://github.com/ipa320/schunk_modular_robotics/issues/191> from ipa-fxm/APACHE_license
  use license apache 2.0
* skip check of alternative SDH device types
* catch exceptions by const reference
* provide messages for successfull service calls
* disable / enable motor power
* change maintainer
* Merge pull request #192 <https://github.com/ipa320/schunk_modular_robotics/issues/192> from christian-rauch/disable_motors
  Services for disabling motors
* rename 'disconnect' service to 'shutdown'
* remove unused 'srvCallback_Recover'
* 'disconnect' and 'emergency_stop' services return true when finished
* close connection to DSA
* deinitialise at stop and disconnect
* services for stopping motors
* Merge pull request #193 <https://github.com/ipa320/schunk_modular_robotics/issues/193> from christian-rauch/pub_temperature
  Publish temperatures for monitoring overheating
* publish temperatures
* enable C++11
* use license apache 2.0
* Contributors: Christian Rauch, Felix Messmer, ipa-fxm
```

## schunk_simulated_tactile_sensors

```
* Merge pull request #198 <https://github.com/ipa320/schunk_modular_robotics/issues/198> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #196 <https://github.com/ipa320/schunk_modular_robotics/issues/196> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #191 <https://github.com/ipa320/schunk_modular_robotics/issues/191> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Florian Weisshardt, ipa-fxm
```
