### PR TITLE
cob_gazebo_plugins: 0.6.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1855,7 +1855,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_gazebo_plugins-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.6-0`

## cob_gazebo_plugins

```
* Merge pull request #33 <https://github.com/ipa320/cob_gazebo_plugins/issues/33> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #31 <https://github.com/ipa320/cob_gazebo_plugins/issues/31> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #28 <https://github.com/ipa320/cob_gazebo_plugins/issues/28> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_gazebo_ros_control

```
* Merge pull request #33 <https://github.com/ipa320/cob_gazebo_plugins/issues/33> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #31 <https://github.com/ipa320/cob_gazebo_plugins/issues/31> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #28 <https://github.com/ipa320/cob_gazebo_plugins/issues/28> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```
