### PR TITLE
cob_gazebo_plugins: 0.7.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1112,7 +1112,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_gazebo_plugins-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.7.2-0`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.1-0`

## cob_gazebo_plugins

```
* Merge pull request #34 <https://github.com/ipa320/cob_gazebo_plugins/issues/34> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #32 <https://github.com/ipa320/cob_gazebo_plugins/issues/32> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_gazebo_plugins into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #31 <https://github.com/ipa320/cob_gazebo_plugins/issues/31> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #28 <https://github.com/ipa320/cob_gazebo_plugins/issues/28> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_gazebo_ros_control

```
* Merge pull request #34 <https://github.com/ipa320/cob_gazebo_plugins/issues/34> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #32 <https://github.com/ipa320/cob_gazebo_plugins/issues/32> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_gazebo_plugins into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #31 <https://github.com/ipa320/cob_gazebo_plugins/issues/31> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #28 <https://github.com/ipa320/cob_gazebo_plugins/issues/28> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```
