### PR TITLE
cob_control: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1011,11 +1011,10 @@ repositories:
       - cob_omni_drive_controller
       - cob_trajectory_controller
       - cob_twist_controller
-      - cob_undercarriage_ctrl_node
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.1-0`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.0-0`

## cob_base_velocity_smoother

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_cartesian_controller

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_collision_velocity_filter

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #164 <https://github.com/ipa320/cob_control/issues/164> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_control

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #164 <https://github.com/ipa320/cob_control/issues/164> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_control_mode_adapter

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_control_msgs

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_footprint_observer

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #164 <https://github.com/ipa320/cob_control/issues/164> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_frame_tracker

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #168 <https://github.com/ipa320/cob_control/issues/168> from ipa-aep/bugfix/checkInfinitesimalTwist
  Bugfix/check infinitesimal twist
* fix wrong axes bug in Infinitesimal distance check
* add rotational distance computation to abortion criteria
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #160 <https://github.com/ipa320/cob_control/issues/160> from ipa-aep/feature/frametracker_pid_debugging
  add publisher for controller error
* remove terminal output of period
* add publisher for controller error
* use license apache 2.0
* Contributors: Alexander Pekarovskiy, Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_model_identifier

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_obstacle_distance

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_omni_drive_controller

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #164 <https://github.com/ipa320/cob_control/issues/164> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_trajectory_controller

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_twist_controller

```
* Merge remote-tracking branch 'origin/kinetic_release_candidate' into kinetic_dev
* Merge pull request #169 <https://github.com/ipa320/cob_control/issues/169> from ipa-fxm/kinetic_updates_indigo
  Kinetic updates indigo
* Merge branch 'indigo_dev' of github.com:ipa320/cob_control into kinetic_dev
  Conflicts:
  .travis.yml
* Merge pull request #159 <https://github.com/ipa320/cob_control/issues/159> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```
