### PR TITLE
cob_manipulation: 0.6.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1898,7 +1898,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.6.6-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.6.5-1`

## cob_collision_monitor

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* updated author/maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Mathias Lüdtke, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_grasp_generation

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* document manual generation of grasp table (#127 <https://github.com/ipa320/cob_manipulation/issues/127>)
  * document manual generation of grasp table
  * document manual generation of grasp table 2
  * Update README.md
  * Update README.md
* Merge pull request #126 <https://github.com/ipa320/cob_manipulation/issues/126> from ipa-fxm/revive_pick_place
  separate openrave independent part query_grasp
* add trivial grasp table for corn_flakes_package
* add coordinates systems to rviz config
* resolve side-dependend joint_names and tune grasp-open config
* tune grasptable
* fix mimic joints and quaternion normalization
* add show_grasp_rviz
* move meshes and kit grasptables
* more consistent naming
* separate openrave independent part query_grasp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-rmb-pz, ipa-uhr-mk
```

## cob_kinematics

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* updated author/maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Mathias Lüdtke, ipa-uhr-mk
```

## cob_lookat_action

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_manipulation

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* updated author/maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Mathias Lüdtke, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_moveit_bringup

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #128 <https://github.com/ipa320/cob_manipulation/issues/128> from ipa-fxm/configurable_moveit_config_helper
  additional arguments for moveit_config helper
* simplify template substitution
* fix setup assistant jade xacro support
* additional arguments for moveit_config helper
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #123 <https://github.com/ipa320/cob_manipulation/issues/123> from ipa-fxm/fix_launch_arguments
  properly pass missing launch arguments
* properly pass missing launch arguments
* updated author/maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Mathias Lüdtke, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_moveit_interface

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_obstacle_distance_moveit

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-uhr-mk
```

## cob_pick_place_action

```
* Merge pull request #133 <https://github.com/ipa320/cob_manipulation/issues/133> from ipa320/indigo_release_candidate
  Indigo release candidate
* Merge pull request #126 <https://github.com/ipa320/cob_manipulation/issues/126> from ipa-fxm/revive_pick_place
  separate openrave independent part query_grasp
* resolve side-dependend joint_names and tune grasp-open config
* move meshes and kit grasptables
* more consistent naming
* tweaks for cob4
* separate openrave independent part query_grasp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```
