### PR TITLE
cob_manipulation: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1154,7 +1154,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.1-0`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.0-0`

## cob_collision_monitor

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* updated author/maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Mathias Lüdtke, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_grasp_generation

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* document manual generation of grasp table (#127 <https://github.com/ipa320/cob_manipulation/issues/127>)
  * document manual generation of grasp table
  * document manual generation of grasp table 2
  * Update README.md
  * Update README.md
* Merge pull request #126 <https://github.com/ipa320/cob_manipulation/issues/126> from ipa-fxm/revive_pick_place
  separate openrave independent part query_grasp
* add trivial grasp table for corn_flakes_package
* add coordinates systems to rviz config
* resolve side-dependend joint_names and tune grasp-open config
* tune grasptable
* fix mimic joints and quaternion normalization
* add show_grasp_rviz
* move meshes and kit grasptables
* more consistent naming
* separate openrave independent part query_grasp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-rmb-pz, ipa-uhr-mk
```

## cob_lookat_action

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_manipulation

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* updated author/maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Mathias Lüdtke, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_moveit_bringup

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* Merge pull request #128 <https://github.com/ipa320/cob_manipulation/issues/128> from ipa-fxm/configurable_moveit_config_helper
  additional arguments for moveit_config helper
* simplify template substitution
* fix setup assistant jade xacro support
* additional arguments for moveit_config helper
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* Merge pull request #123 <https://github.com/ipa320/cob_manipulation/issues/123> from ipa-fxm/fix_launch_arguments
  properly pass missing launch arguments
* properly pass missing launch arguments
* updated author/maintainer
* use license apache 2.0
* Contributors: Felix Messmer, Mathias Lüdtke, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_moveit_interface

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```

## cob_obstacle_distance_moveit

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, ipa-fxm, ipa-uhr-mk
```

## cob_pick_place_action

```
* Merge pull request #134 <https://github.com/ipa320/cob_manipulation/issues/134> from ipa320/kinetic_release_candidate
  Kinetic release candidate
* Merge pull request #132 <https://github.com/ipa320/cob_manipulation/issues/132> from ipa-fxm/kinetic_dev
  [kinetic] updates from indigo_dev
* fix ROS_INFO
* fix move_group return value handling
* Merge branch 'indigo_dev' of github.com:ipa320/cob_manipulation into kinetic_dev
  Conflicts:
  .travis.yml
  cob_kinematics/ikfast/src/ikfast_lbr.cpp
  cob_kinematics/ikfast/src/ikfast_ur10.cpp
  cob_kinematics/ikfast/src/ikfast_ur5.cpp
  cob_kinematics/package.xml
  cob_kinematics/ros/bin/genikfast.py
  cob_kinematics/ros/src/ikfast_plugin.cpp
  cob_kinematics/ros/src/urdf_openrave.cpp
* Merge pull request #126 <https://github.com/ipa320/cob_manipulation/issues/126> from ipa-fxm/revive_pick_place
  separate openrave independent part query_grasp
* resolve side-dependend joint_names and tune grasp-open config
* move meshes and kit grasptables
* more consistent naming
* tweaks for cob4
* separate openrave independent part query_grasp
* Merge pull request #124 <https://github.com/ipa320/cob_manipulation/issues/124> from ipa-fxm/update_maintainer
  update maintainer
* update maintainer
* Merge pull request #120 <https://github.com/ipa320/cob_manipulation/issues/120> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Contributors: Felix Messmer, Richard Bormann, ipa-fxm, ipa-uhr-mk
```
