### PR TITLE
add blender for arch and debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -235,6 +235,8 @@ bison:
   macports: [bison]
   ubuntu: [bison]
 blender:
+  arch: [blender]
+  debian: [blender]
   fedora: [blender]
   gentoo: [media-gfx/blender]
   ubuntu: [blender]


### PR DESCRIPTION
arch: https://www.archlinux.org/packages/community/x86_64/blender/
debian: https://packages.debian.org/search?suite=default&section=all&arch=any&lang=de&searchon=names&keywords=blender