### PR TITLE
care_o_bot: 0.6.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -787,6 +787,22 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  care_o_bot:
+    doc:
+      type: git
+      url: https://github.com/ipa320/care-o-bot.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - care_o_bot
+      - care_o_bot_desktop
+      - care_o_bot_robot
+      - care_o_bot_simulation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/care-o-bot-release.git
+      version: 0.6.6-0
+    status: maintained
   cartesian_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `care_o_bot` to `0.6.6-0`:

- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## care_o_bot

```
* Merge pull request #44 <https://github.com/ipa320/care-o-bot/issues/44> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Merge pull request #23 <https://github.com/ipa320/care-o-bot/issues/23> from ipa320/indigo_release_candidate
  Updates from latest release
* Contributors: Felix Messmer, Florian Weisshardt, ipa-uhr-mk
```

## care_o_bot_desktop

```
* Merge pull request #44 <https://github.com/ipa320/care-o-bot/issues/44> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Merge pull request #40 <https://github.com/ipa320/care-o-bot/issues/40> from ipa320/ipa-fmw-patch-2
  add catkin tools
* add catkin tools
* Update package.xml
* Merge pull request #23 <https://github.com/ipa320/care-o-bot/issues/23> from ipa320/indigo_release_candidate
  Updates from latest release
* Contributors: Felix Messmer, Florian Weisshardt, ipa-uhr-mk
```

## care_o_bot_robot

```
* Merge pull request #48 <https://github.com/ipa320/care-o-bot/issues/48> from ipa-fxm/fix_travis_cron_job
  fix travis cron job
* add robot tools to care-o-bot-robot variant
* Merge pull request #44 <https://github.com/ipa320/care-o-bot/issues/44> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Merge pull request #29 <https://github.com/ipa320/care-o-bot/issues/29> from ipa320/ipa-fmw-patch-1
  add robot upstart as a dependency to the robot variant
* add robot upstart as a dependency to the robot variant
* Merge pull request #23 <https://github.com/ipa320/care-o-bot/issues/23> from ipa320/indigo_release_candidate
  Updates from latest release
* Contributors: Felix Messmer, Florian Weisshardt, ipa-uhr-mk
```

## care_o_bot_simulation

```
* Merge pull request #44 <https://github.com/ipa320/care-o-bot/issues/44> from ipa-fxm/APACHE_license
  use license apache 2.0
* use license apache 2.0
* Merge pull request #23 <https://github.com/ipa320/care-o-bot/issues/23> from ipa320/indigo_release_candidate
  Updates from latest release
* Contributors: Felix Messmer, Florian Weisshardt, ipa-uhr-mk
```
