### PR TITLE
Disable test pull request for roswww

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8264,7 +8264,6 @@ repositories:
       url: https://github.com/ros-gbp/roswww-release.git
       version: 0.1.10-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/tork-a/roswww.git
       version: develop


### PR DESCRIPTION
Since this is already tested on travis, it is not necesary to test it also on buildfirm.