### PR TITLE
Add azure-iothub-device-client pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8,6 +8,16 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+azure-iothub-device-client-pip:
+  debian:
+    pip:
+      packages: [azure-iothub-device-client]
+  fedora:
+    pip:
+      packages: [azure-iothub-device-client]
+  ubuntu:
+    pip:
+      packages: [azure-iothub-device-client]
 catkin_pkg:
   gentoo: [dev-python/catkin_pkg]
 cmakelint-pip:


### PR DESCRIPTION
This PR provides the azure-iothub-device-client Python pip package to ROS. The package provides a Python SDK for device clients connecting to the Microsoft Azure IoT Hub service. This would be a dependency for any projects making use of the IoT Hub service within a rospy package.

**PyPi Package Description:** https://pypi.org/project/azure-iothub-device-client/
**Source Repository:** https://github.com/Azure/azure-iot-sdk-python/tree/master/device



