### PR TITLE
trac_ik: 1.4.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9984,10 +9984,11 @@ repositories:
       - trac_ik_examples
       - trac_ik_kinematics_plugin
       - trac_ik_lib
+      - trac_ik_python
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.4.7-0
+      version: 1.4.9-0
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.4.9-0`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.4.7-0`

## trac_ik

```
* Fixed MoveIt! plugin params to look in the correct place
* Added a swig wrapper around TRAC-IK courtesy of mailto:Sammy.Pfeiffer@student.uts.edu.au
```
