### PR TITLE
jsk_recognition: 1.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5658,7 +5658,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.3-0
+      version: 1.2.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.4-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.2.3-0`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* jsk_pcl_ros/multi_plane_extraction: fix typo 'maginify' (#2237 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2237>)
  * test_depth_image_creator.test: increase time limit (#2236 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2236>)
* Fix uninitialized pointer error in some recognition nodelets (#2234 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2234>)
  * [tilt_laser_listener] Initialize cloud_vital_checker_ before subscribe input/cloud because cloud_vital_checker_ is referred in cloudCallback
* add test/test_pointcloud_screenpoint.test, enable to run run pointcloud_screenpoint sample launch in indigo (#2233 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2233>)
  * update pointcloud_screenpoint.rviz
  * sample/pointcloud_screenpoint_sample.launch: enable to use rviz
  * merge jsk_pcl/PointcloudScreenpoint for both with or without USE_VIEW
  * update test_pointcloud_screenpoint, use base_frame, instead of PUBLISH_BASE_FOOTPRINT
  * pointcloud_screenpoint_nodelet.cpp: add more ROS_INFO messages when start up
  * remove image_view2 from pointcloud_screenpoint_sample.launch, because pointcloud_screenpoint.launch is already start image_view2
  * use common camera prefix for openni
  * run pointcloud_screenpoint sample in localhost not pr2, fix for indigo/kinetic setup for openni, machine env-loader, etc...
* add base_frame param in pointcloud_screenpoint.l
  * add test/test_pointcloud_screenpoint.test
* install euslisp/ directory (#2232 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2232>)
* Contributors: Yuki Furuta, Iori Kumagai, Kei Okada, Shingo Kitagawa
```

## jsk_pcl_ros_utils

```
* jsk_pcl_ros_utils: pointcloud_to_mask_image:  add depth image for input (#2229)
  
  jsk_pcl_ros_utils: add depth image for input to pointcloud_to_mask_image
  jsk_pcl_ros_utils: update doc for pointcloud_to_mask_image
* Contributors: Yuki Furuta
```

## jsk_perception

```
* jsk_perception: install template dir (#2222 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2222>)
* Contributors: Yuki Furuta
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

```
* Add image gallery to README (#2225 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2225>)
* Contributors: Kentaro Wada
```

## resized_image_transport

```
* Fix uninitialized pointer error in some recognition nodelets (#2234 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2234>)
  * [image_processing] Check validity of vital checker in updateDiagnostic because this callback might be called before initPublishersAndSubscribers is finished
* Contributors: Iori Kumagai
```
