### PR TITLE
serial_utils: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9248,6 +9248,17 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: master
     status: maintained
+  serial_utils:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wjwwood/serial_utils-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/wjwwood/serial_utils.git
+      version: master
+    status: maintained
   shared_autonomy_manipulation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `serial_utils` to `0.1.0-0`:

- upstream repository: https://github.com/wjwwood/serial_utils.git
- release repository: https://github.com/wjwwood/serial_utils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
