### PR TITLE
openni_camera: 1.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5941,11 +5941,12 @@ repositories:
     release:
       packages:
       - openni_camera
+      - openni_description
       - openni_launch
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/openni_camera-release.git
-      version: 1.10.0-0
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.11.0-0`:

- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.10.0-0`

## openni_camera

- No changes

## openni_description

```
* Initial release. See https://discourse.ros.org/t/common-location-for-sensor-urdf-files/1758/
* Contributors: Isaac I.Y. Saito
```

## openni_launch

- No changes
