### PR TITLE
fiducials: 0.8.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2239,16 +2239,13 @@ repositories:
     release:
       packages:
       - aruco_detect
-      - fiducial_detect
-      - fiducial_lib
       - fiducial_msgs
-      - fiducial_pose
       - fiducial_slam
       - fiducials
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.7.5-0
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.8.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.7.5-0`

## aruco_detect

- No changes

## fiducial_msgs

- No changes

## fiducial_slam

- No changes

## fiducials

```
* Remove old style fiducial code
* Contributors: Jim Vaughan
```
