### PR TITLE
Revert "bump OpenCV3"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5872,7 +5872,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.3.1-1
+      version: 3.3.1-0
     status: maintained
   opencv_apps:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2111,7 +2111,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.3.1-1
+      version: 3.3.1-0
     status: maintained
   openni2_camera:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#16772

Binary files apparently need to be added to debian/source/include-binaries :
http://build.ros.org/job/Lsrc_uX__opencv3__ubuntu_xenial__source/20/console
I'll make a new release.