### PR TITLE
jsk_control: 0.1.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5558,6 +5558,7 @@ repositories:
       version: master
     release:
       packages:
+      - cmd_vel_smoother
       - contact_states_observer
       - eus_nlopt
       - eus_qp
@@ -5572,7 +5573,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.13-0
+      version: 0.1.14-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
     status: developed
   jsk_demos:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.14-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.13-0`

## cmd_vel_smoother

```
* add cmd_vel_smoother package (#683 <https://github.com/jsk-ros-pkg/jsk_control/issues/683>)
  * add cmd_vel_smoother package
* Contributors: Yuki Furuta
```

## contact_states_observer

- No changes

## eus_nlopt

- No changes

## eus_qp

```
* [eus_qp/euslisp/test-model-predictive-control.l] Add walking example by footstep list (#682 <https://github.com/jsk-ros-pkg/jsk_control/issues/682>)
* Contributors: Shunichi Nozawa
```

## eus_qpoases

- No changes

## joy_mouse

- No changes

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

```
* [jsk_footstep_planner] add grid_path_planner (#688 <https://github.com/jsk-ros-pkg/jsk_control/issues/688>)
  * [jsk_foostep_planner/footstep_marker] add use_default_step_as_goal
* [jsk_foostep_planner/JAXON] update launch (#687 <https://github.com/jsk-ros-pkg/jsk_control/issues/687>)
* Add follow_path heuristic to footstep_planner (#675 <https://github.com/jsk-ros-pkg/jsk_control/issues/675>)
  * [jsk_footstep_planner] remove not used settings from CMakeLists.txt and change order of include
  * [jsk_footstep_planner] add set heuristic path service
  * [jsk_footstep_planner] update follow_path heuristic
  * [jsk_footstep_planner] fix method name
  * [jsk_footstep_planner] refine solver
  * [jsk_footstep_planner] fix include
  * [jsk_footstep_planner] add follow_path heuristic to cfg
  * [footstep_planner] add follow_path footstep_planning
* Contributors: Yohei Kakiuchi, Yuki Furuta
```

## jsk_ik_server

- No changes

## jsk_teleop_joy

- No changes
