### PR TITLE
rviz_visual_tools: 3.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9109,7 +9109,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/rviz_visual_tools-release.git
-      version: 3.5.1-3
+      version: 3.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.6.0-0`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/davetcoleman/rviz_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `3.5.1-3`

## rviz_visual_tools

```
* Addresses Issue #49 - Default Constructor Not Nodelet Friendly
* Added option to pass in a node handle in the constructor that defaults to
* Reset marker should publish initialized quaternion
* Improve code quality - add const, static, C++11 features, clang-format
* Create demo executable for IMarkerSimple
* Improve memory efficiency of functions
* Contributors: Dave Coleman, Geoffrey Chiou, Victor Lamoine
```
