### PR TITLE
rtmros_nextage: 0.8.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8969,7 +8969,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.8.3-0
+      version: 0.8.4-0
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.8.4-0`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.8.3-0`

## nextage_calibration

- No changes

## nextage_description

- No changes

## nextage_gazebo

- No changes

## nextage_ik_plugin

- No changes

## nextage_moveit_config

```
* add moveit_armarker.rviz (#356 <https://github.com/tork-a/rtmros_nextage/issues/356>)
* Contributors: Yosuke Yamamoto
```

## nextage_ros_bridge

- No changes

## rtmros_nextage

- No changes
