### PR TITLE
Add python-rx-pip package to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2999,6 +2999,16 @@ python-ruamel.yaml:
     xenial: [python-ruamel.yaml]
     yakkety: [python-ruamel.yaml]
     zesty: [python-ruamel.yaml]
+python-rx-pip:
+  debian:
+    pip:
+      packages: [rx]
+  osx:
+    pip:
+      packages: [rx]
+  ubuntu:
+    pip:
+      packages: [rx]
 python-scapy:
   debian: [python-scapy]
   fedora: [scapy]


### PR DESCRIPTION
Provide RxPy as a pip package to ROS. This package provides reactive extensions to python. (RxPy)[https://github.com/ReactiveX/RxPY] is _a library for composing asynchronous and event-based programs using observable collections and LINQ-style query operators in Python_.