### PR TITLE
Pointed repository link to new maintainer

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2897,7 +2897,7 @@ repositories:
   optris_drivers:
     doc:
       type: git
-      url: https://github.com/ohm-ros-pkg/optris_drivers.git
+      url: https://github.com/evocortex/optris_drivers
       version: kinetic-devel
   orocos_kinematics_dynamics:
     doc:


### PR DESCRIPTION
The repository optris_drivers has moved. The link for this package points now to the current stable releases.