### PR TITLE
Added pyrebase to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -134,7 +134,7 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   ubuntu: [pyqt5-dev-tools]
-pyrebase:
+pyrebase-pip:
   debian:
     pip:
       packages: [pyrebase]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -134,6 +134,16 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   ubuntu: [pyqt5-dev-tools]
+pyrebase:
+  debian:
+    pip:
+      packages: [pyrebase]
+  fedora:
+    pip:
+      packages: [pyrebase]
+  ubuntu:
+    pip:
+      packages: [pyrebase]
 pyro4:
   arch: [python2-pyro]
   debian: [python2-pyro4]


### PR DESCRIPTION
This package provides a firebase client on python. It is useful for robots that use firebase as external storage.
Package: [https://pypi.python.org/pypi/Pyrebase](https://pypi.python.org/pypi/Pyrebase)