### PR TITLE
Adding svenzva_ros to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9685,6 +9685,16 @@ repositories:
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git
       version: kinetic-devel
     status: maintained
+  svenzva_ros:
+    doc:
+      type: git
+      url: https://github.com/SvenzvaRobotics/svenzva_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/SvenzvaRobotics/svenzva_ros.git
+      version: master
+    status: developed
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add svenzva_ros to be doc'd and indexed.

Cheers!