### PR TITLE
robot_calibration: 0.5.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10942,7 +10942,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.5.4-0`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.5.3-0`

## robot_calibration

```
* only add observations when complete
* Adds plane calibration
* minor style fixes, remove outdated comments
* fix warning (#28 <https://github.com/mikeferguson/robot_calibration/issues/28>)
* pick correct sensor in each error block
* use proper indices for multiple finders
* fix: don't append observations if finder has failed
* Contributors: Martin Günther, Michael Ferguson, Niharika Arora
```

## robot_calibration_msgs

- No changes
