### PR TITLE
trac_ik: 1.4.9-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3889,7 +3889,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.4.9-1
+      version: 1.4.9-2
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.4.9-2`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.4.9-1`

## trac_ik

```
* Fixed MoveIt! plugin params to look in the correct place
* Added a swig wrapper around TRAC-IK courtesy of mailto:Sammy.Pfeiffer@student.uts.edu.au
```
