### PR TITLE
adi_driver: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -120,6 +120,21 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: indigo-devel
     status: maintained
+  adi_driver:
+    doc:
+      type: git
+      url: https://github.com/tork-a/adi_driver.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/adi_driver-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/tork-a/adi_driver.git
+      version: master
+    status: developed
   agile_grasp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_driver` to `1.0.0-0`:

- upstream repository: https://github.com/tork-a/adi_driver.git
- release repository: https://github.com/tork-a/adi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## adi_driver

```
* note that you need to restart after addgroup (#3 <https://github.com/tork-a/adi_driver/issues/3>)
* Add publish_tf argument for launch file
* Change to load model only if use rviz
* Update index.rst
* Fix schematics, add documents
  - Schematics of ADIS16470 cable was wrong
  - Add ADXL345 cable schematics
* Add docbuild (#2 <https://github.com/tork-a/adi_driver/issues/2>)
  * add circle.yml
  * add docbuild command to CMakeLists.txt
  * Update index.rst contents
  * Put travis badge.
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534, Y. Suzuki
```
