### PR TITLE
rqt_joint_trajectory_plot: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8446,6 +8446,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
     status: maintained
+  rqt_joint_trajectory_plot:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    status: developed
   rqt_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_joint_trajectory_plot` to `0.0.1-0`:

- upstream repository: https://github.com/tork-a/rqt_joint_trajectory_plot.git
- release repository: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rqt_joint_trajectory_plot

```
* Organize and format package files
  - roslint check
  - autopep8 for python scripts
* Port to PyQt5 as used in kinetic(#1 <https://github.com/7675t/rqt_joint_trajectory_plot/issues/1>)
* Port to PyQt5
  no toolbar so far, apparently this is not yet(?!) available in matplotlibs Qt5Agg backend.
* add screenshot to README.md
* add a screenshot file.
* Initial commit
* Contributors: Ryosuke Tajima, Simon Schmeisser
```
