### PR TITLE
fanuc: 0.4.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3196,6 +3196,10 @@ repositories:
       packages:
       - fanuc
       - fanuc_driver
+      - fanuc_lrmate200ib3l_moveit_config
+      - fanuc_lrmate200ib_moveit_config
+      - fanuc_lrmate200ib_moveit_plugins
+      - fanuc_lrmate200ib_support
       - fanuc_lrmate200ic5h_moveit_config
       - fanuc_lrmate200ic5l_moveit_config
       - fanuc_lrmate200ic_moveit_config
@@ -3222,7 +3226,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.4.3-0
+      version: 0.4.4-0
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.4.4-0`:

- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.4.3-0`

## fanuc

```
* promote experimental packages for LR Mate 200iB to main repository.
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_driver

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ib3l_moveit_config

```
* first Indigo release of this package.
* promote experimental packages for LR Mate 200iB to main repository.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ib_moveit_config

```
* first Indigo release of this package.
* promote experimental packages for LR Mate 200iB to main repository.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ib_moveit_plugins

```
* first Indigo release of this package.
* promote experimental packages for LR Mate 200iB to main repository.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ib_support

```
* first Indigo release of this package.
* promote experimental packages for LR Mate 200iB to main repository.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ic5h_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ic5l_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ic_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ic_moveit_plugins

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_lrmate200ic_support

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m10ia_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m10ia_moveit_plugins

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m10ia_support

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m16ib20_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m16ib_moveit_plugins

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m16ib_support

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m20ia10l_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m20ia_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m20ia_moveit_plugins

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m20ia_support

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m430ia2f_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m430ia2p_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m430ia_moveit_plugins

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m430ia_support

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m6ib_moveit_config

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m6ib_moveit_plugins

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_m6ib_support

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```

## fanuc_resources

```
* add custom manifest tags to make package support level explicit.
* for a complete list of changes see the commit log for 0.4.4 <https://github.com/ros-industrial/fanuc/compare/0.4.3...0.4.4>.
```
