### PR TITLE
catkin: 0.7.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -857,7 +857,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.8-0
+      version: 0.7.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.9-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.7.8-0`

## catkin

```
* add support for GMock (#897 <https://github.com/ros/catkin/pull/897>)
* provide default values to unbound variables in setup.sh.in (#907 <https://github.com/ros/catkin/pull/907>)
* cleanup environment changes reliably (#906 <https://github.com/ros/catkin/pull/906>)
* call the find PythonInterp with version in the arguments (#898 <https://github.com/ros/catkin/issues/898>)
* fix python3 support for builder.py (#903 <https://github.com/ros/catkin/pull/903>)
* fix Unicode write error (#902 <https://github.com/ros/catkin/pull/902>)
```
