### PR TITLE
catkin: 0.7.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -20,7 +20,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: None-0
+      version: 0.7.9-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11,5 +11,21 @@ release_platforms:
   - artful
   - bionic
 repositories:
+  catkin:
+    doc:
+      type: git
+      url: https://github.com/ros/catkin.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/catkin-release.git
+      version: None-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/catkin.git
+      version: kinetic-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `None-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## catkin

```
* add support for GMock (#897 <https://github.com/ros/catkin/pull/897>)
* provide default values to unbound variables in setup.sh.in (#907 <https://github.com/ros/catkin/pull/907>)
* cleanup environment changes reliably (#906 <https://github.com/ros/catkin/pull/906>)
* call the find PythonInterp with version in the arguments (#898 <https://github.com/ros/catkin/issues/898>)
* fix python3 support for builder.py (#903 <https://github.com/ros/catkin/pull/903>)
* fix Unicode write error (#902 <https://github.com/ros/catkin/pull/902>)
```
