### PR TITLE
Clearing continuously failing kinetic builds

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1592,7 +1592,6 @@ repositories:
       version: master
     release:
       packages:
-      - darknet_ros
       - darknet_ros_msgs
       tags:
         release: release/kinetic/{package}/{version}
@@ -7242,7 +7241,6 @@ repositories:
       packages:
       - cm_740_module
       - op3_action_module
-      - op3_direct_control_module
       - op3_head_control_module
       - op3_kinematics_dynamics
       - open_cr_module
@@ -9544,7 +9542,6 @@ repositories:
   srv_tools:
     release:
       packages:
-      - bag_tools
       - launch_tools
       - plot_tools
       - pointcloud_tools


### PR DESCRIPTION
These jobs are all continuously failing and are ticketed upstream.

 * bag_tools: http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__bag_tools__ubuntu_xenial_amd64__binary/96/console https://github.com/srv/srv_tools/issues/17 @miquelmassot 
 * op3_direct_control_module https://github.com/ROBOTIS-GIT/ROBOTIS-OP3/issues/24 @robotpilot 
 * darknet_ros https://github.com/leggedrobotics/darknet_ros/issues/55 @mbjelonic 