### PR TITLE
msp: 2.2.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5048,7 +5048,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/christianrauch/msp-release.git
-      version: 2.2.1-0
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/christianrauch/msp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `msp` to `2.2.1-1`:

- upstream repository: https://github.com/christianrauch/msp.git
- release repository: https://github.com/christianrauch/msp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `2.2.1-0`
