### PR TITLE
slam_gmapping: 1.3.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14143,7 +14143,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.9-0
+      version: 1.3.10-0
     source:
       type: git
       url: https://github.com/ros-perception/slam_gmapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.10-0`:

- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.3.9-0`

## gmapping

```
* Install nodelet plugin descriptor file. (#56 <https://github.com/ros-perception/slam_gmapping/issues/56>)
* Contributors: Mikael Arguedas, gavanderhoorn
```

## slam_gmapping

- No changes
