### PR TITLE
slam_gmapping: 1.3.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3725,6 +3725,10 @@ repositories:
       version: lunar
     status: developed
   slam_gmapping:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: hydro-devel
     release:
       packages:
       - gmapping
@@ -3732,7 +3736,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.3.9-0
+      version: 1.3.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.3.10-0`:

- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.3.9-0`

## gmapping

```
* Install nodelet plugin descriptor file. (#56 <https://github.com/ros-perception/slam_gmapping/issues/56>)
* Contributors: Mikael Arguedas, gavanderhoorn
```

## slam_gmapping

- No changes
