### PR TITLE
remove cartographer from lunar

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -270,21 +270,6 @@ repositories:
       url: https://github.com/davetcoleman/cartesian_msgs.git
       version: jade-devel
     status: maintained
-  cartographer:
-    doc:
-      type: git
-      url: https://github.com/googlecartographer/cartographer.git
-      version: master
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/cartographer-release.git
-    source:
-      test_commits: false
-      type: git
-      url: https://github.com/googlecartographer/cartographer.git
-      version: master
-    status: developed
   catkin:
     doc:
       type: git


### PR DESCRIPTION
As the dependencies [cannot be met](https://github.com/googlecartographer/cartographer_ros/issues/158#issuecomment-352259028) in Lunar's targeted platforms, cartographer will target melodic.
