### PR TITLE
Add python-rosrx-pip package to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2732,6 +2732,16 @@ python-rospkg:
     yakkety_python3: [python3-rospkg]
     zesty: [python-rospkg]
     zesty_python3: [python3-rospkg]
+python-rosrx-pip:
+  debian:
+    pip:
+      packages: [rosrx]
+  osx:
+    pip:
+      packages: [rosrx]
+  ubuntu:
+    pip:
+      packages: [rosrx]
 python-rpi.gpio:
   debian:
     buster: [python-rpi.gpio]


### PR DESCRIPTION
Provide ROSRx as a pip package. ROSRx provides reactive extensions to
ROS making it easier to work with ROS and reactive data streams.