### PR TITLE
genmsg: 0.5.10-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -27,5 +27,20 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  genmsg:
+    doc:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.5.10-0
+    source:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: indigo-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.10-0`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## genmsg

```
* add architecture_independent flag (#71 <https://github.com/ros/genmsg/issues/71>)
```
