### PR TITLE
roscompile: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12150,10 +12150,13 @@ repositories:
       url: https://github.com/DLu/roscompile.git
       version: master
     release:
+      packages:
+      - ros_introspection
+      - roscompile
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 0.0.2-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/DLu/roscompile.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.0.0-0`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.2-0`
