### PR TITLE
marti_common: 2.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4530,6 +4530,7 @@ repositories:
       packages:
       - marti_data_structures
       - swri_console_util
+      - swri_dbw_interface
       - swri_geometry_util
       - swri_image_util
       - swri_math_util
@@ -4547,7 +4548,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.0.0-0
+      version: 2.1.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.1.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `2.0.0-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

```
* Add swri_dbw_interface package. (#503 <https://github.com/swri-robotics/marti_common/issues/503>)
* Contributors: Marc Alban
```

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes

## swri_yaml_util

- No changes
