### PR TITLE
ros_environment: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7813,6 +7813,21 @@ repositories:
       url: https://github.com/code-iai/ros_emacs_utils.git
       version: master
     status: maintained
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_environment-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: kinetic
+    status: maintained
   ros_explorer:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `1.0.0-0`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros-gbp/ros_environment-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
