### PR TITLE
ros_environment: 1.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2787,6 +2787,21 @@ repositories:
       url: https://github.com/code-iai/ros_emacs_utils.git
       version: master
     status: maintained
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: lunar
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ros_environment-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: lunar
+    status: maintained
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `1.1.0-0`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros-gbp/ros_environment-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
