### PR TITLE
ros_environment: 1.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -42,5 +42,20 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_environment-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: melodic
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `1.2.0-0`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros-gbp/ros_environment-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
