### PR TITLE
roscpp_core: 0.6.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -57,5 +57,27 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: melodic
     status: maintained
+  roscpp_core:
+    doc:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: kinetic-devel
+    release:
+      packages:
+      - cpp_common
+      - roscpp_core
+      - roscpp_serialization
+      - roscpp_traits
+      - rostime
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/roscpp_core-release.git
+      version: 0.6.8-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: kinetic-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.8-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## cpp_common

```
* define console_bridge macro with API call rather than relying on short macro being defined (#71 <https://github.com/ros/roscpp_core/issues/71>)
```

## roscpp_serialization

- No changes

## roscpp_traits

- No changes

## rostime

- No changes
