### PR TITLE
gennodejs: 2.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -42,6 +42,21 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  gennodejs:
+    doc:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/gennodejs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RethinkRobotics-release/gennodejs-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/gennodejs.git
+      version: kinetic-devel
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `2.0.1-0`:

- upstream repository: https://github.com/RethinkRobotics-opensource/gennodejs.git
- release repository: https://github.com/RethinkRobotics-release/gennodejs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## gennodejs

```
* Fix an issue uncovered in checking fixed size message fields
* Contributors: Chris Smith
```
