### PR TITLE
genpy: 0.6.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -42,6 +42,22 @@ repositories:
       url: https://github.com/ros/genmsg.git
       version: indigo-devel
     status: maintained
+  genpy:
+    doc:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/genpy-release.git
+      version: 0.6.7-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: kinetic-devel
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.7-0`:

- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## genpy

```
* use errno to detect existing dir (#89 <https://github.com/ros/genpy/issues/89>)
* fix typo (#84 <https://github.com/ros/genpy/issues/84>)
```
