### PR TITLE
ifopt: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4801,6 +4801,16 @@ repositories:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
+    release:
+      packages:
+      - ifopt
+      - ifopt_core
+      - ifopt_ipopt
+      - ifopt_snopt
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ethz-adrl/ifopt-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `1.0.0-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## ifopt

```
* add ifopt metapackage for documentation
* improve finding of ipopt/snopt installation
* remove dependency on environmental variables
* add separate repo for snopt solver
* separate ipopt into new repository
* Contributors: Alexander Winkler
```

## ifopt_core

```
* move IPOPT and SNOPT interfaces to separate package
* add ifopt metapackage for documentation
* Contributors: Alexander Winkler
```

## ifopt_ipopt

```
* add ifopt metapackage for documentation
* improve finding of ipopt/snopt installation
* remove dependency on environmental variables
* add separate repo for snopt solver
* separate ipopt into new repository
* Contributors: Alexander Winkler
```

## ifopt_snopt

```
* add ifopt metapackage for documentation
* improve finding of ipopt/snopt installation
* remove dependency on environmental variables
* add separate repo for snopt solver
* Contributors: Alexander Winkler
```
