### PR TITLE
geneus: 2.2.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -27,6 +27,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  geneus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/geneus-release.git
+      version: 2.2.6-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
+    status: maintained
   genmsg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geneus` to `2.2.6-0`:

- upstream repository: https://github.com/jsk-ros-pkg/geneus
- release repository: https://github.com/tork-a/geneus-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## geneus

```
* [geneus_main.py] suppress warning (#52 <https://github.com/jsk-ros-pkg/geneus/issues/52>)
  * [geneus_main.py] do not write timestamp that makes different md5
  * [geneus_main.py] write depends by alphabetical order in manifest.l
* [.travis.yml] : add jade test  (#49 <https://github.com/jsk-ros-pkg/geneus/issues/49>)
  * .travis.yml: add BUILDER=catkin_make_isolated
  * .travis.yml: add indigo/jade and catkin_make/catkin test
* [geneus_main.py]: add comment : 152683d depends on comment line (#44 <https://github.com/jsk-ros-pkg/geneus/issues/44>)
* Contributors: Yuki Furuta, Kei Okada
```
