### PR TITLE
ifopt: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4810,7 +4810,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `1.0.1-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.0.0-0`

## ifopt

```
* update package xml
* Contributors: Alexander Winkler
```

## ifopt_core

```
* update package xml
* make eigen 3.2 compatible (remove header Eigen/Eigen)
* Contributors: Alexander Winkler
```

## ifopt_ipopt

```
* update package xml
* make eigen 3.2 compatible (remove header Eigen/Eigen)
* Contributors: Alexander Winkler
```

## ifopt_snopt

```
* update package xml
* make eigen 3.2 compatible (remove header Eigen/Eigen)
* Contributors: Alexander Winkler
```
