### PR TITLE
ifopt: 1.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1073,6 +1073,16 @@ repositories:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
+    release:
+      packages:
+      - ifopt
+      - ifopt_core
+      - ifopt_ipopt
+      - ifopt_snopt
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ethz-adrl/ifopt-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `1.0.1-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ifopt

```
* update package xml
* Contributors: Alexander Winkler
```

## ifopt_core

```
* update package xml
* make eigen 3.2 compatible (remove header Eigen/Eigen)
* Contributors: Alexander Winkler
```

## ifopt_ipopt

```
* update package xml
* make eigen 3.2 compatible (remove header Eigen/Eigen)
* Contributors: Alexander Winkler
```

## ifopt_snopt

```
* update package xml
* make eigen 3.2 compatible (remove header Eigen/Eigen)
* Contributors: Alexander Winkler
```
