### PR TITLE
gencpp: 0.6.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -27,6 +27,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  gencpp:
+    doc:
+      type: git
+      url: https://github.com/ros/gencpp.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/gencpp-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/ros/gencpp.git
+      version: indigo-devel
+    status: maintained
   geneus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.6.0-0`:

- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## gencpp

```
* add plugin support for generated C++ message headers (#32 <https://github.com/ros/gencpp/pull/32>)
* put all the message integer constants into a common enum (#25 <https://github.com/ros/gencpp/issues/25>)
```
