### PR TITLE
message_runtime: 0.4.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -134,6 +134,21 @@ repositories:
       url: https://github.com/ros/message_generation.git
       version: kinetic-devel
     status: maintained
+  message_runtime:
+    doc:
+      type: git
+      url: https://github.com/ros/message_runtime.git
+      version: groovy-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/message_runtime-release.git
+      version: 0.4.12-0
+    source:
+      type: git
+      url: https://github.com/ros/message_runtime.git
+      version: groovy-devel
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_runtime` to `0.4.12-0`:

- upstream repository: https://github.com/ros/message_runtime.git
- release repository: https://github.com/ros-gbp/message_runtime-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
