### PR TITLE
std_msgs: 0.5.11-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -193,5 +193,20 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  std_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/std_msgs.git
+      version: groovy-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/std_msgs-release.git
+      version: 0.5.11-0
+    source:
+      type: git
+      url: https://github.com/ros/std_msgs.git
+      version: groovy-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs` to `0.5.11-0`:

- upstream repository: git@github.com:ros/std_msgs.git
- release repository: https://github.com/ros-gbp/std_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
