### PR TITLE
ros_comm_msgs: 1.11.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -149,6 +149,24 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  ros_comm_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_comm_msgs.git
+      version: indigo-devel
+    release:
+      packages:
+      - rosgraph_msgs
+      - std_srvs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_comm_msgs-release.git
+      version: 1.11.2-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_comm_msgs.git
+      version: indigo-devel
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm_msgs` to `1.11.2-0`:

- upstream repository: https://github.com/ros/ros_comm_msgs.git
- release repository: https://github.com/ros-gbp/ros_comm_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rosgraph_msgs

- No changes

## std_srvs

```
* add SetBool service (#7 <https://github.com/ros/ros_comm_msgs/pull/7>)
```
