### PR TITLE
cmake_modules: 0.4.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -27,6 +27,22 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.4-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/cmake_modules-release.git
+      version: 0.4.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.4-devel
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.4.1-0`:

- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## cmake_modules

```
* Add FindTinyXML2 module (#42 <https://github.com/ros/cmake_modules/issues/42>)
  Signed-off-by: Dmitry Rozhkov <mailto:dmitry.rozhkov@linux.intel.com>
* Add FindGflags for supporting Gflags
* Contributors: Dave Coleman, Dmitry Rozhkov, William Woodall
```
