### PR TITLE
rospack: 2.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -227,6 +227,22 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  rospack:
+    doc:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rospack-release.git
+      version: 2.5.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: lunar-devel
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.5.0-0`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rospack

```
* skip warning if permission to read directory was denied (#87 <https://github.com/ros/rospack/issues/87>)
```
