### PR TITLE
ros: 1.14.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -165,6 +165,34 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  ros:
+    doc:
+      type: git
+      url: https://github.com/ros/ros.git
+      version: kinetic-devel
+    release:
+      packages:
+      - mk
+      - ros
+      - rosbash
+      - rosboost_cfg
+      - rosbuild
+      - rosclean
+      - roscreate
+      - roslang
+      - roslib
+      - rosmake
+      - rosunit
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros-release.git
+      version: 1.14.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros.git
+      version: kinetic-devel
+    status: maintained
   ros_comm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.14.3-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## mk

- No changes

## rosbash

```
* do not remove paths containing ./ or ../ from completion (#162 <https://github.com/ros/ros/issues/162>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* replace env hooks with a dependency on ros_environment (#166 <https://github.com/ros/ros/issues/166>)
```

## rosmake

- No changes

## rosunit

- No changes
