### PR TITLE
gl_dependency: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -135,6 +135,21 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  gl_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/gl_dependency.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/gl_dependency-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/gl_dependency.git
+      version: kinetic-devel
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gl_dependency` to `1.1.0-0`:

- upstream repository: https://github.com/ros-visualization/gl_dependency.git
- release repository: https://github.com/ros-gbp/gl_dependency-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
