### PR TITLE
python_qt_binding: 0.3.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -180,6 +180,21 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/python_qt_binding-release.git
+      version: 0.3.3-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: kinetic-devel
+    status: maintained
   qwt_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.3.3-0`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## python_qt_binding

```
* Prefer qmake-qt5 over qmake when available (#43 <https://github.com/ros-visualization/python_qt_binding/issues/43>)
```
