### PR TITLE
Add rosdep entry for gtk3

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1119,6 +1119,19 @@ gtk2:
     slackpkg:
       packages: [gtk+2]
   ubuntu: [libgtk2.0-dev]
+gtk3:
+  arch: [gtk3]
+  debian: [libgtk-3-dev]
+  fedora: [gtk3-devel]
+  freebsd: [gtk3]
+  gentoo: ['x11-libs/gtk+:3']
+  macports: [gtk3]
+  opensuse: [gtk3-devel]
+  rhel: [gtk3-devel]
+  slackware:
+    slackpkg:
+      packages: [gtk+3]
+  ubuntu: [libgtk-3-dev]
 gv:
   arch: [gv]
   debian: [gv]


### PR DESCRIPTION
This is for the gtk3 package.  I needed this as a dependency of GLFW:
https://github.com/chadrockey/glfw/tree/catkin

I did google searching to try to confirm all of the package names relative to their gtk2 versions.  I could use some more eyes to confirm these names though.