### PR TITLE
rqt_reconfigure: 0.4.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3364,7 +3364,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.4.8-0
+      version: 0.4.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.4.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.8-0`

## rqt_reconfigure

```
* Added error handling for dynamic_reconfigure exceptions (#10 <https://github.com/ros-visualization/rqt_reconfigure/pull/10>)
* Fix left pane tree view resizing (#11 <https://github.com/ros-visualization/rqt_reconfigure/pull/11>)
```
