### PR TITLE
tuw_msgs: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10417,12 +10417,18 @@ repositories:
       version: master
     release:
       packages:
+      - tuw_airskin_msgs
       - tuw_gazebo_msgs
+      - tuw_geometry_msgs
       - tuw_msgs
-      - tuw_spline_msgs
+      - tuw_multi_robot_msgs
+      - tuw_nav_msgs
+      - tuw_object_msgs
+      - tuw_vehicle_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_msgs-release.git
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_msgs` to `0.0.5-0`:

- upstream repository: https://github.com/tuw-robotics/tuw_msgs.git
- release repository: https://github.com/tuw-robotics/tuw_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
