### PR TITLE
sick_tim: 0.0.12-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3732,7 +3732,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.12-0`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.11-0`

## sick_tim

```
* Fix memory leak (#56 <https://github.com/uos/sick_tim/issues/56>)
  s should be deleted before returning.
* mrs1000: Make output REP-117 compliant (invalid = +inf)
  This is a port of e964fb4c to the MRS-1000.
* sick mrs1000 driver (#55 <https://github.com/uos/sick_tim/issues/55>)
  This commit adds SICK MRS-1000 support. The initialization of the device
  has to be different, due to that I have made the methods for initialization
  virtual and now the mrs1000 driver runs different init code. Also the
  support for PointCloud2 is new.
* Contributors: Sebastian Pütz, Jochen Sprickerhof, Martin Günther
```
