### PR TITLE
transform_graph: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15349,7 +15349,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/transform_graph-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/jstnhuang/transform_graph.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transform_graph` to `0.3.0-0`:

- upstream repository: https://github.com/jstnhuang/transform_graph.git
- release repository: https://github.com/jstnhuang-release/transform_graph-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.1-0`

## transform_graph

```
* Added methods for converting Position, Orientation, and Transform back to common types.
* Made LocalFrame implicitly convertable from strings, which makes the API cleaner.
* Updated docs.
* Contributors: Justin Huang
```
