### PR TITLE
o3m151_driver: 1.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5664,6 +5664,21 @@ repositories:
       url: https://github.com/vooon/ntpd_driver.git
       version: master
     status: maintained
+  o3m151_driver:
+    doc:
+      type: git
+      url: https://github.com/labex-imobs3/ifm_o3m151.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/labex-imobs3-gbp/o3m151_driver-release.git
+      version: 1.2.1-0
+    source:
+      type: git
+      url: https://github.com/labex-imobs3/ifm_o3m151.git
+      version: master
+    status: developed
   object_recognition_capture:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `o3m151_driver` to `1.2.1-0`:

- upstream repository: https://github.com/labex-imobs3/ifm_o3m151.git
- release repository: https://github.com/labex-imobs3-gbp/o3m151_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## o3m151_driver

```
* Update package xml to format 2
* Update doc and comment
* Change library name to not conflict with velodyne nodelet library
* Add amplitude normalization and calibration offset
  But does not work...
* Remove close point and align XYZ axes with axes convention
* Support nodelet
* Uniforming code style
* Replay using pcap
* Add generic process function
* Move some variables as class member
* Cleaning code
* Add intensity in point cloud and remove pcl viewer
* Add width in pcl msg to be displayed by rviz
* Getting data from sensor
* Clean files
* Clean files
* o3m151_driver based on ROS velodyne_driver
* Contributors: Vincent Rousseau
```
