### PR TITLE
xpp: 1.0.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4252,7 +4252,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.5-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.0.4-0`

## xpp

- No changes

## xpp_examples

```
* add new example bags generated with towr
* update launch scripts
* Contributors: Alexander Winkler
```

## xpp_hyq

```
* modernize CMake files
* use default keyword for empty destructors
* use default BSD license
* Contributors: Alexander Winkler
```

## xpp_msgs

```
* modernize CMake files
* use default BSD license
* Contributors: Alexander Winkler
```

## xpp_quadrotor

```
* update launch scripts
* modernize CMake files
* use default BSD license
* Contributors: Alexander Winkler
```

## xpp_states

```
* modernize CMake files
* use default keyword for empty destructors
* use default BSD license
* move terrain types to towr_ros
* Contributors: Alexander Winkler
```

## xpp_vis

```
* update launch scripts
* cleaned-up some cmake files
* modernize CMake files
* move terrain types to towr_ros
* Contributors: Alexander Winkler
```
