### PR TITLE
Adding raspigibbon_ros to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6871,6 +6871,16 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspigibbon_ros:
+    doc:
+      type: git
+      url: https://github.com/raspberrypigibbon/raspigibbon_ros.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/raspberrypigibbon/raspigibbon_ros.git
+      version: kinetic-devel
+    status: developed
   razor_imu_9dof:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspigibbon_ros to be doc'd and indexed.