### PR TITLE
raspigibbon_ros: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6876,6 +6876,16 @@ repositories:
       type: git
       url: https://github.com/raspberrypigibbon/raspigibbon_ros.git
       version: kinetic-devel
+    release:
+      packages:
+      - futaba_serial_servo
+      - raspigibbon_bringup
+      - raspigibbon_description
+      - raspigibbon_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/raspberrypigibbon/raspigibbon_ros-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/raspberrypigibbon/raspigibbon_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspigibbon_ros` to `0.1.1-1`:

- upstream repository: https://github.com/raspberrypigibbon/raspigibbon_ros.git
- release repository: https://github.com/raspberrypigibbon/raspigibbon_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## futaba_serial_servo

```
* The first public release for kinetic
```

## raspigibbon_bringup

```
* The first release for kinetic
```

## raspigibbon_description

```
* The first public release for kinetic
```

## raspigibbon_ros

```
* The first release for kinetic
```
