### PR TITLE
Add rosdep entries for xcursor and xkbcommon

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3255,6 +3255,9 @@ libxaw:
   opensuse: [xorg-x11-devel]
   rhel: [libXaw-devel]
   ubuntu: [libxaw7-dev]
+libxcursor-dev:
+  debian: [libxcursor-dev]
+  ubuntu: [libxcursor-dev]
 libxenomai-dev:
   debian:
     jessie: [libxenomai-dev]
@@ -3286,6 +3289,9 @@ libxinerama-dev:
   fedora: [libXinerama-devel]
   gentoo: [x11-libs/libXinerama]
   ubuntu: [libxinerama-dev]
+libxkbcommon-dev:
+  debian: [libxkbcommon-dev]
+  ubuntu: [libxkbcommon-dev]
 libxml++-2.6:
   arch: [libxml++]
   debian: [libxml++2.6-2, libxml++2.6-dev]


### PR DESCRIPTION
This is needed for a fork of glfw.  To the best of my knowledge, these are the correct package names for ubuntu and debian.

I tried to infer naming conventions as best I could in terms of prefixing with lib and/or postfixing with -dev in the rosdep key name itself, but I see examples of various combinations.  Did I name these correctly?

Are entries for any other platforms required?