### PR TITLE
adi_driver: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -129,7 +129,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/adi_driver-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/tork-a/adi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_driver` to `1.0.1-0`:

- upstream repository: https://github.com/tork-a/adi_driver.git
- release repository: https://github.com/tork-a/adi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.0.0-0`

## adi_driver

```
* fix deb path (#8 <https://github.com/tork-a/adi_driver/issues/8>)
* workaround for run_tests on installed space (#7 <https://github.com/tork-a/adi_driver/issues/7>)
  * enable deb build
  * add rosdoc.yaml
  * add .github_release.sh
  * Change photo of the sensor
  * Add author to package.xml (#5 <https://github.com/tork-a/adi_driver/issues/5>)
  * Add urdf to install (#5 <https://github.com/tork-a/adi_driver/issues/5>)
  * add roslaunch-check with_rviz:=true with_plot:=true
  * install test directory
  * workaround for run_tests on installed space
* Add adxl345 descrption into README.md (#4 <https://github.com/tork-a/adi_driver/issues/4>)
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```
