### PR TITLE
loki_base_node: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4336,7 +4336,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/loki_base_node-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
   loki_robot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `loki_base_node` to `0.2.2-0`:

- upstream repository: https://github.com/UbiquityRobotics/loki_base_node.git
- release repository: https://github.com/UbiquityRobotics-release/loki_base_node-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.1-0`

## loki_base_node

```
* Publish all sonars on a single topic /sonars, in addition to individual topics
* Contributors: Jim Vaughan
```
