### PR TITLE
ifopt: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3221,7 +3221,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `1.0.2-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.0.1-0`

## ifopt

- No changes

## ifopt_core

```
* add correct catkin install folder for ifopt_core
* Contributors: Alexander Winkler
```

## ifopt_ipopt

- No changes

## ifopt_snopt

- No changes
