### PR TITLE
Add libvlccore-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3138,6 +3138,10 @@ libvlc-dev:
   fedora: [libvlc-devel]
   gentoo: [media-video/vlc]
   ubuntu: [libvlc-dev]
+libvlccore-dev:
+  debian: [libvlccore-dev]
+  fedora: [vlc-devel]
+  ubuntu: [libvlccore-dev]
 libvpx-dev:
   debian: [libvpx-dev]
   fedora: [libvpx-devel]


### PR DESCRIPTION
https://packages.ubuntu.com/trusty/libvlccore-dev
https://packages.ubuntu.com/xenial/libvlccore-dev
https://packages.ubuntu.com/artful/libvlccore-dev
https://packages.debian.org/stretch/libvlccore-dev
https://packages.debian.org/jessie/libvlccore-dev
http://www.rpmfind.net/linux/rpm2html/search.php?query=libvlccore.so&submit=Search+...&system=&arch=

I think maybe the libvlc-dev key for fedora is wrong? According to rpmfind, libvlc-devel is the package name on Mageia, and on Fedora it is vlc-devel. I don't have a Fedora system to test, though.

I also couldn't find a gentoo key for libvlccore-dev, since their portage/package web search has been broken for quite a while. And I also don't have a gentoo system to test.