### PR TITLE
catkin: 0.7.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -290,7 +290,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.8-0
+      version: 0.7.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.11-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.7.8-0`

## catkin

```
* catkin_add_gtest: drop explicit add_dependencies(), rely on CMake. (#917 <https://github.com/ros/catkin/issues/917>)
* prevent reading non-whitelisted properties of interface targets (#916 <https://github.com/ros/catkin/issues/916>)
* fix logic when only gtest is present (#919 <https://github.com/ros/catkin/issues/919>)
* add option to pass specific version to catkin_prepare_release (#918 <https://github.com/ros/catkin/issues/918>)
```
