### PR TITLE
gencpp: 0.6.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -789,7 +789,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.5.5-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.6.0-0`:

- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.5.5-0`

## gencpp

```
* add plugin support for generated C++ message headers (#32 <https://github.com/ros/gencpp/pull/32>)
* put all the message integer constants into a common enum (#25 <https://github.com/ros/gencpp/issues/25>)
```
