### PR TITLE
trac_ik: 1.4.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3930,7 +3930,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.4.10-0
+      version: 1.4.11-0
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.4.11-0`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.4.10-0`

## trac_ik

```
* Change to python install location for swig wrapper
```
