### PR TITLE
multi_jackal-release: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5085,7 +5085,7 @@ repositories:
       url: https://github.com/christianrauch/msp.git
       version: master
     status: developed
-  multi_jackal-release:
+  multi_jackal:
     release:
       packages:
       - multi_jackal_base
@@ -5095,11 +5095,11 @@ repositories:
       - multi_jackal_tutorials
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/NicksSimulationsROS/multi_jackal-release
+      url: https://github.com/NicksSimulationsROS/multi_jackal-release.git
       version: 0.0.1-0
     source:
       type: git
-      url: https://github.com/NicksSimulationsROS/multi_jackal
+      url: https://github.com/NicksSimulationsROS/multi_jackal.git
       version: ros-kinetic
     status: developed
   multikey_teleop:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5085,6 +5085,23 @@ repositories:
       url: https://github.com/christianrauch/msp.git
       version: master
     status: developed
+  multi_jackal-release:
+    release:
+      packages:
+      - multi_jackal_base
+      - multi_jackal_control
+      - multi_jackal_description
+      - multi_jackal_nav
+      - multi_jackal_tutorials
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/NicksSimulationsROS/multi_jackal-release
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/NicksSimulationsROS/multi_jackal
+      version: ros-kinetic
+    status: developed
   multikey_teleop:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_jackal-release` to `0.0.1-0`:

- upstream repository: https://github.com/NicksSimulationsROS/multi_jackal
- release repository: https://github.com/NicksSimulationsROS/multi_jackal-release
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## multi_jackal_base

```
* Contributors: Nick Sullivan
```

## multi_jackal_control

```
* Contributors: Nick Sullivan
```

## multi_jackal_description

```
* Contributors: Nick Sullivan
```

## multi_jackal_nav

```
* Contributors: Nick Sullivan
```

## multi_jackal_tutorials

```
* Contributors: Nick Sullivan
```
