### PR TITLE
common_msgs: 1.12.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -65,6 +65,33 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  common_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: jade-devel
+    release:
+      packages:
+      - actionlib_msgs
+      - common_msgs
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/common_msgs-release.git
+      version: 1.12.5-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: jade-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.5-0`:

- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## actionlib_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```

## common_msgs

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```

## nav_msgs

- No changes

## sensor_msgs

```
* Deal with abstract image encodings
* Fix spelling mistakes
* Fix year
* Contributors: Jochen Sprickerhof, Kentaro Wada, trorornmn
```

## shape_msgs

- No changes

## stereo_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```

## trajectory_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```

## visualization_msgs

```
* Fix spelling mistakes
* Contributors: trorornmn
```
