### PR TITLE
astra_camera: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -716,7 +716,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_camera-release.git
-      version: 0.1.5-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_camera` to `0.2.0-0`:

- upstream repository: https://github.com/orbbec/ros_astra_camera.git
- release repository: https://github.com/ros-drivers-gbp/astra_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.5-0`

## astra_camera

```
* add support for astra mini s
* Contributors: Tim Liu
```
