### PR TITLE
roscpp_core: 0.6.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8123,7 +8123,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.7-0
+      version: 0.6.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.9-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.6.7-0`

## cpp_common

- No changes

## roscpp_serialization

- No changes

## roscpp_traits

- No changes

## rostime

```
* expose ros_walltime and ros_steadytime (#73 <https://github.com/ros/roscpp_core/issues/73>)
```
