### PR TITLE
ros: 1.14.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7709,7 +7709,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.13.6-0
+      version: 1.14.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.14.3-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.13.6-0`

## mk

- No changes

## rosbash

```
* do not remove paths containing ./ or ../ from completion (#162 <https://github.com/ros/ros/issues/162>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* replace env hooks with a dependency on ros_environment (#166 <https://github.com/ros/ros/issues/166>)
```

## rosmake

- No changes

## rosunit

- No changes
