### PR TITLE
[dep][py] Add GitPython.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1134,6 +1134,12 @@ python-gi:
   fedora: [pygobject3]
   gentoo: [dev-python/pygobject]
   ubuntu: [python-gi]
+python-git:
+  arch: [python2-gobject]
+  debian: [python-git]
+  fedora: [GitPython]
+  gentoo: [dev-python/git-python]
+  ubuntu: [python-git]
 python-github-pip:
   osx:
     pip:


### PR DESCRIPTION
- debian http://neuro.debian.net/pkgs/python-git.html
- fedora https://apps.fedoraproject.org/packages/GitPython/overview/
- gentoo https://packages.gentoo.org/packages/dev-python/git-python
- ubuntu https://packages.ubuntu.com/search?keywords=python-git

Looks like `pip` version is already added in https://github.com/ros/rosdistro/pull/13583. What are we supposed to do in these case?