### PR TITLE
updated repository url for packages of Team ProAut

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8926,16 +8926,16 @@ repositories:
   parameter_pa:
     doc:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/peterweissig/ros_parameter-release.git
+      url: https://github.com/tuc-proaut/ros_parameter-release.git
       version: 1.2.1-0
     source:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     status: maintained
   parrot_arsdk:
@@ -8969,16 +8969,16 @@ repositories:
       depends:
       - parameter_pa
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/peterweissig/ros_pcdfilter-release.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter-release.git
       version: 1.2.0-0
     source:
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     status: maintained
   pcl_conversions:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4306,16 +4306,16 @@ repositories:
   parameter_pa:
     doc:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/peterweissig/ros_parameter-release.git
+      url: https://github.com/tuc-proaut/ros_parameter-release.git
       version: 1.0.2-0
     source:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     status: maintained
   parrot_arsdk:
@@ -4338,11 +4338,11 @@ repositories:
   pcdfilter_pa:
     doc:
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     source:
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     status: maintained
   pcl_conversions:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6177,16 +6177,16 @@ repositories:
   parameter_pa:
     doc:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/peterweissig/ros_parameter-release.git
+      url: https://github.com/tuc-proaut/ros_parameter-release.git
       version: 1.2.1-0
     source:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     status: maintained
   parrot_arsdk:
@@ -6203,16 +6203,16 @@ repositories:
   pcdfilter_pa:
     doc:
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/peterweissig/ros_pcdfilter-release.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter-release.git
       version: 1.2.0-0
     source:
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     status: maintained
   pcl_conversions:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2209,31 +2209,31 @@ repositories:
   parameter_pa:
     doc:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/peterweissig/ros_parameter-release.git
+      url: https://github.com/tuc-proaut/ros_parameter-release.git
       version: 1.2.1-0
     source:
       type: git
-      url: https://github.com/peterweissig/ros_parameter.git
+      url: https://github.com/tuc-proaut/ros_parameter.git
       version: master
     status: maintained
   pcdfilter_pa:
     doc:
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     release:
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/peterweissig/ros_pcdfilter-release.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter-release.git
       version: 1.2.0-0
     source:
       type: git
-      url: https://github.com/peterweissig/ros_pcdfilter.git
+      url: https://github.com/tuc-proaut/ros_pcdfilter.git
       version: master
     status: maintained
   pcl_conversions:


### PR DESCRIPTION
moved from https://github.com/peterweissig/ros_xyz to https://github.com/TUC-ProAut/ros_xyz