### PR TITLE
ros_tutorials: 0.8.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -385,6 +385,27 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: melodic
     status: maintained
+  ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: lunar-devel
+    release:
+      packages:
+      - ros_tutorials
+      - roscpp_tutorials
+      - rospy_tutorials
+      - turtlesim
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_tutorials-release.git
+      version: 0.8.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: lunar-devel
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.8.1-0`:

- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ros_tutorials

- No changes

## roscpp_tutorials

- No changes

## rospy_tutorials

- No changes

## turtlesim

```
* theta ranges from -pi to +pi (#31 <https://github.com/ros/ros_tutorials/issues/31>)
```
