### PR TITLE
qt_ros: 0.2.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6857,6 +6857,10 @@ repositories:
       version: kinetic-devel
     status: maintained
   qt_ros:
+    doc:
+      type: git
+      url: https://github.com/stonier/qt_ros.git
+      version: indigo
     release:
       packages:
       - qt_build
@@ -6866,7 +6870,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/qt_ros-release.git
-      version: 0.2.9-0
+      version: 0.2.10-0
+    source:
+      type: git
+      url: https://github.com/stonier/qt_ros.git
+      version: indigo
     status: maintained
   qwt_dependency:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros` to `0.2.10-0`:

- upstream repository: https://github.com/stonier/qt_ros.git
- release repository: https://github.com/yujinrobot-release/qt_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.2.9-0`

## qt_create

```
* Workaround applied for Qt4 and BOOST_JOIN problems
```
