### PR TITLE
multi_jackal: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5106,7 +5106,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/NicksSimulationsROS/multi_jackal-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/NicksSimulationsROS/multi_jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_jackal` to `0.0.2-0`:

- upstream repository: https://github.com/NicksSimulationsROS/multi_jackal
- release repository: https://github.com/NicksSimulationsROS/multi_jackal-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.1-0`

## multi_jackal_base

- No changes

## multi_jackal_control

- No changes

## multi_jackal_description

```
* added nav_msgs dependency
* Contributors: Nick Sullivan
```

## multi_jackal_nav

- No changes

## multi_jackal_tutorials

- No changes
