### PR TITLE
add rc_visard to indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10612,6 +10612,24 @@ repositories:
       url: https://bitbucket.org/rbdl/rbdl
       version: default
     status: developed
+  rc_visard:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_visard_ros.git
+      version: 1.2.0
+    release:
+      packages:
+      - rc_visard
+      - rc_visard_driver
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/roboception/rc_visard-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/roboception/rc_visard_ros.git
+      version: master
+    status: developed
   rcll_fawkes_sim:
     doc:
       type: git


### PR DESCRIPTION
manual pull request for first release of rc_visard via bloom...

Side-note/question:
I have two-factor authentication enabled, so creation of the oauth token didn't work.
But I couldn't find any info on which scopes are needed when I manually create a new personal access token for bloom.