### PR TITLE
astra_camera: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -424,7 +424,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_camera-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_camera` to `0.2.1-0`:

- upstream repository: https://github.com/orbbec/ros_astra_camera.git
- release repository: https://github.com/ros-drivers-gbp/astra_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.0-0`

## astra_camera

```
* 1,patch for catkin_make -j1 in docker 2,patch for x64 use x86 in docker 3,arm/arm64 use no-filter library
* Contributors: Tim
```
