### PR TITLE
rosparam_handler: 0.1.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -5947,7 +5947,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/cbandera/rosparam_handler-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/cbandera/rosparam_handler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_handler` to `0.1.2-0`:

- upstream repository: https://github.com/cbandera/rosparam_handler.git
- release repository: https://github.com/cbandera/rosparam_handler-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `0.1.1-0`

## rosparam_handler

```
* std::endl -> n
  YamlGenerator closes #30 <https://github.com/artivis/rosparam_handler/issues/30>
* Bugfixes
* Uncomment lines without default, to force user to set them
* Added documentation for generator script
* Reformatted python files
* ClangFormat files
* Simplified utility functions
* Fix for failing tests
* Added functionality for setting parameters on server.
* Added documentation to functions
* Moved common function to util header
* Removed debugging leftover
  Add Python support
* Display correct test names for each test
* Replaced errors with warnings
  For python, when min/max is corrected. The behaviour is now similar to cpp
* Made tests visible
  Replaced individual testcases with TestSuite
* Set default values on param server, add python tests for that
* Remove useless comment leftovers
  Bugfix/force clean builds
* Readded check for C++11 support.
* Force travis to do a clean build
* Removed verbose output during build
  Fix initialisation order in parameter class template
* Fixed merge error in template
  Remove useless character
  Set default values on parameter server if no value is set
* Updated the documentation
* Remove duplicate test
* Add unittests
* Name tests properly, add cmake dependency
* Throw more informative exception if parameters without default value are unset
* Add python unittests
  Feature/add continous integration
* Changed build flag to display develop branch
* Updated README contribution guide
* Added matrix job and removed C++14 check
* Added initial travis config
* Added first set of tests
* Added LICENSE file. Closes #25 <https://github.com/artivis/rosparam_handler/issues/25>
* Updated README to include release information. Closes #17 <https://github.com/artivis/rosparam_handler/issues/17>.
* Moved common functions to utilities.hpp. Fixes #11 <https://github.com/artivis/rosparam_handler/issues/11>
* Handler is now throwing an exception upon failure.
  Before, it was calling std::exit(EXIT_FAILURE) but it was causing problems during testing.
* Add min/max check for map and vector to be consistent with C++
* Include python usage in documentation
* Set default values on parameter server if no value is set
* Fix initialisation order in parameter class template
* param handler now generates python parameter files too
* Remove useless character
* Contributors: Claudio Bandera, Fabian Poggenhans, Jan-Hendrik Pauls, Jeremie Deray, Niels Ole Salscheider, vincentrou
```
