### PR TITLE
astra_launch: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -731,7 +731,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_launch-release.git
-      version: 0.1.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_launch` to `0.2.1-0`:

- upstream repository: https://github.com/orbbec/ros_astra_launch.git
- release repository: https://github.com/ros-drivers-gbp/astra_launch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.0-0`

## astra_launch

```
* sync with astra_camera
* Contributors: Tim
```
