### PR TITLE
multi_jackal: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5106,7 +5106,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/NicksSimulationsROS/multi_jackal-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/NicksSimulationsROS/multi_jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_jackal` to `0.0.3-0`:

- upstream repository: https://github.com/NicksSimulationsROS/multi_jackal
- release repository: https://github.com/NicksSimulationsROS/multi_jackal-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.2-0`

## multi_jackal_base

```
* licensing, URL's, tutorials updated
* Contributors: Nick Sullivan
```

## multi_jackal_control

```
* licensing, URL's, tutorials updated
* Contributors: Nick Sullivan
```

## multi_jackal_description

```
* licensing, URL's, tutorials updated
* Contributors: Nick Sullivan
```

## multi_jackal_nav

```
* licensing, URL's, tutorials updated
* Contributors: Nick Sullivan
```

## multi_jackal_tutorials

```
* licensing, URL's, tutorials updated
* Contributors: Nick Sullivan
```
