### PR TITLE
pr2_power_drivers: 1.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6572,6 +6572,26 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pr2_power_drivers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_power_drivers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ocean_battery_driver
+      - power_monitor
+      - pr2_power_board
+      - pr2_power_drivers
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
+      version: 1.1.6-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_power_drivers.git
+      version: kinetic-devel
+    status: unmaintained
   puma_motor_driver:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_power_drivers` to `1.1.6-0`:

- upstream repository: https://github.com/pr2/pr2_power_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_power_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ocean_battery_driver

```
* change maintainer to ROS orphaned package maintaner
* Contributors: Kei Okada
```

## power_monitor

```
* change maintainer to ROS orphaned package maintaner
* Contributors: Kei Okada
```

## pr2_power_board

```
* change maintainer to ROS orphaned package maintaner
* pr2_power_board: add missing include dirs
* Contributors: Furushchev, Kei Okada
```

## pr2_power_drivers

```
* change maintainer to ROS orphaned package maintaner
* Contributors: Kei Okada
```
