### PR TITLE
rqt_pr2_dashboard: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8762,6 +8762,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_pose_view.git
       version: master
     status: maintained
+  rqt_pr2_dashboard:
+    doc:
+      type: git
+      url: https://github.com/PR2/rqt_pr2_dashboard.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/pr2/rqt_pr2_dashboard.git
+      version: kinetic-devel
+    status: unmaintained
   rqt_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.4.0-0`:

- upstream repository: https://github.com/PR2/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rqt_pr2_dashboard

```
* fix for kinetic (fix Qt path) #19 <https://github.com/pr2/rqt_pr2_dashboard/issues/19>
* Contributors: Furushchev
```
