### PR TITLE
pr2_mechanism_msgs: 1.8.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6572,6 +6572,21 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pr2_mechanism_msgs:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_mechanism_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
+      version: 1.8.2-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism_msgs.git
+      version: master
+    status: unmaintained
   pr2_power_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism_msgs` to `1.8.2-0`:

- upstream repository: https://github.com/PR2/pr2_mechanism_msgs.git
- release repository: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## pr2_mechanism_msgs

```
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
