### PR TITLE
pr2_common: 1.12.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6566,7 +6566,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_common-release.git
-      version: 1.12.0-0
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/pr2/pr2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.1-0`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.12.0-0`

## pr2_common

```
* Merge pull request #267 <https://github.com/pr2/pr2_common/issues/267> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_dashboard_aggregator

```
* Merge pull request #267 <https://github.com/pr2/pr2_common/issues/267> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_description

```
* Merge pull request #267 <https://github.com/pr2/pr2_common/issues/267> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge pull request #266 <https://github.com/pr2/pr2_common/issues/266> from furushchev/use-arg
  pr2.urdf.xacro: support xacro:arg
* pr2.urdf.xacro: support xacro:arg
* Merge pull request #260 <https://github.com/pr2/pr2_common/issues/260> from davetcoleman/inconsistent_namespace
  Fix inconsistent namespace redefinitions for xmlns:xacro
* Merge pull request #259 <https://github.com/pr2/pr2_common/issues/259> from davetcoleman/prepend_xacro_namespace
  Prepend xacro tags with xacro xml namespace
* Merge pull request #258 <https://github.com/pr2/pr2_common/issues/258> from PR2/indigo-devel
  Sync Indigo into Kinetic
* Prepend xacro tags with xacro xml namespace
* Fix inconsistent namespace redefinitions for xmlns:xacro
* Merge pull request #255 <https://github.com/pr2/pr2_common/issues/255> from furushchev/fix-gripper
  [pr2_description] fix: gripper reduction 3141.6 -> 314.16
* [pr2_description] fix: gripper reduction 3141.6 -> 314.16
* Contributors: Dave Coleman, Devon Ash, Furushchev, Kei Okada
```

## pr2_machine

```
* Merge pull request #267 <https://github.com/pr2/pr2_common/issues/267> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_msgs

```
* Merge pull request #267 <https://github.com/pr2/pr2_common/issues/267> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
