### PR TITLE
pr2_mechanism: 1.8.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6572,6 +6572,28 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pr2_mechanism:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_controller_interface
+      - pr2_controller_manager
+      - pr2_hardware_interface
+      - pr2_mechanism
+      - pr2_mechanism_diagnostics
+      - pr2_mechanism_model
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_mechanism-release.git
+      version: 1.8.17-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_mechanism_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.17-0`:

- upstream repository: https://github.com/pr2/pr2_mechanism.git
- release repository: https://github.com/pr2-gbp/pr2_mechanism-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## pr2_controller_interface

```
* Merge pull request #332 <https://github.com/pr2/pr2_mechanism/issues/332> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_controller_manager

```
* Merge pull request #334 <https://github.com/pr2/pr2_mechanism/issues/334> from k-okada/fix_cmake_warning
  Fix cmake warning
* Merge pull request #332 <https://github.com/pr2/pr2_mechanism/issues/332> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* use TinyXML instead of tinyxml
* Use Eigen3, instad of Eigen
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_hardware_interface

```
* Merge pull request #332 <https://github.com/pr2/pr2_mechanism/issues/332> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_mechanism

```
* Merge pull request #332 <https://github.com/pr2/pr2_mechanism/issues/332> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_mechanism_diagnostics

```
* Merge pull request #334 <https://github.com/pr2/pr2_mechanism/issues/334> from k-okada/fix_cmake_warning
  Fix cmake warning
* Merge pull request #332 <https://github.com/pr2/pr2_mechanism/issues/332> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* target pr2_mechanism_diagnostics is not exists
* change maintainer to ROS orphaned package maintainer
* Added dependency on pr2_mechanism_msgs
* Contributors: Kei Okada, dash
```

## pr2_mechanism_model

```
* Merge pull request #336 <https://github.com/pr2/pr2_mechanism/issues/336> from k-okada/hardware_interface_0.13.0
  set hardware_interface >= 0.13.0
* set hardware_interface >= 0.13.0
  https://github.com/ros-controls/ros_control/pull/285 (which is included in hardware_interface 0.13.0) allow us to use class hardware_interface::HardwareResourceManager API
* Merge pull request #335 <https://github.com/pr2/pr2_mechanism/issues/335> from k-okada/fix_cmake
  fix compile warning
* fix compile warning
* Merge pull request #332 <https://github.com/pr2/pr2_mechanism/issues/332> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
