### PR TITLE
pr2_controllers: 1.10.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6572,6 +6572,32 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pr2_controllers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ethercat_trigger_controllers
+      - joint_trajectory_action
+      - pr2_calibration_controllers
+      - pr2_controllers
+      - pr2_controllers_msgs
+      - pr2_gripper_action
+      - pr2_head_action
+      - pr2_mechanism_controllers
+      - robot_mechanism_controllers
+      - single_joint_position_action
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_controllers-release.git
+      version: 1.10.14-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_mechanism_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.14-0`:

- upstream repository: https://github.com/pr2/pr2_controllers.git
- release repository: https://github.com/pr2-gbp/pr2_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ethercat_trigger_controllers

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## joint_trajectory_action

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_calibration_controllers

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* Merge pull request #369 <https://github.com/PR2/pr2_controllers/issues/369> from muratsevim/hydro-devel
  std namespace prefix is added to isnan calls
* change maintainer to ROS orphaned package maintainer
* std namespace prefix is added to isnan calls
* Contributors: Kei Okada, Mehmet Murat Sevim
```

## pr2_controllers

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_controllers_msgs

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_gripper_action

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_head_action

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_mechanism_controllers

```
* Merge pull request #389 <https://github.com/PR2/pr2_controllers/issues/389> from k-okada/kinetic-devel
  - use Eigen3 instead of Eigen
* use Eigen3 instead of Eigen
* Merge pull request #388 <https://github.com/PR2/pr2_controllers/issues/388> from k-okada/add_missing_dep
  add missing dependency
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* Merge pull request #369 <https://github.com/PR2/pr2_controllers/issues/369> from muratsevim/hydro-devel
  std namespace prefix is added to isnan calls
* mechanism_controllers: add missing pr2_msgs dependency
* change maintainer to ROS orphaned package maintainer
* std namespace prefix is added to isnan calls
* Contributors: Kei Okada, Mehmet Murat Sevim, Michael Görner
```

## robot_mechanism_controllers

```
* Merge pull request #388 <https://github.com/PR2/pr2_controllers/issues/388> from k-okada/add_missing_dep
  add missing dependency
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* robot_mechanism_controllers: add missing deps
* change maintainer to ROS orphaned package maintainer
* Contributors: Furushchev, Kei Okada
```

## single_joint_position_action

```
* Merge pull request #387 <https://github.com/PR2/pr2_controllers/issues/387> from k-okada/maintain
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
