### PR TITLE
custom_landmark_2d: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2363,6 +2363,21 @@ repositories:
       url: https://github.com/AndreaCensi/csm.git
       version: master
     status: maintained
+  custom_landmark_2d:
+    doc:
+      type: git
+      url: https://github.com/matthew-liu/custom_landmark_2d.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/MatthewLiuRelease/custom_landmark_2d-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/matthew-liu/custom_landmark_2d.git
+      version: indigo-devel
+    status: developed
   cv_backports:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `custom_landmark_2d` to `1.0.0-0`:

- upstream repository: https://github.com/matthew-liu/custom_landmark_2d.git
- release repository: https://github.com/MatthewLiuRelease/custom_landmark_2d-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## custom_landmark_2d

```
* Initial release of custom_landmark_2d
* Contributors: Matthew Liu
```
