### PR TITLE
pr2_common_actions: 0.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6572,6 +6572,29 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: unmaintained
+  pr2_common_actions:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common_actions.git
+      version: kinetic-devel
+    release:
+      packages:
+      - joint_trajectory_action_tools
+      - joint_trajectory_generator
+      - pr2_arm_move_ik
+      - pr2_common_action_msgs
+      - pr2_common_actions
+      - pr2_tilt_laser_interface
+      - pr2_tuck_arms_action
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common_actions-release.git
+      version: 0.0.10-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common_actions.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common_actions` to `0.0.10-0`:

- upstream repository: https://github.com/PR2/pr2_common_actions.git
- release repository: https://github.com/pr2-gbp/pr2_common_actions-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## joint_trajectory_action_tools

```
* Merge pull request #36 <https://github.com/pr2/pr2_common_actions/issues/36> from k-okada/kinetic-devel
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## joint_trajectory_generator

```
* Merge pull request #37 <https://github.com/pr2/pr2_common_actions/issues/37> from k-okada/add_pr2_msgs
  add depend to pr2_controller_msgs
* Merge pull request #36 <https://github.com/pr2/pr2_common_actions/issues/36> from k-okada/kinetic-devel
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* add depend to pr2_controller_msgs
* Contributors: Kei Okada
```

## pr2_arm_move_ik

```
* Merge pull request #36 <https://github.com/pr2/pr2_common_actions/issues/36> from k-okada/kinetic-devel
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_common_action_msgs

```
* Merge pull request #36 <https://github.com/pr2/pr2_common_actions/issues/36> from k-okada/kinetic-devel
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_common_actions

```
* Merge pull request #36 <https://github.com/pr2/pr2_common_actions/issues/36> from k-okada/kinetic-devel
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_tilt_laser_interface

```
* Merge pull request #36 <https://github.com/pr2/pr2_common_actions/issues/36> from k-okada/kinetic-devel
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_tuck_arms_action

```
* Merge pull request #36 <https://github.com/pr2/pr2_common_actions/issues/36> from k-okada/kinetic-devel
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
