### PR TITLE
Remove robotican from indexing.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11165,16 +11165,6 @@ repositories:
       url: https://github.com/ecostech/roboteq_diff_driver.git
       version: master
     status: maintained
-  robotican:
-    doc:
-      type: git
-      url: https://github.com/robotican/robotican.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/robotican/robotican.git
-      version: master
-    status: maintained
   robotiq:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -220,16 +220,6 @@ repositories:
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
     status: developed
-  armadillo2:
-    doc:
-      type: git
-      url: https://github.com/robotican/armadillo2.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/robotican/armadillo2.git
-      version: master
-    status: maintained
   asr_approx_mvbb:
     doc:
       type: git


### PR DESCRIPTION
There are forked copies of packages masking released packages.

Indigo: https://github.com/robotican/robotican/issues/21
Kinetic: https://github.com/robotican/armadillo2/issues/1