### PR TITLE
pr2_ethercat_drivers: 1.8.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6588,6 +6588,23 @@ repositories:
       url: https://github.com/pr2/pr2_controllers.git
       version: kinetic-devel
     status: unmaintained
+  pr2_ethercat_drivers:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - fingertip_pressure
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
+      version: 1.8.17-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.17-0`:

- upstream repository: https://github.com/pr2/pr2_ethercat_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## fingertip_pressure

```
* Merge pull request #70 <https://github.com/PR2/pr2_ethercat_drivers/issues/70> from k-okada/orp
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
