### PR TITLE
pr2_apps: 0.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6541,6 +6541,29 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  pr2_apps:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_app_manager
+      - pr2_apps
+      - pr2_mannequin_mode
+      - pr2_position_scripts
+      - pr2_teleop
+      - pr2_teleop_general
+      - pr2_tuckarm
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_apps-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.6.0-0`:

- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/pr2-gbp/pr2_apps-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## pr2_app_manager

```
* Merge pull request #15 <https://github.com/pr2/pr2_apps/issues/15> from k-okada/remove_build_depend
  we do not need any package during build process
* Merge pull request #29 <https://github.com/pr2/pr2_apps/issues/29> from k-okada/kinetic-devel
  Kinetic devel
* Merge pull request #30 <https://github.com/pr2/pr2_apps/issues/30> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge branch 'hydro-devel' into kinetic-devel
* we do not need any package during build process
* Contributors: Kei Okada
```

## pr2_apps

```
* Merge pull request #29 <https://github.com/pr2/pr2_apps/issues/29> from k-okada/kinetic-devel
  Kinetic devel
* Merge pull request #30 <https://github.com/pr2/pr2_apps/issues/30> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge branch 'hydro-devel' into kinetic-devel
* Contributors: Kei Okada
```

## pr2_mannequin_mode

```
* Merge pull request #23 <https://github.com/pr2/pr2_apps/issues/23> from 23pointsNorth/patch-2
  Add queue size to trajectory_lock script
* Merge pull request #29 <https://github.com/pr2/pr2_apps/issues/29> from k-okada/kinetic-devel
  Kinetic devel
* Merge pull request #30 <https://github.com/pr2/pr2_apps/issues/30> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge branch 'hydro-devel' into kinetic-devel
* Add queue size to trajectory_lock script
  Add queue_size as to remove following error:
  /opt/ros/indigo/share/pr2_mannequin_mode/scripts/trajectory_lock.py:77: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  pub = rospy.Publisher("command", trajectory_msgs.msg.JointTrajectory)
  Size of 10 was selected arbitrary as working.
* Contributors: Daniel Angelov, Kei Okada
```

## pr2_position_scripts

```
* Merge pull request #29 <https://github.com/pr2/pr2_apps/issues/29> from k-okada/kinetic-devel
  Kinetic devel
* Merge pull request #30 <https://github.com/pr2/pr2_apps/issues/30> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge branch 'hydro-devel' into kinetic-devel
* Contributors: Kei Okada
```

## pr2_teleop

```
* Merge pull request #26 <https://github.com/pr2/pr2_apps/issues/26> from TAMS-Group/pr-indigo-stop-spamming-on-slight-delays
  Only warn the user on outdated repeated messages
* Merge pull request #27 <https://github.com/pr2/pr2_apps/issues/27> from TAMS-Group/head_fix
  Using state controller feedback to update pan and tilt values of the head
* Merge pull request #29 <https://github.com/pr2/pr2_apps/issues/29> from k-okada/kinetic-devel
  Kinetic devel
* Merge pull request #30 <https://github.com/pr2/pr2_apps/issues/30> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge branch 'hydro-devel' into kinetic-devel
* Only warn the user on outdated repeated messages
  dornhege's commit recently added a safety mechanism to ensure
  a properly working dead-man switch with the PS2 controller.
  However, in some setups this problem appears during normal operation
  but does not persist for long. In order to avoid spamming the log
  console, we warn the user only if the received messages are additionally
  out of date.
  The overall safety mechanism still triggers, this only affects the log.
* use desired position for head feedback
  With the actual position the head tilts down because of gravity
  when the controller is idle and head movements are less responsive.
* Pan and tilt values updated via state controller
  When controlling the head with a different controller, the head moved with a very high speed, which can be harmful to the hardware.
  It was assumed that the head was only moved via teleop, thus the position was not updated when the head was moved with a different controller.
  This was fixed by reading the actual values for pan and tilt from the state controller.
* Merge pull request #25 <https://github.com/pr2/pr2_apps/issues/25> from dornhege/indigo-devel
  Do not process the same joystick message twice.
* Do not process the same joystick message twice.
  Happens if joystick hangs on old command.
* Contributors: 2scholz, Christian Dornhege, Devon Ash, Kei Okada, v4hn
```

## pr2_teleop_general

```
* Merge pull request #35 <https://github.com/pr2/pr2_apps/issues/35> from k-okada/remove_GetKinematicSolverInfo
  remove GetKinematicSolverInfo
* remove GetKinematicSolverInfo
  GetKinematicSolverInfo.srv has been removed from moveit_msgs by https://github.com/ros-planning/moveit_msgs/issues/3,
  since I'm not sure what is the best way to re-write code without this service, but to write the list of joint names directory
* Merge pull request #34 <https://github.com/pr2/pr2_apps/issues/34> from PR2/k-okada-patch-1
  remove bullet depend from package.xml
* remove bullet depend from package.xml
  emove depend to bullet, it already removed from code long time ago https://github.com/PR2/pr2_apps/pull/8/commits/64b60278bc02e83b1826f6f122b573e298476285
* Merge pull request #32 <https://github.com/pr2/pr2_apps/issues/32> from k-okada/fix_cmake_teleop
  fix cmake of pr2_teleop_general
* fix cmake of pr2_teleop_general
  - remove depend to bullet, it already removed from code long time ago https://github.com/PR2/pr2_apps/pull/8/commits/64b60278bc02e83b1826f6f122b573e298476285
  - use  ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS}, instead of *msgs_gencpp
* Merge pull request #31 <https://github.com/pr2/pr2_apps/issues/31> from k-okada/19
  add pr2_mannequin_mode as run_depend for pr2_teleop_general.
* add pr2_mannequin_mode as run_depend for pr2_teleop_general.
* Merge pull request #29 <https://github.com/pr2/pr2_apps/issues/29> from k-okada/kinetic-devel
  Kinetic devel
* Merge pull request #30 <https://github.com/pr2/pr2_apps/issues/30> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge branch 'hydro-devel' into kinetic-devel
* Contributors: Christian Dornhege, Kei Okada
```

## pr2_tuckarm

```
* Merge pull request #33 <https://github.com/pr2/pr2_apps/issues/33> from k-okada/add_tuckle_arm
  fix tuck arm client code back to tuck_arm_main.py
* fix tuck arm client code back to tuck_arm_main.py
  at this moment, pr2_tuckarm tuck_arms.py just start action server, but we expect to run client code see http://wiki.ros.org/pr2_tuckarm
  c.f. https://github.com/PR2/pr2_common_actions/pull/33
* Merge pull request #15 <https://github.com/pr2/pr2_apps/issues/15> from k-okada/remove_build_depend
  we do not need any package during build process
* Merge pull request #29 <https://github.com/pr2/pr2_apps/issues/29> from k-okada/kinetic-devel
  Kinetic devel
* Merge pull request #30 <https://github.com/pr2/pr2_apps/issues/30> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Merge branch 'hydro-devel' into kinetic-devel
* we do not need any package during build process
* Contributors: Kei Okada
```
