### PR TITLE
pr2_simulator: 2.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6718,6 +6718,26 @@ repositories:
       url: https://github.com/pr2/pr2_power_drivers.git
       version: kinetic-devel
     status: unmaintained
+  pr2_simulator:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_controller_configuration_gazebo
+      - pr2_gazebo
+      - pr2_gazebo_plugins
+      - pr2_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_simulator-release.git
+      version: 2.0.8-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: kinetic-devel
+    status: unmaintained
   puma_motor_driver:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.8-0`:

- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## pr2_controller_configuration_gazebo

```
* Merge pull request #135 <https://github.com/pr2/pr2_simulator/issues/135> from k-okada/kinetic-devel
  fix more cmake warnings
* fix compile error on catkin_package() DEPENDS on 'SDF' but neither 'SDF_INCLUDE_DIRS' nor...
* Merge pull request #133 <https://github.com/pr2/pr2_simulator/issues/133> from k-okada/125
  Removed repeated arg "gui", see https://github.com/PR2/pr2_simulator/pull/125
* Merge pull request #128 <https://github.com/pr2/pr2_simulator/issues/128> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* Removed repeated arg "gui", see https://github.com/PR2/pr2_simulator/pull/125
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```

## pr2_gazebo

```
* Merge pull request #135 <https://github.com/pr2/pr2_simulator/issues/135> from k-okada/kinetic-devel
  fix more cmake warnings
* fix compile error on catkin_package() DEPENDS on 'SDF' but neither 'SDF_INCLUDE_DIRS' nor...
* Merge pull request #134 <https://github.com/pr2/pr2_simulator/issues/134> from furushchev/arg-kinect
  pr2_gazebo: add arg KINECT
* Merge pull request #133 <https://github.com/pr2/pr2_simulator/issues/133> from k-okada/125
  Removed repeated arg "gui", see https://github.com/PR2/pr2_simulator/pull/125
* Merge pull request #132 <https://github.com/pr2/pr2_simulator/issues/132> from furushchev/headless
  [pr2_gazebo/launch/pr2_empty_world.launch] add headless/debug arguments for gazebo
* Merge pull request #131 <https://github.com/pr2/pr2_simulator/issues/131> from MatthewRueben/hydro-devel
  Rename "gazebo" package to "gazebo_ros"
* Merge pull request #128 <https://github.com/pr2/pr2_simulator/issues/128> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* Removed repeated arg "gui", see https://github.com/PR2/pr2_simulator/pull/125
* change maintainer to ROS orphaned package maintainer
* pr2_gazebo: add arg KINECT
* [pr2_gazebo/launch/pr2_empty_world.launch] add headless/debug argument for gazebo
* Merge pull request #118 <https://github.com/pr2/pr2_simulator/issues/118> from PR2/revert-117-indigo-devel
  Revert "Added argument passing for Kinect2"
* Revert "Added argument passing for Kinect2"
* Merge pull request #117 <https://github.com/pr2/pr2_simulator/issues/117> from archielee/indigo-devel
  Added argument passing for Kinect2
* Added argument passing for Kinect2
* Changed all instances of "gazebo" package to "gazebo_ros". The "gazebo" package was renamed "gazebo_ros" in hydro.
* Contributors: Devon Ash, Furushchev, Kei Okada, Yuki Furuta, archielee, elliot
```

## pr2_gazebo_plugins

```
* Merge pull request #135 <https://github.com/pr2/pr2_simulator/issues/135> from k-okada/kinetic-devel
  fix more cmake warnings
* fix warning on The dependency target pr2_gazebo_plugins_gencfg does not exists
* fix compile error on catkin_package() DEPENDS on 'SDF' but neither 'SDF_INCLUDE_DIRS' nor...
* Merge pull request #130 <https://github.com/pr2/pr2_simulator/issues/130> from k-okada/driver_base
  pr2_gazebo_plugins is no longer depend on driver_base
* Merge pull request #128 <https://github.com/pr2/pr2_simulator/issues/128> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* pr2_gazebo_plugins is no longer depend on driver_base
* change maintainer to ROS orphaned package maintainer
* Merge pull request #120 <https://github.com/pr2/pr2_simulator/issues/120> from v4hn/missing_gazebo_flags
  add missing GAZEBO_CXX_FLAGS
* add missing GAZEBO_CXX_FLAGS
  This is required to compile the plugins with Gazebo 7.
  add_compile_options requires cmake 2.8.12 which is around in ubuntu since 14.04.
* Contributors: Devon Ash, Kei Okada, v4hn
```

## pr2_simulator

```
* Merge pull request #129 <https://github.com/pr2/pr2_simulator/issues/129> from k-okada/license
  set license from TODO to BSD
* Merge pull request #128 <https://github.com/pr2/pr2_simulator/issues/128> from k-okada/maintainer
  change maintainer to ROS orphaned package maintainer
* set license from TODO to BSD
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
