### PR TITLE
Adding yoctopuce_altimeter to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11694,14 +11694,9 @@ repositories:
       type: git
       url: https://github.com/amstrudy/yoctopuce_altimeter.git
       version: kinetic
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/amstrudy/yoctopuce_altimeter.git
-      version: 0.1.0-1
     source:
       type: git
-      url: https://github.com/amstrudy/yoctopuce_altimeter.git
+      url: https://github.com/amstrudy/yoctopuce_altimeter.git  
       version: kinetic
     status: maintained
   youbot_description:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11689,6 +11689,21 @@ repositories:
       url: https://github.com/yujinrobot/yocs_msgs.git
       version: kinetic
     status: developed
+  yoctopuce_altimeter:
+    doc:
+      type: git
+      url: https://github.com/amstrudy/yoctopuce_altimeter.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/amstrudy/yoctopuce_altimeter.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/amstrudy/yoctopuce_altimeter.git
+      version: kinetic
+    status: maintained
   youbot_description:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11696,7 +11696,7 @@ repositories:
       version: kinetic
     source:
       type: git
-      url: https://github.com/amstrudy/yoctopuce_altimeter.git  
+      url: https://github.com/amstrudy/yoctopuce_altimeter.git
       version: kinetic
     status: maintained
   youbot_description:


### PR DESCRIPTION
I'd like my repo yoctopuce_altimeter to be indexed and documented on ros.org.