### PR TITLE
axis_camera: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -870,7 +870,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/axis_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.2.1-0`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.0-0`

## axis_camera

```
* add ros-orphaned-maintaner to package.xml (#50 <https://github.com/ros-drivers/axis_camera/issues/50>)
* Set queue_size to Publishers in axis_camera (#47 <https://github.com/ros-drivers/axis_camera/issues/47>)
* Point package.xml URLs at ros-drivers org. (#39 <https://github.com/ros-drivers/axis_camera/issues/39>)
* sending camera_info (#38 <https://github.com/ros-drivers/axis_camera/issues/38>)
  * copying stamp so rectification happens
  * sending camera_info
* Contributors: Kei Okada, Kentaro Wada, Mike Purvis, Sam Pfeiffer, Micah Corah
```
