### PR TITLE
class_loader: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -59,6 +59,11 @@ repositories:
       type: git
       url: https://github.com/ros/class_loader.git
       version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/class_loader-release.git
+      version: 0.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.4.0-0`:

- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## class_loader

```
* Stop checking for c++11 support (#87 <https://github.com/ros/class_loader/pull/87>)
  all Melodic targeted platforms use gnu++14 so checking and forcing -std=c++11 doesn't make sense anymore
* [ABI breaking] use std::string references for exceptions (#86 <https://github.com/ros/class_loader/issues/86>)
* deprecate .h headers in favor of .hpp headers (#81 <https://github.com/ros/class_loader/pull/81>)
* provide a script with exhaustive rules for header replacement
* comply with package format2 xsd (#83 <https://github.com/ros/class_loader/issues/83>)
* [ABI breaking] Exceptions fixups (#82 <https://github.com/ros/class_loader/issues/82>)
  * inline exceptions
  * use throw statement rather than function
* [linter] add nolint for global std::string used for testing (#79 <https://github.com/ros/class_loader/issues/79>)
* use auto for all for loops iterating on vectors/maps (#78 <https://github.com/ros/class_loader/issues/78>)
* Add systemLibraryFormat and systemLibraryPrefix functions (#77 <https://github.com/ros/class_loader/issues/77>)
* [ABI breaking] Bring melodic-devel closer to ros2 branch (#76 <https://github.com/ros/class_loader/issues/76>)
  * comply with extra and pedantic compiler flags
  * use c++11 nullptr instead of NULL
  * make ABI breaking change for explicit constructors
  * make linters happy
  * no need to support console_bridge < 0.3.0 anymore
  * remove obsolete todo
  * add virtual destructor in test
  * vector size() returns size_t
  * simplify branching
* [fix warnings] c++11 requires at least one argument for ... (#71 <https://github.com/ros/class_loader/issues/71>)
* [linter] Use std::string::empty instead comparing with an empty string (#69 <https://github.com/ros/class_loader/issues/69>)
* [linter] wrap console bridge invocation lines (#68 <https://github.com/ros/class_loader/issues/68>)
* OSRF and not willow in licence header (#67 <https://github.com/ros/class_loader/issues/67>)
* Contributors: David Wagner, Mikael Arguedas
```
