### PR TITLE
Add More Gentoo Deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3805,6 +3805,8 @@ openni-dev:
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
   ubuntu: [libopenni-dev]
+opensplice:
+  gentoo: [sci-libs/opensplice]
 openssh-client:
   debian: [openssh-client]
   fedora: [openssh-clients]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -115,6 +115,7 @@ pydocstyle:
   debian:
     buster: [pydocstyle]
     stretch: [pydocstyle]
+  gentoo: [dev-python/pydocstyle]
   ubuntu:
     artful: [pydocstyle]
     bionic: [pydocstyle]
@@ -3870,6 +3871,7 @@ python3-pep8:
   ubuntu: [python3-pep8]
 python3-pkg-resources:
   debian: [python3-pkg-resources]
+  gentoo: [dev-python/setuptools]
   ubuntu: [python3-pkg-resources]
 python3-pyparsing:
   arch: [python-pyparsing]


### PR DESCRIPTION
I created the `dev-python/pydocstyle` ebuild personally, and it now exists in the ROS Overlay. Also, the `ros-pkg-resources` module is just a part of setuptools on Gentoo.