### PR TITLE
camera1394stereo: 1.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -768,6 +768,21 @@ repositories:
       url: https://github.com/ros-drivers/camera1394.git
       version: master
     status: maintained
+  camera1394stereo:
+    doc:
+      type: git
+      url: https://github.com/srv/camera1394stereo.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/srv/camera1394stereo-release.git
+      version: 1.0.6-0
+    source:
+      type: git
+      url: https://github.com/srv/camera1394stereo.git
+      version: kinetic
+    status: maintained
   camera_info_manager_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera1394stereo` to `1.0.6-0`:

- upstream repository: https://github.com/srv/camera1394stereo.git
- release repository: https://github.com/srv/camera1394stereo-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## camera1394stereo

```
* Merge pull request #7 <https://github.com/srv/camera1394stereo/issues/7> from mikaelarguedas/patch-1
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* install launchfiles
* Fix #5 <https://github.com/srv/camera1394stereo/issues/5>: Install targets
* Contributors: Mikael Arguedas, Miquel Massot
```
