### PR TITLE
robotnik_msgs: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7610,7 +7610,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_msgs` to `0.2.2-0`:

- upstream repository: https://github.com/RobotnikAutomation/robotnik_msgs.git
- release repository: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.1-0`

## robotnik_msgs

```
* added list of strings of active status word and flags
* added set/get modbus register message
* alarms msgs
* adding new msgs and srvs for a Elevator system
* adding voltage to BatteryStatus.msg
* adding new msg for robotnik_base_hw
* adding I/O to motor status
* renamed InverterState.msg to InverterStatus.msg
* added InverterState message
* Contributors: Marc Bosch-Jorge, RomanRobotnik, RomanRobotnik.es, asoriano1, jmapariciorobotnik, marbosjo
```
