### PR TITLE
dnn_detect: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1764,11 +1764,15 @@ repositories:
       version: indigo-devel
     status: maintained
   dnn_detect:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/dnn_detect.git
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/dnn_detect.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dnn_detect` to `0.0.3-0`:

- upstream repository: https://github.com/UbiquityRobotics/dnn_detect.git
- release repository: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.2-0`

## dnn_detect

```
* Add optional rotation of image
* Added one shot mode, which requires a service call to trigger detection.
* Update README.md
* Contributors: Jim Vaughan
```
