### PR TITLE
octomap_pa: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5893,6 +5893,11 @@ repositories:
       type: git
       url: https://github.com/TUC-ProAut/ros_octomap.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/TUC-ProAut/ros_octomap-release.git
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/TUC-ProAut/ros_octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_pa` to `1.2.0-0`:

- upstream repository: https://github.com/TUC-ProAut/ros_octomap.git
- release repository: https://github.com/TUC-ProAut/ros_octomap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## octomap_pa

```
* Initial ROS-Package
* Contributors: Peter Weissig
```
