### PR TITLE
octomap_pa: 1.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2072,6 +2072,11 @@ repositories:
       type: git
       url: https://github.com/TUC-ProAut/ros_octomap.git
       version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/TUC-ProAut/ros_octomap-release.git
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/TUC-ProAut/ros_octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_pa` to `1.2.0-0`:

- upstream repository: https://github.com/TUC-ProAut/ros_octomap.git
- release repository: https://github.com/TUC-ProAut/ros_octomap-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## octomap_pa

```
* Initial ROS-Package
* Contributors: Peter Weissig
```
