### PR TITLE
pr2_simulator: 2.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6789,7 +6789,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_simulator-release.git
-      version: 2.0.8-0
+      version: 2.0.9-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.9-0`:

- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.0.8-0`

## pr2_controller_configuration_gazebo

```
* Merge pull request #137 <https://github.com/pr2/pr2_simulator/issues/137> from v4hn/config-build-depends
  Config build depends
* remove build-dependencies on gazebo from configuration package
  The CMakeLists.txt does not build anything.
  It should not find-package things it does not need during build.
* add build and run depend to gazebo
  (note that pr2_gazebo  depend on pr2_controller_configuration_gazebo)
* Contributors: Kei Okada, v4hn
```

## pr2_gazebo

- No changes

## pr2_gazebo_plugins

- No changes

## pr2_simulator

- No changes
