### PR TITLE
add trivial Gentoo dep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -777,6 +777,7 @@ g++-static:
   arch: [gcc]
   debian: [g++]
   fedora: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
+  gentoo: [sys-devel/gcc]
   ubuntu: [g++]
 gawk:
   arch: [gawk]


### PR DESCRIPTION
There's no GCC 'static' USE flag on Gentoo

```
cdc2000a4c08 / # equery uses gcc
[ Legend : U - final flag setting for installation]
[        : I - package is installed with flag     ]
[ Colors : set, unset                             ]
 * Found these USE flags for sys-devel/gcc-7.3.0:
 U I
 - - cilk            : Support the Cilk Plus language (C/C++ based languages
                       for parallel programming)
 + + cxx             : Build support for C++ (bindings, extra libraries, code
                       generation, ...)
 - - debug           : Enable extra debug codepaths, like asserts and extra
                       output. If you want to get meaningful backtraces see htt
                       ps://wiki.gentoo.org/wiki/Project:Quality_Assurance/Back
                       traces
 - - doc             : Add extra documentation (API, Javadoc, etc). It is
                       recommended to enable per package instead of globally
 + + fortran         : Add support for fortran
 - - go              : Build the GCC Go language frontend.
 - - graphite        : Add support for the framework for loop optimizations
                       based on a polyhedral intermediate representation
 - - mpx             : Enable support for Intel Memory Protection Extensions
                       (MPX)
 + + nls             : Add Native Language Support (using gettext - GNU locale
                       utilities)
 + + nptl            : Enable support for Native POSIX Threads Library, the new
                       threading module (requires linux-2.6 or better usually)
 - - objc            : Build support for the Objective C code language
 - - objc++          : Build support for the Objective C++ language
 - - objc-gc         : Build support for the Objective C code language Garbage
                       Collector
 + + openmp          : Build support for the OpenMP (support parallel
                       computing), requires >=sys-devel/gcc-4.2 built with
                       USE="openmp"
 + - pch             : Enable precompiled header support for faster compilation
                       at the expense of disk space and memory
                       (>=sys-devel/gcc-3.4 only)
 - - pgo             : Build GCC using Profile Guided Optimization (PGO)
 - - pie             : Build programs as Position Independent Executables (a
                       security hardening technique)
 - - regression-test : Run the testsuite and install the results (requires
                       FEATURES=test)
 + - sanitize        : Build support for various sanitizer functions
                       (ASAN/TSAN/etc...)
 + - ssp             : Build packages with stack smashing protector on by
                       default
 - - vanilla         : Do not add extra patches which change default behaviour;
                       DO NOT USE THIS ON A GLOBAL SCALE as the severity of the
                       meaning changes drastically
 + - vtv             : Build support for virtual table verification (a C++
                       hardening feature)
```

So it should be fine to just emerge GCC here (though, to be clear, I don't think any of these distros are actually targeting a _static_ version of g++, and I'm not sure what that would mean in the first place).

This is needed to generate `cartographer` ebuilds for ROS 2.