### PR TITLE
sync_params: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10148,6 +10148,21 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  sync_params:
+    doc:
+      type: svn
+      url: https://github.com/NicksSimulationsROS/sync_params.git
+      version: ros-kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/NicksSimulationsROS/sync_params-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/NicksSimulationsROS/sync_params.git
+      version: ros-kinetic
+    status: developed
   tango_ros:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10150,7 +10150,7 @@ repositories:
     status: developed
   sync_params:
     doc:
-      type: svn
+      type: git
       url: https://github.com/NicksSimulationsROS/sync_params.git
       version: ros-kinetic
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_params` to `1.0.1-0`:

- upstream repository: https://github.com/NicksSimulationsROS/sync_params.git
- release repository: https://github.com/NicksSimulationsROS/sync_params-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## sync_params

```
* added tests
* Merge branch 'master' of https://github.com/NicksSimulationsROS/sync_params
* cpp time to wall time
* Update package.xml
* Update example1.launch
* Update example2.launch
* Create README.md
* first commit
* Contributors: Nick Sullivan
```
