### PR TITLE
Revert "dynamixel-workbench: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1828,7 +1828,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.2.0-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Reverts ros/rosdistro#17017

dynamixel_workbench_toolbox FTBFS:  https://github.com/ROBOTIS-GIT/dynamixel-workbench/issues/112

I'm reverting this since that failure cascades and breaks the majority of packages in this repository.