### PR TITLE
Add keys for cpprest

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1497,13 +1497,13 @@ libconsole-bridge-dev:
 libcpprest-dev:
   debian:
     buster: [libcpprest-dev]
-    sid: [libcpprest-dev]
     stretch: [libcpprest-dev]
   fedora: [cpprest-devel]
   ubuntu:
     artful: [libcpprest-dev]
     bionic: [libcpprest-dev]
     xenial: [libcpprest-dev]
+    yakkety: [libcpprest-dev]
     zesty: [libcpprest-dev]
 libdbus-dev:
   arch: [dbus-core]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1494,6 +1494,17 @@ libconsole-bridge-dev:
   opensuse: [libconsole_bridge0]
   slackware: [console_bridge]
   ubuntu: [libconsole-bridge-dev]
+libcpprest-dev:
+  debian:
+    buster: [libcpprest-dev]
+    sid: [libcpprest-dev]
+    stretch: [libcpprest-dev]
+  fedora: [cpprest-devel]
+  ubuntu:
+    artful: [libcpprest-dev]
+    bionic: [libcpprest-dev]
+    xenial: [libcpprest-dev]
+    zesty: [libcpprest-dev]
 libdbus-dev:
   arch: [dbus-core]
   debian: [libdbus-1-dev]


### PR DESCRIPTION
Add key for cpprest. Was not able to find package names for fedora, gentoo, or arch. `cpprest` is just C++ REST library and we use it for an `HTTP` server

Ubuntu: https://packages.ubuntu.com/xenial/libdevel/libcpprest-dev
Debian: https://packages.debian.org/search?keywords=libcpprest-dev
Fedora: https://copr.fedorainfracloud.org/coprs/c72578/cpprest/