### PR TITLE
rqt_robot_steering: 0.5.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13176,7 +13176,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_steering-release.git
-      version: 0.5.7-0
+      version: 0.5.9-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `0.5.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros-gbp/rqt_robot_steering-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.5.7-0`

## rqt_robot_steering

```
* always send zero twist when stop button is pressed (#2 <https://github.com/ros-visualization/rqt_robot_steering/issues/2>)
```
