### PR TITLE
ros_comm: 1.12.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8027,7 +8027,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.12-0
+      version: 1.12.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.13-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.12.12-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* return an error status on error in rosbag (#1257 <https://github.com/ros/ros_comm/issues/1257>)
* fix warn of --max-splits without --split (#1237 <https://github.com/ros/ros_comm/issues/1237>)
```

## rosbag_storage

```
* performance improvement for lower/upper bound (#1223 <https://github.com/ros/ros_comm/issues/1223>)
* place console_bridge macros definition in header and use it everywhere console_bridge is included (#1238 <https://github.com/ros/ros_comm/issues/1238>)
```

## rosconsole

- No changes

## roscpp

```
* avoid recreating poll set (#1281 <https://github.com/ros/ros_comm/pull/1281>)
* switch to using epoll (#1217 <https://github.com/ros/ros_comm/pull/1217>)
* monotonic clock for callback queue timeouts (#1250 <https://github.com/ros/ros_comm/pull/1250>)
* fix IPv6 initialization order (#1262 <https://github.com/ros/ros_comm/issues/1262>)
* changed error message for single threaded spinner  (#1164 <https://github.com/ros/ros_comm/pull/1164>)
```

## rosgraph

- No changes

## roslaunch

```
* add process listeners to XML RPC server (#1319 <https://github.com/ros/ros_comm/issues/1319>)
* make master process explicitly 'required' for parent launch (#1228 <https://github.com/ros/ros_comm/issues/1228>)
```

## roslz4

```
* adding decompress to free(state) before return (#1313 <https://github.com/ros/ros_comm/issues/1313>)
```

## rosmaster

```
* add TCP_INFO availability check (#1211 <https://github.com/ros/ros_comm/issues/1211>)
```

## rosmsg

- No changes

## rosnode

```
* fix docstrings (#1278 <https://github.com/ros/ros_comm/issues/1278>)
* fix documentation for cleanup_master_blacklist() (#1253 <https://github.com/ros/ros_comm/issues/1253>)
```

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* raise the correct exception from AnyMsg.serialize (#1311 <https://github.com/ros/ros_comm/issues/1311>)
```

## rosservice

- No changes

## rostest

```
* add_rostest_gmock function (#1303 <https://github.com/ros/ros_comm/issues/1303>)
```

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* replace deprecated syntax (backticks with repr()) (#1259 <https://github.com/ros/ros_comm/issues/1259>)
```

## xmlrpcpp

```
* fix xmlrpc timeout using monotonic clock (#1249 <https://github.com/ros/ros_comm/issues/1249>)
* make xmlrpcpp specific include directory work in devel space (#1261 <https://github.com/ros/ros_comm/issues/1261>)
```
