### PR TITLE
urdfdom_py: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -502,6 +502,22 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  urdfdom_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/urdfdom_py-release.git
+      version: 0.4.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: melodic-devel
+    status: maintained
   webkit_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.4.0-0`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## urdfdom_py

```
* Add Link.visual and Link.collision properties (#28 <https://github.com/ros/urdf_parser_py/issues/28>)
* Add tests for mutli-visual and multi-collision
* links and collisions load properly as aggregates
* Add XPath information when a parse error is encountered
* Remove travis support. (#22 <https://github.com/ros/urdf_parser_py/issues/22>)
* Reformat python code to pep8 standard (#21 <https://github.com/ros/urdf_parser_py/issues/21>)
* Update core.py to allow passing addHeader arg to to_xml_string function (#19 <https://github.com/ros/urdf_parser_py/issues/19>)
* fixed defaults for xyz/rpy, fixed set_default for Param, added unit tests (#16 <https://github.com/ros/urdf_parser_py/issues/16>)
* Make unit test run with catkin_make run_tests (#15 <https://github.com/ros/urdf_parser_py/issues/15>)
* Contributors: Chris Lalancette, Chris Paxton, Eric Cousineau, Shane Loretz, Will Baker, eugene-katsevman
```
