### PR TITLE
franka_ros: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2394,7 +2394,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.3.0-0`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.2-0`

Requires the `libfranka` update
