### PR TITLE
Revert "Patch OpenCV3 build type."

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6000,7 +6000,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.3.1-3
+      version: 3.3.1-0
     status: maintained
   opencv_apps:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#17030

Rolling back because this creates an invalid debian diff

```
modified version)
dpkg-source: warning: file source/opencv_contrib/structured_light/include/opencv2/structured_light/graycodepattern.hpp has no final newline (either original or modified version)
dpkg-source: warning: file source/opencv_contrib/structured_light/include/opencv2/structured_light/structured_light.hpp has no final newline (either original or modified version)
dpkg-source: warning: file source/opencv_contrib/text/doc/text.bib has no final newline (either original or modified version)
dpkg-source: warning: file source/opencv_contrib/text/tutorials/install_tesseract/install_tesseract.markdown has no final newline (either original or modified version)
dpkg-source: warning: file source/opencv_contrib/ximgproc/include/opencv2/ximgproc/brightedges.hpp has no final newline (either original or modified version)
dpkg-source: warning: file source/opencv_contrib/ximgproc/samples/paillou_demo.cpp has no final newline (either original or modified version)
dpkg-source: warning: file source/samples/dnn/face_detector/deploy.prototxt has no final newline (either original or modified version)
dpkg-source: warning: file source/samples/dnn/face_detector/test.prototxt has no final newline (either original or modified version)
dpkg-source: warning: file source/samples/dnn/face_detector/train.prototxt has no final newline (either original or modified version)
dpkg-source: warning: file source/samples/dnn/yolo_object_detection.cpp has no final newline (either original or modified version)
```