### PR TITLE
octomap_pa: 1.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5887,7 +5887,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/TUC-ProAut/ros_octomap-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/TUC-ProAut/ros_octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_pa` to `1.2.2-0`:

- upstream repository: https://github.com/TUC-ProAut/ros_octomap.git
- release repository: https://github.com/TUC-ProAut/ros_octomap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.2.1-0`

## octomap_pa

```
* add missing dependency on messages from this package
* Contributors: Mikael Arguedas
```
