### PR TITLE
Adding raspigibbon_apps and raspigibbon_sim to documentation index for kinetic 

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7149,6 +7149,16 @@ repositories:
       url: https://github.com/raspberrypigibbon/raspigibbon_ros.git
       version: kinetic-devel
     status: developed
+  raspigibbon_sim:
+    doc:
+      type: git
+      url: https://github.com/raspberrypigibbon/raspigibbon_sim.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/raspberrypigibbon/raspigibbon_sim.git
+      version: kinetic-devel
+    status: developed
   razor_imu_9dof:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7119,6 +7119,16 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspigibbon_apps:
+    doc:
+      type: git
+      url: https://github.com/raspberrypigibbon/raspigibbon_apps.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/raspberrypigibbon/raspigibbon_apps.git
+      version: kinetic-devel
+    status: developed
   raspigibbon_ros:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspigibbon_apps and raspigibbon_sim to be doc'd and indexed.