### PR TITLE
rc_visard: 1.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10656,7 +10656,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboception/rc_visard-release.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `1.2.1-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception/rc_visard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.2.0-0`

## rc_visard

- No changes

## rc_visard_driver

```
* use rc_genicam_api as dependency
  instead of including as submodule
  also remove launchfile, as the device is a required parameter anyway...
* Contributors: Felix Ruess
```
