### PR TITLE
Adding realsense_ros_camera to documentation index for Kinetic and Indigo distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10638,6 +10638,12 @@ repositories:
       url: https://github.com/timn/ros-rcll_ros_msgs.git
       version: master
     status: developed
+  realsense2_camera:
+    doc:
+      type: git
+      url: https://github.com/intel-ros/realsense.git
+      version: development
+    status: maintained
   realsense_camera:
     doc:
       type: git
@@ -10653,12 +10659,6 @@ repositories:
       type: git
       url: https://github.com/intel-ros/realsense.git
       version: indigo-devel
-    status: maintained
-  realsense_ros_camera:
-    doc:
-      type: git
-      url: https://github.com/intel-ros/realsense.git
-      version: development
     status: maintained
   realtime_tools:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10654,6 +10654,12 @@ repositories:
       url: https://github.com/intel-ros/realsense.git
       version: indigo-devel
     status: maintained
+  realsense_ros_camera:
+    doc:
+      type: git
+      url: https://github.com/intel-ros/realsense.git
+      version: development
+    status: maintained
   realtime_tools:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6938,6 +6938,12 @@ repositories:
       url: https://gitlab.com/jlack/rdl.git
       version: master
     status: developed
+  realsense2_camera:
+    doc:
+      type: git
+      url: https://github.com/intel-ros/realsense.git
+      version: development
+    status: maintained
   realsense_camera:
     doc:
       type: git
@@ -6953,12 +6959,6 @@ repositories:
       type: git
       url: https://github.com/intel-ros/realsense.git
       version: indigo-devel
-    status: maintained
-  realsense_ros_camera:
-    doc:
-      type: git
-      url: https://github.com/intel-ros/realsense.git
-      version: development
     status: maintained
   realtime_tools:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6954,6 +6954,12 @@ repositories:
       url: https://github.com/intel-ros/realsense.git
       version: indigo-devel
     status: maintained
+  realsense_ros_camera:
+    doc:
+      type: git
+      url: https://github.com/intel-ros/realsense.git
+      version: development
+    status: maintained
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
I'd like `realsense_ros_camera` to be indexed and documented on ros.org.