### PR TITLE
mavros: 0.23.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4662,7 +4662,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.23.0-0
+      version: 0.23.1-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.23.1-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.23.0-0`

## libmavconn

```
* compile also with boost >= 1.66.0
  In boost 1.66.0, which includes boost-asio 1.12.0, the asio
  interfaces have been changed to follow the "C++ Extensions for
  Networking" Technical Specification [1]. As a consequence,
  resolvers now produce ranges rather than iterators.
  In boost < 1.66.0, resolver.resolve returns an iterator that must
  be passed to std::for_each. As this iterator in boost < 1.66.0
  does not provide begin() and end() member functions, it cannot be
  simply turned into a proper range.
  For boost >= 1.66.0, resolver.resolve returns a range, which
  can be just iterated through with for (auto v : _) syntax.
  As it is not possible to have one way to iterate through the result
  independent of the boost version, a preprocessing directive selects
  the proper synactic iteration construction depending on the provided
  boost-asio library version [2].
  This way, this commit is backwards compatible with boost < 1.66.0
  and compiles properly with boost >= 1.66.0.
  The issue was identified in a build with the cross-compilation tool
  chain provided in the meta-ros OpenEmbedded layer [3].
  [1] http://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html
  [2] https://github.com/boostorg/asio/commit/0c9cbdfbf217146c096265b5eb56089e8cebe608
  [3] http://github.com/bmwcarit/meta-ros
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@gmail.com>
* Contributors: Lukas Bulwahn
```

## mavros

```
* lib: Update to_string
* plugin fix #957 <https://github.com/mavlink/mavros/issues/957>: set MISSION_ITEM::mission_type
* Contributors: Vladimir Ermakov
```

## mavros_extras

```
* odom plugin: initialize matrix with zeros
* extras fix #950 <https://github.com/mavlink/mavros/issues/950>: fix unit conversions
* Contributors: ChristophTobler, Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
