### PR TITLE
rc_visard: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10668,11 +10668,12 @@ repositories:
     release:
       packages:
       - rc_visard
+      - rc_visard_description
       - rc_visard_driver
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboception/rc_visard-release.git
-      version: 1.2.1-0
+      version: 2.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.0.0-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception/rc_visard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.2.1-0`

## rc_visard

```
* rc_visard_description package added
* Contributors: Felix Ruess, florek
```

## rc_visard_description

```
* rc_visard_description package added
* Contributors: florek
```

## rc_visard_driver

```
* rc_genicam_api and rc_dynamics_api as dependency instead of submodule
* don't reset if datastreams time out
* added get_trajectory service
* Use new statemachine interface
  Return codes are now strings.
* Add services start_slam, restart_slam and stop_slam
* Publishing dynamics as odometry message
* visualizing dynamics message
  - angular velocity, linear accelerarion published as marker
  for visualization
  - cam2imu-transform is published with re-created timestamp
* Contributors: Christian Emmerich, Felix Endres, Felix Ruess, Heiko Hirschmueller
```
