### PR TITLE
rc_dynamics_api: 0.5.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2501,6 +2501,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  rc_dynamics_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/roboception/rc_dynamics_api-release.git
+      version: 0.5.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    status: developed
   rc_genicam_api:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_dynamics_api` to `0.5.0-0`:

- upstream repository: https://github.com/roboception/rc_dynamics_api.git
- release repository: https://github.com/roboception/rc_dynamics_api-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rc_dynamics_api

```
* Updates for rc_visard image version v1.1.x with support for SLAM
* added startSlam, restartSlam, stopSlam and getTrajectory
* support Windows build
```
