### PR TITLE
random_numbers: 0.3.1-0 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -306,6 +306,21 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
+  random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION

* upstream repository: https://github.com/ros-planning/random_numbers
* release repository: https://github.com/ros-gbp/random_numbers-release.git
* distro file: melodic/distribution.yaml
* bloom version: 0.6.2
* previous version for package: null

## random_numbers

* no changes
