### PR TITLE
rc_visard: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7287,6 +7287,26 @@ repositories:
       url: https://github.com/roboception/rc_genicam_api.git
       version: master
     status: developed
+  rc_visard:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_visard_ros.git
+      version: master
+    release:
+      packages:
+      - rc_visard
+      - rc_visard_description
+      - rc_visard_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/roboception/rc_visard-release.git
+      version: 2.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_visard_ros.git
+      version: master
+    status: developed
   rcll_fawkes_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.0.0-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception/rc_visard-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rc_visard

```
* rc_visard_description package added
* Contributors: Felix Ruess, florek
```

## rc_visard_description

```
* rc_visard_description package added
* Contributors: florek
```

## rc_visard_driver

```
* rc_genicam_api and rc_dynamics_api as dependency instead of submodule
* don't reset if datastreams time out
* added get_trajectory service
* Use new statemachine interface
  Return codes are now strings.
* Add services start_slam, restart_slam and stop_slam
* Publishing dynamics as odometry message
* visualizing dynamics message
  - angular velocity, linear accelerarion published as marker
  for visualization
  - cam2imu-transform is published with re-created timestamp
* Contributors: Christian Emmerich, Felix Endres, Felix Ruess, Heiko Hirschmueller
```
