### PR TITLE
raspigibbon_ros: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7139,11 +7139,12 @@ repositories:
       - futaba_serial_servo
       - raspigibbon_bringup
       - raspigibbon_description
+      - raspigibbon_msgs
       - raspigibbon_ros
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/raspberrypigibbon/raspigibbon_ros-release.git
-      version: 0.1.1-1
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/raspberrypigibbon/raspigibbon_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspigibbon_ros` to `0.2.1-0`:

- upstream repository: https://github.com/raspberrypigibbon/raspigibbon_ros.git
- release repository: https://github.com/raspberrypigibbon/raspigibbon_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.1-1`

## futaba_serial_servo

```
* Fix circular dependencies
  https://github.com/ros/rosdistro/pull/17057
```

## raspigibbon_bringup

- No changes

## raspigibbon_description

- No changes

## raspigibbon_msgs

- No changes

## raspigibbon_ros

```
* Fix circular dependencies
  https://github.com/ros/rosdistro/pull/17057
```
