### PR TITLE
Adding raspimouse_ros to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7159,6 +7159,16 @@ repositories:
       url: https://github.com/raspberrypigibbon/raspigibbon_sim.git
       version: kinetic-devel
     status: developed
+  raspimouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ryuichiueda/raspimouse_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ryuichiueda/raspimouse_ros.git
+      version: master
+    status: maintained
   razor_imu_9dof:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspimouse_ros to be doc'd and indexed.