### PR TITLE
raspigibbon_sim: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7155,6 +7155,15 @@ repositories:
       type: git
       url: https://github.com/raspberrypigibbon/raspigibbon_sim.git
       version: kinetic-devel
+    release:
+      packages:
+      - raspigibbon_control
+      - raspigibbon_gazebo
+      - raspigibbon_sim
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/raspberrypigibbon/raspigibbon_sim-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/raspberrypigibbon/raspigibbon_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspigibbon_sim` to `0.0.1-0`:

- upstream repository: https://github.com/raspberrypigibbon/raspigibbon_sim.git
- release repository: https://github.com/raspberrypigibbon/raspigibbon_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## raspigibbon_control

```
* The first release of raspigibbon_control for kinetic
```

## raspigibbon_gazebo

```
* The first release of raspigibbon_gazebo for kinetic
```

## raspigibbon_sim

```
* The first release of raspigibbon_sim for kinetic
```
