### PR TITLE
Added pyquaternion to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2332,6 +2332,16 @@ python-pyproj:
     pip:
       packages: [pyproj]
   ubuntu: [python-pyproj]
+python-pyquaternion-pip:
+  debian:
+    pip:
+      packages: [pyquaternion]
+  fedora:
+    pip:
+      packages: [pyquaternion]
+  ubuntu:
+    pip:
+      packages: [pyquaternion]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]


### PR DESCRIPTION
Added pip package pyquaternion as python-pyquaternion-pip

pyquaternion (http://kieranwynn.github.io/pyquaternion/) is used by us in a project to do some quaternion calculations.

To my knowledge it is only available via pip