### PR TITLE
Adding python-geopy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1125,6 +1125,10 @@ python-geographiclib:
   debian: [python-geographiclib]
   fedora: [python-GeographicLib]
   ubuntu: [python-geographiclib]
+python-geopy:
+  debian: [python-geopy]
+  gentoo: [dev-python/geopy]
+  ubuntu: [python-geopy]
 python-gevent:
   debian: [python-gevent]
   fedora: [python-gevent]


### PR DESCRIPTION
Added python package geopy as python-geopy.

geopy (https://github.com/geopy/geopy) we use for GNSS calculations and other handy utilities.