### PR TITLE
Adding python-gpxpy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1219,6 +1219,7 @@ python-gpxpy:
       pip:
         packages: [gpxpy]
     stretch: [python-gpxpy]
+  gentoo: [sci-geosciences/gpxpy]
   ubuntu:
     artful: [python-gpxpy]
     bionic: [python-gpxpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1218,7 +1218,6 @@ python-gpxpy:
     jessie:
       pip:
         packages: [gpxpy]
-    sid: [python-gpxpy]
     stretch: [python-gpxpy]
   ubuntu:
     artful: [python-gpxpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1212,6 +1212,38 @@ python-gpiozero:
       pip:
         packages: [gpiozero]
     zesty: [python-gpiozero]
+python-gpxpy:
+  debian:
+    buster: [python-gpxpy]
+    jessie:
+      pip:
+        packages: [gpxpy]
+    sid: [python-gpxpy]
+    stretch: [python-gpxpy]
+  ubuntu:
+    artful: [python-gpxpy]
+    bionic: [python-gpxpy]
+    trusty:
+      pip:
+        packages: [gpxpy]
+    utopic:
+      pip:
+        packages: [gpxpy]
+    vivid:
+      pip:
+        packages: [gpxpy]
+    wily:
+      pip:
+        packages: [gpxpy]
+    xenial:
+      pip:
+        packages: [gpxpy]
+    yakkety:
+      pip:
+        packages: [gpxpy]
+    zesty:
+      pip:
+        packages: [gpxpy]
 python-graphviz-pip:
   debian:
     pip:


### PR DESCRIPTION
Added python pip package as python-gpxpy since not available as a system package.

gpxpy (https://github.com/tkrajina/gpxpy) we use for reading and writing GPX files.