### PR TITLE
minas: 1.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4802,7 +4802,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/minas-release.git
-      version: 1.0.7-1
+      version: 1.0.9-0
     source:
       type: git
       url: https://github.com/tork-a/minas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.9-0`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.0.7-1`

## ethercat_manager

```
* enable to publish actual position/velocity/torque value as /diagnostics (#67 <https://github.com/tork-a/minas/issues/67>)
* add EtherCatManager::getStatus
* Contributors: Tokyo Opensource Robotics Developer 534
```

## minas

- No changes

## minas_control

```
* enable to publish actual position/velocity/torque value as /diagnostics (#67 <https://github.com/tork-a/minas/issues/67>)
* fix simple test without arguments (#68 <https://github.com/tork-a/minas/issues/68>)
* onsite fix for encoder offset(#66 <https://github.com/tork-a/minas/issues/66>)
* set default ifname to eth0
* add try/catch in main function of test_simple.cpp, show help() when it failes to run EtherCatManager
* display input.position_actual_value in EtherCATJointControlInterface::EtherCATJointControlInterface
* fix wrong variable print
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## tra1_bringup

```
* Set home_encoder_offset zero as default
* Onsite fix for encoder offset
* Contributors: Ryosuke Tajima
```

## tra1_description

- No changes

## tra1_moveit_config

- No changes
