### PR TITLE
fix moveit_commander dependency in gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2141,7 +2141,7 @@ python-pyassimp:
   arch: [python2-pyassimp]
   debian: [python-pyassimp]
   fedora: [assimp-python]
-  gentoo: [dev-libs/assimp]
+  gentoo: [media-libs/assimp]
   osx:
     lion:
       homebrew:


### PR DESCRIPTION
dev-libs/assimp -> media-libs/assimp (as exists in gentoo main repository)