### PR TITLE
bond_core: 1.8.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -32,6 +32,17 @@ repositories:
       type: git
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/bond_core-release.git
+      version: 1.8.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.1-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## bond

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## bond_core

- No changes

## bondcpp

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## bondpy

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```

## smclib

```
* fix package.xml to comply with schema (#30 <https://github.com/ros/bond_core/issues/30>)
* Contributors: Mikael Arguedas
```
