### PR TITLE
rqt_ez_publisher: 0.5.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8881,7 +8881,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.4.0-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.5.0-0`:

- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.4.0-0`

## rqt_ez_publisher

```
* Add congigure checkbox and publish button by rein, thank you
```
