### PR TITLE
Adding python-voluptuous

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3674,6 +3674,11 @@ python-vlc-pip:
   ubuntu:
     pip:
       packages: [python-vlc]
+python-voluptuous:
+  debian: [python-voluptuous]
+  fedora: [python-voluptuous]
+  gentoo: [dev-python/voluptuous]
+  ubuntu: [python-voluptuous]
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]


### PR DESCRIPTION
PR to add the JSON validation library [Voluptuous](https://github.com/alecthomas/voluptuous). We use this to validate JSON commands coming from external sources (laptop, cloud etc).

Ubuntu: https://packages.ubuntu.com/search?keywords=python-voluptuous&searchon=names&suite=all&section=all
Fedora: https://admin.fedoraproject.org/pkgdb/packages/volup%2A/
Debian: https://packages.debian.org/search?keywords=voluptuous&searchon=names&suite=stable&section=all
Gentoo: https://packages.gentoo.org/packages/dev-python/voluptuous

