### PR TITLE
Adding python AWSIoTPythonSDK

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8,6 +8,19 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+awsiotpythonsdk-pip:
+  debian:
+    pip:
+      packages: [awsiotpythonsdk]
+  fedora:
+    pip:
+      packages: [awsiotpythonsdk]
+  gentoo:
+    pip:
+      packages: [awsiotpythonsdk]
+  ubuntu:
+    pip:
+      packages: [awsiotpythonsdk]
 azure-iothub-device-client-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -15,9 +15,6 @@ awsiotpythonsdk-pip:
   fedora:
     pip:
       packages: [awsiotpythonsdk]
-  gentoo:
-    pip:
-      packages: [awsiotpythonsdk]
   ubuntu:
     pip:
       packages: [awsiotpythonsdk]


### PR DESCRIPTION
This PR is to add [AWSIotPythonSDK](https://github.com/aws/aws-iot-device-sdk-python). We use it to connect and communicate with AWS IoT service.

Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=awsiotpythonsdk
Fedora: https://admin.fedoraproject.org/pkgdb/packages/%2AAWSIoTPythonSDK%2A/
Gentoo: https://packages.gentoo.org/packages/search?q=awsiot
Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=awsiot&searchon=names