### PR TITLE
surface_perception: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15002,7 +15002,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/surface_perception-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/jstnhuang/surface_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `surface_perception` to `1.0.1-0`:

- upstream repository: https://github.com/jstnhuang/surface_perception.git
- release repository: https://github.com/jstnhuang-release/surface_perception-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.0.0-0`

## surface_perception

```
* Allowed surfaces with no object on them.
* Fixed occasional crashes due to convex hull computation.
* Added optional point cloud frame argument in demo to support target frame other than base_link.
* Contributors: Justin Huang, Yu-Tang Peng
```
