### PR TITLE
mavros: 0.23.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.23.1-0
+      version: 0.23.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.23.2-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.23.1-0`

## libmavconn

```
* mavconn: small style fix
* Libmavconn : Set the serial port on Raw mode to prevent EOF error
* Libmavconn: ensure the ports are cleanly closed before end connexions.
* Contributors: Pierre Kancir, Vladimir Ermakov
```

## mavros

```
* launch: add optional respawn_mavros arg
* Contributors: Anthony Lamping
```

## mavros_extras

- No changes

## mavros_msgs

- No changes

## test_mavros

- No changes
