### PR TITLE
ddynamic_reconfigure_python: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 141: http://ros.org/reps/rep-0141.html
+# see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
   fedora:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1,6 +1,6 @@
 %YAML 1.1
 # ROS distribution file
-# see REP 143: http://ros.org/reps/rep-0143.html
+# see REP 141: http://ros.org/reps/rep-0141.html
 ---
 release_platforms:
   fedora:
@@ -2453,6 +2453,12 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
       version: default
     status: developed
+  ddynamic_reconfigure_python:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
+      version: 0.0.1-0
   declination:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure_python` to `0.0.1-0`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ddynamic_reconfigure_python

```
* Add namespace to reconfigure server
* Added examples, making the api easier to use
* Initial commit
* Contributors: Sam Pfeiffer
```
