### PR TITLE
ddynamic_reconfigure_python: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1645,6 +1645,12 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
       version: default
     status: developed
+  ddynamic_reconfigure_python:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
+      version: 0.0.1-0
   demo_pioneer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure_python` to `0.0.1-0`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ddynamic_reconfigure_python

```
* Add namespace to reconfigure server
* Added examples, making the api easier to use
* Initial commit
* Contributors: Sam Pfeiffer
```
