### PR TITLE
Adding raspimouse_sim to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10496,6 +10496,16 @@ repositories:
       url: https://github.com/jstnhuang/rapid_pbd_msgs.git
       version: indigo-devel
     status: developed
+  raspimouse_sim:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: indigo-devel
+    status: developed
   razer_hydra:
     release:
       tags:


### PR DESCRIPTION
I'd like to add raspimouse_sim to be doc'd and indexed.