### PR TITLE
dynamixel-workbench: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1834,7 +1834,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.2.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.2-0`

## dynamixel_workbench

```
* modified dialog rotate direction
* added dynamixel_sdk lib
* added debug code
* deleted anotation
* Contributors: Darby Lim
```

## dynamixel_workbench_controllers

```
* added dynamixel_sdk lib
* added debug code
* deleted anotation
* Contributors: Darby Lim
```

## dynamixel_workbench_operators

```
* None
```

## dynamixel_workbench_single_manager

```
* added dynamixel_sdk lib
* Contributors: Darby Lim
```

## dynamixel_workbench_single_manager_gui

```
* modified dialog rotate direction
* added dynamixel_sdk lib
* Contributors: Darby Lim
```

## dynamixel_workbench_toolbox

```
* None
```
