### PR TITLE
Adding topics_rviz_plugin to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10554,6 +10554,12 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
       version: master
+  topics_rviz_plugin:
+    doc:
+      type: git
+      url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
+      version: kinetic
+    status: developed
   towr:
     doc:
       type: git


### PR DESCRIPTION
I have run `rosdistro_reformat index.yaml` to make sure the format is correct.

This package allows to display ROS built-in topics (from `std_msgs`) within RViz thanks to a Qt panel.
https://answers.ros.org/question/283388/is-there-a-package-to-display-topic-values-in-rviz/

![Pick topics](https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin/raw/kinetic/documentation/pick_topics.png)

![GUI](https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin/raw/kinetic/documentation/gui.png)