### PR TITLE
adding pr2-calibration to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9486,6 +9486,29 @@ repositories:
       url: https://github.com/pr2/pr2_apps.git
       version: hydro-devel
     status: maintained
+  pr2_calibration:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_calibration.git
+      version: indigo-devel
+    release:
+      packages:
+      - dense_laser_assembler
+      - laser_joint_processor
+      - laser_joint_projector
+      - pr2_calibration
+      - pr2_calibration_launch
+      - pr2_dense_laser_snapshotter
+      - pr2_se_calibration_launch
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/TheDash/pr2_calibration-release.git
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_calibration.git
+      version: indigo-devel
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
pr2-calibration package should now compile with all packages for indigo:

dense_laser_assembler
laser_joint_processor
laser_joint_projector
pr2_calibration
pr2_calibration_launch
pr2_dense_laser_snapshotter
pr2_se_calibration_launch
