### PR TITLE
pr2_calibration: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9486,6 +9486,30 @@ repositories:
       url: https://github.com/pr2/pr2_apps.git
       version: hydro-devel
     status: maintained
+  pr2_calibration:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_calibration.git
+      version: indigo-devel
+    release:
+      packages:
+      - dense_laser_assembler
+      - laser_joint_processor
+      - laser_joint_projector
+      - pr2_calibration
+      - pr2_calibration_launch
+      - pr2_dense_laser_snapshotter
+      - pr2_se_calibration_launch
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration-release.git
+      version: 1.0.9-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/PR2/pr2_calibration.git
+      version: indigo-devel
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_calibration` to `1.0.9-0`:

- upstream repository: https://github.com/PR2/pr2_calibration.git
- release repository: https://github.com/UNR-RoboticsResearchLab/pr2_calibration-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
