### PR TITLE
rospilot: 1.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8688,7 +8688,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.4.0-0
+      version: 1.4.1-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.4.1-0`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.4.0-0`

## rospilot

```
* Switch to HTTPS for openstreetmap.org
* Workaround camera drivers that don't set keyframe flag
* Add support for reading raw YUV from camera
* Refactor pixel format handling
* Contributors: Christopher Berner
```
