### PR TITLE
Add cantools and pandacan python (pip) packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -486,6 +486,10 @@ python-cairo:
     slackpkg:
       packages: [pycairo]
   ubuntu: [python-cairo]
+python-cantools:
+  ubuntu:
+    pip:
+      packages: [cantools]
 python-catkin-lint:
   fedora: [python-catkin_lint]
   ubuntu: [python-catkin-lint]
@@ -1946,6 +1950,10 @@ python-paho-mqtt-pip:
   ubuntu:
     pip:
       packages: [paho-mqtt]
+python-pandacan:
+  ubuntu:
+    pip:
+      packages: [pandacan]
 python-pandas:
   arch: [python2-pandas]
   debian: [python-pandas]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -486,7 +486,10 @@ python-cairo:
     slackpkg:
       packages: [pycairo]
   ubuntu: [python-cairo]
-python-cantools:
+python-cantools-pip:
+  debian:
+    pip:
+      packages: [cantools]
   ubuntu:
     pip:
       packages: [cantools]
@@ -1950,7 +1953,10 @@ python-paho-mqtt-pip:
   ubuntu:
     pip:
       packages: [paho-mqtt]
-python-pandacan:
+python-pandacan-pip:
+  debian:
+    pip:
+      packages: [pandacan]
   ubuntu:
     pip:
       packages: [pandacan]


### PR DESCRIPTION
Adding [cantools](https://pypi.python.org/pypi/cantools/5.2.0) python pip package (not available in Ubuntu repos). It contains a very useful library to read [DBC files](http://socialledge.com/sjsu/index.php/DBC_Format) for CAN message protocols.

Adding [pandacan](https://github.com/commaai/panda) python pip package (not available in Ubuntu repos). It contains the code to interface with the panda can board.

Both of these packages are needed as part of packages & tools we are developing to hack the driving system of some cars (as part of the [pixmoving moveit hackathon](https://www.pixmoving.com/move-it)), which we will release at the end of the hackathon.

