### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: python
 
-python: "2.7"
+python:
+  - "2.7"
+  - "3.6"
+
+matrix:
+  allow_failures:
+    - python: "3.6"
 
 sudo: false
 

--- a/doc/scripts/distro_to_rosinstall.py
+++ b/doc/scripts/distro_to_rosinstall.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import os
 import sys
 import yaml
@@ -21,11 +22,11 @@ def translate(distro, translate_dir):
 
         path = os.path.join(translate_dir, "%s.rosinstall" % item.name)
         with open(path, 'w+') as f:
-            print "writing to %s" % path
+            print("writing to %s" % path)
             yaml.safe_dump(rosinstall, f, default_flow_style=False)
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print "Use %s distro install_folder" % sys.argv[0]
+        print("Use %s distro install_folder" % sys.argv[0])
         sys.exit()
     translate(sys.argv[1], sys.argv[2])

--- a/scripts/add_devel_repo.py
+++ b/scripts/add_devel_repo.py
@@ -52,7 +52,8 @@ def add_devel_repository_fuerte(yaml_file, data, name, vcs_type, url, version):
     values['version'] = version
     data['repositories'][name] = values
     sort_yaml_data(data)
-    yaml.dump(data, file(yaml_file, 'w'), default_flow_style=False)
+    with open(yaml_file, 'w') as out_file:
+        yaml.dump(data, out_file, default_flow_style=False)
 
 
 if __name__ == "__main__":

--- a/scripts/add_release_repo.py
+++ b/scripts/add_release_repo.py
@@ -25,7 +25,8 @@ def add_release_repository_fuerte(yaml_file, data, name, url, version):
         'version': version,
     }
     sort_yaml_data(data)
-    yaml.dump(data, file(yaml_file, 'w'), default_flow_style=False)
+    with open(yaml_file, 'w') as out_file:
+        yaml.dump(data, out_file, default_flow_style=False)
 
 
 if __name__ == "__main__":

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -26,6 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
 import argparse
 import os
 import sys

--- a/scripts/check_rosdistro.py
+++ b/scripts/check_rosdistro.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import re
 import yaml
 import argparse
@@ -31,9 +32,9 @@ codeCodes = {
 def printc(text, color):
     """Print in color."""
     if sys.stdout.isatty():
-        print "\033["+codeCodes[color]+"m"+text+"\033[0m"
+        print("\033["+codeCodes[color]+"m"+text+"\033[0m")
     else:
-        print text
+        print(text)
 
 def print_test(msg):
     printc(msg, 'yellow')

--- a/scripts/count_rosdistro_packages.py
+++ b/scripts/count_rosdistro_packages.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import argparse
 from dateutil import parser as dateparser
 import os

--- a/scripts/sort_yaml.py
+++ b/scripts/sort_yaml.py
@@ -13,7 +13,8 @@ def sort_yaml(yaml_file):
         print('This script does not support the new rosdistro yaml files', file=sys.stderr)
         sys.exit(1)
     sort_yaml_data(data)
-    yaml.dump(data, file(yaml_file, 'w'), default_flow_style=False)
+    with open(yaml_file, 'w') as out_file:
+        yaml.dump(data, out_file, default_flow_style=False)
 
 
 def sort_yaml_data(data):

--- a/scripts/yaml2rosinstall.py
+++ b/scripts/yaml2rosinstall.py
@@ -10,7 +10,8 @@ import yaml
 def convert_yaml_to_rosinstall(yaml_file, rosinstall_file):
     data = yaml.load(open(yaml_file, 'r'))
     data = convert_yaml_data_to_rosinstall_data(data)
-    yaml.dump(data, file(rosinstall_file, 'w'), default_flow_style=False)
+    with open(rosinstall_file, 'w') as out_file:
+        yaml.dump(data, out_file, default_flow_style=False)
 
 
 def convert_yaml_data_to_rosinstall_data(data):

--- a/test/fold_block.py
+++ b/test/fold_block.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 next_block_id = 1

--- a/test/rosdep_duplicates_test.py
+++ b/test/rosdep_duplicates_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 
 from scripts.check_duplicates import main as check_duplicates

--- a/test/rosdep_formatting_test.py
+++ b/test/rosdep_formatting_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 
 from scripts.check_rosdep import main as check_rosdep

--- a/test/rosdistro_check_urls_test.py
+++ b/test/rosdistro_check_urls_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 
 from rosdistro import get_index

--- a/test/rosdistro_verify_test.py
+++ b/test/rosdistro_verify_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 
 from rosdistro.verify import verify_files_identical

--- a/test/test_build_caches.py
+++ b/test/test_build_caches.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from collections import OrderedDict
 import os
 

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -11,7 +11,10 @@ import os
 import subprocess
 import sys
 import unittest
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse  # Python 3
+except ImportError:
+    from urlparse import urlparse      # Python 2
 
 import rosdistro
 from scripts import eol_distro_names


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There may be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

* __print()__ is a function in Python 3.
* __file()__ was removed in Python 3 so this PR substitutes __with open() as__ to ensure file handles are closed and promptly garbage collected on all implementations of Python.
* Added Python 3.6 in __allow_failures__ mode as a parallel run in the Travis CI tests.
* Added [__flake8__](http://flake8.pycqa.org) to the Travis CI tests to find __syntax errors__ and __undefined names__.

@mikepurvis @dirk-thomas 
