### PR TITLE
turtlebot3: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10634,13 +10634,14 @@ repositories:
       - turtlebot3
       - turtlebot3_bringup
       - turtlebot3_description
+      - turtlebot3_example
       - turtlebot3_navigation
       - turtlebot3_slam
       - turtlebot3_teleop
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 0.1.6-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.6-0`

## turtlebot3

```
* added turtlebot3_rpicamera.launch for raspberry pi camera
* added waffle pi model (urdf and gazebo)
* added verion check function
* added diagnostics node
* added scripts for reload rules
* added example package
* modified firmware version
* modified param config
* modified topic of gazebo plugin
* modified r200 tf tree
* modified gazebo imu link
* removed the large bag file and added download command from other site
* refactoring for release
* Contributors: Darby Lim, Gilbert, Leon Jung, Pyo
```

## turtlebot3_bringup

```
* refactoring for release
* updated firmware version
* modified param config
* added turtlebot3_rpicamera.launch for raspberry pi camera
* added waffle pi model
* added verion check function
* added diagnostics node
* added scripts for reload rules
* Contributors: Darby Lim, Gilbert, Leon Jung, Pyo
```

## turtlebot3_description

```
* added waffle pi model (urdf and gazebo)
* modified topic of gazebo plugin
* refactoring for release
* modified r200 tf tree
* modified gazebo imu link
* Contributors: Darby Lim, Pyo
```

## turtlebot3_example

```
* added example package
* refactoring for release
* Contributors: Gilbert, Pyo
```

## turtlebot3_navigation

```
* added waffle pi model (urdf and gazebo)
* refactoring for release
* Contributors: Darby Lim, Pyo
```

## turtlebot3_slam

```
* removed the large bag file and added download command from other site
* refactoring for release
* Contributors: Hunter L. Allen, Pyo
```

## turtlebot3_teleop

```
* refactoring for release
* Contributors: Pyo
```
