### PR TITLE
sbg_driver: 1.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9674,7 +9674,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
-      version: 1.1.2-0
+      version: 1.1.5-0
     source:
       type: git
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `1.1.5-0`:

- upstream repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
- release repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.1.2-0`
