### PR TITLE
turtlebot3_simulations: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10682,12 +10682,13 @@ repositories:
     release:
       packages:
       - turtlebot3_fake
-      - turtlebot3_gazebo
+      - turtlebot3_gazebo_plugin
+      - turtlebot3_gazebo_ros
       - turtlebot3_simulations
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 0.1.7-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.7-0`

## turtlebot3_fake

```
* added TurtleBot3 Waffle Pi
* Contributors: Darby Lim
```

## turtlebot3_gazebo_plugin

```
* added turtlebot3_house
* added msg function
* modified gazebo plugin
* modified tb3 control
* modified sensor param
* modified camera position
* modified image_listener
* deleted build folder
* Contributors: Darby Lim
```

## turtlebot3_gazebo_ros

```
* added slam with multiple tb3
* added multi example
* added turtlebot3_house
* modified cmake file
* modified spwn model name
* modified multi slam param
* modified camera position
* modified folder name
* Contributors: Darby Lim
```

## turtlebot3_simulations

```
* added TurtleBot3 Waffle Pi
* added slam with multiple tb3
* added multi example
* added turtlebot3_house
* added turtlebot3_house
* added msg function
* modified gazebo plugin
* modified tb3 control
* modified sensor param
* modified camera position
* modified image_listener
* modified cmake file
* modified spwn model name
* modified multi slam param
* modified camera position
* modified folder name
* Contributors: Darby Lim
```
