### PR TITLE
ifm_o3mxxx: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3242,6 +3242,11 @@ repositories:
       type: git
       url: https://github.com/takiaine/ifm_o3mxxx.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/takiaine/ifm_o3mxxx-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/takiaine/ifm_o3mxxx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm_o3mxxx` to `1.0.1-0`:

- upstream repository: https://github.com/takiaine/ifm_o3mxxx.git
- release repository: https://github.com/takiaine/ifm_o3mxxx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
