### PR TITLE
rosflight: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8511,13 +8511,15 @@ repositories:
     release:
       packages:
       - rosflight
+      - rosflight_firmware
       - rosflight_msgs
       - rosflight_pkgs
+      - rosflight_sim
       - rosflight_utils
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosflight/rosflight-release.git
-      version: 0.1.3-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/rosflight/rosflight.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosflight` to `1.0.0-0`:

- upstream repository: https://github.com/rosflight/rosflight.git
- release repository: https://github.com/rosflight/rosflight-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.3-0`

## rosflight

```
* Fixed Eigen build errors for debian
* Fixed eigen_stl_containers dependency
* Added timer to throttle rate at which params are sent
* made time retrieval 32 bit for millisecond and 64 bit for microsecond
* add includes for std libs to fix build
* use one timer with 10 Hz update
* Cleaned up rosconsole output on startup
* added declarations to rosflight_io header. Successfully tested on a board
* added callback and service advertisement for reboot_to_bootloader
* added header stamp
* some tweaks to the calibration routine
* got rid of stupid eigen size format warning
* added viz_mag to rosflight_utils
* Increased UDP buffer size for sim communications
* changed deque to STL containers in EigenSTL for proper memory alignment
* CMakelists update and include the boost library
* removed sensors from mavrosflight
* Print error codes by name
* Updated mavlink and status message
* updated Jerel's mag and made it a node
* fixed timestamping issue with simulator (need to test on hardware)
* updated firmware
* Got UDP comms working with SIL in Gazebo
* Added UDP support
* Abstracted serial communication layer
* Variable name change to be in accordance with ROS c++ style guide. Changed handle_small_range function name to handle_small_range_msg, to be consistent with the other message handler functions. Changed the if within handle_small_range to a switch. Compiled and run on my machine, works.
* Updated mavlink submodule to latest commit: 5f399ef
* More user-friendly autopilot error-code printing
* Contributors: Cameron McQuinn, Daniel Koch, Devon, Erich Nygaard, James Jackson, Jerel Nielsen, tyler
```

## rosflight_firmware

```
* Update firmware to v1.1.0
* added the firmware library. I think it's right, at least until the firmware changes
* Contributors: Daniel Koch, Gary Ellingson, James Jackson
```

## rosflight_msgs

```
* Small updates to package.xml's and readme
* Updated mavlink and status message
* Contributors: Daniel Koch, James Jackson, tyler
```

## rosflight_pkgs

```
* Small updates to package.xml's and readme
* Contributors: Daniel Koch, James Jackson
```

## rosflight_sim

```
* Update firmware to v1.1.0
* improved acceleration calculation in simulation
* some tweaks to make multi-agent possible
* fixed some issues in SIL
* working SIL multirotor
* Cleaned up simulation launch and parameter files
* updated board layer and python joy nodes
* fixed a memory file write bug
* able to arm, and disarm in simulation, IMU noise activated with motor spinning
* fixed timestamping issue with simulator (need to test on hardware)
* updated firmware
* Got UDP comms working with SIL in Gazebo
* launch files, xacro files, and aircraft parameters for generic multirotor and fixedwing aircraft are added.  They currently use a .dae that comes with gazebo, which might be confusing.  The best solution would be to create our own and include them here
* added some noise with no bias
* added sim, not tested, lacks udp and sensor noise
* Contributors: Daniel Koch, Gary Ellingson, James Jackson, Skyler Tolman, mailto:superjax08@gmail.com
```

## rosflight_utils

```
* parse GLONASS nmea sentences
* headless joy node
* added xbox to command mappings
* added Taranis mappings
* Fixed gps reporting of the number of satellites to report the actual number of satellites instead of a fixed number of 0 when not connected or 4 when connected.
* Contributors: Daniel Koch, Devon, Gary Ellingson, James Jackson, Jesse Wynn, pmarke, mailto:superjax08@gmail.com
```
