### PR TITLE
dartsim: 6.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1633,7 +1633,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/dartsim/dart.git
-      version: v6.3.1
+      version: release-6.3
   dataspeed_can:
     doc:
       type: hg

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1623,6 +1623,17 @@ repositories:
       url: https://github.com/leggedrobotics/darknet_ros.git
       version: master
     status: developed
+  dartsim:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/dartsim/ros-dartsim-release.git
+      version: 6.3.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dartsim/dart.git
+      version: v6.3.1
   dataspeed_can:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `dartsim` to `6.3.1-0`:

- upstream repository: https://github.com/dartsim/dart.git
- release repository: https://github.com/dartsim/ros-dartsim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
