### PR TITLE
turtlebot3_simulations: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10700,13 +10700,12 @@ repositories:
     release:
       packages:
       - turtlebot3_fake
-      - turtlebot3_gazebo_plugin
       - turtlebot3_gazebo_ros
       - turtlebot3_simulations
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 0.2.0-0
+      version: 0.2.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `0.2.4-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## turtlebot3_fake

```
* none
```

## turtlebot3_gazebo_ros

```
* none
```

## turtlebot3_simulations

```
* solved DuplicateVersionsException error
* Contributors: Pyo
```
