### PR TITLE
turtlebot3: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10669,7 +10669,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `0.2.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## turtlebot3

```
* added install directory
* refactoring for release
* Contributors: Pyo
```

## turtlebot3_bringup

```
* refactoring for release
* Contributors: Pyo
```

## turtlebot3_description

```
* refactoring for release
* Contributors: Pyo
```

## turtlebot3_example

```
* added install directory
* refactoring for release
* Contributors: Pyo
```

## turtlebot3_navigation

```
* refactoring for release
* Contributors: Pyo
```

## turtlebot3_slam

```
* none
```

## turtlebot3_teleop

```
* none
```
