### PR TITLE
marvelmind_nav: 1.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6791,7 +6791,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
-      version: 1.0.6-0
+      version: 1.0.8-0
   mastering_ros_demo_pkg:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav` to `1.0.8-0`:

- upstream repository: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package
- release repository: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.6-0`

## marvelmind_nav

- No changes
