### PR TITLE
marvelmind_nav: 1.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4654,7 +4654,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
-      version: 1.0.7-2
+      version: 1.0.8-0
   mav_comm:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav` to `1.0.8-0`:

- upstream repository: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package
- release repository: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.22`
- previous version for package: `1.0.7-2`

## marvelmind_nav

- No changes
