### PR TITLE
turtlebot3_applications: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10701,6 +10701,27 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: kinetic-devel
     status: maintained
+  turtlebot3_applications:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: kinetic-devel
+    release:
+      packages:
+      - turtlebot3_applications
+      - turtlebot3_automatic_parking
+      - turtlebot3_follow_filter
+      - turtlebot3_follower
+      - turtlebot3_panorama
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: kinetic-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications` to `0.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## turtlebot3_applications

```
* added turtlebot3_automatic_parking pkg
* added turtlebot3_follow_filter pkg
* added turtlebot3_follower pkg
* added turtlebot3_automatic_parking pkg
* refactoring to release
* Contributors: Ashe, Chris, Leon Jung, Darby Lim, Gilbert, Pyo
```

## turtlebot3_automatic_parking

```
* added turtlebot3_automatic_parking pkg
* refactoring to release
* Contributors: Gilbert, Leon Jung, Pyo
```

## turtlebot3_follow_filter

```
* added turtlebot3_follow_filter pkg
* refactoring to release
* Contributors: Ashe, Chris
```

## turtlebot3_follower

```
* added turtlebot3_follower pkg
* refactoring to release
* Contributors: Ashe, Chris, Darby Lim
```

## turtlebot3_panorama

```
* added turtlebot3_automatic_parking pkg
* refactoring to release
* Contributors: Chris, Darby Lim
```
