### PR TITLE
pluginlib: 1.12.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -308,6 +308,11 @@ repositories:
       type: git
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/pluginlib-release.git
+      version: 1.12.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.12.0-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## pluginlib

```
* [warning fix]Cherry-pick #103 <https://github.com/ros/pluginlib/issues/103> to melodic-devel (#105 <https://github.com/ros/pluginlib/issues/105>)
* [migration helper] provide a script to convert include statements to use new headers (#104 <https://github.com/ros/pluginlib/issues/104>)
* [migration] use new class_loader headers and fix deprecation warnings (#101 <https://github.com/ros/pluginlib/issues/101>)
* [bugfix] Continue loading classes on error (#85 <https://github.com/ros/pluginlib/issues/85>) (#88 <https://github.com/ros/pluginlib/issues/88>)
* [style] Fix cpplint and lint_cmake errors (#84 <https://github.com/ros/pluginlib/issues/84>)
* move pluginlib in its own folder (#83 <https://github.com/ros/pluginlib/issues/83>)
* Contributors: Mikael Arguedas
```
