### PR TITLE
actionlib: 1.11.13-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -16,6 +16,11 @@ repositories:
       type: git
       url: https://github.com/ros/actionlib.git
       version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/actionlib-release.git
+      version: 1.11.13-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15,7 +15,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/actionlib.git
-      version: melodic-devel
+      version: indigo-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -25,7 +25,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/actionlib.git
-      version: melodic-devel
+      version: indigo-devel
     status: maintained
   angles:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.13-0`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## actionlib

```
* [bugfix] added missing boost/thread/reverse_lock.hpp include (#95 <https://github.com/ros/actionlib/issues/95>)
* Contributors: Robert Haschke
```
