### PR TITLE
open_manipulator: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6026,7 +6026,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `0.1.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## open_manipulator

```
* modified build setting for using yaml-cpp
* Contributors: Pyo
```

## open_manipulator_description

```
* none
```

## open_manipulator_dynamixel_ctrl

```
* none
```

## open_manipulator_gazebo

```
* none
```

## open_manipulator_moveit

```
* none
```

## open_manipulator_msgs

```
* none
```

## open_manipulator_position_ctrl

```
* modified build setting for using yaml-cpp
* Contributors: Pyo
```

## open_manipulator_with_tb3

```
* none
```
