### PR TITLE
dartsim: 6.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1628,7 +1628,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/dartsim/ros-dartsim-release.git
-      version: 6.3.1-0
+      version: 6.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dartsim` to `6.3.1-1`:

- upstream repository: https://github.com/dartsim/dart.git
- release repository: https://github.com/dartsim/ros-dartsim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `6.3.1-0`
