### PR TITLE
robotis_framework: 0.2.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7699,7 +7699,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.7-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.6-0`

## robotis_controller

```
* changed the License and package format to version 2
* changed all values read by bulk read are saved to dxl_state_->bulk_read_table_.
* Modified to prevent duplicate indirect address write
* Contributors: SCH, Zerom, Pyo
```

## robotis_device

```
* fixed a bug that occur when handling bulk read item that does not exist
* changed the License and package format to version 2
* Contributors: SCH, Pyo
```

## robotis_framework

```
* changed all values read by bulk read are saved to dxl_state_->bulk_read_table_.
* Modified to prevent duplicate indirect address write
* fixed a bug that occur when handling bulk read item that does not exist
* changed the License and package format to version 2
* Contributors: SCH, Zerom, Pyo
```

## robotis_framework_common

```
* change the License and package format to version 2
* Contributors: Pyo
```
