### PR TITLE
Add graphviz-dev to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1003,6 +1003,7 @@ graphviz:
   ubuntu: [graphviz]
 graphviz-dev:
   debian: [libgraphviz-dev]
+  fedora: [graphviz-devel]
   ubuntu: [libgraphviz-dev]
 gringo:
   debian: [gringo]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1001,6 +1001,9 @@ graphviz:
   rhel: [graphviz]
   slackware: [graphviz]
   ubuntu: [graphviz]
+graphviz-dev:
+  debian: [libgraphviz-dev]
+  ubuntu: [libgraphviz-dev]
 gringo:
   debian: [gringo]
   fedora: [gringo]


### PR DESCRIPTION
Graphviz development package. Needed by a not yet publicly available catkinized version of [rfsmTools](https://github.com/robotology/rfsmTools).

- https://packages.ubuntu.com/xenial/libgraphviz-dev
- https://packages.debian.org/stretch/libgraphviz-dev

Package exists in all Ubuntu and Debian versions listed in packages.ubuntu.com and packages.debian.org respectively, ~~but I've not checked all supported Ubuntu versions (i.e. haven't checked utopic, vivid, wily, yakkety and zesty)~~. Is there any easy way to check other than manually going through the releases in http://old-releases.ubuntu.com?

I also could not find the package in Fedora, Gentoo or OSX, but I'm not very familiar with those platforms and I may be missing something.

**Edit:** I ended up manually checking those, but the question stands. Is there an easier way?