### PR TITLE
ros_emacs_utils: 0.4.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -473,6 +473,27 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_emacs_utils:
+    doc:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    release:
+      packages:
+      - ros_emacs_utils
+      - rosemacs
+      - roslisp_repl
+      - slime_ros
+      - slime_wrapper
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/code-iai-release/ros_emacs_utils-release.git
+      version: 0.4.12-0
+    source:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_emacs_utils` to `0.4.12-0`:

- upstream repository: https://github.com/code-iai/ros_emacs_utils.git
- release repository: https://github.com/code-iai-release/ros_emacs_utils-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
