### PR TITLE
class_loader: 0.3.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -337,7 +337,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.3.9-0`:

- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.3.8-0`

## class_loader

```
* [bugfix] define PACKAGE_X_DESTINATION to match catkin behavior (#88 <https://github.com/ros/class_loader/issues/88>)
* [migration] Provide alternative headers (#84 <https://github.com/ros/class_loader/issues/84>)
* [style] comply with package format2 xsd (#83 <https://github.com/ros/class_loader/issues/83>) (#85 <https://github.com/ros/class_loader/issues/85>)
* [warnings] c++11 requires at least one argument for ... (#71 <https://github.com/ros/class_loader/issues/71>)
* [style] Use std::string::empty instead comparing with an empty string (#69 <https://github.com/ros/class_loader/issues/69>)
* [style] wrap console bridge invocation lines (#68 <https://github.com/ros/class_loader/issues/68>)
* [copyright] OSRF and not willow in licence header (#67 <https://github.com/ros/class_loader/issues/67>)
* Contributors: David Wagner, Diego Cesar, Mikael Arguedas
```
