### PR TITLE
pluginlib: 1.10.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9379,7 +9379,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.6-0
+      version: 1.10.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.10.7-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.10.6-0`

## pluginlib

```
* Provide a script to convert include statements to use new headers (#108 <https://github.com/ros/pluginlib/issues/108>)
* Provide alternative headers for multi distro support (#106 <https://github.com/ros/pluginlib/issues/106>)
* Contributors: Mikael Arguedas, William Woodall
```
