### PR TITLE
pluginlib: 1.11.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6578,7 +6578,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.11.3-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.11.2-0`

## pluginlib

```
* Provide a script to convert include statements to use new headers (#107 <https://github.com/ros/pluginlib/issues/107>)
* docs: fix minor typo (#100 <https://github.com/ros/pluginlib/issues/100>)
  Replace wrong/outdated manifext.xml with package.xml in the docstring of the constructor.
* Contributors: Alireza, Mikael Arguedas
```
