### PR TITLE
pluginlib: 1.11.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2348,7 +2348,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.11.3-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.11.2-0`

## pluginlib

```
* Provide a script to convert include statements to use new headers (#107 <https://github.com/ros/pluginlib/issues/107>)
* docs: fix minor typo (#100 <https://github.com/ros/pluginlib/issues/100>)
  Replace wrong/outdated manifext.xml with package.xml in the docstring of the constructor.
* Contributors: Alireza, Mikael Arguedas
```
