### PR TITLE
dynamic_reconfigure: 1.5.49-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2739,7 +2739,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.48-0
+      version: 1.5.49-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.49-0`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.5.48-0`

## dynamic_reconfigure

```
* Pep8 (#93 <https://github.com/ros/dynamic_reconfigure/issues/93>)
* Python3 use print function and not statement (#92 <https://github.com/ros/dynamic_reconfigure/issues/92>)
* add shebang line in setup_custom_pythonpath.sh.in template (#91 <https://github.com/ros/dynamic_reconfigure/issues/91>)
* switch to package format 2 (#89 <https://github.com/ros/dynamic_reconfigure/issues/89>)
* remove trailing whitespaces (#88 <https://github.com/ros/dynamic_reconfigure/issues/88>)
* Reraising DynamicReconfigureCallbackException in case of a failing service call (#87 <https://github.com/ros/dynamic_reconfigure/issues/87>)
* Contributors: Arne Hitzmann, Mikael Arguedas
```
