### PR TITLE
change mapping of python-imaging since the package was removed from bionic

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1399,7 +1399,7 @@ python-imaging:
       packages: [python-pillow]
   ubuntu:
     artful: [python-imaging]
-    bionic: [python-imaging]
+    bionic: [python-pil]
     lucid: [python-imaging]
     maverick: [python-imaging]
     natty: [python-imaging]


### PR DESCRIPTION
To address the failing CI from ros/ros_comm#1350 as well as the now failing binary job (http://build.ros.org/view/Msrc_uB/job/Mbin_uB64__rosbag__ubuntu_bionic_amd64__binary/3/).