### PR TITLE
navigation: 1.14.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5487,7 +5487,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.2-0
+      version: 1.14.3-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.14.3-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.14.2-0`

## amcl

```
* Merge pull request #678 <https://github.com/ros-planning/navigation/issues/678> from SammysHP/patch-1
  Fix minor typo
* Merge pull request #666 <https://github.com/ros-planning/navigation/issues/666> from SteveMacenski/kinetic-devel
  removing recomputation of cluster stats causing assertion error (#634 <https://github.com/ros-planning/navigation/issues/634>)
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson, SammysHP, stevemacenski
```

## base_local_planner

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* CostmapModel: Make lineCost and pointCost public (#660 <https://github.com/ros-planning/navigation/issues/660>)
  Make the methods lineCost and pointCost of the CostmapModel class
  public so they can be used outside of the class.
  Both methods are not changing the instance, so this should not cause any
  problems.  To emphasise their constness, add the actual const keyword.
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Felix Widmaier, Michael Ferguson
```

## carrot_planner

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## clear_costmap_recovery

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
* Contributors: Aaron Hoy, Michael Ferguson, Mikael Arguedas
```

## costmap_2d

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Fixes #206 <https://github.com/ros-planning/navigation/issues/206> for kinetic (#663 <https://github.com/ros-planning/navigation/issues/663>)
  * Fixes #206 <https://github.com/ros-planning/navigation/issues/206> for kinetic
* fix 'enable' for static_layer with rolling window (#659 <https://github.com/ros-planning/navigation/issues/659>)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, David V. Lu!!, Jannik Abbenseth, Michael Ferguson
```

## dwa_local_planner

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## fake_localization

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## global_planner

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo (#636 <https://github.com/ros-planning/navigation/issues/636>)
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## map_server

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Contributors: Aaron Hoy, Aurélien Labate, Michael Ferguson
```

## move_base

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo (`#636
* Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
* Contributors: Aaron Hoy, David V. Lu!!, Jorge Santos Simón, Michael Ferguson
```

## move_slow_and_clear

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
* Contributors: Aaron Hoy, Michael Ferguson, Mikael Arguedas
```

## nav_core

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## navfn

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* added message_generation to build deps to prevent failing generation of GetStatus, MakeNavPlan and SetCostmap (#640 <https://github.com/ros-planning/navigation/issues/640>)
* Rebase PRs from Indigo (#636 <https://github.com/ros-planning/navigation/issues/636>)
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
* update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
* Contributors: Aaron Hoy, David V. Lu!!, Leroy Rügemer, Michael Ferguson, Mikael Arguedas
```

## navigation

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## robot_pose_ekf

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Fixes #313 <https://github.com/ros-planning/navigation/issues/313> (kinetic) (#654 <https://github.com/ros-planning/navigation/issues/654>)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* added message_generation to build deps to prevent failing generation of GetStatus, MakeNavPlan and SetCostmap (#640 <https://github.com/ros-planning/navigation/issues/640>)
* Contributors: Aaron Hoy, David V. Lu!!, Leroy Rügemer, Michael Ferguson
```

## rotate_recovery

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* update to use non deprecated pluginlib macro (`#630
* Contributors: Aaron Hoy, Michael Ferguson, Mikael Arguedas
```

## voxel_grid

```
* Merge pull request #672 <https://github.com/ros-planning/navigation/issues/672> from ros-planning/email_update_kinetic
  update maintainer email (kinetic)
* Merge pull request #648 <https://github.com/ros-planning/navigation/issues/648> from aaronhoy/kinetic_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```
