### PR TITLE
nodelet_core: 1.9.15-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.14-0
+      version: 1.9.15-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.15-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.9.14-0`

## nodelet

```
* use new pluginlib headers (#73 <https://github.com/ros/nodelet_core/issues/73>)
* Contributors: Mikael Arguedas
```

## nodelet_core

- No changes

## nodelet_topic_tools

```
* use new pluginlib headers (#73 <https://github.com/ros/nodelet_core/issues/73>)
* Contributors: Mikael Arguedas
```
