### PR TITLE
pr2_simulator: 2.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6836,7 +6836,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_simulator-release.git
-      version: 2.0.9-0
+      version: 2.0.10-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.10-0`:

- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `2.0.9-0`

## pr2_controller_configuration_gazebo

- No changes

## pr2_gazebo

```
* Merge pull request (#139 <https://github.com/pr2/pr2_simulator/issues/139>)
  remove find_package(gazebo), to solve -pthread linking errors
* remove find_package(gazebo), to sovle -pthread linking errors
* Contributors: Kei Okada
```

## pr2_gazebo_plugins

- No changes

## pr2_simulator

- No changes
