### PR TITLE
sbg_driver: 1.1.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3787,6 +3787,21 @@ repositories:
       url: https://github.com/davetcoleman/rviz_visual_tools.git
       version: kinetic-devel
     status: developed
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
+      version: 1.1.6-0
+    source:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
+      version: master
+    status: developed
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `1.1.6-0`:

- upstream repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
- release repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
