### PR TITLE
add Adafruit-MCP3008 and Adafruit-GPIO to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1,3 +1,11 @@
+adafruit-mcp3008-pip:
+  debian:
+    pip:
+      packages: [Adafruit-MCP3008]
+adafruit-gpio-pip:
+  debian:
+    pip:
+      packages: [Adafruit-GPIO]
 adafruit-pca9685-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2,8 +2,14 @@ adafruit-gpio-pip:
   debian:
     pip:
       packages: [Adafruit-GPIO]
+  ubuntu:
+    pip:
+      packages: [Adafruit-GPIO]
 adafruit-mcp3008-pip:
   debian:
+    pip:
+      packages: [Adafruit-MCP3008]
+  ubuntu:
     pip:
       packages: [Adafruit-MCP3008]
 adafruit-pca9685-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1,11 +1,11 @@
-adafruit-mcp3008-pip:
-  debian:
-    pip:
-      packages: [Adafruit-MCP3008]
 adafruit-gpio-pip:
   debian:
     pip:
       packages: [Adafruit-GPIO]
+adafruit-mcp3008-pip:
+  debian:
+    pip:
+      packages: [Adafruit-MCP3008]
 adafruit-pca9685-pip:
   debian:
     pip:


### PR DESCRIPTION
This adds two rosdep Python pip package definitions for Adafruit-MCP3008 and Adafruit-GPIO which I am using in my ROS project.

Tested as suggested in the contribution guidelines:
```
ros-dev:sources.list.d $ rosdep update
reading in sources list data from /etc/ros/rosdep/sources.list.d
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Hit https://raw.githubusercontent.com/sheaffej/rosdistro/master/rosdep/python.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
Add distro "groovy"
Add distro "hydro"
Add distro "indigo"
Add distro "jade"
Add distro "kinetic"
Add distro "lunar"
Add distro "melodic"
updated cache in /home/jsheaffe/.ros/rosdep/sources.cache

ros-dev:sources.list.d $ rosdep resolve adafruit-mcp3008-pip
#pip
Adafruit-MCP3008

ros-dev:sources.list.d $ rosdep resolve adafruit-gpio-pip
#pip
Adafruit-GPIO

ros-dev:sources.list.d $ pip search Adafruit | grep MCP3008
Adafruit-MCP3008 (1.0.2)                   - Python code to use the MCP3008 analog to digital converter with a Raspberry Pi or BeagleBone black.

ros-dev:sources.list.d $ pip search Adafruit | grep GPIO
Adafruit-GPIO (1.0.3)                      - Library to provide a cross-platform GPIO interface on the Raspberry Pi and Beaglebone Black using the RPi.GPIO and Adafruit_BBIO libraries.

ros-dev:sources.list.d $
```