### PR TITLE
python-pathos: add package in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1998,7 +1998,7 @@ python-path.py:
   ubuntu:
     pip:
       packages: [path.py]
-python-pathos:
+python-pathos-pip:
   debian:
     pip:
       packages: [pathos]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1998,6 +1998,13 @@ python-path.py:
   ubuntu:
     pip:
       packages: [path.py]
+python-pathos:
+  debian:
+    pip:
+      packages: [pathos]
+  ubuntu:
+    pip:
+      packages: [pathos]
 python-pathtools:
   debian: [python-pathtools]
   ubuntu:


### PR DESCRIPTION
This is a standard pip package, located [here](https://pypi.python.org/pypi/pathos).

pathos is used to provide interfaces to do distributed computing and to do computations in parallel. We use it for the latter using the pool interface.

From the docs:
`The high-level pool.map interface, yields a map implementation that hides the RPC internals from the user. With pool.map, the user can launch their code in parallel, and as a distributed service, using standard python and without writing a line of server or parallel batch code.`

I am conscious it is not much but we use it for less than 5 LOC in our package for now.


