### PR TITLE
urdf: 1.13.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -621,6 +621,25 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: melodic-devel
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf-release.git
+      version: 1.13.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: melodic-devel
+    status: maintained
   urdfdom_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `1.13.0-0`:

- upstream repository: https://github.com/ros/urdf.git
- release repository: https://github.com/ros-gbp/urdf-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## urdf

```
* Add in TinyXML2 versions of the initXml API.
  Also add in some tests, and add in a deprecation warning
  for the TinyXML versions of the APIs.
* Add some tests for the 'initXml' family of methods.
* Small CMake fixups.
  In particular, make sure we define the correct define when
  building on WIN32.  Also do whitespace cleanup.
* Windows compatibility from ROS2.
* Style fixes from ROS2
* update links now that this is in its own repo (#7 <https://github.com/ros/urdf/issues/7>)
* Contributors: Chris Lalancette, Dmitry Rozhkov, Mikael Arguedas
```

## urdf_parser_plugin

```
* update links now that this is in its own repo (#7 <https://github.com/ros/urdf/issues/7>)
* Contributors: Mikael Arguedas
```
