### PR TITLE
resource_retriever: 1.12.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -389,6 +389,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/resource_retriever-release.git
+      version: 1.12.4-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: kinetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.4-0`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## resource_retriever

```
* Fix an intermittent test failure.
  Both the C++ and python tests were using test/large_file.dat,
  which means if they were run concurrently, they would sometimes
  collide.  Avoid this by having them use different filenames.
* Cleanup resource_retriever packaging.
  In particular, make sure that resource_retriever properly
  depends on all of the things it needs.  While we are in here,
  switch over to package xml version 2.
* Contributors: Chris Lalancette
```
