### PR TITLE
joint_state_publisher: 1.12.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3611,7 +3611,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.12.12-0
+      version: 1.12.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `1.12.13-0`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros-gbp/joint_state_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `1.12.12-0`

## joint_state_publisher

```
* add bugtracker link now that this is not hosted on robot_model anymore
* Added a scrollarea around the gridlayout to support large number of joints
* pass robot objects into init_collada() and init_urdf()
* add test for collada supports
* add support for collada model : moved from https://github.com/ros/robot_model/pull/97
* Contributors: Guillaume Walck, Kei Okada, Mikael Arguedas
```
