### PR TITLE
control_msgs: 1.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -145,6 +145,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.4.0-0`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## control_msgs

```
* Add antiwindup to JointControllerState message definition
* Add PidState message
* Contributors: Paul Bovbel
```
