### PR TITLE
realtime_tools: 1.11.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -441,6 +441,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.11.0-0`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## realtime_tools

```
* Updated RT goal handle to handle cancel requests (#22 <https://github.com/ros-controls/realtime_tools/issues/22>)
* switch to industrial_ci (#20 <https://github.com/ros-controls/realtime_tools/issues/20>)
* Contributors: Mathias Lüdtke, Nick Lamprianidis
```
