### PR TITLE
unique_identifier: 1.0.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -699,6 +699,15 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
+    release:
+      packages:
+      - unique_id
+      - unique_identifier
+      - uuid_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-geographic-info/unique_identifier-release.git
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/unique_identifier.git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier` to `1.0.6-0`:

- upstream repository: https://github.com/ros-geographic-info/unique_identifier.git
- release repository: https://github.com/ros-geographic-info/unique_identifier-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## unique_id

- No changes

## unique_identifier

- No changes

## uuid_msgs

- No changes
