### PR TITLE
turtlebot3_autorace: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10733,6 +10733,27 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
       version: kinetic-devel
     status: developed
+  turtlebot3_autorace:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: kinetic-devel
+    release:
+      packages:
+      - turtlebot3_autorace
+      - turtlebot3_autorace_camera
+      - turtlebot3_autorace_control
+      - turtlebot3_autorace_core
+      - turtlebot3_autorace_detect
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: kinetic-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_autorace` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## turtlebot3_autorace

```
* refactoring to release
* updated control_parking.py
* fixed the dependencies
* first upload of turtlebot3_autorace
* Contributors: Leon Jung, Pyo
```

## turtlebot3_autorace_camera

```
* refactoring to release
* fixed the dependencies
* first upload of turtlebot3_autorace
* Contributors: Leon Jung, Pyo
```

## turtlebot3_autorace_control

```
* refactoring to release
* fixed the dependencies
* updated control_parking.py
* first upload of turtlebot3_autorace
* Contributors: Leon Jung, Pyo
```

## turtlebot3_autorace_core

```
* refactoring to release
* fixed the dependencies
* first upload of turtlebot3_autorace
* Contributors: Leon Jung, Pyo
```

## turtlebot3_autorace_detect

```
* refactoring to release
* fixed the dependencies
* first upload of turtlebot3_autorace
* Contributors: Leon Jung, Pyo
```
