### PR TITLE
navigation_msgs: 1.13.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -339,6 +339,24 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: jade-devel
+    release:
+      packages:
+      - map_msgs
+      - move_base_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_msgs-release.git
+      version: 1.13.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: jade-devel
+    status: maintained
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `1.13.0-0`:

- upstream repository: https://github.com/ros-planning/navigation_msgs.git
- release repository: https://github.com/ros-gbp/navigation_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## map_msgs

```
* initial release from new repository
* Contributors: Michael Ferguson
```

## move_base_msgs

```
* initial release from new repository
* Contributors: Michael Ferguson
```
