### PR TITLE
dynamixel-workbench-msgs: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1862,7 +1862,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
-      version: 0.1.7-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench-msgs` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.7-0`

## dynamixel_workbench_msgs

```
* changed package.xml to format v2
* created .travis.yml
* Contributors: Pyo
```
