### PR TITLE
pr2_robot: 1.6.26-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9872,14 +9872,17 @@ repositories:
     release:
       packages:
       - imu_monitor
+      - pr2_bringup
+      - pr2_camera_synchronizer
       - pr2_computer_monitor
       - pr2_controller_configuration
       - pr2_ethercat
+      - pr2_robot
       - pr2_run_stop_auto_restart
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_robot-release.git
-      version: 1.6.23-1
+      version: 1.6.26-0
     source:
       type: git
       url: https://github.com/pr2/pr2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.26-0`:

- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.6.23-1`

## imu_monitor

- No changes

## pr2_bringup

- No changes

## pr2_camera_synchronizer

- No changes

## pr2_computer_monitor

- No changes

## pr2_controller_configuration

- No changes

## pr2_ethercat

- No changes

## pr2_robot

- No changes

## pr2_run_stop_auto_restart

- No changes
