### PR TITLE
dynamixel-workbench: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1845,7 +1845,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.2.4-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.3-0`

## dynamixel_workbench

```
* changed package.xml to format v2
* Contributors: Pyo
```

## dynamixel_workbench_controllers

```
* changed package.xml to format v2
* Contributors: Pyo
```

## dynamixel_workbench_operators

```
* changed package.xml to format v2
* Contributors: Pyo
```

## dynamixel_workbench_single_manager

```
* changed package.xml to format v2
* Contributors: Pyo
```

## dynamixel_workbench_single_manager_gui

```
* changed package.xml to format v2
* Contributors: Pyo
```

## dynamixel_workbench_toolbox

```
* changed package.xml to format v2
* Contributors: Pyo
```
