### PR TITLE
robotis_framework: 0.2.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7699,7 +7699,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.8-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.7-0`

## robotis_controller

```
* modified CMakeLists.txt for system dependencies (yaml-cpp)
* Contributors: Zerom, Pyo
```

## robotis_device

```
* added RH-P12-RN.device file
* Contributors: Zerom, Pyo
```

## robotis_framework

```
* added RH-P12-RN.device file
* modified CMakeLists.txt for system dependencies (yaml-cpp)
* Contributors: Zerom, Pyo
```

## robotis_framework_common

```
* tested for system dependencies
* Contributors: Pyo
```
