### PR TITLE
agni_tf_tools: release 0.1.0 into indigo, kinetic, lunar

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -150,6 +150,21 @@ repositories:
       url: https://github.com/atenpas/agile_grasp.git
       version: master
     status: maintained
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    status: maintained
   agvs_common:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -121,6 +121,21 @@ repositories:
       url: https://github.com/tork-a/adi_driver.git
       version: master
     status: developed
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    status: maintained
   agvs_common:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -62,6 +62,21 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/advanced_navigation_driver.git
       version: master
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    status: maintained
   angles:
     doc:
       type: git


### PR DESCRIPTION
- upstream repository: https://github.com/ubi-agni/agni_tf_tools.git
- release repository: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
- distro file: `[indigo | kinetic | lunar]/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`
