### PR TITLE
Adding vtec_ros to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11659,6 +11659,11 @@ repositories:
       url: https://github.com/ros-drivers/vrpn_client_ros.git
       version: kinetic-devel
     status: maintained
+  vtec_ros:
+    doc:
+      type: git
+      url: https://github.com/lukscasanova/vtec_ros.git
+      version: master
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add vtec_ros to be indexed and documented on ros.org