### PR TITLE
robotis_utility: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7789,7 +7789,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_utility` to `0.1.3-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## robotis_utility

```
* fixed movement_done msg publish bug
* changed package format to v2 and LICENSE to Apache 2.0
* Contributors: Zerom, Pyo
```

## ros_madplay_player

```
* changed package format to v2 and LICENSE to Apache 2.0
* fixed movement_done msg publish bug
* Contributors: Zerom, Pyo
```

## ros_mpg321_player

```
* fixed movement_done msg publish bug
* changed package format to v2 and LICENSE to Apache 2.0
* Contributors: Zerom, Pyo
```
