### PR TITLE
robotis_op3_msgs: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7765,12 +7765,13 @@ repositories:
       packages:
       - op3_action_module_msgs
       - op3_offset_tuner_msgs
+      - op3_online_walking_module_msgs
       - op3_walking_module_msgs
       - robotis_op3_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3_msgs` to `0.1.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## op3_action_module_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## op3_offset_tuner_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## op3_online_walking_module_msgs

```
* added online walking module msgs
* changed package.xml format to v2
* Contributors: SCH, Pyo
```

## op3_walking_module_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## robotis_op3_msgs

```
* added online walking module msgs
* changed package.xml format to v2
* Contributors: Pyo
```
