### PR TITLE
qt_gui_core: 0.3.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -423,6 +423,29 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: kinetic-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/qt_gui_core-release.git
+      version: 0.3.8-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: kinetic-devel
+    status: maintained
   qwt_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.8-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## qt_dotgraph

```
* add recursive subgraph parsing, box3d shape, graphics items now immediately parented (#87 <https://github.com/ros-visualization/qt_gui_core/issues/87>)
```

## qt_gui

- No changes

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
