### PR TITLE
rqt: 0.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -740,6 +740,27 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.5.0-0`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rqt_gui

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_gui_cpp

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_gui_py

```
* version bump to match version of migrated package rqt_py_common
```

## rqt_py_common

```
* migrated from rqt_common_plugins repo
```
