### PR TITLE
roslint: 0.11.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -709,6 +709,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  roslint:
+    doc:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/roslint-release.git
+      version: 0.11.2-0
+    source:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    status: maintained
   roslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslint` to `0.11.2-0`:

- upstream repository: https://github.com/ros/roslint.git
- release repository: https://github.com/ros-gbp/roslint-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `null`

## roslint

```
* Define xrange() for Python 3 (#60 <https://github.com/ros/roslint/issues/60>)
* Contributors: cclauss
```
