### PR TITLE
rqt_logger_level: 0.4.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -791,6 +791,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_graph.git
       version: master
     status: maintained
+  rqt_logger_level:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_logger_level-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    status: maintained
   rqt_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rqt_logger_level

- No changes
