### PR TITLE
rqt_msg: 0.4.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -852,6 +852,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_logger_level.git
       version: master
     status: maintained
+  rqt_msg:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_msg-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: master
+    status: maintained
   rqt_plot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros-gbp/rqt_msg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rqt_msg

- No changes
