### PR TITLE
rqt_bag: 0.4.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -804,7 +804,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_bag-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `0.4.12-0`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros-gbp/rqt_bag-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.4.11-0`

## rqt_bag

```
* add support for opening multiple bag files at once (#25 <https://github.com/ros-visualization/rqt_bag/issues/25>)
* fix debug/warning messages for unicode filenames (#26 <https://github.com/ros-visualization/rqt_bag/issues/26>)
```

## rqt_bag_plugins

- No changes
