### PR TITLE
geometry2: 0.5.17-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -293,6 +293,34 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    release:
+      packages:
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry2-release.git
+      version: 0.5.17-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    status: maintained
   gl_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.5.17-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## geometry2

- No changes

## tf2

```
* Merge pull request #278 <https://github.com/ros/geometry2/issues/278> from ros/chain_as_vec_test2
  Clean up results of _chainAsVector
* Simple test to check BufferCore::_chainAsVector.
  Unit tests for walk and chain passing now.
* Merge pull request #267 <https://github.com/ros/geometry2/issues/267> from at-wat/speedup-timecache-for-large-buffer
  Speed-up TimeCache search for large cache time.
* Merge pull request #265 <https://github.com/ros/geometry2/issues/265> from vsherrod/interpolation_fix
  Corrected time output on interpolation function.
* Add time_interval option to tf2 speed-test.
* Merge pull request #269 <https://github.com/ros/geometry2/issues/269> from ros/frames_as_yaml
  allFrameAsYaml consistently outputting a dict
* resolve https://github.com/ros/geometry/pull/153 at the source instead of needing the workaround.
* Speed-up TimeCache search for large cache time.
* Modified tests for correct time in interpolation to existing tests.
* Corrected time output on interpolation function.
  Added unit test to check for this.
* Contributors: Atsushi Watanabe, Miguel Prada, Tully Foote, Vallan Sherrod
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

```
* Merge pull request #257 <https://github.com/ros/geometry2/issues/257> from delftrobotics-forks/python3
  Make tf2_py python3 compatible again
* Use python3 print function.
* Contributors: Maarten de Vries, Tully Foote
```

## tf2_msgs

- No changes

## tf2_py

```
* Merge pull request #266 <https://github.com/ros/geometry2/issues/266> from randoms/indigo-devel
  fix METH_OLDARGS is no longer supported error in python3
* Merge pull request #260 <https://github.com/ros/geometry2/issues/260> from randoms/indigo-devel
  fix python3 import error
* Merge pull request #257 <https://github.com/ros/geometry2/issues/257> from delftrobotics-forks/python3
  Make tf2_py python3 compatible again
* Use string conversion from python_compat.h.
* Contributors: Maarten de Vries, Tully Foote, randoms
```

## tf2_ros

```
* Merge pull request #260 <https://github.com/ros/geometry2/issues/260> from randoms/indigo-devel
  fix python3 import error
* Merge pull request #257 <https://github.com/ros/geometry2/issues/257> from delftrobotics-forks/python3
  Make tf2_py python3 compatible again
* Use python3 print function.
* Contributors: Maarten de Vries, Tully Foote, randoms
```

## tf2_sensor_msgs

```
* Merge pull request #257 <https://github.com/ros/geometry2/issues/257> from delftrobotics-forks/python3
  Make tf2_py python3 compatible again
* Use python3 print function.
* Contributors: Maarten de Vries, Tully Foote
```

## tf2_tools

```
* Merge pull request #268 <https://github.com/ros/geometry2/issues/268> from smnogar/indigo-devel
  Fixed for cases of non-standard python install
* Contributors: Steve Nogar, Tully Foote
```
