### PR TITLE
Added Arch names for libqt5x11extras5-dev and libqtwebkit-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2747,6 +2747,7 @@ libqt5-widgets:
   slackware: [qt5]
   ubuntu: [libqt5widgets5]
 libqt5x11extras5-dev:
+  arch: [qt5-x11extras]
   debian: [libqt5x11extras5-dev]
   fedora: [qt5-qtx11extras-devel]
   freebsd: [qt5-x11extras]
@@ -2759,6 +2760,7 @@ libqtgui4:
   gentoo: ['dev-qt/qtgui:4']
   ubuntu: [libqtgui4]
 libqtwebkit-dev:
+  arch: [qt5-webkit]
   debian: [libqtwebkit-dev]
   fedora: [qtwebkit-devel]
   gentoo: [dev-qt/qtwebkit]


### PR DESCRIPTION
Nothing crazy, these were just missing their arch naming variants.