### PR TITLE
geometry2: 0.6.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.5.17-0
+      version: 0.6.0-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -319,7 +319,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/geometry2.git
-      version: indigo-devel
+      version: melodic-devel
     release:
       packages:
       - geometry2
@@ -341,7 +341,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/geometry2.git
-      version: indigo-devel
+      version: melodic-devel
     status: maintained
   gl_dependency:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.6.0-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.17-0`

## geometry2

- No changes

## tf2

```
* Replaced deprecated log macro calls
* Contributors: Tim Rakowski, Tully Foote
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* Boilerplate for Sphinx (#284 <https://github.com/ros/geometry2/issues/284>)
  Fixes #264 <https://github.com/ros/geometry2/issues/264>
* tf2_geometry_msgs added doTransform implementations for not stamped types (#262 <https://github.com/ros/geometry2/issues/262>)
  * tf2_geometry_msgs added doTransform implementations for not stamped Point, Quaterion, Pose and Vector3 message types
* New functionality to transform PoseWithCovarianceStamped messages. (#282 <https://github.com/ros/geometry2/issues/282>)
  * New functionality to transform PoseWithCovarianceStamped messages.
* Contributors: Blake Anderson, Tully Foote, cwecht
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* tf2_ros::Buffer: canTransform can now deal with timeouts smaller than 10ms by using the hunderdth of the timeout for sleeping (#286 <https://github.com/ros/geometry2/issues/286>)
* More spinning to make sure the message gets through for #129 <https://github.com/ros/geometry2/issues/129> #283 <https://github.com/ros/geometry2/issues/283>
* Contributors: Tully Foote, cwecht
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
