### PR TITLE
rh_p12_rn: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7567,6 +7567,29 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: jade-devel
     status: maintained
+  rh_p12_rn:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/RH-P12-RN.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rh_p12_rn
+      - rh_p12_rn_base_module
+      - rh_p12_rn_base_module_msgs
+      - rh_p12_rn_description
+      - rh_p12_rn_gazebo
+      - rh_p12_rn_gui
+      - rh_p12_rn_manager
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/RH-P12-RN-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/RH-P12-RN.git
+      version: kinetic-devel
+    status: developed
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rh_p12_rn` to `0.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/RH-P12-RN.git
- release repository: https://github.com/ROBOTIS-GIT-release/RH-P12-RN-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## rh_p12_rn

```
* fixed dependency problems
* changed (torque control -> current control, goal torque -> goal current)
* changed RH-P12-RN.png
* changed package.xml to use format v2
* refactoring to release
* first release
* Contributors: Zerom, Pyo
```

## rh_p12_rn_base_module

```
* fixed dependency problems
* changed (torque control -> current control, goal torque -> goal current)
* changed RH-P12-RN.png
* changed package.xml to use format v2
* refactoring to release
* first release
* Contributors: Zerom, Pyo
```

## rh_p12_rn_base_module_msgs

```
* changed package.xml to use format v2
* refactoring to release
* first release
* Contributors: Zerom, Pyo
```

## rh_p12_rn_description

```
* changed package.xml to use format v2
* refactoring to release
* first release
* Contributors: Zerom, Pyo
```

## rh_p12_rn_gazebo

```
* changed package.xml to use format v2
* refactoring to release
* first release
* Contributors: SCH, Zerom, Pyo
```

## rh_p12_rn_gui

```
* fixed dependency problems
* changed (torque control -> current control, goal torque -> goal current)
* changed RH-P12-RN.png
* changed package.xml to use format v2
* refactoring to release
* first release
* Contributors: Zerom, Pyo
```

## rh_p12_rn_manager

```
* fixed dependency problems
* changed package.xml to use format v2
* refactoring to release
* first release
* Contributors: Zerom, Pyo
```
