### PR TITLE
robotis_framework: 0.2.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7751,7 +7751,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.8-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_framework` to `0.2.9-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.8-0`

## robotis_controller

```
* added serivce for setting module
* deleted comment for debug
* modified to prevent duplicate indirect address write
* added boost system dependencies
* fixed a bug that occure when handling bulk read item that does not exist.
* Contributors: Kayman, Zerom, Pyo
```

## robotis_device

```
* modified to prevent duplicate indirect address write
* fixed a bug that occure when handling bulk read item that does not exist
* Contributors: Zerom
```

## robotis_framework

```
* added serivce for setting module
* deleted comment for debug
* modified to prevent duplicate indirect address write
* added boost system dependencies
* fixed a bug that occure when handling bulk read item that does not exist
* Contributors: Kayman, Zerom, Pyo
```

## robotis_framework_common

```
* none
```
