### PR TITLE
google-cloud-bigquery: add package in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1194,6 +1194,13 @@ python-gnupg:
   fedora: [python-gnupg]
   gentoo: [dev-python/python-gnupg]
   ubuntu: [python-gnupg]
+python-google-cloud-bigquery-pip:
+  debian:
+    pip:
+      packages: [google-cloud-bigquery]
+  ubuntu:
+    pip:
+      packages: [google-cloud-bigquery]
 python-google-cloud-vision-pip:
   debian:
     pip:


### PR DESCRIPTION
Add [google-cloud-bigquery](https://pypi.python.org/pypi/google-cloud-bigquery) pip package. It contains library to communicate with google big query.

Google big query us used to store and do analytics of large datasets. It provides the hardware, infrastructure, UI and command line tools.

We use it to optimize map generation parameters. There are also third-party tools to interact with BigQuery, such as visualizing the data or loading the data.

