### PR TITLE
move_base_flex: 0.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1693,6 +1693,30 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  move_base_flex:
+    doc:
+      type: git
+      url: https://github.com/magazino/move_base_flex.git
+      version: lunar
+    release:
+      packages:
+      - mbf_abstract_core
+      - mbf_abstract_nav
+      - mbf_costmap_core
+      - mbf_costmap_nav
+      - mbf_msgs
+      - mbf_simple_nav
+      - mbf_utility
+      - move_base_flex
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/uos-gbp/move_base_flex-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/magazino/move_base_flex.git
+      version: lunar
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.1.0-0`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## mbf_abstract_core

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_abstract_nav

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_costmap_core

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_costmap_nav

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_msgs

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_simple_nav

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_utility

```
* First release of move_base_flex for kinetic and lunar
```

## move_base_flex

```
* First release of move_base_flex for kinetic and lunar
```
