### PR TITLE
move_base_flex: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4927,7 +4927,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.1.0-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `0.1.0-0`

## mbf_abstract_core

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_abstract_nav

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_costmap_core

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_costmap_nav

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_msgs

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_simple_nav

```
* First release of move_base_flex for kinetic and lunar
```

## mbf_utility

```
* First release of move_base_flex for kinetic and lunar
```

## move_base_flex

```
* First release of move_base_flex for kinetic and lunar
```
