### PR TITLE
rqt_action: 0.4.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -861,6 +861,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_action-release.git
+      version: 0.4.9-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: master
+    status: maintained
   rqt_bag:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `0.4.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros-gbp/rqt_action-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## rqt_action

```
* Add gbiggs as maintainer (#2 <https://github.com/ros-visualization/rqt_action/issues/2>)
```
