### PR TITLE
[lunar][opencv3] Upgrade to patched version of 3.3.1

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2157,7 +2157,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.3.1-0
+      version: 3.3.1-2
     status: maintained
   openni2_camera:
     doc:


### PR DESCRIPTION
Including https://github.com/ros-gbp/opencv3-release/pull/15

The same as Kinetic update: #17136 
@mikaelarguedas @nuclearsandwich Note that to merge this we must manually clear the orig.tar.gz for this rebuild.