### PR TITLE
cartographer: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -65,6 +65,17 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
     status: maintained
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer-release.git
+      version: 0.3.0-0
+    status: developed
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `0.3.0-0`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## cartographer

```
https://github.com/googlecartographer/cartographer/compare/0.2.0...0.3.0
```
