### PR TITLE
Update Gentoo gmock dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -962,7 +962,7 @@ google-mock:
   debian: [google-mock]
   fedora: [gmock-devel]
   freebsd: [googlemock]
-  gentoo: [dev-cpp/gmock]
+  gentoo: [dev-cpp/gtest]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
   ubuntu: [google-mock]


### PR DESCRIPTION
It seems `gmock` was absorbed by `gtest`.

```
# equery belongs /usr/lib64/libgmock.so
 * Searching for /usr/lib64/libgmock.so ... 
dev-cpp/gtest-1.8.0-r1 (/usr/lib64/libgmock.so)
```

I'm not exactly sure how the other distributions are affected, but the Ubuntu gtest version seems to be up to date (at `1.8.0`).