### PR TITLE
navigation: 1.15.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1912,7 +1912,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.15.1-0
+      version: 1.15.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.15.2-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.15.1-0`

## amcl

```
* Fix minor typo (#682 <https://github.com/ros-planning/navigation/issues/682>)
  This typo caused some confusion because we were searching for a semicolon in our configuration.
* Merge pull request #677 <https://github.com/ros-planning/navigation/issues/677> from ros-planning/lunar_634
  removing recomputation of cluster stats causing assertion error (#634 <https://github.com/ros-planning/navigation/issues/634>)
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Remove Dead Code [Lunar] (#646 <https://github.com/ros-planning/navigation/issues/646>)
  * Clean up navfn
  * Cleanup amcl
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson, stevemacenski
```

## base_local_planner

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* CostmapModel: Make lineCost and pointCost public (#658 <https://github.com/ros-planning/navigation/issues/658>)
  Make the methods lineCost and pointCost of the CostmapModel class
  public so they can be used outside of the class.
  Both methods are not changing the instance, so this should not cause any
  problems.  To emphasise their constness, add the actual const keyword.
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Felix Widmaier, Michael Ferguson
```

## carrot_planner

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## clear_costmap_recovery

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo/Kinetic (#637 <https://github.com/ros-planning/navigation/issues/637>)
  * Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
  * Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## costmap_2d

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #670 <https://github.com/ros-planning/navigation/issues/670> from DLu/fix206_lunar
  Fixes #206 <https://github.com/ros-planning/navigation/issues/206> for Lunar
* fix 'enable' for static_layer with rolling window (#659 <https://github.com/ros-planning/navigation/issues/659>) (#665 <https://github.com/ros-planning/navigation/issues/665>)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, David V. Lu!!, Jannik Abbenseth, Michael Ferguson
```

## dwa_local_planner

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## fake_localization

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## global_planner

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo/Kinetic (#637 <https://github.com/ros-planning/navigation/issues/637>)
  * Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
  * Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## map_server

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo/Kinetic (#637 <https://github.com/ros-planning/navigation/issues/637>)
  * Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
  * Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Use occupancy values when saving a map (#613 <https://github.com/ros-planning/navigation/issues/613>)
* Closes #625 <https://github.com/ros-planning/navigation/issues/625> (#627 <https://github.com/ros-planning/navigation/issues/627>)
* Contributors: Aaron Hoy, David V. Lu!!, Hunter Allen, Michael Ferguson
```

## move_base

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo/Kinetic (#637 <https://github.com/ros-planning/navigation/issues/637>)
  * Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
  * Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## move_slow_and_clear

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo/Kinetic (#637 <https://github.com/ros-planning/navigation/issues/637>)
  * Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
  * Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## nav_core

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## navfn

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Remove Dead Code [Lunar] (#646 <https://github.com/ros-planning/navigation/issues/646>)
  * Clean up navfn
  * Cleanup amcl
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo/Kinetic (#637 <https://github.com/ros-planning/navigation/issues/637>)
  * Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
  * Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## navigation

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```

## robot_pose_ekf

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Fixes #313 <https://github.com/ros-planning/navigation/issues/313> (Lunar) (#655 <https://github.com/ros-planning/navigation/issues/655>)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## rotate_recovery

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Rebase PRs from Indigo/Kinetic (#637 <https://github.com/ros-planning/navigation/issues/637>)
  * Respect planner_frequency intended behavior (#622 <https://github.com/ros-planning/navigation/issues/622>)
  * Only do a getRobotPose when no start pose is given (#628 <https://github.com/ros-planning/navigation/issues/628>)
  Omit the unnecessary call to getRobotPose when the start pose was
  already given, so that move_base can also generate a path in
  situations where getRobotPose would fail.
  This is actually to work around an issue of getRobotPose randomly
  failing.
  * Update gradient_path.cpp (#576 <https://github.com/ros-planning/navigation/issues/576>)
  * Update gradient_path.cpp
  * Update navfn.cpp
  * update to use non deprecated pluginlib macro (#630 <https://github.com/ros-planning/navigation/issues/630>)
  * update to use non deprecated pluginlib macro
  * multiline version as well
  * Print SDL error on IMG_Load failure in server_map (#631 <https://github.com/ros-planning/navigation/issues/631>)
* Contributors: Aaron Hoy, David V. Lu!!, Michael Ferguson
```

## voxel_grid

```
* Merge pull request #673 <https://github.com/ros-planning/navigation/issues/673> from ros-planning/email_update_lunar
  update maintainer email (lunar)
* Merge pull request #649 <https://github.com/ros-planning/navigation/issues/649> from aaronhoy/lunar_add_ahoy
  Add myself as a maintainer.
* Contributors: Aaron Hoy, Michael Ferguson
```
