### PR TITLE
python-sklearn-pip: add package in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3198,6 +3198,13 @@ python-sklearn:
     vivid: [python-sklearn]
     wily: [python-sklearn]
     xenial: [python-sklearn]
+python-sklearn-pip:
+  debian:
+    pip:
+      packages: [python-sklearn]
+  ubuntu:
+    pip:
+      packages: [python-sklearn]
 python-slackclient-pip:
   debian:
     pip:


### PR DESCRIPTION
Add [python-scikit-learn](http://scikit-learn.org) pip package. It contains libraries and tools to data mining and data analysis. It's built on NumPy, SciPy, and matplotlib.

It is mainly used for machine learning and features various classification, regression and clustering algorithms.

We use it in our machine learning process to optimize map generation parameters.

Pypi link: https://pypi.python.org/pypi/scikit-learn/0.19.1