### PR TITLE
python-sklearn-deap-pip: add package in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3198,6 +3198,13 @@ python-sklearn:
     vivid: [python-sklearn]
     wily: [python-sklearn]
     xenial: [python-sklearn]
+python-sklearn-deap-pip:
+  debian:
+    pip:
+      packages: [python-sklearn-deap]
+  ubuntu:
+    pip:
+      packages: [python-sklearn-deap]
 python-slackclient-pip:
   debian:
     pip:


### PR DESCRIPTION
Add [python-sklearn-deap](https://github.com/rsteca/sklearn-deap) pip package. It contains libraries to use evolutionary algorithms instead of gridsearch in scikit-learn

This allows you to exponentially reduce the time required to find the best parameters for your estimator. Instead of trying out every possible combination of parameters, evolve only the combinations that give the best results.

We use it in our machine learning process to optimize map generation parameters.

Pypi link: https://pypi.python.org/pypi/sklearn-deap