### PR TITLE
python-fastdtw-pip: add package in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -963,6 +963,13 @@ python-falcon:
   fedora: [python-falcon]
   gentoo: [dev-python/falcon]
   ubuntu: [python-falcon]
+python-fastdtw-pip:
+  debian:
+    pip:
+      packages: [python-fastdtw]
+  ubuntu:
+    pip:
+      packages: [python-fastdtw]
 python-fcn-pip:
   debian:
     pip:


### PR DESCRIPTION
Add [python-fastdtw-pip](https://github.com/slaypni/fastdtw) package. It contains python implementation of the FastDTW algorithm:
http://cs.fit.edu/~pkc/papers/tdm04.pdf

It is an approximate Dynamic Time Warping (DTW) algorithm that provides optimal or near-optimal alignments with an O(N) time and memory complexity.

We use it to find similarities between two temporal sequences in different paths.

Pypi link: https://pypi.python.org/pypi/fastdtw