### PR TITLE
astra_camera: 0.2.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -444,7 +444,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_camera-release.git
-      version: 0.2.1-0
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_camera` to `0.2.2-1`:

- upstream repository: https://github.com/orbbec/ros_astra_camera.git
- release repository: https://github.com/ros-drivers-gbp/astra_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.1-0`

## astra_camera

```
* Add launchfile info and reformat nicely
* Publish projector/camera_info (fixes disparity img)
* modify gcc  optimizate problem
* Contributors: Chan Jun Shern, Martin Günther, Mikael Arguedas, Tim
```
