### PR TITLE
astra_launch: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -459,7 +459,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_launch-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astra_launch` to `0.2.2-0`:

- upstream repository: https://github.com/orbbec/ros_astra_launch.git
- release repository: https://github.com/ros-drivers-gbp/astra_launch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.1-0`

## astra_launch

```
* modifty multi launch
* Contributors: tim_liu
```
