### PR TITLE
rosparam_handler: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12606,7 +12606,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/cbandera/rosparam_handler-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/cbandera/rosparam_handler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_handler` to `0.1.3-0`:

- upstream repository: https://github.com/cbandera/rosparam_handler.git
- release repository: https://github.com/cbandera/rosparam_handler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.2-0`

## rosparam_handler

```
* Merge pull request #50 <https://github.com/cbandera/rosparam_handler/issues/50> from cbandera/develop
  Use industrial_ci & docker
* Merge pull request #45 <https://github.com/cbandera/rosparam_handler/issues/45> from cbandera/feature/travis_industrial_ci
  Change travis conf to use industrial_ci & docker
* Merge pull request #48 <https://github.com/cbandera/rosparam_handler/issues/48> from cbandera/develop
  Fix install rule
* Merge branch 'develop' into feature/travis_industrial_ci
* Merge pull request #46 <https://github.com/cbandera/rosparam_handler/issues/46> from plusone-robotics/plusone/master
  Fix CI Breaking on External Projects
* Merge pull request #3 <https://github.com/cbandera/rosparam_handler/issues/3> from geoffreychiou/gc_fix_ci
  Fixed CI Build Error Caused by rosparam_handler
* added slash at end of include dir
* Merge branch 'develop' into feature/travis_industrial_ci
* change travis conf to use industrial_ci & docker
  - using industrial_ci simplifies a lot the travis conf file
  - using Docker enables CI for kinetic & lunar
* Contributors: Claudio Bandera, Geoffrey Chiou, Jeremie Deray, geoffreychiou
```
