### PR TITLE
rosparam_handler: 0.1.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3158,6 +3158,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rosparam_handler:
+    doc:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/cbandera/rosparam_handler-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    status: developed
   rosparam_shortcuts:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_handler` to `0.1.3-0`:

- upstream repository: https://github.com/cbandera/rosparam_handler.git
- release repository: https://github.com/cbandera/rosparam_handler-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rosparam_handler

```
* Merge pull request #50 <https://github.com/cbandera/rosparam_handler/issues/50> from cbandera/develop
  Use industrial_ci & docker
* Merge pull request #45 <https://github.com/cbandera/rosparam_handler/issues/45> from cbandera/feature/travis_industrial_ci
  Change travis conf to use industrial_ci & docker
* Merge pull request #48 <https://github.com/cbandera/rosparam_handler/issues/48> from cbandera/develop
  Fix install rule
* Merge branch 'develop' into feature/travis_industrial_ci
* Merge pull request #46 <https://github.com/cbandera/rosparam_handler/issues/46> from plusone-robotics/plusone/master
  Fix CI Breaking on External Projects
* Merge pull request #3 <https://github.com/cbandera/rosparam_handler/issues/3> from geoffreychiou/gc_fix_ci
  Fixed CI Build Error Caused by rosparam_handler
* added slash at end of include dir
* Merge branch 'develop' into feature/travis_industrial_ci
* change travis conf to use industrial_ci & docker
  - using industrial_ci simplifies a lot the travis conf file
  - using Docker enables CI for kinetic & lunar
* Contributors: Claudio Bandera, Geoffrey Chiou, Jeremie Deray, geoffreychiou
```
