### PR TITLE
multimaster_fkie: 0.7.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7596,7 +7596,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.7.8-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.7.7-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

```
* Fix catkin_lint warnings
* Merge pull request #69 <https://github.com/fkie/multimaster_fkie/issues/69> from AlexisTM/fix_exit_zeroconf
  Solve zeroconf sys.exit( ..., ...) issue
* Contributors: Alexander Tiderko, Alexis Paques, Timo Röhling
```

## master_sync_fkie

```
* Fix catkin_lint warnings
* Contributors: Timo Röhling
```

## multimaster_fkie

```
* Fix catkin_lint warnings
* node_manager_fkie: fixed crash on errors while open network discovery dialog
* node_manager_fkie: fixed copy function in launch file browser
* node_manager_fkie: fixed file name copy crash
* node_manager_fkie: added more checks while handle nodelet restarts
* node_manager_fkie: added check for restart of nodelet manager
* node_manager_fkie: reset package cache on reload in lauch widget
  so you don't need to restart node_manager if new packages are added at
  runtime
* node_manager_fkie: changed behaviour of detailed message box
* node_manager_fkie: fixed clear in echo dialog
* node_manager_fkie: added shortcut Ctrl+R to restart nodes
* Merge pull request #69 <https://github.com/fkie/multimaster_fkie/issues/69> from AlexisTM/fix_exit_zeroconf
  Solve zeroconf sys.exit( ..., ...) issue
* Contributors: Alexander Tiderko, Alexis Paques, Timo Röhling
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* Fix catkin_lint warnings
* node_manager_fkie: fixed crash on errors while open network discovery dialog
* node_manager_fkie: fixed copy function in launch file browser
* node_manager_fkie: fixed file name copy crash
* node_manager_fkie: added more checks while handle nodelet restarts
* node_manager_fkie: added check for restart of nodelet manager
* node_manager_fkie: reset package cache on reload in lauch widget
  so you don't need to restart node_manager if new packages are added at
  runtime
* node_manager_fkie: changed behaviour of detailed message box
* node_manager_fkie: fixed clear in echo dialog
* node_manager_fkie: added shortcut Ctrl+R to restart nodes
* Contributors: Alexander Tiderko, Timo Röhling
```
