### PR TITLE
hokuyo3d: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1094,6 +1094,21 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: unmaintained
+  hokuyo3d:
+    doc:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/at-wat/hokuyo3d-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: master
+    status: developed
   ifopt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo3d` to `0.2.0-0`:

- upstream repository: https://github.com/at-wat/hokuyo3d.git
- release repository: https://github.com/at-wat/hokuyo3d-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## hokuyo3d

```
* Fix timestamp estimation (#35 <https://github.com/at-wat/hokuyo3d/issues/35>)
  * Fix timestamp estimation
  * Decrease timstamp base lpf
  * Drop timestamp jump back
  * Add median filter to the timestamp estimation
  * Add debug output of estimated timestamp epoch
  * Add parameter to allow timstamp jump back (default: false)
* Install launch files (#32 <https://github.com/at-wat/hokuyo3d/issues/32>)
* Fix horizontal table precision bug (#30 <https://github.com/at-wat/hokuyo3d/issues/30>)
* Fix connection start timing (#29 <https://github.com/at-wat/hokuyo3d/issues/29>)
  * Suppress Transmission timeout error from the sensor
* Support auto reset setting (#27 <https://github.com/at-wat/hokuyo3d/issues/27>)
  * Support auto reset setting
  * Don't send auto reset command if the parameter is not given
* Support vertical interlace added on VSSP2.1 (#25 <https://github.com/at-wat/hokuyo3d/issues/25>)
* Fix local variable naming style (#26 <https://github.com/at-wat/hokuyo3d/issues/26>)
* Use timer instead of polling (#23 <https://github.com/at-wat/hokuyo3d/issues/23>)
* Remove needless semicolons (#22 <https://github.com/at-wat/hokuyo3d/issues/22>)
* Fix CI bot setting (#24 <https://github.com/at-wat/hokuyo3d/issues/24>)
* Fix aux data factors. (#18 <https://github.com/at-wat/hokuyo3d/issues/18>)
* Add a sample launch file to publish frames. (#17 <https://github.com/at-wat/hokuyo3d/issues/17>)
* Fix socket read buffer size. (#14 <https://github.com/at-wat/hokuyo3d/issues/14>)
* Add const attribute to constant things. (#16 <https://github.com/at-wat/hokuyo3d/issues/16>)
* Fix naming style of local variables. (#15 <https://github.com/at-wat/hokuyo3d/issues/15>)
* Fix coding styles. (#12 <https://github.com/at-wat/hokuyo3d/issues/12>)
  - fix coding rules
  - fix naming styles
  - add roslint test
* Fix mag frame_id. (#13 <https://github.com/at-wat/hokuyo3d/issues/13>)
* Change IMU coordinate frame. (#10 <https://github.com/at-wat/hokuyo3d/issues/10>)
* Add build test on Travis. (#11 <https://github.com/at-wat/hokuyo3d/issues/11>)
* Contributors: Atsushi Watanabe
```
