### PR TITLE
manipulator_h: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4548,7 +4548,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git


### PR DESCRIPTION
Increasing version of package(s) in repository `manipulator_h` to `0.3.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.3.0-0`

## manipulator_h

```
* added roslib for catkin dependencies
* Contributors: Pyo
```

## manipulator_h_base_module

```
* added roslib for catkin dependencies
* Contributors: Pyo
```

## manipulator_h_base_module_msgs

```
* added roslib for catkin dependencies
* Contributors: Pyo
```

## manipulator_h_bringup

```
* none
```

## manipulator_h_description

```
* none
```

## manipulator_h_gazebo

```
* none
```

## manipulator_h_gui

```
* none
```

## manipulator_h_kinematics_dynamics

```
* none
```

## manipulator_h_manager

```
* none
```
