### PR TITLE
robotis_op3: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7784,13 +7784,21 @@ repositories:
       packages:
       - cm_740_module
       - op3_action_module
+      - op3_balance_control
+      - op3_base_module
+      - op3_direct_control_module
       - op3_head_control_module
       - op3_kinematics_dynamics
+      - op3_localization
+      - op3_manager
+      - op3_online_walking_module
+      - op3_walking_module
       - open_cr_module
+      - robotis_op3
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## cm_740_module

```
* added C++11 build option
* changed package.xml to use format v2
* refactoring to release
* Contributors: Kayman, Pyo
```

## op3_action_module

```
* changed package.xml to use format v2
* refactoring to release
* Contributors: Kayman, SCH, Pyo
```

## op3_balance_control

```
* first release of op3_balance_control package
* added wholebody module
* added C++11 build option
* changed package.xml to use format v2
* refactoring to release
* Contributors: Kayman, SCH, Pyo
```

## op3_base_module

```
* changed method to setting module(msg -> srv)
* fixed a bug to jump to init pose
* fixed a bug in head_control_module that wrong init vel or accel is set for generating trajectory in middle of moving
* changed a method of setting module in base_module
* added C++11 build option
* changed package.xml to use format v2
* refactoring to release
* Contributors: Kayman, Pyo
```

## op3_direct_control_module

```
* refactoring to release
* changed package.xml to use format v2
* Contributors: Pyo
```

## op3_head_control_module

```
* increased scanning speed
* fixed bug that the garbage value entered the initial value of velocity/acceleration to generate a trajectory
* fixed a bug in head_control_module that wrong init vel or accel is set for generating trajectory in middle of moving
* changed a method of setting module in base_module
* changed package.xml to use format v2
* refactoring to release
* Contributors: Kayman, Pyo
```

## op3_kinematics_dynamics

```
* added wholebody module
* changed package.xml to use format v2
* refactoring to release
* Contributors: Pyo, SCH
```

## op3_localization

```
* first release of op3_localization package
* added wholebody module update & localization
* added online walking module
* changed package.xml to use format v2
* refactoring to release
* Contributors: Kayman, SCH, Pyo
```

## op3_manager

```
* added wholebody module
* added online walking module
* added body offset z
* added C++11 build option
* deleted op3_optimization node in op3_manager.launch
* changed dynamixel code for deprecated function
* changed package.xml to use format v2
* refactoring to rele
* Contributors: Kayman, Pyo, SCH
```

## op3_online_walking_module

```
* first release of op3_online_walking_module package
* added LICENSE
* deleted op3_optimization
* deleted debug print
* Contributors: Kayman, Pyo, SCH
```

## op3_walking_module

```
* added debug print
* changed package.xml to use format v2
* refactoring to release
* Contributors: Kayman, Pyo
```

## open_cr_module

```
* refactoring to release
* changed package.xml to use format v2
* Contributors: Pyo
```

## robotis_op3

```
* first release of op3_online_walking_module package
* first release of op3_localization package
* first release of op3_balance_control package
* added C++11 build option
* deleted op3_optimization
* changed package.xml to use format v2
* op3_base_module:
  changed method to setting module(msg -> srv)
  fixed a bug to jump to init pose
  fixed a bug in head_control_module that wrong init vel or accel is set for generating trajectory in middle of moving
  changed a method of setting module in base_module
  added C++11 build option
* op3_head_control_module:
  increased scanning speed
  fixed bug that the garbage value entered the initial value of velocity/acceleration to generate a trajectory
  fixed a bug in head_control_module that wrong init vel or accel is set for generating trajectory in middle of moving.
  changed a method of setting module in base_module
* op3_manager:
  added wholebody module
  added online walking module
  added body offset z
  added C++11 build option
  deleted op3_optimization node in op3_manager.launch
  changed dynamixel code for deprecated function
* op3_walking_module:
  added debug print
* refactoring to release
* Contributors: Kayman, SCH, Pyo
```
