### PR TITLE
robotis_op3_common: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7804,6 +7804,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git
       version: kinetic-devel
     status: developed
+  robotis_op3_common:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - op3_description
+      - op3_gazebo
+      - robotis_op3_common
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-Common-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Common.git
+      version: kinetic-devel
+    status: developed
   robotis_op3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3_common` to `0.1.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Common.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-Common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## op3_description

```
* changed package names and paths related for OP Series
* Contributors: Pyo
```

## op3_gazebo

```
* changed package names and paths related for OP Series
* Contributors: Pyo
```

## robotis_op3_common

```
* changed package names and paths related for OP Series
* Contributors: Pyo
```
