### PR TITLE
robotis_op3: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7798,7 +7798,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3` to `0.2.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## cm_740_module

```
* none
```

## op3_action_module

```
* none
```

## op3_balance_control

```
* none
```

## op3_base_module

```
* none
```

## op3_direct_control_module

```
* none
```

## op3_head_control_module

```
* none
```

## op3_kinematics_dynamics

```
* none
```

## op3_localization

```
* none
```

## op3_manager

```
* none
```

## op3_online_walking_module

```
* modified preview_response to fix operator matching bug on i386 machine
* Contributors: SCH
```

## op3_walking_module

```
* none
```

## open_cr_module

```
* none
```

## robotis_op3

```
* modified preview_response to fix operator matching bug on i386 machine
* Contributors: SCH
```
