### PR TITLE
Added libb64-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1390,6 +1390,12 @@ libavahi-core-dev:
   fedora: [avahi-devel]
   gentoo: [net-dns/avahi]
   ubuntu: [libavahi-core-dev]
+libb64-dev:
+  arch: [libb64]
+  debian: [libb64-dev]
+  fedora: [libb64-devel]
+  gentoo: [libb64]
+  ubuntu: [libb64-dev]
 libbison-dev:
   debian: [libbison-dev]
   fedora: [bison-devel]


### PR DESCRIPTION
Added a (DAMN fast[sic!]) c++ lib for encoding/decoding base64

arch: https://www.archlinux.org/packages/community/x86_64/libb64/
debian: https://packages.debian.org/sid/libb64-dev
fedora: https://fedora.pkgs.org/25/rpm-sphere/libb64-devel-1.2.1-9.1.i686.rpm.html
gentoo: https://packages.gentoo.org/packages/dev-libs/libb64
ubuntu: https://packages.ubuntu.com/xenial/libb64-dev
