### PR TITLE
ros_control: 0.14.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -708,6 +708,23 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_control.git
       version: melodic-devel
+    release:
+      packages:
+      - combined_robot_hw
+      - combined_robot_hw_tests
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - controller_manager_tests
+      - hardware_interface
+      - joint_limits_interface
+      - ros_control
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_control-release.git
+      version: 0.14.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.14.0-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## combined_robot_hw

```
* migrate classloader headers
* Contributors: Mathias Lüdtke
```

## combined_robot_hw_tests

```
* migrate to new class list macros header
* Contributors: Mathias Lüdtke
```

## controller_interface

```
* Switch MultiInterfaceController to use variadic templates.
* Use public virtual for Controller inheritance.
* Contributors: Mike Purvis
```

## controller_manager

```
* migrate classloader headers
* refactored controller_manager unspawner
* fix controller_manager list: migrated to new ControllerState with claimed_resources
* remove debug prints from controller_manager script
* Contributors: Mathias Lüdtke
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Copyright blocks.
* Tests for extensible controllers.
* migrate to new class list macros header
* add tests for controller_manager scripts and nodes
* Contributors: Mathias Lüdtke, Mike Purvis
```

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* migrate to new class list macros header
* migrate classloader headers
* Contributors: Mathias Lüdtke
```
