### PR TITLE
ros_control: 0.13.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2856,7 +2856,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.13.0-0
+      version: 0.13.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.13.1-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `0.13.0-0`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* refactored controller_manager unspawner
* fix controller_manager list: migrated to new ControllerState with claimed_resources
* remove debug prints from controller_manager script
* Contributors: Mathias Lüdtke
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* add tests for controller_manager scripts and nodes
* return 0 in dummy_app main
* Contributors: Mathias Lüdtke
```

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
