### PR TITLE
Add werkzeug to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4721,12 +4721,6 @@ vrep:
     trusty:
       source:
         uri: 'https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest'
-werkzeug:
-  arch: [python-werkzeug]
-  debian: [python-werkzeug]
-  fedora: [python-werkzeug]
-  gentoo: [dev-python/werkzeug]
-  ubuntu: [python-werkzeug]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4721,6 +4721,12 @@ vrep:
     trusty:
       source:
         uri: 'https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest'
+werkzeug:
+  arch: [python-werkzeug]
+  debian: [python-werkzeug]
+  fedora: [python-werkzeug]
+  gentoo: [dev-python/werkzeug]
+  ubuntu: [python-werkzeug]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3828,6 +3828,7 @@ python-webtest:
   gentoo: [dev-python/webtest]
   ubuntu: [python-webtest]
 python-werkzeug:
+  arch: [python-werkzeug]
   debian: [python-werkzeug]
   fedora: [python-werkzeug]
   gentoo: [dev-python/werkzeug]


### PR DESCRIPTION
Web development package used for creating simple web-based operator interfaces.

Package exists for arch, debian, fedora, gentoo, and ubuntu. I tested with `rosdep resolve werkzeug --os=<OS:version>` for all of those distributions. The `nosetests` all pass.