### PR TITLE
oxford_gps_eth: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8894,7 +8894,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `0.0.6-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.5-0`

## oxford_gps_eth

```
* Changed default listen address from broadcast to any
* Added unit tests and rostests
* Added launch file
* Contributors: Kevin Hallenbeck
```
