### PR TITLE
oxford_gps_eth: 0.0.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -472,6 +472,21 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  oxford_gps_eth:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
+      version: 0.0.6-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    status: maintained
   pcl_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `0.0.6-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## oxford_gps_eth

```
* Changed default listen address from broadcast to any
* Added unit tests and rostests
* Added launch file
* Contributors: Kevin Hallenbeck
```
