### PR TITLE
[rosdep][py] Adds svgwrite & svgpathtools

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3332,6 +3332,10 @@ python-support:
     pip:
       packages: []
   ubuntu: [python-support]
+python-svgpathtools:
+  ubuntu: [python-svgpathtools]
+python-svgwrite:
+  ubuntu: [python-svgwrite]
 python-svn:
   debian: [python-svn]
   fedora: [pysvn]


### PR DESCRIPTION
Adds python-svgwrite and svgpathtools for ubuntu.