### PR TITLE
web_interface: 1.0.7-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16560,6 +16560,28 @@ repositories:
       url: https://github.com/jihoonl/waypoint.git
       version: master
     status: developed
+  web_interface:
+    release:
+      packages:
+      - image_stream
+      - launchman
+      - pyclearsilver
+      - ros_apache2
+      - rosjson
+      - rosweb
+      - web_interface
+      - web_msgs
+      - webui
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/UNR-RoboticsResearchLab/web_interface-release.git
+      version: 1.0.7-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/web_interface.git
+      version: indigo-devel
+    status: maintained
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_interface` to `1.0.7-2`:

- upstream repository: https://github.com/UNR-RoboticsResearchLab/web_interface.git
- release repository: https://github.com/UNR-RoboticsResearchLab/web_interface-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## image_stream

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## launchman

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## pyclearsilver

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## ros_apache2

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## rosjson

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## rosweb

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## web_interface

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## web_msgs

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## webui

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```
