### PR TITLE
thormang3_msgs: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10628,7 +10628,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.2-0`

## thormang3_action_module_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## thormang3_feet_ft_module_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## thormang3_head_control_module_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## thormang3_manipulation_module_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## thormang3_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## thormang3_offset_tuner_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```

## thormang3_walking_module_msgs

```
* changed package.xml format to v2
* Contributors: Pyo
```
