### PR TITLE
roch_robot: 1.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11401,10 +11401,8 @@ repositories:
     release:
       packages:
       - roch_base
-      - roch_capabilities
       - roch_control
       - roch_description
-      - roch_ftdi
       - roch_msgs
       - roch_robot
       - roch_safety_controller
@@ -11412,7 +11410,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.16-0
+      version: 1.0.17-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch_robot` to `1.0.17-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch_robot.git
- release repository: https://github.com/SawYerRobotics-release/roch_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.16-0`

## roch_base

```
* Remap email and website.
* Contributors: doudou0114
```

## roch_control

```
* Remap email and website.
* Contributors: doudou0114
```

## roch_description

```
* Remap email and website.
* Contributors: doudou0114
```

## roch_msgs

```
* Remap email and website.
* Contributors: doudou0114
```

## roch_robot

```
* Deprecated roch_capabilities.
* Discard unused packages: roch_ftdi.
* Remap email and website.
* Contributors: SawYer-Robotics, doudou0114
```

## roch_safety_controller

```
* Remap email and website.
* Contributors: doudou0114
```

## roch_sensorpc

```
* Remap email and website.
* Contributors: doudou0114
```
