### PR TITLE
thormang3_mpc_sensors: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10628,6 +10628,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git
       version: kinetic-devel
     status: maintained
+  thormang3_mpc_sensors:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC-SENSORs.git
+      version: kinetic-devel
+    release:
+      packages:
+      - thormang3_imu_3dm_gx4
+      - thormang3_mpc_sensors
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-SENSORs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC-SENSORs.git
+      version: kinetic-devel
+    status: developed
   thormang3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_mpc_sensors` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC-SENSORs.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-SENSORs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## thormang3_imu_3dm_gx4

```
* added meta package for thormang3_mpc_sensors
* added imu package for thormang3
* moved header file
* refactoring to release
* Contributors: SCH, Pyo
```

## thormang3_mpc_sensors

```
* added meta package for thormang3_mpc_sensors
* added imu package for thormang3
* moved header file
* refactoring to release
* Contributors: SCH, Pyo
```
