### PR TITLE
roch: 1.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11367,12 +11367,11 @@ repositories:
       - roch_bringup
       - roch_follower
       - roch_navigation
-      - roch_rapps
       - roch_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch-release.git
-      version: 1.0.15-0
+      version: 1.0.16-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roch` to `1.0.16-0`:

- upstream repository: https://github.com/SawYer-Robotics/roch.git
- release repository: https://github.com/SawYerRobotics-release/roch-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.23`
- previous version for package: `1.0.15-0`

## roch

```
* Clear package.
* Remap email and website.
* Contributors: SawYer-Robotics, doudou0114
```

## roch_bringup

```
* Deprecated rocon.
* Deprecated roch_capabilities.
* Remap email and website.
* Remap official web.
* Contributors: SawYer-Robotics, doudou0114
```

## roch_follower

```
* Remap email and website.
* Contributors: doudou0114
```

## roch_navigation

```
* Remap email and website.
* Contributors: doudou0114
```

## roch_teleop

```
* Update xbox360_teleop.launch
* Update CMakeLists.txt
* Update xbox360_teleop.launch
* Remap email and website.
* Update roch_xbox_joy.cpp
  Add linear & angular speed increase and reduce, buttons are up and down select key.
* Contributors: SawYer-Robotics, Soy Robotics, doudou0114
```
