### PR TITLE
xacro: 1.11.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11974,7 +11974,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.11.3-0`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.11.2-0`

## xacro

```
* extend list of allowed python builtins: min, max, round
* #173 <https://github.com/ros/xacro/issues/173>: allow default values for properties
* #172 <https://github.com/ros/xacro/issues/172>: fix formatting of XacroException
* #182 <https://github.com/ros/xacro/issues/182>: suppress xacro warnings when determining dependencies
* #171 <https://github.com/ros/xacro/issues/171>: fix dependency handling (--deps option)
  * allow to specify extra dependencies for xacro_add_xacro_file(s)
  * consider yaml files loaded with load_yaml
* fixes for #148 <https://github.com/ros/xacro/issues/148> and #149 <https://github.com/ros/xacro/issues/149>
* fix #156 <https://github.com/ros/xacro/issues/156>: avoid access to undefined variable target_table
* fix #148 <https://github.com/ros/xacro/issues/148>: silently ignore extra attributes that are namespace specifiers
* allow True/False literals in python expressions
* Contributors: Robert Haschke, Morgan Quigley, Steven Peters
```
