### PR TITLE
xacro: 1.12.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4426,7 +4426,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.12.0-1
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.12.1-0`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.0-1`

## xacro

```
* #183 <https://github.com/ros/xacro/issues/183>: unicode support for python2 and python3
* #178 <https://github.com/ros/xacro/issues/178>: extend list of allowed python builtins: min, max, round
* #182 <https://github.com/ros/xacro/issues/182>: suppress xacro warnings when determining dependencies
* #151 <https://github.com/ros/xacro/issues/151>: fixes for #149 <https://github.com/ros/xacro/issues/149> and #148 <https://github.com/ros/xacro/issues/148>
* #157 <https://github.com/ros/xacro/issues/157>: fix #156 <https://github.com/ros/xacro/issues/156> access to undefined target_table
* #150 <https://github.com/ros/xacro/issues/150>: allow True/False literals in python expressions
* #159 <https://github.com/ros/xacro/issues/159>: load ROS-related packages on demand, thus becoming more independent from ROS
* #173 <https://github.com/ros/xacro/issues/173>: allow default values for properties
* #172 <https://github.com/ros/xacro/issues/172>: fix formatting of XacroException
* #171 <https://github.com/ros/xacro/issues/171>: fix dependency handling (--deps option)
* #163 <https://github.com/ros/xacro/issues/163>: full python 3 compatibility
* Contributors: Robert Haschke, Kartik Mohta, Morgan Quigley, Steven Peters
```
