### PR TITLE
thormang3_ppc: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10692,11 +10692,13 @@ repositories:
     release:
       packages:
       - thormang3_manipulation_demo
+      - thormang3_ppc
       - thormang3_sensors
+      - thormang3_walking_demo
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_ppc` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## thormang3_manipulation_demo

```
* changed package.xml format to v2
* refactoring to release
* Contributors: Pyo
```

## thormang3_ppc

```
* modified cmake & package for yaml-cpp
* changed package.xml format to v2
* refactoring to release
* Contributors: Pyo
```

## thormang3_sensors

```
* changed package.xml format to v2
* refactoring to release
* Contributors: Pyo
```

## thormang3_walking_demo

```
* modified cmake & package for yaml-cpp
* changed package.xml format to v2
* refactoring to release
* Contributors: Pyo, SCH
```
