### PR TITLE
srdfdom: 0.4.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1243,6 +1243,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_web.git
       version: master
     status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/srdfdom-release.git
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: kinetic-devel
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.4.2-0`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## srdfdom

```
* [fix] gcc6 build error #28 <https://github.com/ros-planning/srdfdom/issues/28>
* [fix] Compile with -std=c++11 (#29 <https://github.com/ros-planning/srdfdom/issues/29>)
* [enhancement] cleanup urdfdom compatibility (#27 <https://github.com/ros-planning/srdfdom/issues/27>)
* Contributors: Dmitry Rozhkov, Isaac I.Y. Saito, Robert Haschke, Victor Matare
```
