### PR TITLE
cartographer: 0.2.0-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -307,6 +307,7 @@ repositories:
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 0.2.0-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/googlecartographer/cartographer.git
       version: master

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -296,6 +296,21 @@ repositories:
       url: https://github.com/davetcoleman/cartesian_msgs.git
       version: jade-devel
     status: maintained
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `0.2.0-1`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## cartographer

```
https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
