### PR TITLE
cartographer_ros: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -327,6 +327,7 @@ repositories:
       url: https://github.com/ros-gbp/cartographer_ros-release.git
       version: 0.2.0-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/googlecartographer/cartographer_ros.git
       version: master

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -312,6 +312,25 @@ repositories:
       url: https://github.com/googlecartographer/cartographer.git
       version: master
     status: maintained
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: master
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer_ros-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `0.2.0-0`:

- upstream repository: https://github.com/googlecartographer/cartographer_ros.git
- release repository: https://github.com/ros-gbp/cartographer_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## cartographer_ros

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```

## cartographer_ros_msgs

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```

## cartographer_rviz

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
