### PR TITLE
xacro: 1.13.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1366,5 +1366,20 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 1.13.0-0
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: melodic-devel
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.0-0`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## xacro

```
* make --inorder processing the default
* Contributors: Robert Haschke
```
