### PR TITLE
nmea_msgs: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -488,6 +488,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jade-devel
     status: maintained
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: master
+    status: maintained
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `1.1.0-0`:

- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## nmea_msgs

```
* Add specific NMEA messages (#5 <https://github.com/ros-drivers/nmea_msgs/issues/5>)
  Add messages for the following NMEA sentences:
  - GPGGA
  - GPGSA
  - GPGSV (and a submessage GpgsvSatellite)
  - GPRMC
  These messages are useful to GPS drivers that parse NMEA sentences
  into specific ROS messages.
* Update maintainer to Ed Venator
* Contributors: Edward Venator, Eric Perko
```
