### PR TITLE
warehouse_ros: 0.9.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1381,6 +1381,21 @@ repositories:
       type: git
       url: https://github.com/Kukanani/vision_msgs.git
       version: melodic-devel
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros-release.git
+      version: 0.9.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: jade-devel
+    status: maintained
   webkit_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.0-0`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## warehouse_ros

```
* [fix] Omit dependency on mongo (and replace with pluginlib) #32 <https://github.com/ros-planning/warehouse_ros/issues/22>
* [fix] Specifically including a header that seems to be required from Ubuntu Xenial.
* [sys] Ensure headers and libraries are present for downstream pkgs #17 <https://github.com/ros-planning/warehouse_ros/issues/17>
* [sys] Update CI config to test Jade and Kinetic #30 <https://github.com/ros-planning/warehouse_ros/issues/30>
* [sys] Add rostest file and configs.
* Contributors: Connor Brew, Dave Coleman, Ioan A Sucan, Isaac I.Y. Saito, Michael Ferguson, Scott K Logan
```
