### PR TITLE
perception_pcl: 1.5.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2380,7 +2380,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.5.3-0
+      version: 1.5.4-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.5.4-0`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.5.3-0`

## pcl_ros

```
* update to use non deprecated pluginlib macro
* Fix config path of sample_voxel_grid.launch
* remove hack now that upstream pcl has been rebuilt
* Looser hzerror in test for extract_clusters to make it pass on Travis
* Add sample & test for surface/convex_hull
* Add sample & test for segmentation/extract_clusters.cpp
* Add sample & test for io/concatenate_data.cpp
* Add sample & test for features/normal_3d.cpp
* Organize samples of pcl_ros/features
* Add test arg to avoid duplicated testing
* LazyNodelet for features/*
* LazyNodelet for filters/ProjectInliers
* Refactor io/PCDReader and io/PCDWriter as child of PCLNodelet
* LazyNodelet for io/PointCloudConcatenateFieldsSynchronizer
* LazyNodelet for io/PointCloudConcatenateDataSynchronizer
* LazyNodelet for segmentation/SegmentDifferences
* LazyNodelet for segmentation/SACSegmentationFromNormals
* LazyNodelet for segmentation/SACSegmentation
* LazyNodelet for segmentation/ExtractPolygonalPrismData
* LazyNodelet for segmentation/EuclideanClusterExtraction
* LazyNodelet for surface/MovingLeastSquares
* LazyNodelet for surface/ConvexHull2D
* Add missing COMPONENTS of PCL
* Inherit NodeletLazy for pipeline with less cpu load
* Set leaf_size 0.02
* Install samples
* Add sample and test for pcl/StatisticalOutlierRemoval
  Conflicts:
  pcl_ros/CMakeLists.txt
* Add sample and test for pcl/VoxelGrid
  Conflicts:
  pcl_ros/CMakeLists.txt
* no need to remove duplicates
* spourious line change
* remove now unnecessary build_depend on qtbase5
* exclude PCL IO libraries exporting Qt flag
* find only PCL components used instead of all PCL
* Remove dependency on vtk/libproj-dev (#145 <https://github.com/ros-perception/perception_pcl/issues/145>)
  * Remove dependency on vtk/libproj-dev
  These dependencies were introduced in #124 <https://github.com/ros-perception/perception_pcl/issues/124> to temporarily fix
  missing / wrong dependencies in upstream vtk. This hack is no longer
  necessary, since fixed vtk packages have been uploaded to
  packages.ros.org (see #124 <https://github.com/ros-perception/perception_pcl/issues/124> and ros-infrastructure/reprepro-updater#32 <https://github.com/ros-infrastructure/reprepro-updater/issues/32>).
  * Remove vtk hack from CMakeLists.txt
* Contributors: Kentaro Wada, Mikael Arguedas
```

## perception_pcl

- No changes
