### PR TITLE
cartographer_ros: 0.2.0-4 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
-      version: 0.2.0-3
+      version: 0.2.0-4
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `0.2.0-4`:

- upstream repository: https://github.com/googlecartographer/cartographer_ros.git
- release repository: https://github.com/ros-gbp/cartographer_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.0-3`

## cartographer_ros

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```

## cartographer_ros_msgs

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```

## cartographer_rviz

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
