### PR TITLE
media_export: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -440,6 +440,21 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     status: maintained
+  media_export:
+    doc:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/media_export-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export` to `0.2.0-0`:

- upstream repository: https://github.com/ros/media_export.git
- release repository: https://github.com/ros-gbp/media_export-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## media_export

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
