### PR TITLE
Drop jsk_apc from indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5529,30 +5529,6 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
       version: master
     status: developed
-  jsk_apc:
-    doc:
-      type: git
-      url: https://github.com/start-jsk/jsk_apc.git
-      version: master
-    release:
-      packages:
-      - jsk_2015_05_baxter_apc
-      - jsk_2016_01_baxter_apc
-      - jsk_apc
-      - jsk_apc2015_common
-      - jsk_apc2016_common
-      - jsk_arc2017_baxter
-      - jsk_arc2017_common
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/tork-a/jsk_apc-release.git
-      version: 4.2.0-0
-    source:
-      test_commits: false
-      type: git
-      url: https://github.com/start-jsk/jsk_apc.git
-      version: master
-    status: developed
   jsk_common:
     doc:
       type: git


### PR DESCRIPTION
Close https://github.com/start-jsk/jsk_apc/issues/2629

Because

- most of the users install jsk_apc from source;
- heavy to build and release to apt (https://github.com/start-jsk/jsk_apc/issues/2629).