### PR TITLE
metapackages: 1.3.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1748,7 +1748,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
-      version: 1.3.1-0
+      version: 1.3.2-0
     source:
       type: git
       url: https://github.com/ros/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.3.2-0`:

- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.3.1-0`
