### PR TITLE
cartographer: 0.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -889,6 +889,7 @@ repositories:
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 0.2.0-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/googlecartographer/cartographer.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -888,11 +888,6 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 0.2.0-1
-    source:
-      test_commits: false
-      type: git
-      url: https://github.com/googlecartographer/cartographer.git
-      version: master
     status: developed
   catch_ros:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -878,6 +878,21 @@ repositories:
       url: https://github.com/davetcoleman/cartesian_msgs.git
       version: jade-devel
     status: maintained
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    status: developed
   catch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `0.2.0-1`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## cartographer

```
https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
