### PR TITLE
Added libtclap-dev to base.yaml

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11401,10 +11401,8 @@ repositories:
     release:
       packages:
       - roch_base
-      - roch_capabilities
       - roch_control
       - roch_description
-      - roch_ftdi
       - roch_msgs
       - roch_robot
       - roch_safety_controller
@@ -11412,7 +11410,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch_robot-release.git
-      version: 1.0.16-0
+      version: 1.0.17-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch_robot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2739,7 +2739,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.48-0
+      version: 1.5.49-0
     source:
       test_pull_requests: true
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -159,7 +159,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1159,7 +1159,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/utexas-bwi/bwi.git
-      version: master
+      version: indigo
     release:
       packages:
       - bwi_desktop
@@ -1172,13 +1172,13 @@ repositories:
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi.git
-      version: master
+      version: indigo
     status: developed
   bwi_common:
     doc:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git
-      version: master
+      version: indigo
     release:
       packages:
       - bwi_common
@@ -1208,7 +1208,7 @@ repositories:
     source:
       type: git
       url: https://github.com/utexas-bwi/bwi_common.git
-      version: master
+      version: indigo
     status: developed
   calibration:
     doc:
@@ -13881,7 +13881,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/utexas-bwi/segbot.git
-      version: master
+      version: indigo
     release:
       packages:
       - segbot
@@ -13902,7 +13902,7 @@ repositories:
     source:
       type: git
       url: https://github.com/utexas-bwi/segbot.git
-      version: master
+      version: indigo
     status: developed
   segway_rmp:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11949,7 +11949,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.9.4-0
+      version: 0.9.5-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9762,6 +9762,26 @@ repositories:
       url: https://github.com/pr2/pr2_navigation.git
       version: hydro-devel
     status: maintained
+  pr2_navigation_apps:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_navigation_apps.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_2dnav
+      - pr2_2dnav_local
+      - pr2_2dnav_slam
+      - pr2_navigation_apps
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_navigation_apps-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_navigation_apps.git
+      version: hydro-devel
+    status: maintained
   pr2_power_drivers:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7977,7 +7977,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.14-0
+      version: 1.12.15-0
     source:
       test_commits: false
       test_pull_requests: true

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -113,7 +113,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.12-0
+      version: 1.11.13-0
     source:
       test_pull_requests: true
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4528,7 +4528,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/at-wat/hokuyo3d-release.git
-      version: 0.1.1-1
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/at-wat/hokuyo3d.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15002,7 +15002,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/surface_perception-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/jstnhuang/surface_perception.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12198,7 +12198,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 1.0.2-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7596,7 +7596,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -746,7 +746,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_launch-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_launch.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10502,6 +10502,16 @@ repositories:
       url: https://github.com/jstnhuang/rapid_pbd_msgs.git
       version: indigo-devel
     status: developed
+  raspimouse_sim:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: indigo-devel
+    status: developed
   razer_hydra:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9486,6 +9486,30 @@ repositories:
       url: https://github.com/pr2/pr2_apps.git
       version: hydro-devel
     status: maintained
+  pr2_calibration:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_calibration.git
+      version: indigo-devel
+    release:
+      packages:
+      - dense_laser_assembler
+      - laser_joint_processor
+      - laser_joint_projector
+      - pr2_calibration
+      - pr2_calibration_launch
+      - pr2_dense_laser_snapshotter
+      - pr2_se_calibration_launch
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration-release.git
+      version: 1.0.9-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/PR2/pr2_calibration.git
+      version: indigo-devel
+    status: maintained
   pr2_common:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11367,12 +11367,11 @@ repositories:
       - roch_bringup
       - roch_follower
       - roch_navigation
-      - roch_rapps
       - roch_teleop
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SawYerRobotics-release/roch-release.git
-      version: 1.0.15-0
+      version: 1.0.16-0
     source:
       type: git
       url: https://github.com/SawYer-Robotics/roch.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2453,6 +2453,12 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
       version: default
     status: developed
+  ddynamic_reconfigure_python:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
+      version: 0.0.1-0
   declination:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11995,7 +11995,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/code-iai-release/ros_emacs_utils-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9379,7 +9379,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.10.6-0
+      version: 1.10.7-0
     source:
       test_pull_requests: true
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6791,7 +6791,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
-      version: 1.0.6-0
+      version: 1.0.8-0
   mastering_ros_demo_pkg:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -150,6 +150,21 @@ repositories:
       url: https://github.com/atenpas/agile_grasp.git
       version: master
     status: maintained
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    status: maintained
   agvs_common:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16233,7 +16233,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers/video_stream_opencv-release.git
-      version: 1.0.2-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/video_stream_opencv.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -731,7 +731,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_camera-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_camera.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9872,14 +9872,17 @@ repositories:
     release:
       packages:
       - imu_monitor
+      - pr2_bringup
+      - pr2_camera_synchronizer
       - pr2_computer_monitor
       - pr2_controller_configuration
       - pr2_ethercat
+      - pr2_robot
       - pr2_run_stop_auto_restart
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_robot-release.git
-      version: 1.6.23-1
+      version: 1.6.26-0
     source:
       type: git
       url: https://github.com/pr2/pr2_robot.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1630,7 +1630,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     source:
       test_pull_requests: true
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12606,7 +12606,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/cbandera/rosparam_handler-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/cbandera/rosparam_handler.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8894,7 +8894,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2372,7 +2372,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/MatthewLiuRelease/custom_landmark_2d-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/matthew-liu/custom_landmark_2d.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1887,7 +1887,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.5.3-0
+      version: 3.5.4-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4927,7 +4927,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7699,7 +7699,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10692,11 +10692,13 @@ repositories:
     release:
       packages:
       - thormang3_manipulation_demo
+      - thormang3_ppc
       - thormang3_sensors
+      - thormang3_walking_demo
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-PPC-release.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11484,7 +11484,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers/video_stream_opencv-release.git
-      version: 1.0.2-2
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/video_stream_opencv.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4914,6 +4914,20 @@ repositories:
       type: git
       url: https://github.com/magazino/move_base_flex.git
       version: kinetic
+    release:
+      packages:
+      - mbf_abstract_core
+      - mbf_abstract_nav
+      - mbf_costmap_core
+      - mbf_costmap_nav
+      - mbf_msgs
+      - mbf_simple_nav
+      - mbf_utility
+      - move_base_flex
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uos-gbp/move_base_flex-release.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4641,7 +4641,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2018.2.2-0
+      version: 2018.3.7-0
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8555,7 +8555,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosflight/rosflight-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/rosflight/rosflight.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7731,7 +7731,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-msgs-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7679,7 +7679,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-msgs-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3242,6 +3242,11 @@ repositories:
       type: git
       url: https://github.com/takiaine/ifm_o3mxxx.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/takiaine/ifm_o3mxxx-release.git
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/takiaine/ifm_o3mxxx.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -459,7 +459,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_launch-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_launch.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7679,7 +7679,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-msgs-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10592,7 +10592,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Common-release.git
-      version: 0.1.3-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2436,7 +2436,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.3.0-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11992,7 +11992,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       type: git
       url: https://github.com/ros/xacro.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5213,7 +5213,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10554,6 +10554,12 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
       version: master
+  topics_rviz_plugin:
+    doc:
+      type: git
+      url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
+      version: kinetic
+    status: developed
   towr:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1800,6 +1800,11 @@ repositories:
       type: git
       url: https://github.com/piraka9011/dialogflow_ros.git
       version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/piraka9011/dialogflow_ros.git
+      version: kinetic-devel
+    status: developed
   dnn_detect:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7784,13 +7784,21 @@ repositories:
       packages:
       - cm_740_module
       - op3_action_module
+      - op3_balance_control
+      - op3_base_module
+      - op3_direct_control_module
       - op3_head_control_module
       - op3_kinematics_dynamics
+      - op3_localization
+      - op3_manager
+      - op3_online_walking_module
+      - op3_walking_module
       - open_cr_module
+      - robotis_op3
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8910,7 +8910,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_bag-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6008,6 +6008,31 @@ repositories:
       url: https://github.com/ros-gbp/open_karto-release.git
       version: 1.1.4-0
     status: maintained
+  open_manipulator:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - open_manipulator
+      - open_manipulator_description
+      - open_manipulator_dynamixel_ctrl
+      - open_manipulator_gazebo
+      - open_manipulator_moveit
+      - open_manipulator_msgs
+      - open_manipulator_position_ctrl
+      - open_manipulator_with_tb3
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator.git
+      version: kinetic-devel
+    status: developed
   open_street_map:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1623,6 +1623,17 @@ repositories:
       url: https://github.com/leggedrobotics/darknet_ros.git
       version: master
     status: developed
+  dartsim:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/dartsim/ros-dartsim-release.git
+      version: 6.3.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dartsim/dart.git
+      version: release-6.3
   dataspeed_can:
     doc:
       type: hg

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8511,13 +8511,15 @@ repositories:
     release:
       packages:
       - rosflight
+      - rosflight_firmware
       - rosflight_msgs
       - rosflight_pkgs
+      - rosflight_sim
       - rosflight_utils
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosflight/rosflight-release.git
-      version: 0.1.3-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/rosflight/rosflight.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7699,7 +7699,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.6-0
+      version: 0.2.7-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4536,16 +4536,19 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - manipulator_h
+      - manipulator_h_base_module
       - manipulator_h_base_module_msgs
       - manipulator_h_bringup
       - manipulator_h_description
       - manipulator_h_gazebo
       - manipulator_h_gui
       - manipulator_h_kinematics_dynamics
+      - manipulator_h_manager
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
-      version: 0.2.3-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4668,7 +4668,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.23.2-0
+      version: 0.23.3-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7765,12 +7765,13 @@ repositories:
       packages:
       - op3_action_module_msgs
       - op3_offset_tuner_msgs
+      - op3_online_walking_module_msgs
       - op3_walking_module_msgs
       - robotis_op3_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-msgs.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4654,7 +4654,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
-      version: 1.0.7-2
+      version: 1.0.8-0
   mav_comm:
     release:
       packages:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6836,7 +6836,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_simulator-release.git
-      version: 2.0.9-0
+      version: 2.0.10-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6026,7 +6026,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11659,6 +11659,11 @@ repositories:
       url: https://github.com/ros-drivers/vrpn_client_ros.git
       version: kinetic-devel
     status: maintained
+  vtec_ros:
+    doc:
+      type: git
+      url: https://github.com/lukscasanova/vtec_ros.git
+      version: master
   warehouse_ros:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10733,6 +10733,27 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
       version: kinetic-devel
     status: developed
+  turtlebot3_autorace:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: kinetic-devel
+    release:
+      packages:
+      - turtlebot3_autorace
+      - turtlebot3_autorace_camera
+      - turtlebot3_autorace_control
+      - turtlebot3_autorace_core
+      - turtlebot3_autorace_detect
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: kinetic-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10701,6 +10701,27 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: kinetic-devel
     status: maintained
+  turtlebot3_applications:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: kinetic-devel
+    release:
+      packages:
+      - turtlebot3_applications
+      - turtlebot3_automatic_parking
+      - turtlebot3_follow_filter
+      - turtlebot3_follower
+      - turtlebot3_panorama
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: kinetic-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10644,13 +10644,14 @@ repositories:
       - turtlebot3
       - turtlebot3_bringup
       - turtlebot3_description
+      - turtlebot3_example
       - turtlebot3_navigation
       - turtlebot3_slam
       - turtlebot3_teleop
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 0.1.6-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1845,7 +1845,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10656,7 +10656,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9728,7 +9728,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
-      version: 1.1.5-0
+      version: 1.1.6-0
     source:
       type: git
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1862,7 +1862,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
-      version: 0.1.7-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10685,7 +10685,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8881,7 +8881,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OTL/rqt_ez_publisher-release.git
-      version: 0.4.0-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/OTL/rqt_ez_publisher.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3145,16 +3145,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/at-wat/hokuyo3d.git
-      version: indigo-devel
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/hokuyo3d-release.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/at-wat/hokuyo3d.git
-      version: indigo-devel
+      version: master
     status: developed
   homer_mapping:
     release:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4662,7 +4662,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.23.1-0
+      version: 0.23.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7729,7 +7729,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
-      version: 0.2.3-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6057,7 +6057,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.3.1-0
+      version: 3.3.1-5
     status: maintained
   opencv_apps:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1822,7 +1822,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.48-0
+      version: 1.5.49-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8557,6 +8557,7 @@ repositories:
       url: https://github.com/rosflight/rosflight-release.git
       version: 1.0.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/rosflight/rosflight.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3611,7 +3611,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.12.12-0
+      version: 1.12.13-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8690,6 +8690,16 @@ repositories:
       url: https://github.com/ros/roslisp_common.git
       version: master
     status: developed
+  rosmon:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    status: maintained
   rospack:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10700,13 +10700,12 @@ repositories:
     release:
       packages:
       - turtlebot3_fake
-      - turtlebot3_gazebo_plugin
       - turtlebot3_gazebo_ros
       - turtlebot3_simulations
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 0.2.0-0
+      version: 0.2.4-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6268,7 +6268,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3237,6 +3237,16 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  ifm_o3mxxx:
+    doc:
+      type: git
+      url: https://github.com/takiaine/ifm_o3mxxx.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/takiaine/ifm_o3mxxx.git
+      version: master
+    status: maintained
   ifopt:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8441,7 +8441,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 1.0.2-1
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2251,7 +2251,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.91-0
+      version: 0.5.91-2
     status: developed
   feed_the_troll:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10669,7 +10669,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7789,7 +7789,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Utility-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -940,7 +940,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4896,7 +4896,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/move_basic-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1645,6 +1645,12 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
       version: default
     status: developed
+  ddynamic_reconfigure_python:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
+      version: 0.0.1-0
   demo_pioneer:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6578,7 +6578,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7804,6 +7804,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git
       version: kinetic-devel
     status: developed
+  robotis_op3_common:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Common.git
+      version: kinetic-devel
+    release:
+      packages:
+      - op3_description
+      - op3_gazebo
+      - robotis_op3_common
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-Common-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Common.git
+      version: kinetic-devel
+    status: developed
   robotis_op3_msgs:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1795,6 +1795,11 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  dialogflow_ros:
+    doc:
+      type: git
+      url: https://github.com/piraka9011/dialogflow_ros.git
+      version: kinetic-devel
   dnn_detect:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6006,7 +6006,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.3.1-3
+      version: 3.3.1-0
     status: maintained
   opencv_apps:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8321,7 +8321,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.13.0-0
+      version: 0.13.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9664,7 +9664,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10595,17 +10595,24 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - ati_ft_sensor
       - motion_module_tutorial
       - sensor_module_tutorial
       - thormang3_action_module
       - thormang3_balance_control
-      - thormang3_imu_3dm_gx4
+      - thormang3_base_module
+      - thormang3_feet_ft_module
+      - thormang3_gripper_module
+      - thormang3_head_control_module
       - thormang3_kinematics_dynamics
+      - thormang3_manager
+      - thormang3_manipulation_module
+      - thormang3_mpc
       - thormang3_walking_module
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-release.git
-      version: 0.1.3-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7808,7 +7808,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-OP3-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1628,7 +1628,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/dartsim/ros-dartsim-release.git
-      version: 6.3.1-0
+      version: 6.3.1-1
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -444,7 +444,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/astra_camera-release.git
-      version: 0.2.1-0
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/orbbec/ros_astra_camera.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2251,7 +2251,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.90-6
+      version: 0.5.91-0
     status: developed
   feed_the_troll:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9674,7 +9674,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
-      version: 1.1.2-0
+      version: 1.1.5-0
     source:
       type: git
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4548,7 +4548,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-MANIPULATOR-H-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10682,12 +10682,13 @@ repositories:
     release:
       packages:
       - turtlebot3_fake
-      - turtlebot3_gazebo
+      - turtlebot3_gazebo_plugin
+      - turtlebot3_gazebo_ros
       - turtlebot3_simulations
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 0.1.7-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -130,7 +130,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9836,6 +9836,12 @@ repositories:
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
       version: master
     status: developed
+  sbpl:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/sbpl-release.git
+      version: 1.2.0-2
   scan_tools:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3110,7 +3110,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3930,7 +3930,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki-release.git
-      version: 0.7.5-0
+      version: 0.7.6-0
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7751,7 +7751,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Framework-release.git
-      version: 0.2.8-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -121,6 +121,21 @@ repositories:
       url: https://github.com/tork-a/adi_driver.git
       version: master
     status: developed
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    status: maintained
   agvs_common:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10628,6 +10628,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git
       version: kinetic-devel
     status: maintained
+  thormang3_mpc_sensors:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC-SENSORs.git
+      version: kinetic-devel
+    release:
+      packages:
+      - thormang3_imu_3dm_gx4
+      - thormang3_mpc_sensors
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-MPC-SENSORs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC-SENSORs.git
+      version: kinetic-devel
+    status: developed
   thormang3_msgs:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8688,7 +8688,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.4.0-0
+      version: 1.4.1-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7729,7 +7729,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-Math-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1834,7 +1834,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4654,7 +4654,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
-      version: 1.0.6-0
+      version: 1.0.7-2
   mav_comm:
     release:
       packages:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8781,7 +8781,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cbandera/rosparam_handler-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/cbandera/rosparam_handler.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9664,7 +9664,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
-      version: 1.0.7-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2387,6 +2387,16 @@ repositories:
       url: https://github.com/danielsnider/follow_waypoints.git
       version: master
     status: maintained
+  force_torque_tools:
+    doc:
+      type: git
+      url: https://github.com/kth-ros-pkg/force_torque_tools.git
+      version: kinetic
+    source:
+      type: git
+      url: https://github.com/kth-ros-pkg/force_torque_tools.git
+      version: kinetic
+    status: maintained
   four_wheel_steering_msgs:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -99,7 +99,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.12-0
+      version: 1.11.13-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1928,7 +1928,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   dynpick_driver:
     doc:
       type: git
@@ -3150,7 +3150,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   hls-lfom-tof-driver:
     doc:
       type: git
@@ -4573,7 +4573,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-MANIPULATOR-H.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   mapviz:
     doc:
       type: git
@@ -6080,7 +6080,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
       version: 0.1.1-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git
       version: kinetic-devel
@@ -7759,7 +7758,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework-msgs.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   robotis_framework:
     doc:
       type: git
@@ -7779,7 +7778,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   robotis_math:
     doc:
       type: git
@@ -7794,7 +7793,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Math.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   robotis_op3:
     doc:
       type: git
@@ -7882,7 +7881,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Utility.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   robotnik_msgs:
     doc:
       type: git
@@ -10597,7 +10596,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Common.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   thormang3_mpc:
     doc:
       type: git
@@ -10627,7 +10626,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-MPC.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   thormang3_mpc_sensors:
     doc:
       type: git
@@ -10668,7 +10667,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   thormang3_opc:
     doc:
       type: git
@@ -10683,7 +10682,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   thormang3_ppc:
     doc:
       type: git
@@ -10703,7 +10702,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-PPC.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   thormang3_tools:
     doc:
       type: git
@@ -10718,7 +10717,7 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   timesync_ros:
     doc:
       type: git
@@ -10837,11 +10836,10 @@ repositories:
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
       version: 0.2.1-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   turtlebot3_applications:
     doc:
       type: git
@@ -10895,11 +10893,10 @@ repositories:
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release.git
       version: 0.1.5-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
       version: kinetic-devel
-    status: maintained
+    status: developed
   turtlebot3_simulations:
     doc:
       type: git
@@ -10915,7 +10912,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
       version: 0.2.4-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: kinetic-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1643,7 +1643,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/dartsim/ros-dartsim-release.git
-      version: 6.3.1-1
+      version: 6.3.1-2
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7567,6 +7567,29 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: jade-devel
     status: maintained
+  rh_p12_rn:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/RH-P12-RN.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rh_p12_rn
+      - rh_p12_rn_base_module
+      - rh_p12_rn_base_module_msgs
+      - rh_p12_rn_description
+      - rh_p12_rn_gazebo
+      - rh_p12_rn_gui
+      - rh_p12_rn_manager
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/RH-P12-RN-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/RH-P12-RN.git
+      version: kinetic-devel
+    status: developed
   robot_calibration:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5487,7 +5487,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.2-0
+      version: 1.14.3-0
     source:
       test_commits: false
       test_pull_requests: true

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7501,7 +7501,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.3-0
+      version: 1.12.4-0
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8294,7 +8294,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/code-iai-release/ros_emacs_utils-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10628,7 +10628,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-msgs-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-msgs.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1456,6 +1456,16 @@ repositories:
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
     status: maintained
+  libcreate:
+    doc:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/AutonomyLab/libcreate.git
+      version: master
+    status: developed
   libfreenect:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1581,7 +1581,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2018.2.2-0
+      version: 2018.3.7-0
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1094,6 +1094,21 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: unmaintained
+  hokuyo3d:
+    doc:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/at-wat/hokuyo3d-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: master
+    status: developed
   ifopt:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3224,7 +3224,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_bag-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1657,7 +1657,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2018.3.7-0
+      version: 2018.4.4-0
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1693,6 +1693,30 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  move_base_flex:
+    doc:
+      type: git
+      url: https://github.com/magazino/move_base_flex.git
+      version: lunar
+    release:
+      packages:
+      - mbf_abstract_core
+      - mbf_abstract_nav
+      - mbf_costmap_core
+      - mbf_costmap_nav
+      - mbf_msgs
+      - mbf_simple_nav
+      - mbf_utility
+      - move_base_flex
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/uos-gbp/move_base_flex-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/magazino/move_base_flex.git
+      version: lunar
+    status: developed
   moveit:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
-      version: 0.2.0-0
+      version: 0.2.0-1
     source:
       test_commits: false
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -305,7 +305,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.2.0-3
+      version: 0.2.0-4
     source:
       test_commits: false
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.23.2-0
+      version: 0.23.3-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2157,7 +2157,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/opencv3-release.git
-      version: 3.3.1-0
+      version: 3.3.1-2
     status: maintained
   openni2_camera:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1748,7 +1748,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
-      version: 1.3.1-0
+      version: 1.3.2-0
     source:
       type: git
       url: https://github.com/ros/metapackages.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1270,7 +1270,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.12.12-0
+      version: 1.12.13-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.23.1-0
+      version: 0.23.2-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -62,6 +62,21 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/advanced_navigation_driver.git
       version: master
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: indigo-devel
+    status: maintained
   angles:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -337,7 +337,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3158,6 +3158,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rosparam_handler:
+    doc:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/cbandera/rosparam_handler-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    status: developed
   rosparam_shortcuts:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -311,7 +311,7 @@ repositories:
       type: git
       url: https://github.com/googlecartographer/cartographer.git
       version: master
-    status: maintained
+    status: developed
   cartographer_ros:
     doc:
       type: git
@@ -331,7 +331,7 @@ repositories:
       type: git
       url: https://github.com/googlecartographer/cartographer_ros.git
       version: master
-    status: maintained
+    status: developed
   catkin:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1912,7 +1912,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.15.1-0
+      version: 1.15.2-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
-      version: 0.2.0-3
+      version: 0.2.0-4
     source:
       test_commits: false
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4185,6 +4185,21 @@ repositories:
       url: https://github.com/beltransen/velo2cam_gazebo.git
       version: master
     status: maintained
+  video_stream_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/video_stream_opencv.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers/video_stream_opencv-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/video_stream_opencv.git
+      version: master
+    status: maintained
   vision_msgs:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -312,6 +312,26 @@ repositories:
       url: https://github.com/googlecartographer/cartographer.git
       version: master
     status: maintained
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: master
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer_ros-release.git
+      version: 0.2.0-0
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     source:
       test_commits: false
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2380,7 +2380,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.5.3-0
+      version: 1.5.4-0
     source:
       type: git
       url: https://github.com/ros-perception/perception_pcl.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2857,7 +2857,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/code-iai-release/ros_emacs_utils-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/code-iai/ros_emacs_utils.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
-      version: 0.2.0-2
+      version: 0.2.0-3
     source:
       test_commits: false
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3787,6 +3787,21 @@ repositories:
       url: https://github.com/davetcoleman/rviz_visual_tools.git
       version: kinetic-devel
     status: developed
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
+      version: 1.1.6-0
+    source:
+      type: git
+      url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
+      version: master
+    status: developed
   sick_ldmrs_laser:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -71,7 +71,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -50,7 +50,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.12-0
+      version: 1.11.13-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4426,7 +4426,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.12.0-1
+      version: 1.12.1-0
     source:
       type: git
       url: https://github.com/ros/xacro.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3025,6 +3025,28 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosflight:
+    doc:
+      type: git
+      url: https://github.com/rosflight/rosflight.git
+      version: master
+    release:
+      packages:
+      - rosflight
+      - rosflight_firmware
+      - rosflight_msgs
+      - rosflight_pkgs
+      - rosflight_sim
+      - rosflight_utils
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/rosflight/rosflight-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/rosflight/rosflight.git
+      version: master
+    status: developed
   roslint:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3167,6 +3167,17 @@ repositories:
       url: https://github.com/ros/roslisp_common.git
       version: master
     status: developed
+  rosmon:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    status: maintained
   rospack:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2856,7 +2856,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.13.0-0
+      version: 0.13.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3043,6 +3043,7 @@ repositories:
       url: https://github.com/rosflight/rosflight-release.git
       version: 1.0.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/rosflight/rosflight.git
       version: master

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -305,7 +305,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.2.0-2
+      version: 0.2.0-3
     source:
       test_commits: false
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2348,7 +2348,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.11.2-0
+      version: 1.11.3-0
     source:
       test_pull_requests: true
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -305,7 +305,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     source:
       test_commits: false
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -296,6 +296,22 @@ repositories:
       url: https://github.com/davetcoleman/cartesian_msgs.git
       version: jade-devel
     status: maintained
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer-release.git
+      version: 0.2.0-1
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2577,7 +2577,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.3-0
+      version: 1.12.4-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -423,6 +423,29 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: kinetic-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/qt_gui_core-release.git
+      version: 0.3.8-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: kinetic-devel
+    status: maintained
   qwt_dependency:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.14-0
+      version: 1.9.15-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -837,6 +837,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_logger_level.git
       version: master
     status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_plot-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: master
+    status: maintained
   rqt_publisher:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -882,6 +882,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: master
     status: maintained
+  rqt_robot_steering:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_robot_steering-release.git
+      version: 0.5.9-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: master
+    status: maintained
   rqt_topic:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -804,7 +804,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_bag-release.git
-      version: 0.4.11-0
+      version: 0.4.12-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -448,7 +448,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.6-0
+      version: 1.13.6-1
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -945,6 +945,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_robot_steering.git
       version: master
     status: maintained
+  rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_service_caller-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: master
+    status: maintained
   rqt_topic:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -566,7 +566,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_msgs-release.git
-      version: 0.3.3-0
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_msgs.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1243,6 +1243,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_web.git
       version: master
     status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/srdfdom-release.git
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: kinetic-devel
+    status: maintained
   std_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -985,6 +985,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_plot.git
       version: master
     status: maintained
+  rqt_pose_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_pose_view.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_pose_view-release.git
+      version: 0.5.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_pose_view.git
+      version: master
+    status: maintained
   rqt_publisher:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -440,6 +440,21 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     status: maintained
+  media_export:
+    doc:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/media_export-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    status: maintained
   message_generation:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -420,6 +420,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  rc_genicam_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/roboception/rc_genicam_api-release.git
+      version: 1.3.6-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    status: developed
   realtime_tools:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -557,6 +557,21 @@ repositories:
       url: https://github.com/OctoMap/octomap.git
       version: devel
     status: maintained
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 0.3.3-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: melodic-devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -508,6 +508,25 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  octomap:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: v1.9.0
+    release:
+      packages:
+      - dynamic_edt_3d
+      - octomap
+      - octovis
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap-release.git
+      version: 1.9.0-0
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap.git
+      version: devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -473,6 +473,27 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_emacs_utils:
+    doc:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    release:
+      packages:
+      - ros_emacs_utils
+      - rosemacs
+      - roslisp_repl
+      - slime_ros
+      - slime_wrapper
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/code-iai-release/ros_emacs_utils-release.git
+      version: 0.4.12-0
+    source:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -339,6 +339,24 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: jade-devel
+    release:
+      packages:
+      - map_msgs
+      - move_base_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_msgs-release.git
+      version: 1.13.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: jade-devel
+    status: maintained
   nodelet_core:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -308,6 +308,11 @@ repositories:
       type: git
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/pluginlib-release.git
+      version: 1.12.0-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -319,6 +319,25 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geographic_info:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-geographic-info/geographic_info-release.git
+      version: 0.5.3-0
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: master
+    status: maintained
   geometry:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -15,12 +15,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/actionlib.git
-      version: melodic-devel
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/actionlib-release.git
+      version: 1.11.13-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/actionlib.git
-      version: melodic-devel
+      version: indigo-devel
     status: maintained
   angles:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -293,6 +293,28 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geometry:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
+    release:
+      packages:
+      - eigen_conversions
+      - geometry
+      - kdl_conversions
+      - tf
+      - tf_conversions
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry-release.git
+      version: 1.11.9-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: indigo-devel
+    status: maintained
   geometry2:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -145,6 +145,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -776,6 +776,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_graph:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_graph-release.git
+      version: 0.4.9-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: master
+    status: maintained
   rqt_py_console:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -440,6 +440,21 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     status: maintained
+  laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/laser_geometry-release.git
+      version: 1.6.4-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: indigo-devel
+    status: maintained
   media_export:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -503,6 +503,21 @@ repositories:
       url: https://github.com/ros-drivers/nmea_msgs.git
       version: master
     status: maintained
+  nmea_navsat_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: master
+    status: maintained
   nodelet_core:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -845,6 +845,17 @@ repositories:
       url: https://github.com/ros/roslisp.git
       version: master
     status: maintained
+  rosmon:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    status: maintained
   rospack:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -867,6 +867,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: master
     status: maintained
+  rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_topic-release.git
+      version: 0.4.10-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -392,6 +392,25 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  orocos_kinematics_dynamics:
+    doc:
+      type: git
+      url: https://github.com/orocos/orocos_kinematics_dynamics.git
+      version: master
+    release:
+      packages:
+      - orocos_kdl
+      - orocos_kinematics_dynamics
+      - python_orocos_kdl
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/orocos/orocos-kdl-release.git
+      version: 1.4.0-0
+    source:
+      type: git
+      url: https://github.com/orocos/orocos_kinematics_dynamics.git
+      version: master
+    status: maintained
   pcl_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11,6 +11,21 @@ release_platforms:
   - artful
   - bionic
 repositories:
+  ackermann_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: master
+    status: maintained
   actionlib:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -155,6 +155,16 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: kinetic-devel
     status: maintained
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: kinetic-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git
@@ -755,6 +765,16 @@ repositories:
       url: https://github.com/ros/urdf.git
       version: melodic-devel
     status: maintained
+  urdf_geometry_parser:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/urdf_geometry_parser.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/ros-controls/urdf_geometry_parser.git
+      version: kinetic-devel
+    status: developed
   urdfdom_py:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -761,6 +761,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_py_console-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -313,6 +313,15 @@ repositories:
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
+    release:
+      packages:
+      - nodelet
+      - nodelet_core
+      - nodelet_topic_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/nodelet_core-release.git
+      version: 1.9.14-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -85,7 +85,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.4.0-0
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -319,7 +319,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/geometry2.git
-      version: indigo-devel
+      version: melodic-devel
     release:
       packages:
       - geometry2
@@ -336,12 +336,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.5.17-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/geometry2.git
-      version: indigo-devel
+      version: melodic-devel
     status: maintained
   gl_dependency:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -166,6 +166,19 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: jade-devel
     status: maintained
+  common_tutorials:
+    release:
+      packages:
+      - actionlib_tutorials
+      - common_tutorials
+      - nodelet_tutorial_math
+      - pluginlib_tutorials
+      - turtle_actionlib
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/common_tutorials-release.git
+      version: 0.1.11-0
+    status: maintained
   control_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1381,6 +1381,21 @@ repositories:
       type: git
       url: https://github.com/Kukanani/vision_msgs.git
       version: melodic-devel
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros-release.git
+      version: 0.9.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: jade-devel
+    status: maintained
   webkit_dependency:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -308,6 +308,17 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  nodelet_core:
+    doc:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: indigo-devel
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -703,6 +703,16 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: indigo-devel
     status: maintained
+  ros_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros_control.git
+      version: melodic-devel
+    status: maintained
   ros_emacs_utils:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -870,6 +870,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_logger_level.git
       version: master
     status: maintained
+  rqt_msg:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_msg-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: master
+    status: maintained
   rqt_plot:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -488,6 +488,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jade-devel
     status: maintained
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_msgs-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: master
+    status: maintained
   nodelet_core:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -160,6 +160,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 1.16.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -822,6 +822,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_graph.git
       version: master
     status: maintained
+  rqt_logger_level:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_logger_level-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    status: maintained
   rqt_publisher:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -621,6 +621,25 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: melodic-devel
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf-release.git
+      version: 1.13.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: melodic-devel
+    status: maintained
   urdfdom_py:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -278,6 +278,22 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/joint_state_publisher-release.git
+      version: 1.12.13-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: kinetic-devel
+    status: maintained
   message_generation:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -791,6 +791,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_graph.git
       version: master
     status: maintained
+  rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_publisher-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: master
+    status: maintained
   rqt_py_console:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -551,7 +551,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.0-0
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -699,6 +699,15 @@ repositories:
       type: git
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
+    release:
+      packages:
+      - unique_id
+      - unique_identifier
+      - uuid_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-geographic-info/unique_identifier-release.git
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/ros-geographic-info/unique_identifier.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1366,5 +1366,20 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 1.13.0-0
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: melodic-devel
+    status: maintained
 type: distribution
 version: 2

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -792,6 +792,24 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_bag:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: master
+    release:
+      packages:
+      - rqt_bag
+      - rqt_bag_plugins
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_bag-release.git
+      version: 0.4.11-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: master
+    status: maintained
   rqt_console:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -392,6 +392,22 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  pcl_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_msgs-release.git
+      version: 0.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -384,6 +384,27 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: hydro-devel
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_common
+      - image_transport
+      - polled_camera
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/image_common-release.git
+      version: 1.11.13-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: hydro-devel
+    status: maintained
   joint_state_publisher:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -213,7 +213,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
-      version: melodic-devel
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -223,7 +223,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/dynamic_reconfigure.git
-      version: melodic-devel
+      version: master
     status: maintained
   eigen_stl_containers:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -472,6 +472,21 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  oxford_gps_eth:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
+      version: 0.0.6-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
+      version: default
+    status: maintained
   pcl_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -293,6 +293,34 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    release:
+      packages:
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry2-release.git
+      version: 0.5.17-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: indigo-devel
+    status: maintained
   gl_dependency:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -441,6 +441,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1104,6 +1104,20 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: melodic-devel
     status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: melodic-devel
   webkit_dependency:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -708,6 +708,23 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_control.git
       version: melodic-devel
+    release:
+      packages:
+      - combined_robot_hw
+      - combined_robot_hw_tests
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - controller_manager_tests
+      - hardware_interface
+      - joint_limits_interface
+      - ros_control
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_control-release.git
+      version: 0.14.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -140,6 +140,16 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: jade-devel
     status: maintained
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: kinetic-devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git
@@ -405,6 +415,16 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: kinetic-devel
+    status: maintained
   resource_retriever:
     doc:
       type: git
@@ -652,6 +672,16 @@ repositories:
       type: git
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
+    status: maintained
+  unique_identifier:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/unique_identifier.git
+      version: master
     status: maintained
   urdf:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -851,6 +851,7 @@ repositories:
       url: https://github.com/ros-gbp/rqt_graph-release.git
       version: 0.4.9-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
       version: master

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -389,6 +389,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/resource_retriever-release.git
+      version: 1.12.4-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: kinetic-devel
+    status: maintained
   ros:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -740,6 +740,27 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    status: maintained
   std_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -961,6 +961,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_service_caller.git
       version: master
     status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_srv-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: master
+    status: maintained
   rqt_topic:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -861,6 +861,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_action-release.git
+      version: 0.4.9-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: master
+    status: maintained
   rqt_bag:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -792,6 +792,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_console-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: master
+    status: maintained
   rqt_dep:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -792,6 +792,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: kinetic-devel
     status: maintained
+  rqt_dep:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_dep.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_dep-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_dep.git
+      version: master
+    status: maintained
   rqt_graph:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -65,6 +65,17 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
     status: maintained
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer-release.git
+      version: 0.3.0-0
+    status: developed
   catkin:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11,6 +11,17 @@ release_platforms:
   - artful
   - bionic
 repositories:
+  actionlib:
+    doc:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: melodic-devel
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: melodic-devel
+    status: maintained
   angles:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -960,6 +960,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: master
     status: maintained
+  rqt_web:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_web-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -709,6 +709,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  roslint:
+    doc:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/roslint-release.git
+      version: 0.11.2-0
+    source:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    status: maintained
   roslisp:
     doc:
       type: git

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -42,6 +42,11 @@ antlr:
   fedora: [antlr3-C, antlr-C++]
   gentoo: [dev-java/antlr]
   ubuntu: [antlr, libantlr-dev]
+apache2:
+  debian: [apache2]
+  fedora: [httpd]
+  gentoo: [www-servers/apache]
+  ubuntu: [apache2]
 apache2-mpm-prefork:
   debian:
     jessie: [apache2-mpm-prefork]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1001,6 +1001,10 @@ graphviz:
   rhel: [graphviz]
   slackware: [graphviz]
   ubuntu: [graphviz]
+graphviz-dev:
+  debian: [libgraphviz-dev]
+  fedora: [graphviz-devel]
+  ubuntu: [libgraphviz-dev]
 gringo:
   debian: [gringo]
   fedora: [gringo]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -306,6 +306,8 @@ bullet:
   macports: [bullet]
   opensuse: [libbullet]
   ubuntu:
+    artful: [libbullet-dev]
+    bionic: [libbullet-dev]
     precise: [libbullet-dev]
     quantal: [libbullet-dev]
     raring: [libbullet-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2755,6 +2755,7 @@ libqt5-widgets:
   slackware: [qt5]
   ubuntu: [libqt5widgets5]
 libqt5x11extras5-dev:
+  arch: [qt5-x11extras]
   debian: [libqt5x11extras5-dev]
   fedora: [qt5-qtx11extras-devel]
   freebsd: [qt5-x11extras]
@@ -2767,6 +2768,7 @@ libqtgui4:
   gentoo: ['dev-qt/qtgui:4']
   ubuntu: [libqtgui4]
 libqtwebkit-dev:
+  arch: [qt5-webkit]
   debian: [libqtwebkit-dev]
   fedora: [qtwebkit-devel]
   gentoo: [dev-qt/qtwebkit]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -101,6 +101,8 @@ assimp:
   rhel: [assimp-devel]
   slackware: [assimp]
   ubuntu:
+    artful: [libassimp-dev]
+    bionic: [libassimp-dev]
     lucid: [assimp-dev]
     maverick: [assimp-dev]
     oneiric: [assimp-dev]
@@ -125,6 +127,8 @@ assimp-dev:
   rhel: [assimp-devel]
   slackware: [assimp]
   ubuntu:
+    artful: [libassimp-dev]
+    bionic: [libassimp-dev]
     lucid: [assimp-dev]
     maverick: [assimp-dev]
     oneiric: [assimp-dev]
@@ -440,6 +444,7 @@ collada-dom:
   slackware: [collada-dom]
   ubuntu:
     artful: [libcollada-dom2.4-dp-dev]
+    bionic: [libcollada-dom2.4-dp-dev]
     lucid: [collada-dom-dev]
     maverick: [collada-dom-dev]
     natty: [collada-dom-dev]
@@ -696,6 +701,8 @@ ffmpeg:
   opensuse: [ffmpeg]
   slackware: [ffmpeg]
   ubuntu:
+    artful: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
+    bionic: [libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
     lucid: [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
     maverick: [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
     natty: [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
@@ -734,6 +741,8 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   opensuse: [fltk-devel]
   slackware: [fltk]
   ubuntu:
+    artful: [fluid, libfltk1.3-dev]
+    bionic: [fluid, libfltk1.3-dev]
     lucid: [fluid, libfltk1.1-dev]
     maverick: [fluid, libfltk1.1-dev]
     natty: [fluid, libfltk1.1-dev]
@@ -1659,6 +1668,8 @@ libfltk-dev:
   opensuse: [fltk-devel]
   slackware: [fltk]
   ubuntu:
+    artful: [libfltk1.3-dev]
+    bionic: [libfltk1.3-dev]
     lucid: [libfltk1.1-dev]
     maverick: [libfltk1.1-dev]
     natty: [libfltk1.1-dev]
@@ -2029,6 +2040,8 @@ libjpeg:
   opensuse: [libjpeg62-devel]
   slackware: [libjpeg-turbo]
   ubuntu:
+    artful: [libjpeg-dev]
+    bionic: [libjpeg-dev]
     lucid: [libjpeg62-dev]
     maverick: [libjpeg62-dev]
     natty: [libjpeg62-dev]
@@ -2253,6 +2266,8 @@ libogre-dev:
   rhel: [ogre-devel]
   slackware: [ogre]
   ubuntu:
+    artful: [libogre-1.9-dev]
+    bionic: [libogre-1.9-dev]
     lucid: [libogre-dev]
     maverick: [libogre-dev]
     natty: [libogre-dev]
@@ -2375,6 +2390,8 @@ libpcl-all:
   opensuse: [pcl]
   slackware: [pcl]
   ubuntu:
+    artful: [libpcl-apps1.8, libpcl-common1.8, libpcl-features1.8, libpcl-filters1.8, libpcl-io1.8, libpcl-kdtree1.8, libpcl-keypoints1.8, libpcl-ml1.8, libpcl-octree1.8, libpcl-outofcore1.8, libpcl-people1.8, libpcl-recognition1.8, libpcl-registration1.8, libpcl-sample-consensus1.8, libpcl-search1.8, libpcl-segmentation1.8, libpcl-stereo1.8, libpcl-surface1.8, libpcl-tracking1.8, libpcl-visualization1.8]
+    bionic: [libpcl-apps1.8, libpcl-common1.8, libpcl-features1.8, libpcl-filters1.8, libpcl-io1.8, libpcl-kdtree1.8, libpcl-keypoints1.8, libpcl-ml1.8, libpcl-octree1.8, libpcl-outofcore1.8, libpcl-people1.8, libpcl-recognition1.8, libpcl-registration1.8, libpcl-sample-consensus1.8, libpcl-search1.8, libpcl-segmentation1.8, libpcl-stereo1.8, libpcl-surface1.8, libpcl-tracking1.8, libpcl-visualization1.8]
     precise: [libpcl-1.7-all]
     quantal: [libpcl-1.7-all]
     raring: [libpcl-1.7-all]
@@ -2396,6 +2413,8 @@ libpcl-all-dev:
   opensuse: [pcl]
   slackware: [pcl]
   ubuntu:
+    artful: [libpcl-dev]
+    bionic: [libpcl-dev]
     precise: [libpcl-1.7-all-dev]
     quantal: [libpcl-1.7-all-dev]
     raring: [libpcl-1.7-all-dev]
@@ -2441,6 +2460,8 @@ libpng-dev:
   opensuse: [libpng12-devel]
   slackware: [libpng]
   ubuntu:
+    artful: [libpng-dev]
+    bionic: [libpng-dev]
     precise: [libpng12-dev]
     quantal: [libpng12-dev]
     raring: [libpng12-dev]
@@ -2976,6 +2997,8 @@ libtiff-dev:
     slackpkg:
       packages: [libtiff]
   ubuntu:
+    artful: [libtiff5-dev]
+    bionic: [libtiff5-dev]
     lucid: [libtiff4-dev]
     maverick: [libtiff4-dev]
     natty: [libtiff4-dev]
@@ -3016,6 +3039,8 @@ libtool:
   rhel: [libtool, libtool-ltdl-devel]
   slackware: [libtool]
   ubuntu:
+    artful: [libtool, libltdl-dev, libtool-bin]
+    bionic: [libtool, libltdl-dev, libtool-bin]
     lucid: [libtool, libltdl-dev]
     maverick: [libtool, libltdl-dev]
     natty: [libtool, libltdl-dev]
@@ -3239,6 +3264,8 @@ libvtk-java:
   opensuse: [vtk-java]
   slackware: [VTK]
   ubuntu:
+    artful: [libvtk6-java]
+    bionic: [libvtk6-java]
     lucid: [libvtk-java]
     precise: [libvtk-java]
     quantal: [libvtk-java]
@@ -3264,6 +3291,8 @@ libvtk-qt:
   opensuse: [vtk-qt]
   slackware: [VTK]
   ubuntu:
+    artful: [libvtk6-qt-dev]
+    bionic: [libvtk6-qt-dev]
     lucid: [libvtk5-qt4-dev]
     maverick: [libvtk5-qt4-dev]
     natty: [libvtk5-qt4-dev]
@@ -4039,6 +4068,8 @@ protobuf:
   opensuse: [libprotobuf9]
   slackware: [protobuf]
   ubuntu:
+    artful: [libprotobuf10]
+    bionic: [libprotobuf10]
     precise: [libprotobuf7]
     raring: [libprotobuf7]
     saucy: [libprotobuf7]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2572,6 +2572,8 @@ libqglviewer-qt4:
   gentoo: ['x11-libs/libQGLViewer:0/qt4-2']
   macports: [libQGLViewer]
   ubuntu:
+    artful: [libqglviewer2-qt4]
+    bionic: [libqglviewer2-qt4]
     lucid: [libqglviewer-qt4-2]
     maverick: [libqglviewer-qt4-2]
     natty: [libqglviewer-qt4-2]
@@ -2597,6 +2599,8 @@ libqglviewer-qt4-dev:
   fedora: [libQGLViewer-devel]
   gentoo: ['x11-libs/libQGLViewer:0/qt4-2']
   ubuntu:
+    artful: [libqglviewer-dev-qt4]
+    bionic: [libqglviewer-dev-qt4]
     lucid: [libqglviewer-qt4-dev]
     maverick: [libqglviewer-qt4-dev]
     natty: [libqglviewer-qt4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4919,6 +4919,8 @@ yaml-cpp:
   rhel: [yaml-cpp-devel]
   slackware: [yaml-cpp]
   ubuntu:
+    artful: [libyaml-cpp-dev]
+    bionic: [libyaml-cpp-dev]
     lucid: [yaml-cpp0.2.6-dev]
     maverick: [yaml-cpp0.2.6-dev]
     natty: [yaml-cpp0.2.6-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -538,6 +538,11 @@ daemontools:
   debian: [daemontools]
   gentoo: [virtual/daemontools]
   ubuntu: [daemontools]
+devscripts:
+  debian: [devscripts]
+  fedora: [devscripts]
+  gentoo: [dev-util/checkbashisms]
+  ubuntu: [devscripts]
 dfu-util:
   debian: [dfu-util]
   fedora: [dfu-util]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1963,6 +1963,11 @@ libicu-dev:
   fedora: [libicu-devel]
   gentoo: [dev-libs/icu]
   ubuntu: [libicu-dev]
+libimage-exiftool-perl:
+  arch: [perl-image-exiftool]
+  debian: [libimage-exiftool-perl]
+  gentoo: [media-libs/exiftool]
+  ubuntu: [libimage-exiftool-perl]
 libirrlicht-dev:
   arch: [irrlicht]
   debian: [libirrlicht-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -962,7 +962,7 @@ google-mock:
   debian: [google-mock]
   fedora: [gmock-devel]
   freebsd: [googlemock]
-  gentoo: [dev-cpp/gmock]
+  gentoo: [dev-cpp/gtest]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
   ubuntu: [google-mock]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3678,6 +3678,11 @@ python-vlc-pip:
   ubuntu:
     pip:
       packages: [python-vlc]
+python-voluptuous:
+  debian: [python-voluptuous]
+  fedora: [python-voluptuous]
+  gentoo: [dev-python/voluptuous]
+  ubuntu: [python-voluptuous]
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1945,6 +1945,8 @@ python-opengl:
       packages: [PyOpenGL]
   slackware: [PyOpenGL]
   ubuntu:
+    artful: [python-opengl]
+    bionic: [python-opengl]
     lucid: [python-opengl]
     maverick: [python-opengl]
     natty: [python-opengl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1611,6 +1611,8 @@ python-matplotlib:
   rhel: [python-matplotlib]
   slackware: [matplotlib]
   ubuntu:
+    artful: [python-matplotlib]
+    bionic: [python-matplotlib]
     lucid: [python-matplotlib]
     maverick: [python-matplotlib]
     natty: [python-matplotlib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1216,6 +1216,38 @@ python-gpiozero:
       pip:
         packages: [gpiozero]
     zesty: [python-gpiozero]
+python-gpxpy:
+  debian:
+    buster: [python-gpxpy]
+    jessie:
+      pip:
+        packages: [gpxpy]
+    stretch: [python-gpxpy]
+  gentoo: [sci-geosciences/gpxpy]
+  ubuntu:
+    artful: [python-gpxpy]
+    bionic: [python-gpxpy]
+    trusty:
+      pip:
+        packages: [gpxpy]
+    utopic:
+      pip:
+        packages: [gpxpy]
+    vivid:
+      pip:
+        packages: [gpxpy]
+    wily:
+      pip:
+        packages: [gpxpy]
+    xenial:
+      pip:
+        packages: [gpxpy]
+    yakkety:
+      pip:
+        packages: [gpxpy]
+    zesty:
+      pip:
+        packages: [gpxpy]
 python-graphviz-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2012,6 +2012,13 @@ python-path.py:
   ubuntu:
     pip:
       packages: [path.py]
+python-pathos-pip:
+  debian:
+    pip:
+      packages: [pathos]
+  ubuntu:
+    pip:
+      packages: [pathos]
 python-pathtools:
   debian: [python-pathtools]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3828,6 +3828,7 @@ python-webtest:
   gentoo: [dev-python/webtest]
   ubuntu: [python-webtest]
 python-werkzeug:
+  arch: [python-werkzeug]
   debian: [python-werkzeug]
   fedora: [python-werkzeug]
   gentoo: [dev-python/werkzeug]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8,6 +8,16 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+awsiotpythonsdk-pip:
+  debian:
+    pip:
+      packages: [awsiotpythonsdk]
+  fedora:
+    pip:
+      packages: [awsiotpythonsdk]
+  ubuntu:
+    pip:
+      packages: [awsiotpythonsdk]
 azure-iothub-device-client-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -486,6 +486,13 @@ python-cairo:
     slackpkg:
       packages: [pycairo]
   ubuntu: [python-cairo]
+python-cantools-pip:
+  debian:
+    pip:
+      packages: [cantools]
+  ubuntu:
+    pip:
+      packages: [cantools]
 python-catkin-lint:
   fedora: [python-catkin_lint]
   ubuntu: [python-catkin-lint]
@@ -1946,6 +1953,13 @@ python-paho-mqtt-pip:
   ubuntu:
     pip:
       packages: [paho-mqtt]
+python-pandacan-pip:
+  debian:
+    pip:
+      packages: [pandacan]
+  ubuntu:
+    pip:
+      packages: [pandacan]
 python-pandas:
   arch: [python2-pandas]
   debian: [python-pandas]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1141,6 +1141,11 @@ python-gcloud-pip:
   ubuntu:
     pip:
       packages: [gcloud]
+python-gdal:
+  debian: [python-gdal]
+  fedora: [python2-gdal]
+  gentoo: ['sci-libs/gdal[python]']
+  ubuntu: [python-gdal]
 python-gdown-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3095,6 +3095,10 @@ python-sip:
     slackpkg:
       packages: [sip]
   ubuntu:
+    artful: [python-sip-dev]
+    artful_python3: [python3-sip-dev]
+    bionic: [python-sip-dev]
+    bionic_python3: [python3-sip-dev]
     lucid: [python-sip-dev]
     maverick: [python-sip-dev]
     natty: [python-sip-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1399,7 +1399,7 @@ python-imaging:
       packages: [python-pillow]
   ubuntu:
     artful: [python-imaging]
-    bionic: [python-imaging]
+    bionic: [python-pil]
     lucid: [python-imaging]
     maverick: [python-imaging]
     natty: [python-imaging]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1194,6 +1194,13 @@ python-gnupg:
   fedora: [python-gnupg]
   gentoo: [dev-python/python-gnupg]
   ubuntu: [python-gnupg]
+python-google-cloud-bigquery-pip:
+  debian:
+    pip:
+      packages: [google-cloud-bigquery]
+  ubuntu:
+    pip:
+      packages: [google-cloud-bigquery]
 python-google-cloud-vision-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -963,6 +963,13 @@ python-falcon:
   fedora: [python-falcon]
   gentoo: [dev-python/falcon]
   ubuntu: [python-falcon]
+python-fastdtw-pip:
+  debian:
+    pip:
+      packages: [python-fastdtw]
+  ubuntu:
+    pip:
+      packages: [python-fastdtw]
 python-fcn-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1,3 +1,17 @@
+adafruit-gpio-pip:
+  debian:
+    pip:
+      packages: [Adafruit-GPIO]
+  ubuntu:
+    pip:
+      packages: [Adafruit-GPIO]
+adafruit-mcp3008-pip:
+  debian:
+    pip:
+      packages: [Adafruit-MCP3008]
+  ubuntu:
+    pip:
+      packages: [Adafruit-MCP3008]
 adafruit-pca9685-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3260,6 +3260,8 @@ python-sphinx:
     pip:
       packages: [Sphinx]
   ubuntu:
+    artful: [python-sphinx]
+    bionic: [python-sphinx]
     lucid: [python-sphinx]
     maverick: [python-sphinx]
     natty: [python-sphinx]


### PR DESCRIPTION
TCLAP (http://tclap.sourceforge.net/manual.html) is a "Templatized C++ Command Line Parser"
We use it in one of our projects to easily parse command line arguments in C++ and create a help page on-the fly.

package references:
https://packages.ubuntu.com/search?keywords=libtclap-dev
https://packages.debian.org/jessie/devel/libtclap-dev
https://www.archlinux.de/packages/community/x86_64/tclap
https://rpms.remirepo.net/rpmphp/zoom.php?rpm=tclap
https://packages.gentoo.org/packages/dev-cpp/tclap
https://www.macports.org/ports.php?by=library&substr=tclap
