### PR TITLE
added libtclap-dev to base.yaml (now rebased)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2957,11 +2957,6 @@ libswscale-dev:
   fedora: [ffmpeg-devel]
   gentoo: [virtual/ffmpeg]
   ubuntu: [libswscale-dev]
-libtesseract:
-  debian: [libtesseract-dev]
-  fedora: [tesseract-devel]
-  gentoo: [app-text/tesseract]
-  ubuntu: [libtesseract-dev]
 libtclap-dev:
   arch: [tclap]
   debian: [libtclap-dev]
@@ -2969,6 +2964,11 @@ libtclap-dev:
   gentoo: [dev-cpp/tclap]
   macports: [tclap]
   ubuntu: [libtclap-dev]
+libtesseract:
+  debian: [libtesseract-dev]
+  fedora: [tesseract-devel]
+  gentoo: [app-text/tesseract]
+  ubuntu: [libtesseract-dev]
 libtheora:
   arch: [libtheora]
   debian: [libtheora-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2962,6 +2962,13 @@ libtesseract:
   fedora: [tesseract-devel]
   gentoo: [app-text/tesseract]
   ubuntu: [libtesseract-dev]
+libtclap-dev:
+  arch: [tclap]
+  debian: [libtclap-dev]
+  fedora: [tclap]
+  gentoo: [dev-cpp/tclap]
+  macports: [tclap]
+  ubuntu: [libtclap-dev]
 libtheora:
   arch: [libtheora]
   debian: [libtheora-dev]


### PR DESCRIPTION
TCLAP (http://tclap.sourceforge.net/manual.html) is a "Templatized C++ Command Line Parser"
We use it in one of our projects to easily parse command line arguments in C++ and create a help page on-the fly.

package references:
https://packages.ubuntu.com/search?keywords=libtclap-dev
https://packages.debian.org/jessie/devel/libtclap-dev
https://www.archlinux.de/packages/community/x86_64/tclap
https://rpms.remirepo.net/rpmphp/zoom.php?rpm=tclap
https://packages.gentoo.org/packages/dev-cpp/tclap
https://www.macports.org/ports.php?by=library&substr=tclap