### PR TITLE
geometry_tutorials: 0.2.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -401,6 +401,26 @@ repositories:
       url: https://github.com/ros/geometry2.git
       version: melodic-devel
     status: maintained
+  geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: indigo-devel
+    release:
+      packages:
+      - geometry_tutorials
+      - turtle_tf
+      - turtle_tf2
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_tutorials-release.git
+      version: 0.2.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: indigo-devel
+    status: maintained
   gl_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.2.2-0`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## geometry_tutorials

- No changes

## turtle_tf

```
* remove old roslib invocations
* Contributors: Tully Foote
```

## turtle_tf2

```
* homogenizing install rules and script locations with older versions
* remove old roslib invocations
* Contributors: Tully Foote
```
