### PR TITLE
Keep source section for jsk_apc package

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5529,6 +5529,13 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
       version: master
     status: developed
+  jsk_apc:
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/start-jsk/jsk_apc.git
+      version: master
+    status: developed
   jsk_common:
     doc:
       type: git


### PR DESCRIPTION
Follow up of https://github.com/ros/rosdistro/pull/17334