### PR TITLE
urdf: 1.13.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1443,7 +1443,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urdf-release.git
-      version: 1.13.0-0
+      version: 1.13.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `1.13.1-0`:

- upstream repository: https://github.com/ros/urdf.git
- release repository: https://github.com/ros-gbp/urdf-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.13.0-0`

## urdf

```
* Eliminate a deprecation warning by renaming class_loader.h -> class_loader.hpp (#16 <https://github.com/ros/urdf/issues/16>)
* Make the pointers const for the new tinyxml2 APIs (#15 <https://github.com/ros/urdf/issues/15>)
* Contributors: Chris Lalancette, Shane Loretz
```

## urdf_parser_plugin

- No changes
