### PR TITLE
kdl_parser: 1.13.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -524,6 +524,25 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     status: maintained
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: melodic-devel
+    release:
+      packages:
+      - kdl_parser
+      - kdl_parser_py
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/kdl_parser-release.git
+      version: 1.13.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: melodic-devel
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `1.13.0-0`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros-gbp/kdl_parser-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## kdl_parser

```
* kdl_parser: switch from TinyXML to TinyXML2 (#4 <https://github.com/ros/kdl_parser/issues/4>)
* Style fixes from ros2 (#11 <https://github.com/ros/kdl_parser/issues/11>)
* Make rostest a test_depend (#3 <https://github.com/ros/kdl_parser/issues/3>)
* update links now that this is in its own repo
* Contributors: Chris Lalancette, Dmitry Rozhkov, Mikael Arguedas
```

## kdl_parser_py

```
* Make rostest a test_depend (#3 <https://github.com/ros/kdl_parser/issues/3>)
* update links now that this is in its own repo
* Contributors: Chris Lalancette, Mikael Arguedas
```
