### PR TITLE
rosdep: adding python-parso-pip entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2017,6 +2017,17 @@ python-paramiko:
   rhel: [python-paramiko]
   slackware: [paramiko]
   ubuntu: [python-paramiko]
+python-parso:
+  debian:
+    buster: [python-parso]
+    stretch:
+      pip:
+        packages: [parso]
+  ubuntu:
+    bionic: [python-parso]
+    xenial:
+      pip:
+        packages: [parso]
 python-passlib:
   debian: [python-passlib]
   fedora: [python-passlib]


### PR DESCRIPTION
Adds a rodep entry for [Parso: A Python Parser](http://parso.readthedocs.io/en/latest/).