### PR TITLE
mavros: 0.24.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1668,7 +1668,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.23.3-0
+      version: 0.24.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.24.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.23.3-0`

## libmavconn

```
* libmavconn: make serial.cpp more portable
* libmavconn : enable low-latency mode on Linux
  Some common USB-UART convertors like the FTDI accumulates individual bytes from the serial link
  in order to send them in a single USB packet (Nagling). This commit sets the ASYNC_LOW_LATENCY flag,
  which the FTDI kernel driver interprets as a request to drop the Nagling timer to 1ms (i.e send all
  accumulated bytes after 1ms.)
  This reduces average link RTT to under 5ms at 921600 baud, and enables the use of mavros in
  systems where low latency is required to get good performance for e.g estimation and controls.
* Contributors: Mohammed Kabir, Vladimir Ermakov
```

## mavros

```
* frame_tf: add assertion over size of covariance matrix URT
* extras: update vision_pose_estimate plugin so it can send the covariance matrix also
* plugins fix #990 <https://github.com/mavlink/mavros/issues/990>: Explicitly cast boolean values. Else someone can shoot in his foot.
* Update Readme for serial0: receive: End of file
* launch : remove vision_pose_estimate from blacklist on ardupilot
* plugin: ftp: fix typo
* Add ability to send STATUSTEXT messages
* Contributors: Anass Al, Andrei Korigodski, Pierre Kancir, TSC21, Vladimir Ermakov
```

## mavros_extras

```
* extras: update vision_pose_estimate plugin so it can send the covariance matrix also
* px4flow: sending OPTICAL_FLOW_RAD messages
* Contributors: Oleg Kalachev, TSC21
```

## mavros_msgs

```
* Add ability to send STATUSTEXT messages
* Contributors: Anass Al
```

## test_mavros

- No changes
