### PR TITLE
robot_state_publisher: 1.13.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -886,6 +886,22 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
     status: maintained
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/robot_state_publisher-release.git
+      version: 1.13.6-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: kinetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.13.6-0`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## robot_state_publisher

```
* added warning when joint is found in joint message but not in the urdf (#83 <https://github.com/ros/robot_state_publisher/issues/83>)
* added ros_warn if JointStateMessage is older than 30 seconds (#84 <https://github.com/ros/robot_state_publisher/issues/84>)
* Add tcp_no_delay to joint_states subscriber (#80 <https://github.com/ros/robot_state_publisher/issues/80>)
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>) (#75 <https://github.com/ros/robot_state_publisher/issues/75>)
* Added c++11 target_compile_options (#78 <https://github.com/ros/robot_state_publisher/issues/78>)
* Contributors: Lukas Bulwahn, Shane Loretz, Victor Lopez, jgueldenstein
```
