### PR TITLE
geometric_shapes: 0.5.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -402,6 +402,21 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: master
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/geometric_shapes-release.git
+      version: 0.5.4-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: melodic-devel
+    status: maintained
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.5.4-0`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.3`
- previous version for package: `null`

## geometric_shapes

```
* gracefully handle negative cylinder height: #64 <https://github.com/ros-planning/geometric_shapes/issues/64>, #80 <https://github.com/ros-planning/geometric_shapes/issues/80>
* clang-formatting of whole repo: #79 <https://github.com/ros-planning/geometric_shapes/issues/79>
* operator<< for ShapeType: #80 <https://github.com/ros-planning/geometric_shapes/issues/80>
* adaption to new CONSOLE_BRIDGE_logXXX API: #75 <https://github.com/ros-planning/geometric_shapes/issues/75>, #72 <https://github.com/ros-planning/geometric_shapes/issues/72>
* [fix] box-ray intersection: #73 <https://github.com/ros-planning/geometric_shapes/issues/73>
* Contributors: Dave Coleman, Leroy Rügemer, Malcolm Mielle, Mike Purvis, Robert Haschke, Michael Goerner
```
