### PR TITLE
json_transport: 0.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1376,6 +1376,25 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
       version: master
     status: developed
+  json_transport:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/json_transport.git
+      version: devel
+    release:
+      packages:
+      - json_msgs
+      - json_transport
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/locusrobotics/json_transport-release.git
+      version: 0.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/json_transport.git
+      version: devel
+    status: developed
   katana_driver:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1390,7 +1390,6 @@ repositories:
       url: https://github.com/locusrobotics/json_transport-release.git
       version: 0.0.1-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/locusrobotics/json_transport.git
       version: devel


### PR DESCRIPTION
Increasing version of package(s) in repository `json_transport` to `0.0.1-0`:

- upstream repository: https://github.com/locusrobotics/json_transport.git
- release repository: https://github.com/locusrobotics/json_transport-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## json_msgs

```
* Initial development (#1 <https://github.com/locusrobotics/json_transport/issues/1>)
  * Initial implementation
* Contributors: Paul Bovbel
```

## json_transport

```
* Initial development (#1 <https://github.com/locusrobotics/json_transport/issues/1>)
  * Initial implementation
  * Binary transport (#2 <https://github.com/locusrobotics/json_transport/issues/2>)
* Contributors: Paul Bovbel
```
