### PR TITLE
json_transport: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3936,6 +3936,25 @@ repositories:
       url: https://github.com/tork-a/jskeus-release.git
       version: 1.1.0-0
     status: developed
+  json_transport:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/json_transport.git
+      version: devel
+    release:
+      packages:
+      - json_msgs
+      - json_transport
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/locusrobotics/json_transport-release.git
+      version: 0.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/json_transport.git
+      version: devel
+    status: developed
   katana_driver:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3950,7 +3950,6 @@ repositories:
       url: https://github.com/locusrobotics/json_transport-release.git
       version: 0.0.1-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/locusrobotics/json_transport.git
       version: devel


### PR DESCRIPTION
Increasing version of package(s) in repository `json_transport` to `0.0.1-0`:

- upstream repository: https://github.com/locusrobotics/json_transport.git
- release repository: https://github.com/locusrobotics/json_transport-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## json_msgs

```
* Initial development (#1 <https://github.com/locusrobotics/json_transport/issues/1>)
  * Initial implementation
* Contributors: Paul Bovbel
```

## json_transport

```
* Initial development (#1 <https://github.com/locusrobotics/json_transport/issues/1>)
  * Initial implementation
  * Binary transport (#2 <https://github.com/locusrobotics/json_transport/issues/2>)
* Contributors: Paul Bovbel
```
