### PR TITLE
urdf_geometry_parser: 0.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1525,6 +1525,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_geometry_parser-release.git
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_geometry_parser` to `0.0.3-0`:

- upstream repository: https://github.com/ros-controls/urdf_geometry_parser.git
- release repository: https://github.com/ros-gbp/urdf_geometry_parser-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## urdf_geometry_parser

```
* add travis config, based on industrial_ci
* Make sure to include urdfdom_compatibility.h.
  This ensures that urdf_geometry_parser will build on all distros
  (including older Debian Jessie).
  Signed-off-by: Chris Lalancette <mailto:clalancette@osrfoundation.org>
* Contributors: Bence Magyar, Chris Lalancette, Mathias Lüdtke
```
