### PR TITLE
Adding radar_omnipresense to documentation index for distro

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2594,6 +2594,21 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
+  radar_omnipresense:
+    doc:
+      type: git
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense
+      version: lunar
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url:
+      version: 1.0-0
+    source:
+      type: git
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense
+      version: lunar
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
I'd like radar_omnipresense to be indexed and documented on ros.org