### PR TITLE
four_wheel_steering_msgs: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -291,6 +291,21 @@ repositories:
       url: https://github.com/ros/filters.git
       version: lunar-devel
     status: maintained
+  four_wheel_steering_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: master
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `four_wheel_steering_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/ros-drivers/four_wheel_steering_msgs.git
- release repository: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## four_wheel_steering_msgs

```
* Update url path
* Initial commit from https://github.com/Romea/romea_controllers
* Contributors: Vincent Rousseau
```
