### PR TITLE
libcreate: 1.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4275,6 +4275,11 @@ repositories:
       type: git
       url: https://github.com/AutonomyLab/libcreate.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AutonomyLab/libcreate-release.git
+      version: 1.6.0-0
     source:
       type: git
       url: https://github.com/AutonomyLab/libcreate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcreate` to `1.6.0-0`:

- upstream repository: https://github.com/AutonomyLab/libcreate.git
- release repository: https://github.com/AutonomyLab/libcreate-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## libcreate

```
* Add unit tests (gtests)
* Refactor Packet API
  
  Declare setData member as protected
  
  Rename 'setTempData' to 'setDataToValidate'
* Remove redundant packets from Data constructor
* Updated setDigits function API comments
  
  added HTML to adjust for spacing in diagram, showing the proper ordering of segments.
* Update examples
  
  More concise and focusing on individual features:
  
  Battery level
  
  Bumpers
  
  Drive circle
  
  LEDs
  
  Serial packets
  
  Play song
  
  Wheeldrop
* Update README
* Refactor cmake files
* Contributors: Jacob Perron, K.Moriarty
```
