### PR TITLE
dynamixel_sdk: 3.5.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2802,6 +2802,21 @@ repositories:
       url: https://github.com/arebgun/dynamixel_motor.git
       version: master
     status: maintained
+  dynamixel_sdk:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
+      version: 3.5.4-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: indigo-devel
+    status: developed
   dynpick_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.5.4-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## dynamixel_sdk

```
* Added : Deprecated is now being shown by attributes #67 #107
* Fixes : DynamixelSDK ROS Indigo Issue - target_sources func in CMake
* Fixes : Bug in protocol1_packet_handler.cpp, line 222 checking the returned Error Mask #120
* Fixes : Packet Handlers - array param uint8_t to uint16_t to avoid closure loop when the packet is too long to be in uint8_t appropriately
* Fixes : Group Syncwrite using multiple ports in c library issue solved (test code is also in this issue bulletin) #124
* Fixes : Support getting of time on MacOSX/XCode versions that doesn't support (CLOCK_REALTIME issue) #141 #144
* Changes : DynamixelSDK Ubuntu Linux usb ftdi latency timer fix issue - changes the default latency timer as 16 ms in all OS, but some about how to change the latency timer was commented in the codes (now the latency timer should be adjusted by yourself... see port_handler_linux source code to see details) #116
* Contributors: Leon
```
