### PR TITLE
jsk_recognition: 1.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3881,7 +3881,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.4-0
+      version: 1.2.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.5-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.2.4-0`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* Fix build of jsk_pcl_ros (on Kinetic) (#2262 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2262>)
* [jsk_pcl_ros/color_histogram_visualizer.py] use facecolor instead of axisbg (#2250 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2250>)
  * use facecolor instead of axisbgaxisbg is removed from matplotlib 2.2.0
* [jsk_pcl_ros] ICP Registration on 2D plane (#1991 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/1991>)
  * [jsk_pcl_ros] add sample launch file for icp_registration 2d
  * [jsk_pcl_ros][icp_registration_nodelet.cpp] add option for 2d transform estimation
* jsk_pcl_ros: add sample door detector (#2182 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2182>)
  * jsk_pcl_ros: fix param for door_detector sample launch
  * jsk_pcl_ros: add sample launch files for icp registration 2d
  * jsk_pcl_ros: add sample data for pr2 sink scenario
  * jsk_pcl_ros: add rviz config / rosbag for sample_door_handle_detector
  * jsk_pcl_ros: add sample door detector
* Contributors: Kentaro Wada, Shingo Kitagawa, Yuki Furuta
```

## jsk_pcl_ros_utils

- No changes

## jsk_perception

```
* Add MaskRCNNInstanceSegmentation node (#2257 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2257>)
  * MaskRCNN node publishes label imgs that have class and instance id
  * Add ~bg_label to label_image_decomposer which is not colorized
  * Add ~cval param to apply_mask_image
  * Add MaskRCNNInstanceSegmentation node
* Improve topic name visualization in tile_image.py (#2256 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2256>)
  * Comment out draw_classification_result test
  * Improve visualization in tile_image.pyUse FONT_HERSHEY_SIMPLEX.
  
  Adjust font_scale according to the new font.
* [jsk_perception/draw_classification_result.py] use LINE_AA for opencv3 in kinetic (#2247 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2247>)
  * enable draw_classification_result test
  * remove unused variables and imports
  * use LINE_AA for opencv3 in kinetic
* Add fcn_depth_prediction node (#2244 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2244>)
  * [jsk_perception] Fix function name in fcn_depth_prediction.py
  * [jsk_perception] Add sample of fcn_depth_prediction
  * [jsk_perception] Add trained data for fcn_depth_prediction to install_trained_data
  * [jsk_perception] Add fcn_depth_prediction node
* [jsk_perception/fast_rcnn.py] fast_rcnn node to follow chainer-v2 version (#2249 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2249>)
  * add MODEL arg for fast rcnn launch
  * check chainer version for volatile variable
* [jsk_perception/label_image_decomposer.py] check img.ndim for gray scale image (#2248 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2248>)
  * check img.ndim for gray scale image
* Contributors: Yuki Furuta, Kei Okada, Kentaro Wada, Shingo Kitagawa, Yuto Uchimi
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

```
* Fix build of jsk_recognition_utils (on Kinetic) (#2262 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2262> )
  * Close https://github.com/jsk-ros-pkg/jsk_recognition/issues/2259
* [jsk_perception/fast_rcnn.py] fast_rcnn node to follow chainer-v2 version (#2249 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2249>)
  * modify fast_rcnn model to follow chainer-v2 version
* Contributors: Yuki Furuta, Kentaro Wada, Shingo Kitagawa
```

## resized_image_transport

- No changes
