### PR TITLE
rosbridge_suite: 0.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8625,7 +8625,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.8.6-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.9.0-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.8.6-0`

## rosapi

- No changes

## rosbridge_library

```
* Fix typo in function call
* Add missing argument to InvalidMessageException (#323 <https://github.com/RobotWebTools/rosbridge_suite/issues/323>)
  Add missing argument to InvalidMessageException constructor
* Make unregister_timeout configurable (#322 <https://github.com/RobotWebTools/rosbridge_suite/issues/322>)
  Pull request #247 <https://github.com/RobotWebTools/rosbridge_suite/issues/247> introduces a 10 second delay to mitigate issue #138 <https://github.com/RobotWebTools/rosbridge_suite/issues/138>.
  This change makes this delay configurable by passing an argument either
  on the command line or when including a launch file.
  Usage example:
  ```xml
  <launch>
  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
  <arg name="unregister_timeout" value="5.0"/>
  </include>
  </launch>
  ```
  Closes #320 <https://github.com/RobotWebTools/rosbridge_suite/issues/320>
* message_conversion: create stand-alone object inst (#319 <https://github.com/RobotWebTools/rosbridge_suite/issues/319>)
  Catching the ROSInitException allows to create object
  instances without an initialized ROS state
* Fixes #313 <https://github.com/RobotWebTools/rosbridge_suite/issues/313> by fixing has_binary in protocol.py (#315 <https://github.com/RobotWebTools/rosbridge_suite/issues/315>)
  * Fixes #313 <https://github.com/RobotWebTools/rosbridge_suite/issues/313> by fixing has_binary in protocol.py
  Checks for lists that have binary content as well as dicts
  * Minor refactoring for protocol.py
* fix fragment bug (#316 <https://github.com/RobotWebTools/rosbridge_suite/issues/316>)
  * fix bug that lost data while sending large packets
  * fixed travis ci failed by @T045T
  * fixed travis ci failed by @T045T
  * travis ci failed
  * fix rosbridge_library/test/experimental/fragmentation+srv+tcp test bug
  * sync .travis.yaml
  * fix the service_response message bug
  * fix the fragment paring error
  * fix indentation of "service" line
* add graceful_shutdown() method to advertise_service capability
  This gives the service a bit of time to cancel any in-flight service requests (which should fix #265 <https://github.com/RobotWebTools/rosbridge_suite/issues/265>).
  This is important because we busy-wait for a rosbridge response for service calls and those threads do not get stopped otherwise.
  Also, rospy service clients do not currently support timeouts, so any clients would be stuck too.
  A new test case in test_service_capabilities.py verifies the fix works
* Add rostest for service capabilities and fix bugs
  also fixed some typos
* Fix Travis config (#311 <https://github.com/RobotWebTools/rosbridge_suite/issues/311>)
  * fix Travis config
  dist: kinetic is currently unsupported
  * fix rostests
  for some reason, rostest seems to hide the rosout node - changed tests to use other services
* Contributors: Anwar, Johannes Rothe, Jørgen Borgesen, Nils Berg, Phil, WH-0501, elgarlepp
```

## rosbridge_server

```
* Make unregister_timeout configurable (#322 <https://github.com/RobotWebTools/rosbridge_suite/issues/322>)
  Pull request #247 <https://github.com/RobotWebTools/rosbridge_suite/issues/247> introduces a 10 second delay to mitigate issue #138 <https://github.com/RobotWebTools/rosbridge_suite/issues/138>.
  This change makes this delay configurable by passing an argument either
  on the command line or when including a launch file.
  Usage example:
  ```xml
  <launch>
  <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
  <arg name="unregister_timeout" value="5.0"/>
  </include>
  </launch>
  ```
  Closes #320 <https://github.com/RobotWebTools/rosbridge_suite/issues/320>
* Remove tornado fork from source code and add python-tornado as run dependency (#317 <https://github.com/RobotWebTools/rosbridge_suite/issues/317>)
  Release only for kinetic+
* Fix bug that lost data while sending large packets (#310 <https://github.com/RobotWebTools/rosbridge_suite/issues/310>)
  * fix bug that lost data while sending large packets
* Contributors: Jørgen Borgesen, MBlistein, WH-0501
```

## rosbridge_suite

- No changes
