### PR TITLE
update version for 3rd party package eml 

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2197,7 +2197,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/eml-release.git
-      version: 1.8.15-3
+      version: 1.8.15-6
   ensenso:
     doc:
       type: git


### PR DESCRIPTION
updated version of 3rd-party package 'eml' (bloom-release failed to push to rosdistro, so manual update required)

this version update fixes the current jenkins build issues