### PR TITLE
dynamixel-workbench-msgs: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -225,6 +225,23 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  dynamixel-workbench-msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: melodic-devel
+    release:
+      packages:
+      - dynamixel_workbench_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: melodic-devel
+    status: developed
   dynamixel_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench-msgs` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## dynamixel_workbench_msgs

```
* changed package.xml to format v2
* created .travis.yml
* Contributors: Pyo
```
