### PR TITLE
ros_comm: 1.13.6-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1008,7 +1008,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.6-1
+      version: 1.13.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.13.6-2`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.13.6-1`

## message_filters

```
* use SteadyTimer in message_filters (#1247 <https://github.com/ros/ros_comm/issues/1247>)
* remove unnecessary xmlrpcpp dependency from message_filters (#1264 <https://github.com/ros/ros_comm/issues/1264>)
```

## ros_comm

- No changes

## rosbag

```
* return an error status on error in rosbag (#1257 <https://github.com/ros/ros_comm/issues/1257>)
* fix warn of --max-splits without --split (#1237 <https://github.com/ros/ros_comm/issues/1237>)
```

## rosbag_storage

```
* performance improvement for lower/upper bound (#1223 <https://github.com/ros/ros_comm/issues/1223>)
* use namespaced logging macros of console_bridge instead of deprecated macros (#1239 <https://github.com/ros/ros_comm/issues/1239>)
```

## rosconsole

```
* rename log macro argument from rate to period (#1318 <https://github.com/ros/ros_comm/issues/1318>)
```

## roscpp

```
* avoid recreating poll set (#1281 <https://github.com/ros/ros_comm/pull/1281>)
* switch to using epoll (#1217 <https://github.com/ros/ros_comm/pull/1217>)
* monotonic clock for callback queue timeouts (#1250 <https://github.com/ros/ros_comm/pull/1250>)
* fix IPv6 initialization order (#1262 <https://github.com/ros/ros_comm/issues/1262>)
* changed error message for single threaded spinner  (#1164 <https://github.com/ros/ros_comm/pull/1164>)
```

## rosgraph

```
* fix search strategy for python_logging config (#1292 <https://github.com/ros/ros_comm/issues/1292>)
```

## roslaunch

```
* add process listeners to XML RPC server (#1319 <https://github.com/ros/ros_comm/issues/1319>)
* pass through command-line args to the xmlloader when using the API (#1115 <https://github.com/ros/ros_comm/issues/1115>)
* make master process explicitly 'required' for parent launch (#1228 <https://github.com/ros/ros_comm/issues/1228>)
* remove unreachable exceptions (#1260 <https://github.com/ros/ros_comm/issues/1260>)
* replace Thread.setDaemon() using new API (#1276 <https://github.com/ros/ros_comm/issues/1276>)
* use roslaunch.core.printerrlog for printing error message (#1193 <https://github.com/ros/ros_comm/issues/1193>, #1317 <https://github.com/ros/ros_comm/issues/1317>)
```

## roslz4

```
* adding decompress to free(state) before return (#1313 <https://github.com/ros/ros_comm/issues/1313>)
* allow building on Trusty (#1236 <https://github.com/ros/ros_comm/issues/1236>)
```

## rosmaster

```
* add TCP_INFO availability check (#1211 <https://github.com/ros/ros_comm/issues/1211>)
* replace Thread.setDaemon() using new API (#1276 <https://github.com/ros/ros_comm/issues/1276>)
```

## rosmsg

- No changes

## rosnode

```
* fix docstrings (#1278 <https://github.com/ros/ros_comm/issues/1278>)
* fix documentation for cleanup_master_blacklist() (#1253 <https://github.com/ros/ros_comm/issues/1253>)
```

## rosout

```
* add parameter to omit topics list from rosout logs (#1234 <https://github.com/ros/ros_comm/issues/1234>)
```

## rosparam

```
* remove preprended '|' from pretty-printed strings (#1114 <https://github.com/ros/ros_comm/issues/1114>)
```

## rospy

```
* raise the correct exception from AnyMsg.serialize (#1311 <https://github.com/ros/ros_comm/issues/1311>)
* remove unreachable exceptions (#1260 <https://github.com/ros/ros_comm/issues/1260>)
* replace Thread.setDaemon() using new API (#1276 <https://github.com/ros/ros_comm/issues/1276>)
```

## rosservice

- No changes

## rostest

```
* add_rostest_gmock function (#1303 <https://github.com/ros/ros_comm/issues/1303>)
```

## rostopic

```
* add --tcpnodelay TransportHint option to hz and delay commands (#1296 <https://github.com/ros/ros_comm/issues/1296>)
* remove unreachable exceptions (#1260 <https://github.com/ros/ros_comm/issues/1260>)
```

## roswtf

- No changes

## topic_tools

```
* replace deprecated syntax (backticks with repr()) (#1259 <https://github.com/ros/ros_comm/issues/1259>)
```

## xmlrpcpp

```
* fix xmlrpc timeout using monotonic clock (#1249 <https://github.com/ros/ros_comm/issues/1249>)
* add tests and bug fixes for XmlRpcServer (#1243 <https://github.com/ros/ros_comm/issues/1243>)
* add test and fix uninitialized data in XmlRpcClient (#1244 <https://github.com/ros/ros_comm/issues/1244>)
* make xmlrpcpp specific include directory work in devel space (#1261 <https://github.com/ros/ros_comm/issues/1261>)
* add base64 tests (#1242 <https://github.com/ros/ros_comm/issues/1242>)
* add unit tests for XmlRpcDispatch (#1232 <https://github.com/ros/ros_comm/issues/1232>)
* add unit tests and bug fixes for XmlRpcClient (#1221 <https://github.com/ros/ros_comm/issues/1221>)
```
