### PR TITLE
cartographer: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -89,7 +89,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.3.0-0
+      version: 0.3.0-1
     status: developed
   catkin:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `0.3.0-1`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.0-0`

## cartographer

```
https://github.com/googlecartographer/cartographer/compare/0.2.0...0.3.0
```
