### PR TITLE
cartographer: 0.2.0-5 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -305,7 +305,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.2.0-4
+      version: 0.2.0-5
     status: developed
   cartographer_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `0.2.0-5`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.0-4`

## cartographer

```
https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
