### PR TITLE
cartographer: 0.2.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -909,7 +909,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     status: developed
   catch_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `0.2.0-2`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.0-1`

## cartographer

```
https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
