### PR TITLE
declination: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1710,6 +1710,21 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
       version: 0.0.1-0
+  declination:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/declination.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/declination-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/declination.git
+      version: master
+    status: maintained
   demo_pioneer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `declination` to `0.0.2-0`:

- upstream repository: https://github.com/clearpathrobotics/declination
- release repository: https://github.com/clearpath-gbp/declination-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## declination

```
* Fix executable name.
```
