### PR TITLE
imu_compass: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3472,6 +3472,21 @@ repositories:
       url: https://github.com/HUAJIEIMI/imi_ros.git
       version: master
     status: developed
+  imu_compass:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/imu_compass-release.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/imu_compass.git
+      version: master
+    status: maintained
   imu_pipeline:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_compass` to `0.0.5-0`:

- upstream repository: https://github.com/clearpathrobotics/imu_compass
- release repository: https://github.com/clearpath-gbp/imu_compass-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## imu_compass

```
* removing bag references from sample hard-iron calibration output file
* fixing example launch file to reflect changes in param intake in the node
* Contributors: Prasenjit Mukherjee
```
