### PR TITLE
robot_localization: 2.5.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2734,7 +2734,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.5.1-1
+      version: 2.5.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.5.2-0`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.5.1-1`

## robot_localization

```
* Add published accel topic to documentation
* adding log statements for nans in the invertable matrix
* Fixing issue with potential seg fault
* Contributors: Oleg Kalachev, Tom Moore, stevemacenski
```
