### PR TITLE
husky: 0.2.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4714,7 +4714,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.2.8-0`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.7-0`

## husky_control

```
* Fixed typo in URLs.
* Revert "Remove twist_mux config."
* Remove twist_mux config.
* Replace twist-mux
* Contributors: Administrator, Peiyi Chen, Tony Baltovski
```

## husky_description

```
* Added a large top plate (used for waterproofing upgrade and UR5 upgrade) and an environment variable for controlling it HUSKY_LARGE_TOP_PLATE
* Moved URDF_EXTRAS into the macro where it belongs
* Added environment variables to enabled or disabled the bumpers and the user rail
* Added urdf_extras so husky is consistent to our other platforms
* Changed the wheel radius to reflect 13 inch outdoor Husky tire
* [husky_description] Updated intertial parameters.
* wheel.urdf.xacro: swap iyy, izz inertias
  Fixes #34 <https://github.com/husky/husky/issues/34>.
* Contributors: Dave Niewinski, Martin Cote, Steven Peters, Tony Baltovski
```

## husky_msgs

```
* Fixed typo in URLs.
* Contributors: Tony Baltovski
```

## husky_navigation

```
* Fixed typo in URLs.
* Contributors: Tony Baltovski
```

## husky_ur5_moveit_config

```
* Fixed typo in URLs.
* Removed old controllers.yaml
* Added dependency fixes and synergy between dualur5 config files
* Added pading to the robot so the real robot doesn't fail
* This package depends on ur_kinematics
* added dependencies on these moveit packages
* created .setup_assistant, needed to run moveit assitant
* Contributors: Dash, Ilia Baranov, TheDash, Tony Baltovski
```
