### PR TITLE
husky_simulator: 0.2.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4769,7 +4769,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/husky_simulator-release.git
-      version: 0.2.6-0
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/husky/husky_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky_simulator` to `0.2.6-1`:

- upstream repository: https://github.com/husky/husky_simulator.git
- release repository: https://github.com/clearpath-gbp/husky_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.6-0`

## husky_gazebo

```
* spawn_husky.launch: enable to use custom controller files, i.e effort controller
* spawn_husky.launch: support argument to set urdf file and initial pose
* Contributors: Kei Okada
```

## husky_simulator

- No changes
