### PR TITLE
ridgeback: 0.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10984,7 +10984,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.1.11-0`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.10-0`

## ridgeback_control

```
* Updated to Package format 2.
* [ridgeback_control] Added ability to override default control parameters with environment variables.
* Contributors: Tony Baltovski
```

## ridgeback_description

```
* Updated to Package format 2.
* Contributors: Tony Baltovski
```

## ridgeback_msgs

```
* Updated to Package format 2.
* Contributors: Tony Baltovski
```

## ridgeback_navigation

```
* Updated to Package format 2.
* Contributors: Tony Baltovski
```
