### PR TITLE
ridgeback: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7731,6 +7731,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/RH-P12-RN.git
       version: kinetic-devel
     status: developed
+  ridgeback:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_control
+      - ridgeback_description
+      - ridgeback_msgs
+      - ridgeback_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback.git
+      version: kinetic-devel
+    status: maintained
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.2.0-0`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ridgeback_control

```
* Removed tight default rolling window
* Updated rolling window for odom responsiveness.  Minor changes to control and urdf syntax for kinetic
* Updated to Package format 2.
* [ridgeback_control] Added ability to override default control parameters with environment variables.
* Contributors: Dave Niewinski, Tony Baltovski
```

## ridgeback_description

```
* Changed to in-order xacro parsing
* Updated rolling window for odom responsiveness.  Minor changes to control and urdf syntax for kinetic
* Updated to Package format 2.
* Contributors: Dave Niewinski, Tony Baltovski
```

## ridgeback_msgs

```
* Updated to Package format 2.
* Contributors: Tony Baltovski
```

## ridgeback_navigation

```
* Updated to Package format 2.
* Contributors: Tony Baltovski
```
