### PR TITLE
ridgeback_desktop: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7751,6 +7751,24 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: kinetic-devel
     status: maintained
+  ridgeback_desktop:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_desktop
+      - ridgeback_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_desktop.git
+      version: kinetic-devel
+    status: maintained
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_desktop` to `0.1.1-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_desktop
- release repository: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ridgeback_desktop

- No changes

## ridgeback_viz

```
* Updated laser scan topic.
* Contributors: Tony Baltovski
```
