### PR TITLE
ridgeback_simulator: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7751,6 +7751,26 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: kinetic-devel
     status: maintained
+  ridgeback_simulator:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - mecanum_gazebo_plugin
+      - ridgeback_gazebo
+      - ridgeback_gazebo_plugins
+      - ridgeback_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: kinetic-devel
+    status: maintained
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.0.2-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mecanum_gazebo_plugin

```
* Disabled tests for mecanum_gazebo_plugin.
* Contributors: Tony Baltovski
```

## ridgeback_gazebo

```
* Changed Ridgeback config to environment variable and minor clean-up of ForceBasedPlugin.
* Updated default world to a wider and less constrained version.
* Contributors: Tony Baltovski
```

## ridgeback_gazebo_plugins

```
* Changed Ridgeback config to environment variable and minor clean-up of ForceBasedPlugin.
* Contributors: Tony Baltovski
```

## ridgeback_simulator

- No changes
