### PR TITLE
jackal: 0.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3705,6 +3705,27 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  jackal:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: kinetic-devel
+    release:
+      packages:
+      - jackal_control
+      - jackal_description
+      - jackal_msgs
+      - jackal_navigation
+      - jackal_tutorials
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: kinetic-devel
+    status: maintained
   jaguar:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.6.0-0`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## jackal_control

```
* [jackal_control] Made the PS4 controller default.
* Made minor changes to syntax for kinetic warnings
* Contributors: Dave Niewinski, Tony Baltovski
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
