### PR TITLE
warthog: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16517,7 +16517,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.0.3-0`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.2-0`

## warthog_control

```
* [warthog_control] Fixed incorrect joint name.
* Added optional config load for teleop.launch
* Added track configuration.
* Contributors: Michael Hosmar, Tony Baltovski
```

## warthog_description

```
* Added track configuration.
* Added track meshes
* Contributors: Dave Niewinski, Tony Baltovski
```

## warthog_msgs

- No changes
