### PR TITLE
jackal_desktop: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3726,6 +3726,24 @@ repositories:
       url: https://github.com/jackal/jackal.git
       version: kinetic-devel
     status: maintained
+  jackal_desktop:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - jackal_desktop
+      - jackal_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_desktop-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: kinetic-devel
+    status: maintained
   jaguar:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `0.3.2-0`:

- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## jackal_desktop

- No changes

## jackal_viz

```
* Changed laser scan topics to /front/scan.
* Contributors: Tony Baltovski
```
