### PR TITLE
pr2_navigation: 0.1.27-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7029,6 +7029,33 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: unmaintained
+  pr2_navigation:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_navigation.git
+      version: hydro-devel
+    release:
+      packages:
+      - laser_tilt_controller_filter
+      - pr2_move_base
+      - pr2_navigation
+      - pr2_navigation_config
+      - pr2_navigation_global
+      - pr2_navigation_local
+      - pr2_navigation_perception
+      - pr2_navigation_self_filter
+      - pr2_navigation_slam
+      - pr2_navigation_teleop
+      - semantic_point_annotator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_navigation-release.git
+      version: 0.1.27-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_navigation.git
+      version: hydro-devel
+    status: unmaintained
   pr2_power_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.27-0`:

- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/pr2-gbp/pr2_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## laser_tilt_controller_filter

- No changes

## pr2_move_base

- No changes

## pr2_navigation

- No changes

## pr2_navigation_config

- No changes

## pr2_navigation_global

```
* Merge pull request #16 <https://github.com/pr2/pr2_navigation/issues/16> from k-okada/remove_build_depend
  we do not need any package during build process
* we do not need any package during build process
* Contributors: Devon Ash, Kei Okada
```

## pr2_navigation_local

```
* Merge pull request #16 <https://github.com/pr2/pr2_navigation/issues/16> from k-okada/remove_build_depend
  we do not need any package during build process
* we do not need any package during build process
* Contributors: Devon Ash, Kei Okada
```

## pr2_navigation_perception

- No changes

## pr2_navigation_self_filter

```
* Support collada dae mesh file as well as stl files
* Install self_filter binary to the package_bin directory
* Contributors: Ryohei Ueda, aginika
```

## pr2_navigation_slam

```
* Merge pull request #16 <https://github.com/pr2/pr2_navigation/issues/16> from k-okada/remove_build_depend
  we do not need any package during build process
* we do not need any package during build process
* Contributors: Devon Ash, Kei Okada
```

## pr2_navigation_teleop

- No changes

## semantic_point_annotator

- No changes
