### PR TITLE
heron: 0.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4509,7 +4509,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/heron-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/heron/heron.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron` to `0.2.3-0`:

- upstream repository: https://github.com/heron/heron
- release repository: https://github.com/clearpath-gbp/heron-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.2-0`

## heron_description

```
* Added missing sonar link.
* Added Ceepulse sonar accessory.
* Contributors: Administrator, Tony Baltovski
```

## heron_msgs

- No changes
