### PR TITLE
heron-desktop: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4515,6 +4515,24 @@ repositories:
       url: https://github.com/heron/heron.git
       version: indigo-devel
     status: developed
+  heron-desktop:
+    doc:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - heron_desktop
+      - heron_viz
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron_desktop-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
+      version: indigo-devel
+    status: maintained
   hironx_rpc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron-desktop` to `0.0.2-0`:

- upstream repository: https://github.com/heron/heron_desktop.git
- release repository: https://github.com/clearpath-gbp/heron_desktop-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## heron_desktop

```
* Updated to include config and other changes in heron_description.
* Heron rename.
* Contributors: Tony Baltovski
```

## heron_viz

```
* Updated to include config and other changes in heron_description.
* Heron rename.
* Contributors: Tony Baltovski
```
