### PR TITLE
odva_ethernetip: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8538,7 +8538,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/odva_ethernetip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `odva_ethernetip` to `0.1.2-0`:

- upstream repository: https://github.com/ros-drivers/odva_ethernetip.git
- release repository: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `0.1.1-0`

## odva_ethernetip

```
* Optional local_ip (#8 <https://github.com/ros-drivers/odva_ethernetip/issues/8>)
* Exclude tests from rosdoc.
* Minor manifest and build script updates.
* Use ros-shadow-fixed for dependencies.
* Contributors: Mike Purvis, Rein Appeldoorn, gavanderhoorn
```
