### PR TITLE
odva_ethernetip: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6198,6 +6198,21 @@ repositories:
       url: https://github.com/xaxxontech/oculusprime_ros.git
       version: master
     status: developed
+  odva_ethernetip:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/odva_ethernetip.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/odva_ethernetip.git
+      version: indigo-devel
+    status: unmaintained
   omip:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `odva_ethernetip` to `0.1.2-0`:

- upstream repository: https://github.com/ros-drivers/odva_ethernetip.git
- release repository: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `null`

## odva_ethernetip

```
* Optional local_ip (#8 <https://github.com/ros-drivers/odva_ethernetip/issues/8>)
* Exclude tests from rosdoc.
* Minor manifest and build script updates.
* Use ros-shadow-fixed for dependencies.
* Contributors: Mike Purvis, Rein Appeldoorn, gavanderhoorn
```
