### PR TITLE
odva_ethernetip: 0.1.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -767,6 +767,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_msgs.git
       version: melodic-devel
     status: maintained
+  odva_ethernetip:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/odva_ethernetip.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/odva_ethernetip.git
+      version: indigo-devel
+    status: unmaintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `odva_ethernetip` to `0.1.2-0`:

- upstream repository: https://github.com/ros-drivers/odva_ethernetip.git
- release repository: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `null`

## odva_ethernetip

```
* Optional local_ip (#8 <https://github.com/ros-drivers/odva_ethernetip/issues/8>)
* Exclude tests from rosdoc.
* Minor manifest and build script updates.
* Use ros-shadow-fixed for dependencies.
* Contributors: Mike Purvis, Rein Appeldoorn, gavanderhoorn
```
