### PR TITLE
warthog-simulator: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16541,6 +16541,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog.git
       version: indigo-devel
     status: developed
+  warthog-simulator:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_gazebo
+      - warthog_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_simulator-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: indigo-devel
+    status: maintained
   warthog_desktop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog-simulator` to `0.0.1-0`:

- upstream repository: https://github.com/warthog-cpr/warthog_simulator.git
- release repository: https://github.com/clearpath-gbp/warthog_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## warthog_gazebo

```
* [warthog_gazebo] Updated joint names.
* Initial commit.
* Contributors: Tony Baltovski
```

## warthog_simulator

```
* Initial commit.
* Contributors: Tony Baltovski
```
