### PR TITLE
heron-desktop: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3204,6 +3204,22 @@ repositories:
     source:
       type: git
       url: https://github.com/heron/heron.git
+  heron-desktop:
+    doc:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - heron_desktop
+      - heron_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron_desktop-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/heron/heron_desktop.git
       version: kinetic-devel
     status: maintained
   hls-lfcd-lds-driver:


### PR DESCRIPTION
Increasing version of package(s) in repository `heron-desktop` to `0.0.2-0`:

- upstream repository: https://github.com/heron/heron_desktop.git
- release repository: https://github.com/clearpath-gbp/heron_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## heron_desktop

```
* Updated to include config and other changes in heron_description.
* Heron rename.
* Contributors: Tony Baltovski
```

## heron_viz

```
* Updated to include config and other changes in heron_description.
* Heron rename.
* Contributors: Tony Baltovski
```
