### PR TITLE
mapviz: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6738,7 +6738,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.0.9-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.8-0`

## mapviz

```
* Add clear history functionality.
* improve text contrast (#552 <https://github.com/swri-robotics/mapviz/issues/552>)
* Glew warning fixed (#539 <https://github.com/swri-robotics/mapviz/issues/539>)
* remove copy and paste of Print...
* add context menu to config_item (#526 <https://github.com/swri-robotics/mapviz/issues/526>) (#532 <https://github.com/swri-robotics/mapviz/issues/532>)
* Add keyboard input support for plugins
* update to use non deprecated pluginlib macro
* Move video recording into its own thread
* Contributors: Davide Faconti, Marc Alban, Matthew Bries, Mikael Arguedas, P. J. Reed
```

## mapviz_plugins

```
* Add clear history functionality.
* Add support for newlines in text marker plugin (#571 <https://github.com/swri-robotics/mapviz/issues/571>)
* Glew warning fixed (#539 <https://github.com/swri-robotics/mapviz/issues/539>)
* Added "keep image ratio" to Image plugin (#543 <https://github.com/swri-robotics/mapviz/issues/543>) (#545 <https://github.com/swri-robotics/mapviz/issues/545>)
* Remove copy and paste of Print...
* PointCloud2 speed improvement (#531 <https://github.com/swri-robotics/mapviz/issues/531>) (#538 <https://github.com/swri-robotics/mapviz/issues/538>)
* Dead code removed (#535 <https://github.com/swri-robotics/mapviz/issues/535>) (#537 <https://github.com/swri-robotics/mapviz/issues/537>)
* Speed up improvement in LaserScan and PointCloud2 (#525 <https://github.com/swri-robotics/mapviz/issues/525>) (#528 <https://github.com/swri-robotics/mapviz/issues/528>)
* Add support for unpacking rgb8 in pointcloud2s
* Update to use non deprecated pluginlib macro
* change the signal that triggers AlphaEdited + minor changes (#514 <https://github.com/swri-robotics/mapviz/issues/514>)
* Added timestamp display to odometry
* Merge pull request #492 <https://github.com/swri-robotics/mapviz/issues/492> from matt-attack/fix_448
* Fix color of covariance display for odometry
* Added timestamp display to odometry
* Contributors: Davide Faconti, Marc Alban, Matthew Bries, Mikael Arguedas, P. J. Reed, jgassaway
```

## multires_image

```
* Add ability to set offset for multires image (#565 <https://github.com/swri-robotics/mapviz/issues/565>)
* Fix multires image scale when projection is WGS84.
* update to use non deprecated pluginlib macro
* Remove dep on libopencv-dev from multires_image (#505 <https://github.com/swri-robotics/mapviz/issues/505>)
* Support transparent tiles in multires_image
* Contributors: Marc Alban, Mikael Arguedas, P. J. Reed, jgassaway
```

## tile_map

```
* Bug fix in TileMap. GenTexture was invoked over and over again (#560 <https://github.com/swri-robotics/mapviz/issues/560>)
* Improve tile loading prioritization.
* Glew warning fixed (#539 <https://github.com/swri-robotics/mapviz/issues/539>)
* update to use non deprecated pluginlib macro
* Contributors: Davide Faconti, Marc Alban, Mikael Arguedas, P. J. Reed
```
