### PR TITLE
mapviz: 0.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4798,7 +4798,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.2.5-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.4-0`

## mapviz

```
* Add clear history functionality.
* New plugin to send commands to move_base
* improve text contrast (#550 <https://github.com/swri-robotics/mapviz/issues/550>)
* Glew warning fixed (#539 <https://github.com/swri-robotics/mapviz/issues/539>)
* remove copy and paste of Print...
* add context menu to config_item (#526 <https://github.com/swri-robotics/mapviz/issues/526>)
* Merge pull request #523 <https://github.com/swri-robotics/mapviz/issues/523> from matt-attack/add-keyboard-input-support-kinetic
* Add keyboard input support for plugins
* update to use non deprecated pluginlib macro
* Fix the "File" menu actions (#513 <https://github.com/swri-robotics/mapviz/issues/513>)
* Merge pull request #481 <https://github.com/swri-robotics/mapviz/issues/481> from pjreed/threaded-video-recording-kinetic
* Move video recording into its own thread
* Contributors: Davide Faconti, Marc Alban, Matthew Bries, Mikael Arguedas, P. J. Reed
```

## mapviz_plugins

```
* Add clear history functionality.
* Add support for newlines in text marker plugin (#572 <https://github.com/swri-robotics/mapviz/issues/572>)
* New plugin to send commands to move_base
* Glew warning fixed (#539 <https://github.com/swri-robotics/mapviz/issues/539>)
* Added "keep image ratio" to Image plugin (#543 <https://github.com/swri-robotics/mapviz/issues/543>)
* Remove copy and paste of Print...
* PointCloud2 speed improvement (#531 <https://github.com/swri-robotics/mapviz/issues/531>)
* Dead code removed (#535 <https://github.com/swri-robotics/mapviz/issues/535>)
* Ratio added to robot_image_plugin (#530 <https://github.com/swri-robotics/mapviz/issues/530>)
* Speed up improvement in LaserScan and PointCloud2 (#525 <https://github.com/swri-robotics/mapviz/issues/525>)
* Re-add GPSFix plugin to kinetic-devel (#519 <https://github.com/swri-robotics/mapviz/issues/519>)
* Add support for unpacking rgb8 in pointcloud2s
* Use non-deprecated pluginlib macro
* Add plug-in for drawing and publishing a polygon.
* change the signal that triggers AlphaEdited + minor changes (#514 <https://github.com/swri-robotics/mapviz/issues/514>)
* Added timestamp display to odometry for kinetic
* Contributors: Davide Faconti, Marc Alban, Matthew Bries, Mikael Arguedas, P. J. Reed, jgassaway
```

## multires_image

```
* Add ability to set offset for multires image (#565 <https://github.com/swri-robotics/mapviz/issues/565>)
* Fix multires image scale when projection is WGS84.
* update to use non deprecated pluginlib macro
* Mapviz tile loader (Kinetic) (#509 <https://github.com/swri-robotics/mapviz/issues/509>)
* Change package.xml dep order
* Support transparent tiles in multires_image
* Contributors: Marc Alban, Mikael Arguedas, P. J. Reed, jgassaway
```

## tile_map

```
* Bug fix in TileMap. GenTexture was invoked over and over again (#559 <https://github.com/swri-robotics/mapviz/issues/559>)
* Improve tile loading prioritization.
* Glew warning fixed (#539 <https://github.com/swri-robotics/mapviz/issues/539>)
* update to use non deprecated pluginlib macro
* Contributors: Davide Faconti, Marc Alban, Mikael Arguedas, P. J. Reed
```
