### PR TITLE
Fixed package names for heron_desktop and warthog_simulator.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4515,7 +4515,7 @@ repositories:
       url: https://github.com/heron/heron.git
       version: indigo-devel
     status: developed
-  heron-desktop:
+  heron_desktop:
     doc:
       type: git
       url: https://github.com/heron/heron_desktop.git
@@ -4527,7 +4527,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_desktop-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/heron/heron_desktop.git
@@ -16541,24 +16541,6 @@ repositories:
       url: https://github.com/warthog-cpr/warthog.git
       version: indigo-devel
     status: developed
-  warthog-simulator:
-    doc:
-      type: git
-      url: https://github.com/warthog-cpr/warthog_simulator.git
-      version: indigo-devel
-    release:
-      packages:
-      - warthog_gazebo
-      - warthog_simulator
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/clearpath-gbp/warthog_simulator-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/warthog-cpr/warthog_simulator.git
-      version: indigo-devel
-    status: maintained
   warthog_desktop:
     doc:
       type: git
@@ -16577,6 +16559,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog_desktop.git
       version: indigo-devel
     status: developed
+  warthog_simulator:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_gazebo
+      - warthog_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_simulator-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: indigo-devel
+    status: maintained
   waypoint:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3211,7 +3211,7 @@ repositories:
     source:
       type: git
       url: https://github.com/heron/heron.git
-  heron-desktop:
+  heron_desktop:
     doc:
       type: git
       url: https://github.com/heron/heron_desktop.git
@@ -3223,7 +3223,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_desktop-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/heron/heron_desktop.git


### PR DESCRIPTION
Sorry guys, I used dashes instead of underscores.  I re-bloomed, thus the version change.