### PR TITLE
libuvc: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4514,7 +4514,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ktossell/libuvc-release.git
-      version: 0.0.5-2
+      version: 0.0.6-0
     status: unmaintained
   libuvc_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.6-0`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ktossell/libuvc-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.5-2`
