### PR TITLE
teraranger_array: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10860,7 +10860,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git
-      version: 1.2.3-0
+      version: 1.3.0-0
     status: maintained
   teraranger_array_converter:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `1.3.0-0`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.2.3-0`

## teraranger_array

```
* Add example launch files
* Update for evo 600hz
* Close serial port on shutdown
* Move input flush
* Fix/default modes
* Make separate function for each reconfigure parameter
* Initilalize all modes at first dynamic reconfigure call
* Remove min and max clipping for One and Evo
* Contributors: Pierre-Louis Kabaradjianm, BaptistePotier
```
