### PR TITLE
teraranger: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10853,7 +10853,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     status: maintained
   teraranger_array:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `1.2.0-0`:

- upstream repository: git@github.com:Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.1.0-0`

## teraranger

```
* Remove unecessary files
* Put the private parameters in define + correct ros info messages
* Update for evo 600Hz
* Contributors: BaptistePotier, Pierre-Louis Kabaradjian
```
