### PR TITLE
flask_cors: 3.0.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2425,6 +2425,13 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: kinetic-devel
     status: maintained
+  flask_cors:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pyros-dev/flask-cors-rosrelease.git
+      version: 3.0.3-2
+    status: maintained
   follow_waypoints:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flask_cors` to `3.0.3-2`:

- upstream repository: https://github.com/corydolphin/flask-cors.git
- release repository: https://github.com/pyros-dev/flask-cors-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
