### PR TITLE
rosmon: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1237,6 +1237,11 @@ repositories:
       type: git
       url: https://github.com/xqms/rosmon.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/xqms/rosmon-release.git
+      version: 1.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.0-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rosmon

```
* Initial release
* Contributors: David Schwarz, Gabriel Arjones, Kartik Mohta, Max Schwarz, Philipp Allgeuer
```
