### PR TITLE
rosmon: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9124,7 +9124,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/xqms/rosmon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.1-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.0-0`

## rosmon

```
* Fix compilation issues on Ubuntu Artful and Debian Stretch.
* Contributors: Max Schwarz
```
