### PR TITLE
pr2_ethercat_drivers: 1.8.18-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7001,18 +7001,18 @@ repositories:
   pr2_ethercat_drivers:
     doc:
       type: git
-      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      url: https://github.com/PR2-prime/pr2_ethercat_drivers.git
       version: kinetic-devel
     release:
       packages:
       - fingertip_pressure
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
+      url: https://github.com/PR2-prime/pr2_ethercat_drivers-release.git
       version: 1.8.18-0
     source:
       type: git
-      url: https://github.com/PR2/pr2_ethercat_drivers.git
+      url: https://github.com/PR2-prime/pr2_ethercat_drivers.git
       version: kinetic-devel
     status: unmaintained
   pr2_kinematics:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7009,7 +7009,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
-      version: 1.8.17-0
+      version: 1.8.18-0
     source:
       type: git
       url: https://github.com/PR2/pr2_ethercat_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.18-0`:

- upstream repository: https://github.com/PR2-prime/pr2_ethercat_drivers.git
- release repository: https://github.com/PR2-prime/pr2_ethercat_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.8.17-0`

## fingertip_pressure

```
* updated maintainer
* Contributors: David Feil-Seifer
```
