### PR TITLE
pr2_ethercat_drivers: 1.8.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7012,11 +7012,13 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - ethercat_hardware
       - fingertip_pressure
+      - pr2_ethercat_drivers
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PR2-prime/pr2_ethercat_drivers-release.git
-      version: 1.8.18-0
+      version: 1.8.18-1
     source:
       type: git
       url: https://github.com/PR2-prime/pr2_ethercat_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.18-1`:

- upstream repository: https://github.com/PR2-prime/pr2_ethercat_drivers.git
- release repository: https://github.com/PR2-prime/pr2_ethercat_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.8.18-0`

## ethercat_hardware

```
* updated maintainer
* fixed compile error
* Contributors: David Feil-Seifer
* fixed compile error
* Contributors: David Feil-Seifer
```

## fingertip_pressure

```
* updated maintainer
* Contributors: David Feil-Seifer
```

## pr2_ethercat_drivers

```
* updated maintainer
* Contributors: David Feil-Seifer
```
