### PR TITLE
adding python-aniso8601

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -266,6 +266,7 @@ python-amqp:
   gentoo: [dev-python/py-amqp]
   ubuntu: [python-amqp]
 python-aniso8601:
+  centos: [python-aniso8601]
   debian: [python-aniso8601]
   fedora: [python2-aniso8601]
   ubuntu: [python-aniso8601]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -265,6 +265,10 @@ python-amqp:
   fedora: [python-amqp]
   gentoo: [dev-python/py-amqp]
   ubuntu: [python-amqp]
+python-aniso8601:
+  debian: [python-aniso8601]
+  fedora: [python2-aniso8601]
+  ubuntu: [python-aniso8601]
 python-annoy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -269,6 +269,7 @@ python-aniso8601:
   centos: [python-aniso8601]
   debian: [python-aniso8601]
   fedora: [python2-aniso8601]
+  gentoo: [dev-python/aniso8601]
   ubuntu: [python-aniso8601]
 python-annoy-pip:
   debian:


### PR DESCRIPTION
Note this package had been backported on indigo http://repositories.ros.org/status_page/ros_indigo_default.html?q=aniso (and jade), and from ubuntu xenial is available as a package which I want to use.
Let me know if there is any renaming needed anywhere...

Ref : https://pkgs.org/download/aniso8601