### PR TITLE
Add libqt5-serialport to 'rosdep/base.yaml'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2763,6 +2763,13 @@ libqt5-printsupport:
   freebsd: [qt5-printsupport]
   gentoo: ['dev-qt/qtprintsupport:5']
   ubuntu: [libqt5printsupport5]
+libqt5-serialport:
+  arch:   [qt5-serialport]
+  debian: [libqt5serialport5]
+  fedora: [qt5-qtserialport]
+  freebsd: [qt5-serialport]
+  gentoo: ['dev-qt/qtserialport:5']
+  ubuntu: [libqt5serialport5]
 libqt5-sql:
   arch:   [qt5-base]
   debian:


### PR DESCRIPTION
This package adds Qt functions to access serial ports.

Package links:
- [arch](https://www.archlinux.org/packages/extra/x86_64/qt5-serialport/)
- [debian](https://packages.debian.org/jessie/libqt5serialport5)
- [fedora](https://apps.fedoraproject.org/packages/qt5-qtserialport)
- [freeBSD](https://svnweb.freebsd.org/ports/head/comms/qt5-serialport/)
- [gentoo](https://packages.gentoo.org/packages/dev-qt/qtserialport)
- [ubuntu](https://packages.ubuntu.com/trusty/libdevel/libqt5serialport5) (available from trusty onwards)