### PR TITLE
ubiquity_motor: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11530,7 +11530,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.6.1-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.7.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.1-0`

## ubiquity_motor

```
* Add script to probe the robot for information
* Add Serial Protocol Documentation
  Fixes #33 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/33>
* Add ROS API documentation (#32 <https://github.com/UbiquityRobotics/ubiquity_motor/issues/32>)
  * Add API documentation
  * Remove unused serial_loop_rate variable
* Contributors: Jim Vaughan, Rohan Agrawal
```
