### PR TITLE
python-aniso8601: 0.8.3-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10147,6 +10147,13 @@ repositories:
       url: https://github.com/andreasBihlmaier/pysdf.git
       version: master
     status: developed
+  python-aniso8601:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pyros-dev/aniso8601-rosrelease.git
+      version: 0.8.3-5
+    status: maintained
   python-ftputil:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -311,13 +311,6 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
-  aniso8601:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/aniso8601-rosrelease.git
-      version: 0.8.3-4
-    status: maintained
   app_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python-aniso8601` to `0.8.3-5`:

- upstream repository: https://bitbucket.org/nielsenb/aniso8601.git
- release repository: https://github.com/pyros-dev/aniso8601-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
