### PR TITLE
added keras to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1533,6 +1533,19 @@ python-kdtree:
   ubuntu:
     pip:
       packages: [kdtree]
+python-keras-pip:
+  debian:
+    pip:
+      packages: [keras]
+  fedora:
+    pip:
+      packages: [keras]
+  osx:
+    pip:
+      packages: [keras]
+  ubuntu:
+    pip:
+      packages: [keras]
 python-kitchen:
   arch: [python2-kitchen]
   debian: [python-kitchen]


### PR DESCRIPTION
This adds keras to the rosdep rules. Keras is an open-source machine learning library for python my robotics team will be using for end-to-end learning on autonomous vehicles. The pypi listing is here: https://pypi.python.org/pypi/Keras 