### PR TITLE
yp-spur: 1.15.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12472,6 +12472,23 @@ repositories:
       type: git
       url: https://github.com/youbot/youbot_driver.git
       version: hydro-devel
+  yp-spur:
+    doc:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    release:
+      packages:
+      - ypspur
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/openspur/yp-spur-release.git
+      version: 1.15.0-0
+    source:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    status: developed
   yujin_ocs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.15.0-0`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
