### PR TITLE
python-flask-restful: 0.3.4-4 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10147,6 +10147,13 @@ repositories:
       url: https://github.com/pyros-dev/aniso8601-rosrelease.git
       version: 0.8.3-5
     status: maintained
+  python-flask-restful:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/pyros-dev/flask-restful-rosrelease.git
+      version: 0.3.4-4
+    status: maintained
   python-ftputil:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3469,13 +3469,6 @@ repositories:
       url: https://github.com/asmodehn/flask-cors-rosrelease.git
       version: 3.0.2-2
     status: developed
-  flask_restful:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/flask-restful-rosrelease.git
-      version: 0.3.4-3
-    status: maintained
   flask_reverse_proxy:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `python-flask-restful` to `0.3.4-4`:

- upstream repository: https://github.com/flask-restful/flask-restful.git
- release repository: https://github.com/pyros-dev/flask-restful-rosrelease.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
