### PR TITLE
Remove duplicate python keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -270,7 +270,12 @@ python-aniso8601:
   debian: [python-aniso8601]
   fedora: [python2-aniso8601]
   gentoo: [dev-python/aniso8601]
-  ubuntu: [python-aniso8601]
+  ubuntu:
+    artful: [python-aniso8601]
+    bionic: [python-aniso8601]
+    xenial: [python-aniso8601]
+    yakkety: [python-aniso8601]
+    zesty: [python-aniso8601]
 python-annoy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1083,9 +1083,6 @@ python-flask-restful:
     saucy:
       pip:
         packages: [flask-restful]
-    trusty:
-      pip:
-        packages: [flask-restful]
     utopic:
       pip:
         packages: [flask-restful]


### PR DESCRIPTION
Now that some python packages have been released in ROS, some rosdep rules are conflicting in the database. 