### PR TITLE
Drop odva_ethernetip from Melodic.

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -772,11 +772,6 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/odva_ethernetip.git
       version: indigo-devel
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
-      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/odva_ethernetip.git


### PR DESCRIPTION
Efforts from @clalancette notwithstanding, this isn't building on Bionic right now.