### PR TITLE
interactive_markers: 1.11.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -566,6 +566,7 @@ repositories:
       url: https://github.com/ros-gbp/interactive_markers-release.git
       version: 1.11.4-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -555,6 +555,21 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_markers-release.git
+      version: 1.11.4-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: indigo-devel
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.11.4-0`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## interactive_markers

```
* Fixed a crash when updates arrive, or are being processed, while shutdown is called (#36 <https://github.com/ros-visualization/interactive_markers/issues/36>)
* Contributors: Simon Schmeisser
```
