### PR TITLE
odva_ethernetip: 0.1.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -776,7 +776,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/odva_ethernetip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `odva_ethernetip` to `0.1.3-0`:

- upstream repository: https://github.com/ros-drivers/odva_ethernetip.git
- release repository: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.0`
- previous version for package: `0.1.2-0`

## odva_ethernetip

```
* Make sure to #include <boost/array.hpp> in the header file.
* Switch to unsigned char arrays in the tests.
  This gets rid of a narrowing error thrown by the compiler.
* Contributors: Chris Lalancette
```
