### PR TITLE
ros_control: 0.14.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1100,7 +1100,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.14.0-0
+      version: 0.14.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.14.1-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.14.0-0`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* Fix controller_manager_interface and add unit tests.
* Contributors: Yong Li
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Fix controller_manager_interface and add unit tests.
* Contributors: Yong Li
```

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
