### PR TITLE
ros_control: 0.13.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8667,7 +8667,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.13.1-0
+      version: 0.13.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.13.2-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.13.1-0`

## combined_robot_hw

```
* migrate classloader headers
* Contributors: Mathias Lüdtke
```

## combined_robot_hw_tests

```
* migrate to new class list macros header
* Contributors: Mathias Lüdtke
```

## controller_interface

- No changes

## controller_manager

```
* Fix controller_manager_interface and add unit tests.
* migrate classloader headers
* Contributors: Mathias Lüdtke, Yong Li
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Fix controller_manager_interface and add unit tests.
* migrate to new class list macros header
* Contributors: Mathias Lüdtke, Yong Li
```

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* migrate to new class list macros header
* migrate classloader headers
* Contributors: Mathias Lüdtke
```
