### PR TITLE
ros_control: 0.9.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11978,7 +11978,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.9.5-0
+      version: 0.9.6-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.9.6-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.9.5-0`

## controller_interface

- No changes

## controller_manager

```
* Fix controller_manager_interface and add unit tests.
* Contributors: Yong Li
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Fix controller_manager_interface and add unit tests.
* Contributors: Yong Li
```

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
