### PR TITLE
vision_opencv: 1.12.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4389,7 +4389,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.12.7-0
+      version: 1.12.8-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.12.8-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.7-0`

## cv_bridge

```
* Merge pull request #191 <https://github.com/ros-perception/vision_opencv/issues/191> from patrickelectric/kinetic
  cv2_to_imgmsg: step must be int
* cv2_to_imgmsg: step must be int
  Signed-off-by: Patrick José Pereira <mailto:patrickelectric@gmail.com>
* Contributors: Patrick José Pereira, Vincent Rabaud
```

## image_geometry

```
* Merge pull request #189 <https://github.com/ros-perception/vision_opencv/issues/189> from ros2/python3_support_in_test
  python 3 compatibility in test
* python 3 compatibility in test
* fix doc job
* Contributors: Mikael Arguedas, Vincent Rabaud
```

## vision_opencv

- No changes
