### PR TITLE
pheeno_ros: 0.1.1-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6773,7 +6773,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ACSLaboratory/pheeno_ros-release.git
-      version: 0.1.1-2
+      version: 0.1.1-3
     source:
       type: git
       url: https://github.com/ACSLaboratory/pheeno_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros` to `0.1.1-3`:

- upstream repository: https://github.com/ACSLaboratory/pheeno_ros.git
- release repository: https://github.com/ACSLaboratory/pheeno_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.1-2`

## pheeno_ros

```
* Initial release
* Contributors: zmk5
```
