### PR TITLE
pheeno_ros_sim: 0.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6787,6 +6787,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/ACSLaboratory/pheeno_ros_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros_sim` to `0.1.5-0`:

- upstream repository: https://github.com/ACSLaboratory/pheeno_ros_sim.git
- release repository: https://github.com/ACSLaboratory/pheeno_ros_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## pheeno_ros_sim

```
* Fixed code with better practices.
* Contributors: zmk5
```
