### PR TITLE
wifi_ddwrt: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12256,6 +12256,20 @@ repositories:
       url: https://github.com/asmodehn/webtest-rosrelease.git
       version: 2.0.18-1
     status: maintained
+  wifi_ddwrt:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/wifi_ddwrt-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wifi_ddwrt` to `0.2.0-0`:

- upstream repository: https://github.com/ros-drivers/wifi_ddwrt.git
- release repository: https://github.com/ros-gbp/wifi_ddwrt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
