### PR TITLE
jsk_3rdparty: 2.1.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3905,7 +3905,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.7-0
+      version: 2.1.8-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.8-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.1.7-0`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

```
* julius: add wget to dependencies (#138 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/138>)
* Contributors: Yuki Furuta
```

## julius_ros

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## ros_speech_recognition

- No changes

## rospatlite

- No changes

## rosping

- No changes

## slic

- No changes

## voice_text

- No changes
