### PR TITLE
yp-spur: 1.15.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -17043,6 +17043,23 @@ repositories:
         release: release/indigo/{package}/{version}
       url: https://github.com/youbot-release/youbot_simulation-release.git
       version: 0.8.0-0
+  yp-spur:
+    doc:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    release:
+      packages:
+      - ypspur
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/openspur/yp-spur-release.git
+      version: 1.15.2-0
+    source:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    status: developed
   yujin_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.15.2-0`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
