### PR TITLE
yp-spur: 1.15.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4596,6 +4596,23 @@ repositories:
       url: https://github.com/rohbotics/xv_11_laser_driver.git
       version: kinetic-devel
     status: maintained
+  yp-spur:
+    doc:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    release:
+      packages:
+      - ypspur
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/openspur/yp-spur-release.git
+      version: 1.15.2-0
+    source:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    status: developed
   zbar_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.15.2-0`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
