### PR TITLE
Add in a key for collada-dom on jessie.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -437,6 +437,7 @@ collada-dom:
   arch: [collada-dom]
   debian:
     buster: [libcollada-dom2.4-dp-dev]
+    jessie: [libcollada-dom2.4-dp-dev]
     stretch: [libcollada-dom2.4-dp-dev]
   fedora: [collada-dom-devel]
   gentoo: [dev-libs/collada-dom]


### PR DESCRIPTION
We need this to do releases of https://github.com/ros/collada_urdf
on Kinetic.

Note that on Jessie, `libcollada-dom2.4-dp-dev` is a package provided by OSRF from http://packages.ros.org/ros/ubuntu/pool/main/c/collada-dom/