### PR TITLE
collada_urdf: 1.12.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1405,7 +1405,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/collada_urdf-release.git
-      version: 1.12.10-0
+      version: 1.12.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `collada_urdf` to `1.12.11-0`:

- upstream repository: https://github.com/ros/collada_urdf.git
- release repository: https://github.com/ros-gbp/collada_urdf-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.10-0`

## collada_parser

```
* Collada cleanup dependencies (#26 <https://github.com/ros/collada_urdf/issues/26>)
* update links now that this is in its own repo
* Make CMakeLists.txt depend on collada-dom version 2.4. (#11 <https://github.com/ros/collada_urdf/issues/11>)
* Contributors: Chris Lalancette, Mikael Arguedas
```

## collada_urdf

```
* Collada cleanup dependencies (#26 <https://github.com/ros/collada_urdf/issues/26>)
* update links now that this is in its own repo
* Switch to using Eigen for Quaternion and Matrix. (#21 <https://github.com/ros/collada_urdf/issues/21>)
* add relicensing comment (#19 <https://github.com/ros/collada_urdf/issues/19>)
* remove unused tinyxml from cmakelists (#15 <https://github.com/ros/collada_urdf/issues/15>)
* Contributors: Chris Lalancette, Mikael Arguedas, Rosen Diankov
```
