### PR TITLE
moveit_msgs: 0.10.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -700,6 +700,21 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  moveit_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_msgs-release.git
+      version: 0.10.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: melodic-devel
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.10.0-0`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## moveit_msgs

```
* [capability] Add fields to store planning time in pick-and-place #43 <https://github.com/ros-planning/moveit_msgs/issues/43>
* Contributors: Akiyoshi Ochiai
```
