### PR TITLE
driver_common: 1.6.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1877,6 +1877,24 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/delftrobotics/dr_base-release.git
       version: 1.0.0-0
+  driver_common:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/driver_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - driver_base
+      - driver_common
+      - timestamp_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/driver_common-release.git
+      version: 1.6.8-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/driver_common.git
+      version: indigo-devel
   dyn_tune:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `driver_common` to `1.6.8-0`:

- upstream repository: https://github.com/ros-drivers/driver_common.git
- release repository: https://github.com/ros-gbp/driver_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## driver_base

- No changes

## driver_common

- No changes

## timestamp_tools

- No changes
