### PR TITLE
prosilica_gige_sdk: 1.26.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7173,6 +7173,21 @@ repositories:
       url: https://github.com/PR2/pr2_simulator.git
       version: kinetic-devel
     status: unmaintained
+  prosilica_gige_sdk:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
+      version: 1.26.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
+    status: maintained
   puma_motor_driver:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_gige_sdk` to `1.26.3-0`:

- upstream repository: https://github.com/ros-drivers/prosilica_gige_sdk.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
