### PR TITLE
wge100_driver: 1.8.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12301,6 +12301,25 @@ repositories:
       url: https://github.com/asmodehn/webtest-rosrelease.git
       version: 2.0.18-1
     status: maintained
+  wge100_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: kinetic-devel
+    release:
+      packages:
+      - wge100_camera
+      - wge100_camera_firmware
+      - wge100_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/wge100_driver-release.git
+      version: 1.8.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: kinetic-devel
+    status: maintained
   wifi_ddwrt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wge100_driver` to `1.8.2-0`:

- upstream repository: https://github.com/ros-drivers/wge100_driver.git
- release repository: https://github.com/ros-drivers-gbp/wge100_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
