### PR TITLE
prosilica_driver: 1.9.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7191,6 +7191,22 @@ repositories:
       url: https://github.com/PR2/pr2_simulator.git
       version: kinetic-devel
     status: unmaintained
+  prosilica_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
+    release:
+      packages:
+      - prosilica_camera
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
+      version: 1.9.4-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
   prosilica_gige_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_driver` to `1.9.4-1`:

- upstream repository: https://github.com/ros-drivers/prosilica_driver.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
