### PR TITLE
pr2_common: 1.12.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6995,7 +6995,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_common-release.git
-      version: 1.12.1-0
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/pr2/pr2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.2-0`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.1-0`

## pr2_common

- No changes

## pr2_dashboard_aggregator

- No changes

## pr2_description

```
* Merge pull request #269 <https://github.com/pr2/pr2_common/issues/269> from bmagyar/kinetic-devel
  Fix pr2_description warnings
* Remove playerstage xml schemas
* xacro.py -> xacro
* Contributors: Bence Magyar
```

## pr2_machine

- No changes

## pr2_msgs

- No changes
