### PR TITLE
pr2_common: 1.12.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2539,8 +2539,8 @@ repositories:
       - pr2_msgs
       tags:
         release: release/lunar/{package}/{version}
-      url: https://github.com/ros-gbp/pr2_common-release.git
-      version: 1.12.0-0
+      url: https://github.com/pr2-gbp/pr2_common-release.git
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/pr2/pr2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.2-0`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.0-0`

## pr2_common

- No changes

## pr2_dashboard_aggregator

- No changes

## pr2_description

```
* Merge pull request #269 <https://github.com/pr2/pr2_common/issues/269> from bmagyar/kinetic-devel
  Fix pr2_description warnings
* Remove playerstage xml schemas
* xacro.py -> xacro
* Contributors: Bence Magyar
```

## pr2_machine

- No changes

## pr2_msgs

- No changes
