### PR TITLE
xpp: 1.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12502,7 +12502,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.6-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.5-0`

## xpp

- No changes

## xpp_examples

- No changes

## xpp_hyq

```
* add missing libxpp_hyq.so library to catkin install
* Contributors: Alexander Winkler
```

## xpp_msgs

- No changes

## xpp_quadrotor

- No changes

## xpp_states

- No changes

## xpp_vis

- No changes
