### PR TITLE
pyzmp: 0.0.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7394,7 +7394,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyzmp-rosrelease.git
-      version: 0.0.15-0
+      version: 0.0.17-0
     source:
       type: git
       url: https://github.com/asmodehn/pyzmp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyzmp` to `0.0.17-0`:

- upstream repository: https://github.com/pyros-dev/pyzmp.git
- release repository: https://github.com/asmodehn/pyzmp-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.15-0`

## pyzmp

```
* Removing quantified code badge. added gitchangelog config. [AlexV]
* Improved tutorial. [AlexV]
* Fixing coprocess test. [AlexV]
* Now passing arguments to context generators. [AlexV]
* Extracted coprocess from node. tests passing. [AlexV]
* Added test to ensure update is called once before we return control
  from start() call. [AlexV]
* Update twine from 1.8.1 to 1.11.0. [pyup-bot]
* Typo. [AlexV]
```
