### PR TITLE
xpp: 1.0.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4570,7 +4570,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.6-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.5-0`

## xpp

- No changes

## xpp_examples

- No changes

## xpp_hyq

```
* add missing libxpp_hyq.so library to catkin install
* Contributors: Alexander Winkler
```

## xpp_msgs

- No changes

## xpp_quadrotor

- No changes

## xpp_states

- No changes

## xpp_vis

- No changes
