### PR TITLE
robot_activity: 0.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1029,6 +1029,15 @@ repositories:
       type: git
       url: https://github.com/snt-robotics/robot_activity.git
       version: master
+    release:
+      packages:
+      - robot_activity
+      - robot_activity_msgs
+      - robot_activity_tutorials
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/snt-robotics/robot_activity-release.git
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_activity` to `0.1.1-0`:

- upstream repository: https://github.com/snt-robotics/robot_activity.git
- release repository: https://github.com/snt-robotics/robot_activity-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## robot_activity

```
* package renamed to robot_activity
* Contributors: Maciej Zurad
```

## robot_activity_msgs

```
* package renamed to robot_activity_msgs
* Contributors: Maciej Zurad
```

## robot_activity_tutorials

```
* package renamed to robot_activity_tutorials
* Contributors: Maciej Zurad
```
