### PR TITLE
rc_genicam_api: 1.3.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7737,7 +7737,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception/rc_genicam_api-release.git
-      version: 1.3.6-0
+      version: 1.3.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `1.3.8-0`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception/rc_genicam_api-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.3.6-0`

## rc_genicam_api

```
* show actually searched path instead of env var in exception if no transport layer found
* improved README
```
