### PR TITLE
surface_perception: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15129,7 +15129,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/surface_perception-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/jstnhuang/surface_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `surface_perception` to `1.0.2-0`:

- upstream repository: https://github.com/jstnhuang/surface_perception.git
- release repository: https://github.com/jstnhuang-release/surface_perception-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.1-0`

## surface_perception

```
* Removed warning message for surfaces with no objects.
* Fixed objects intersecting with surface.
* Fixed bugs with shape extraction.
* Decouple the usage of margin_above_surface and max_point_distance
* Fixed bug with standardizing object orientation (#9 <https://github.com/jstnhuang/surface_perception/issues/9>)
  * Pulled code to standardize object orientations into a separate function
  * Fixed a bug with this function
  * Added tests
  * Added a visualization of the object orientations
* Updated Doxygen mainpage.
* Contributors: Justin Huang, Yu-Tang Peng
```
