### PR TITLE
grpc: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4213,7 +4213,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.8-0`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.7-0`

## grpc

```
* Install grpcpp headers which was missing.
* Contributors: Shengye Wang
```
