### PR TITLE
gcloud_speech: 0.0.5-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -814,7 +814,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/CogRobRelease/gcloud_speech-release.git
-      version: 0.0.4-0
+      version: 0.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gcloud_speech` to `0.0.5-1`:

- upstream repository: https://github.com/CogRob/gcloud_speech.git
- release repository: https://github.com/CogRobRelease/gcloud_speech-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.4-0`

## gcloud_speech

```
* Sync googleapis with upstream, and fixes a bug that gcloud_speech not
  working with latest grpc.
* Contributors: Shengye Wang
```

## gcloud_speech_msgs

- No changes

## gcloud_speech_utils

- No changes
