### PR TITLE
moveit_resources: 0.6.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -715,6 +715,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: melodic-devel
     status: maintained
+  moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_resources-release.git
+      version: 0.6.3-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.3-0`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## moveit_resources

```
* [enhance] Update param scope (#17 <https://github.com/ros-planning/moveit_resources/issues/17>)
* [enhance] Use the "Hybrid" collision checker and created a sample config file for parameters (#16 <https://github.com/ros-planning/moveit_resources/issues/16>)
* Contributors: Simon Schmeisser, Will Baker
```
