### PR TITLE
humanoid_navigation: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3403,6 +3403,27 @@ repositories:
       url: https://github.com/ahornung/humanoid_msgs.git
       version: devel
     status: maintained
+  humanoid_navigation:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/humanoid_navigation.git
+      version: kinetic-devel
+    release:
+      packages:
+      - footstep_planner
+      - gridmap_2d
+      - humanoid_localization
+      - humanoid_navigation
+      - humanoid_planner_2d
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/humanoid_navigation-release.git
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/humanoid_navigation.git
+      version: kinetic-devel
+    status: maintained
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_navigation` to `0.4.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/humanoid_navigation.git
- release repository: https://github.com/ROBOTIS-GIT-release/humanoid_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## footstep_planner

```
* refacotoring to release on kinetic
* added documents related to footstep_planner packages
* added information new maintainer
* fixed CMakeLists.txt and package.xml files for dependency
* fixed footstep_planner node crashes when map changesth
* Contributors: Aleksey Titov, Kayman, Pyo
```

## gridmap_2d

```
* refacotoring to release on kinetic
* added documents related to gridmap_2d packages
* added information new maintainer
* fixed CMakeLists.txt and package.xml files for dependency
* Contributors: Kayman, Pyo
```

## humanoid_localization

```
* refacotoring to release on kinetic
* added documents related to humanoid_localization packages
* added information new maintainer
* fixed CMakeLists.txt and package.xml files for dependency
* resolved warnings
* Contributors: Kayman, Pyo
```

## humanoid_navigation

```
* refacotoring to release on kinetic
* added documents related to footstep_planner packages
* added information new maintainer
* fixed CMakeLists.txt and package.xml files for dependency
* fixed footstep_planner node crashes when map changesth
* Contributors: Aleksey Titov, Kayman, Pyo
```

## humanoid_planner_2d

```
* refacotoring to release on kinetic
* added documents related to humanoid_planner_2d packages
* added information new maintainer
* fixed CMakeLists.txt and package.xml files for dependency
* Contributors: Kayman, Pyo
```
