### PR TITLE
robotis_op3_tools: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8291,6 +8291,30 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-msgs.git
       version: kinetic-devel
     status: developed
+  robotis_op3_tools:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Tools.git
+      version: kinetic-devel
+    release:
+      packages:
+      - op3_action_editor
+      - op3_camera_setting_tool
+      - op3_gui_demo
+      - op3_navigation
+      - op3_offset_tuner_client
+      - op3_offset_tuner_server
+      - op3_web_setting_tool
+      - robotis_op3_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/robotis_op3_tools-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Tools.git
+      version: kinetic-devel
+    status: developed
   robotis_utility:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3_tools` to `0.2.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Tools.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_op3_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## op3_action_editor

```
* tested for dependencies of ncurses
* Contributors: Pyo
```

## op3_camera_setting_tool

```
* none
```

## op3_gui_demo

```
* tested for dependencies of ncurses
* tested for dependencies of footstep_planner
* Contributors: Pyo
```

## op3_navigation

```
* tested for dependencies of ncurses
* tested for dependencies of footstep_planner
* Contributors: Pyo
```

## op3_offset_tuner_client

```
* none
```

## op3_offset_tuner_server

```
* none
```

## op3_web_setting_tool

```
* none
```

## robotis_op3_tools

```
* tested for dependencies of ncurses
* tested for dependencies of footstep_planner
* Contributors: Pyo
```
