### PR TITLE
pyros_common: 0.5.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7318,7 +7318,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-common-rosrelease.git
-      version: 0.5.2-2
+      version: 0.5.3-0
     status: developed
   pyros_config:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_common` to `0.5.3-0`:

- upstream repository: https://github.com/pyros-dev/pyros-common.git
- release repository: https://github.com/asmodehn/pyros-common-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.2-2`

## pyros_common

```
* Expliciting constructor as it might be useful to manager different
  version of Python Exceptions. [AlexV]
* Fixing exceptions to get any number of args. adding test. [AlexV]
* Fixing version in changelog. [AlexV]
```
