### PR TITLE
pyros_interfaces_ros: 0.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7336,7 +7336,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosinterface-rosrelease.git
-      version: 0.4.0-0
+      version: 0.4.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/pyros-dev/pyros-rosinterface.git
+      version: master
     status: developed
   pyros_test:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_interfaces_ros` to `0.4.1-0`:

- upstream repository: https://github.com/asmodehn/pyros-rosinterface.git
- release repository: https://github.com/asmodehn/pyros-rosinterface-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.0-0`

## pyros_interfaces_ros

```
* adjusting package version
* Merge pull request #10 <https://github.com/pyros-dev/pyros-rosinterface/issues/10> from pyros-dev/pyros_common_5
  adating pyros exceptionsto recent pyros_common.exception base class.
* fixing super call
* now exposing __version__ as usually done
* bumping packages version
* reviewing rosinstall file for this package.
* Adapting Pyros Exceptions to new format
* adating pyros exceptionsto recent pyros_common.exception base class.
* Merge pull request #8 <https://github.com/pyros-dev/pyros-rosinterface/issues/8> from pyros-dev/improved_logging
  now logging config values
* Merge pull request #7 <https://github.com/pyros-dev/pyros-rosinterface/issues/7> from cehberlin/master
  Fixed missing forwards that are used by rostful
* fixed broken manifest loading in message_conversion and safe api
* Fixed missing ServiceException forwarding
* now logging config values
* Merge pull request #6 <https://github.com/pyros-dev/pyros-rosinterface/issues/6> from asmodehn/namespace
  Namespace
* filling up readme
* adding setup.py commands to make release easier...
* adding main module and launch file to be able to launch pyros node by itself.
* removing the debug print of sys.path
* now exposing PyrosROS class from the package.
* Contributors: AlexV, Christopher Hrabia, alexv
```
