### PR TITLE
robotis_op3_demo: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8270,6 +8270,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Common.git
       version: kinetic-devel
     status: developed
+  robotis_op3_demo:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Demo.git
+      version: kinetic-devel
+    release:
+      packages:
+      - op3_ball_detector
+      - op3_bringup
+      - op3_demo
+      - robotis_op3_demo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/robotis_op3_demo-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Demo.git
+      version: kinetic-devel
+    status: developed
   robotis_op3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3_demo` to `0.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Demo.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_op3_demo-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## op3_ball_detector

```
* first release for ROS Kinetic
* added launch files in order to move the camera setting to op3_camera_setting package
* added missing package in find_package()
* refacoring to release
* split repositoryfrom ROBOTIS-OP3
* Contributors: Kayman, Zerom, Pyo
```

## op3_bringup

```
* first release for ROS Kinetic
* updated CMakeLists.txt and package.xml of op3_bringup
* changed rviz config file
* refacoring to release
* Contributors: Kayman, Pyo
```

## op3_demo

```
* first release for ROS Kinetic
* added launch files in order to move the camera setting to op3_camera_setting package
* added missing package in find_package()
* refacoring to release
* split repositoryfrom ROBOTIS-OP3
* Contributors: Kayman, Zerom, Yoshimaru Tanaka, Pyo
```

## robotis_op3_demo

```
* first release for ROS Kinetic
* added launch files in order to move the camera setting to op3_camera_setting package
* added missing package in find_package()
* updated CMakeLists.txt and package.xml of op3_bringup
* changed rviz config file
* refacoring to release
* split repositoryfrom ROBOTIS-OP3
* Contributors: Kayman, Zerom, Yoshimaru Tanaka, Pyo
```
