### PR TITLE
rc_dynamics_api: 0.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7747,7 +7747,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception/rc_dynamics_api-release.git
-      version: 0.5.0-0
+      version: 0.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_dynamics_api` to `0.6.0-0`:

- upstream repository: https://github.com/roboception/rc_dynamics_api.git
- release repository: https://github.com/roboception/rc_dynamics_api-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.0-0`

## rc_dynamics_api

```
* add methods to access slam "reset" service
* use single json.hpp include instead of submodule
```
