### PR TITLE
robotis_op3_tools: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8334,7 +8334,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/robotis_op3_tools-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_op3_tools` to `0.2.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-OP3-Tools.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_op3_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.1-0`

## op3_action_editor

```
* none
```

## op3_camera_setting_tool

```
* modified package.xml for dependency (yaml-cpp)
* Contributors: Pyo
```

## op3_gui_demo

```
* modified package.xml for dependency (yaml-cpp)
* Contributors: Pyo
```

## op3_navigation

```
* none
```

## op3_offset_tuner_client

```
* modified package.xml for dependency (yaml-cpp)
* Contributors: Pyo
```

## op3_offset_tuner_server

```
* none
```

## op3_web_setting_tool

```
* none
```

## robotis_op3_tools

```
* modified package.xml for dependency (yaml-cpp)
* Contributors: Pyo
```
