### PR TITLE
thormang3_opc: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11183,10 +11183,17 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
       version: kinetic-devel
     release:
+      packages:
+      - thormang3_action_script_player
+      - thormang3_demo
+      - thormang3_foot_step_generator
+      - thormang3_navigation
+      - thormang3_offset_tuner_client
+      - thormang3_opc
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-OPC-release.git
-      version: 0.2.0-1
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_opc` to `0.3.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-OPC.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-OPC-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-1`

## thormang3_action_script_player

```
* refactoring to release
* updated balance param
* Contributors: Zerom, Kayman, SCH, Pyo
```

## thormang3_demo

```
* refactoring to release
* updated yaml files
* updated balance param
* updated walking balance
* Contributors: Zerom, Kayman, SCH, Pyo
```

## thormang3_foot_step_generator

```
* refactoring to release
* Contributors: Pyo, Zerom, kayman
```

## thormang3_navigation

```
* refactoring to release
* Contributors: Zerom, Kayman, Pyo
```

## thormang3_offset_tuner_client

```
* refactoring to release
* updated yaml files
* updated balance param
* updated walking balance
* Contributors: Zerom, Kayman, SCH, Pyo
```

## thormang3_opc

```
* refactoring to release
* updated yaml files
* updated balance param
* updated walking balance
* Contributors: Zerom, Kayman, SCH, Pyo
```
