### PR TITLE
thormang3_tools: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11218,10 +11218,14 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
       version: kinetic-devel
     release:
+      packages:
+      - thormang3_action_editor
+      - thormang3_offset_tuner_server
+      - thormang3_tools
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thormang3_tools` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/ROBOTIS-THORMANG-Tools.git
- release repository: https://github.com/ROBOTIS-GIT-release/ROBOTIS-THORMANG-Tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.2-0`

## thormang3_action_editor

```
* refactoring to release
* added extra functions
* modified cmake & package setting for yaml-cpp
* fixed "go" command bug
* Contributors: Kayman, Zerom, SCH, Pyo
```

## thormang3_offset_tuner_server

```
* refactoring to release
* modified cmake & package setting for yaml-cpp
* Contributors: Pyo, SCH
```

## thormang3_tools

```
* refactoring to release
* added extra functions
* modified cmake & package setting for yaml-cpp
* fixed "go" command bug
* Contributors: Kayman, Zerom, SCH, Pyo
```
