### PR TITLE
rqt_reconfigure: 0.4.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3637,7 +3637,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.4.9-0
+      version: 0.4.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.4.10-0`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.9-0`

## rqt_reconfigure

```
* Lazy load dynamic_reconfigure client for each node
  Fixes #20 <https://github.com/ros-visualization/rqt_reconfigure/issues/20>
* Use English locale in QDoubleValidator
  Fixes #21 <https://github.com/ros-visualization/rqt_reconfigure/issues/21>
* Contributors: Arkady Shapkin, Yuki Furuta
```
