### PR TITLE
rqt_reconfigure: 0.4.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13281,7 +13281,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.4.8-0
+      version: 0.4.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.4.10-0`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.8-0`

## rqt_reconfigure

```
* Lazy load dynamic_reconfigure client for each node
  Fixes #20 <https://github.com/ros-visualization/rqt_reconfigure/issues/20>
* Use English locale in QDoubleValidator
  Fixes #21 <https://github.com/ros-visualization/rqt_reconfigure/issues/21>
* Contributors: Arkady Shapkin, Yuki Furuta
```
