### PR TITLE
Adding omronsentech_camera to documentation index for distro 

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6306,6 +6306,16 @@ repositories:
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.2.1-1
     status: maintained
+  omronsentech_camera:
+    doc:
+      type: git
+      url: https://github.com/ose-support-ros/omronsentech_camera.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ose-support-ros/omronsentech_camera.git
+      version: master
+    status: developed
   open_karto:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2227,6 +2227,16 @@ repositories:
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.3.1-3
     status: maintained
+  omronsentech_camera:
+    doc:
+      type: git
+      url: https://github.com/ose-support-ros/omronsentech_camera.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ose-support-ros/omronsentech_camera.git
+      version: master
+    status: developed
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
I'd like omronsentech_camera to be indexed and documented on ros.org.