### PR TITLE
ypspur_ros: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -17080,6 +17080,21 @@ repositories:
       url: https://github.com/openspur/yp-spur.git
       version: master
     status: developed
+  ypspur_ros:
+    doc:
+      type: git
+      url: https://github.com/openspur/ypspur_ros.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/openspur/ypspur_ros-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/openspur/ypspur_ros.git
+      version: master
+    status: developed
   yujin_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.1.0-0`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ypspur_ros

```
* Update CI settings (#25 <https://github.com/openspur/ypspur_ros/issues/25>)
  
    * Use docker hub as a cache
  
* Fix build dependencies (#24 <https://github.com/openspur/ypspur_ros/issues/24>)
  
    * Fix cmake target build deps
    * Fix package deps
  
* Fix joint state timestamp coherency (#23 <https://github.com/openspur/ypspur_ros/issues/23>)
  
    * Fix joint state timestamp coherency
    * Use system time if yp-spur didn't provide stamp
  
* Add build test on indigo. (#20 <https://github.com/openspur/ypspur_ros/issues/20>)
* Fix coding style. (#19 <https://github.com/openspur/ypspur_ros/issues/19>)
* Fix timestamp in simulation mode. (#18 <https://github.com/openspur/ypspur_ros/issues/18>)
* Add build test. (#17 <https://github.com/openspur/ypspur_ros/issues/17>)
  
    * Add build test.
    * Fix indent in CMakeFile.
    * Fix package deps.
  
* Support running ypspur-coordinator by using PATH env. (#14 <https://github.com/openspur/ypspur_ros/issues/14>)
* Use find_package(ypspur) instead of catkin_package. (#12 <https://github.com/openspur/ypspur_ros/issues/12>)
* Use CMake version of ypspur. (#10 <https://github.com/openspur/ypspur_ros/issues/10>)
  
    * Also, fix dummy dependency to system_lib.
  
* adds README (#9 <https://github.com/openspur/ypspur_ros/issues/9>)
* publishes digital input port state (#8 <https://github.com/openspur/ypspur_ros/issues/8>)
* fixes to compile with old versions of YP-Spur which does not have joint_ang_vel command
* adds error handling on joint trajectory control
* joint_position_to_joint_trajectory: temporary removes time to accelerate
* joint_position_to_joint_trajectory: skips duplicated joint command
* joint_position_to_joint_trajectory: takes care of the current joint position
* adds joint_position_to_joint_trajectory converter
* fixes uncleared joint trajectory command cache
* increases cmd_joint input buffer
* allows divided joint trajectory command
* adds joint trajectory control
* fixes DIO default status parameter setting
* supports joint effort output (#4 <https://github.com/openspur/ypspur_ros/issues/4>)
  
    * This also fixes a bug that joint effort field was filled by velocity value on the version of YP-Spur without joint control support.
  
* changes default vel/acc settings to use values defined in the parameter file
* fixes ypspur-coordinator process monitoring
* adds vehicle control mode interface
* fixes digital IO control
* adds param to set tf timestamp offset
* adds simple simulation of robot control and joint angle control
* adds ros::shutdown before quiting the main loop
* fixes A/D output message type
* joint_tf_publisher: adds node to generate tf messages from joint topic
* adds combined joint position control input
* adds parameters to specify A/D port name in the output message
* adds digital I/O port output
* changes A/D related parameter names (ad_enable0 to ad0_enable)
* changes names of the joint control inputs according to the specified joint names
* supports more than two joint control
* adds retry and error handling in getID script
* improves ypspur-coordinator availability check
* ROS interface of the mobile robot control platform "YP-Spur"
* Contributors: Atsushi Watanabe
```
