### PR TITLE
turtlebot3_applications: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11379,13 +11379,14 @@ repositories:
       packages:
       - turtlebot3_applications
       - turtlebot3_automatic_parking
+      - turtlebot3_automatic_parking_vision
       - turtlebot3_follow_filter
       - turtlebot3_follower
       - turtlebot3_panorama
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications` to `0.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.0-0`

## turtlebot3_applications

```
* added turtlebot3 automatic parking vision example source code (turtlebot3_automatic_parking_vision)
* changes to ar_marker_alvar from ar_pose package (turtlebot3_automatic_parking_vision)
* fixed recovering method of automatic parking using vision (turtlebot3_automatic_parking_vision)
* added angles of center, start, end into spot filter (turtlebot3_automatic_parking)
* Contributors: Leon Jung, Gilbert, Pyo
```

## turtlebot3_automatic_parking

```
* added angles of center, start, end into spot filter
* Contributors: Gilbert
```

## turtlebot3_automatic_parking_vision

```
* added turtlebot3 automatic parking vision example source code
* changes to ar_marker_alvar from ar_pose package
* fixed recovering method of automatic parking using vision
* Contributors: Leon Jung, Pyo
```

## turtlebot3_follow_filter

```
* none
```

## turtlebot3_follower

```
* none
```

## turtlebot3_panorama

```
* fixed typo
* Contributors: Pyo
```
