### PR TITLE
Add bson

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -496,6 +496,7 @@ python-bs4:
 python-bson:
   debian: [python-bson]
   fedora: [python-bson]
+  gentoo: [dev-python/bson]
   osx:
     pip:
       packages: [bson]


### PR DESCRIPTION
`bson` is a dependency for `rosbridge_library`, needed for Gentoo (as seen in https://github.com/ros/ros-overlay/issues/560).

~~`xdot` is a run depend of [ecto](https://github.com/plasmodic/ecto/blob/master/package.xml#L17).~~