### PR TITLE
video_stream_opencv: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16282,7 +16282,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers/video_stream_opencv-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/video_stream_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_stream_opencv` to `1.1.1-0`:

- upstream repository: https://github.com/ros-drivers/video_stream_opencv.git
- release repository: https://github.com/ros-drivers/video_stream_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.1.0-0`

## video_stream_opencv

```
* Fix error of using camera_name instead of identifying the type of the provider
  to check when the provider is a video file, and act accordingly in the producer thread
* Prevent locking when ROS SIGINT arrives and the image queue is empty.
* Added rate limiting to camera_fps_rate also if videofile is used as input
* Contributors: Andrea Ranieri, Avio, Sam Pfeiffer, Sammy Pfeiffer
```
