### PR TITLE
pyros: 0.4.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7317,7 +7317,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosrelease.git
-      version: 0.4.1-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/asmodehn/pyros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros` to `0.4.3-1`:

- upstream repository: https://github.com/pyros-dev/pyros.git
- release repository: https://github.com/asmodehn/pyros-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.1-1`

## pyros

```
* Disabling integration tests in python for now. [AlexV]
* Removing ros interface as test requirement as there is no python
  package for it just yet. [AlexV]
* Adding ros interface to testing requirements on ROS. [AlexV]
* Moving tests outside of the package, to ease test dependency
  maintenance. [AlexV]
* Adding pyup config. [AlexV]
* Fixing tox config. [AlexV]
* Improving testing by adding requirements matching rosdistro packages
  versions. [AlexV]
* Fixing badge links. [AlexV]
```
