### PR TITLE
aruco_ros: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -277,6 +277,15 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git
       version: kinetic-devel
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `0.2.3-0`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## aruco

```
* Remove debug log msg
* forcing opencv3 build for kinetic
* Contributors: Bence Magyar, Christopher Hrabia, Jordi Pages, Victor Lopez
```

## aruco_msgs

```
* Kinetic devel merge
* Contributors: Victor Lopez
```

## aruco_ros

```
* Force marker_publisher to build after all dependencies.
* Fixed OpenCV Calib3D link error on ROS Kinetic
* Add aruco_ros_utils lib and fix some missing dependencies
* Replace assert by error message to keep library functional
* Contributors: Bence Magyar, Christopher Hrabia, Jordi Pages, Ugnius Malūkas, Victor Lopez, Voidminded, ethanfowler
```
