### PR TITLE
pr2_robot: 1.6.27-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7221,6 +7221,30 @@ repositories:
       url: https://github.com/pr2/pr2_power_drivers.git
       version: kinetic-devel
     status: unmaintained
+  pr2_robot:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - imu_monitor
+      - pr2_bringup
+      - pr2_camera_synchronizer
+      - pr2_computer_monitor
+      - pr2_controller_configuration
+      - pr2_ethercat
+      - pr2_robot
+      - pr2_run_stop_auto_restart
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_robot-release.git
+      version: 1.6.27-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_robot.git
+      version: kinetic-devel
+    status: maintained
   pr2_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.27-0`:

- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## imu_monitor

- No changes

## pr2_bringup

```
* updated hokuyo node dependencies to urg_ndoe
* Contributors: David Feil-Seifer
```

## pr2_camera_synchronizer

- No changes

## pr2_computer_monitor

- No changes

## pr2_controller_configuration

- No changes

## pr2_ethercat

- No changes

## pr2_robot

- No changes

## pr2_run_stop_auto_restart

- No changes
