### PR TITLE
pr2_calibration: 1.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7030,6 +7030,29 @@ repositories:
       url: https://github.com/pr2/pr2_apps.git
       version: kinetic-devel
     status: unmaintained
+  pr2_calibration:
+    doc:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration.git
+      version: kinetic-devel
+    release:
+      packages:
+      - dense_laser_assembler
+      - laser_joint_processor
+      - laser_joint_projector
+      - pr2_calibration
+      - pr2_calibration_launch
+      - pr2_dense_laser_snapshotter
+      - pr2_se_calibration_launch
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration-release.git
+      version: 1.0.11-0
+    source:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration.git
+      version: kinetic-devel
+    status: maintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_calibration` to `1.0.11-0`:

- upstream repository: https://github.com/UNR-RoboticsResearchLab/pr2_calibration.git
- release repository: https://github.com/UNR-RoboticsResearchLab/pr2_calibration-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## dense_laser_assembler

```
* updated CMakeLists to address warnings
* Contributors: David Feil-Seifer
```

## laser_joint_processor

- No changes

## laser_joint_projector

```
* updated CMakeLists to address warnings
* Contributors: David Feil-Seifer
```

## pr2_calibration

- No changes

## pr2_calibration_launch

- No changes

## pr2_dense_laser_snapshotter

- No changes

## pr2_se_calibration_launch

- No changes
