### PR TITLE
surface_perception: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15129,7 +15129,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/jstnhuang-release/surface_perception-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/jstnhuang/surface_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `surface_perception` to `1.0.3-0`:

- upstream repository: https://github.com/jstnhuang/surface_perception.git
- release repository: https://github.com/jstnhuang-release/surface_perception-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.2-0`

## surface_perception

```
* Changed pose to be a const ref.
* Exported axes marker library.
* Contributors: Justin Huang
```
