### PR TITLE
libcreate: 1.6.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1509,7 +1509,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/AutonomyLab/libcreate-release.git
-      version: 1.6.0-0
+      version: 1.6.1-0
     source:
       type: git
       url: https://github.com/AutonomyLab/libcreate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcreate` to `1.6.1-0`:

- upstream repository: https://github.com/AutonomyLab/libcreate.git
- release repository: https://github.com/AutonomyLab/libcreate-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.6.0-0`

## libcreate

```
* Build and install gtest as part of CI
* Update README with instructions for building and running unit tests
* Remove external cmake project for gtest
  Now only build tests if a gtest installation already exists on the system. This should expedite time to build for users that do not care about building/running unit tests and also eliminates the need for internet access when building.
* Add test depend to gtest in package.xml
* Contributors: Jacob Perron
```
