### PR TITLE
pyros_interfaces_ros: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7412,7 +7412,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosinterface-rosrelease.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_interfaces_ros` to `0.4.2-0`:

- upstream repository: https://github.com/asmodehn/pyros-rosinterface.git
- release repository: https://github.com/asmodehn/pyros-rosinterface-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.1-0`

## pyros_interfaces_ros

```
* Adding rosservice dependency. [AlexV]
* Fixing param getval/setval interface. [AlexV]
* Updating README. [AlexV]
* Changed travis config to not attempt to build packages. ros build farm
  will do it. [AlexV]
```
