### PR TITLE
rostful: 0.2.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9472,6 +9472,13 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: jade-devel
     status: maintained
+  rostful:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pyros-dev/rostful-rosrelease.git
+      version: 0.2.0-3
+    status: developed
   rostune:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rostful` to `0.2.0-3`:

- upstream repository: https://github.com/asmodehn/rostful.git
- release repository: https://github.com/pyros-dev/rostful-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rostful

```
* Integrated release commands to setup.py. [AlexV]
* Cleaning up param interface to only keep a working minimum view.
  [AlexV]
* Fixing getting param value. [AlexV]
* Removing unused scripts. __main__ is now the entrypoint. [AlexV]
* Pin numpy to latest version 1.14.2. [pyup-bot]
* Pin hypothesis to latest version 3.56.3. [pyup-bot]
* Pin pytest-xdist to latest version 1.22.2. [pyup-bot]
* Pin pytest to latest version 3.5.0. [pyup-bot]
* Removing outdated ros content. has already been moved to examples or
  pyros interface. [AlexV]
* Adding pyup badges. [AlexV]
* Cleaning up Readmes. added gitchangelog and pyup configuration.
  [AlexV]
* Updating sphinx config. [AlexV]
* Fixing dependencies to latest pyros. [AlexV]
* Reverting to latest tox. [AlexV]
* Reviewing dependencies and ROS packages versions. [AlexV]
* Cleaning up travis matrix in yml. fixing travis-env in tox.ini.
  [AlexV]
* Pinning tox to 2.9.1 for travis testing. [AlexV]
* Quick fix to install python-catkin-pip on travis (doesn't get
  automatically pulled by rosdep apparently) [alexv]
* Adding pyros dependency. [AlexV]
* Fixing imports for new pyros_04. forcing PyrosROS node. removed unused
  server module. cleaning up instance config file. [alexv]
* Migrating to latest catkin_pip. [AlexV]
* Readme file command correction. [Thomas]Fixed the command to Install and setup the virtualenvwrapper
* Not upgrading tox on travis just yet. [AlexV]
* Fixing tox params. [AlexV]
* Removing tox options for hypothesis. [AlexV]
* Removing ROS specific files. adding tox and requirements. [AlexV]
* Fixing python-flask-restful dependency. [AlexV]
* Adding kinetic travis checks. [AlexV]
* Preventing switch to tornado 5 for now (breaking install on lder
  systems). [AlexV]
* Making dependency on backports.ssl-mach-hostname system version
  dependent. [AlexV]
* Adding python install dependency on backports.ssl-match-hostname on
  python <=3.4. [AlexV]
* Now travis install current package in venv before running tests to
  make sure we retrieve dependencies. [AlexV]
* Removing submodules from setup.py packages_dir. they re gone. [AlexV]
* Default config exposes everything. Better for ease of use for now...
  [AlexV]
* Commenting useless stuff. [AlexV]
* Getting flask restful resource to work. [AlexV]
* Getting ROS interface by defaut. better for now. [AlexV]
* Cleaning up setup.py. [alexv]
* Now relying on catkin_pip 0.2.3. [alexv]
* Changing nose -> pytest comments about package_data. [alexv]
* Removing jade as it is EOL and we are missing dependencies. commenting
  kinetic as upgrading dependencies from ROS package to system package
  is not working yet : https://github.com/ros-
  infrastructure/rosdep/issues/539. [alexv]
* Fixing package data for templates. [alexv]
* Removing git submodules to now rely on python dependencies. [alexv]
* Fixing package-data description for jquery-mobile. [alexv]
* Adding tblib dependency since we use it directly. [alexv]
* Hack to work around potential catkin_pip bug. [alexv]
* Fixing tests on xenial with pytests. [alexv]
* Now using catkin_pip 0.2. [AlexV]
* Fixing tests with pyros 0.4. [AlexV]
* Comments and requirements changes. [AlexV]
* Fixing import to work with pyros_04. [AlexV]
* Change branch name for pyros. [Thomas]Changed pyros branch used in indigo-devel.rosinstall
  as the specified branch for pyros (eg: indigo-devel) no longer
  exist.
* Adding flask_restful dependency for ROS build. adding pyros_config
  dependency for python setup. [alexv]
* Added flask_reverse_proxy for ROS and pyros_setup for python. [alexv]
* Ddign flask_cors dependency for ros and fixing pyros version for
  python. [alexv]
* Changes to use catkin_pip with setuptools. [alexv]
* Removed static data from manifest.in, to match pyros manifest, hoping
  to fix travis. [alexv]
* Adding detailed description of all package data we want, both in
  setup.py and Manifest.in. [alexv]
* Fixed some dependencies. improves how to find the configuration file
  or generate if needed. [alexv]
* Fixing how we determine instance_path in ROS usecase. adding
  simplejson dependency for python. [alexv]
* Temporary declaring a dependency on python-mock, because of pyros
  0.3.0. [alexv]
* Adding roslint dependency to build with current CMakeLists. [alexv]
* Removing passlib and rester from dependencies list. not needed now.
  [alexv]
* Upgrading to package.xml v2, updating travis script and fixing tests.
  [alexv]
```
