### PR TITLE
pr2_robot: 1.6.28-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7262,7 +7262,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_robot-release.git
-      version: 1.6.27-0
+      version: 1.6.28-0
     source:
       type: git
       url: https://github.com/pr2/pr2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.28-0`:

- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.6.27-0`

## imu_monitor

- No changes

## pr2_bringup

```
* made sure tests only run if CATKIN_ENABLE_TESTING is set
* Contributors: David Feil-Seifer
```

## pr2_camera_synchronizer

```
* made sure tests only run if CATKIN_ENABLE_TESTING is set
* Contributors: David Feil-Seifer
```

## pr2_computer_monitor

```
* made sure tests only run if CATKIN_ENABLE_TESTING is set
* Contributors: David Feil-Seifer
```

## pr2_controller_configuration

- No changes

## pr2_ethercat

- No changes

## pr2_robot

- No changes

## pr2_run_stop_auto_restart

- No changes
