### PR TITLE
openrave_planning: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6495,6 +6495,22 @@ repositories:
       url: https://github.com/ros-drivers/openni_camera.git
       version: indigo-devel
     status: maintained
+  openrave_planning:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/openrave_planning.git
+      version: master
+    release:
+      packages:
+      - arm_navigation_msgs
+      - collada_robots
+      - openrave
+      - openrave_planning
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/openrave_planning-release.git
+      version: 0.0.6-0
+    status: developed
   openrtm_aist:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrave_planning` to `0.0.6-0`:

- upstream repository: https://github.com/jsk-ros-pkg/openrave_planning.git
- release repository: https://github.com/tork-a/openrave_planning-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## arm_navigation_msgs

- No changes

## collada_robots

- No changes

## openrave

```
* Merge pull request #20 <https://github.com/jsk-ros-pkg/openrave_planning/issues/20> from k-okada/master
  update  openrave package as of 2017/02/19
* remove collada_robots from build_depend
* update openrave to Feb/19/2018 versoin, which does not require sympy==0.7.1, as described in https://github.com/rdiankov/openrave/issues/375#issuecomment-155994724
* Merge pull request #18 <https://github.com/jsk-ros-pkg/openrave_planning/issues/18> from k-okada/fix_catkin_source
  do not import openravepy if it working... need to this when deb settings
* do not import openravepy if it working... need to this when deb settings
* Merge pull request #17 <https://github.com/jsk-ros-pkg/openrave_planning/issues/17> from k-okada/add_travis_kinetic
  run all test within docker, specially for kinetic
* compile openrave with -Wno-deprecated
* add libxml2
* Contributors: Kei Okada
```

## openrave_planning

- No changes
