### PR TITLE
add python-pydbus to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2321,6 +2321,18 @@ python-pyaudio:
   fedora: [pyaudio]
   gentoo: [dev-python/pyaudio]
   ubuntu: [python-pyaudio]
+python-pydbus:
+  ubuntu:
+    artful: [python-pydbus]
+    bionic: [python-pydbus]
+    trusty:
+      pip:
+        depends: [python-gi]
+        packages: [pydbus]
+    xenial:
+      pip:
+        depends: [python-gi]
+        packages: [pydbus]
 python-pydot:
   arch: [python2-pydot]
   debian: [python-pydot]


### PR DESCRIPTION
python-pydbus

https://pypi.org/project/pydbus/

Pythonic DBus library.

This package is used to get information from and interact with systemd in your python module.

This package is available as an apt package in artful, but not prior.  So I didn't use the -pip extension, but am still installing it with pip.