### PR TITLE
rostful: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9477,7 +9477,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pyros-dev/rostful-rosrelease.git
-      version: 0.2.0-3
+      version: 0.2.1-0
     status: developed
   rostune:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rostful` to `0.2.1-0`:

- upstream repository: https://github.com/asmodehn/rostful.git
- release repository: https://github.com/pyros-dev/rostful-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.0-3`

## rostful

```
* Now storing log in ROS_HOME when running on ROS as installed package.
  cosmetics. [AlexV]
```
