### PR TITLE
cht10_node: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -998,6 +998,22 @@ repositories:
       url: https://github.com/asmodehn/certifi-rosrelease.git
       version: 2015.11.20-3
     status: maintained
+  cht10_node:
+    doc:
+      type: git
+      url: https://github.com/Playfish/cht10_node.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Playfish/cht10_node_release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Playfish/cht10_node.git
+      version: master
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cht10_node` to `0.0.1-1`:

- upstream repository: https://github.com/Playfish/cht10_node.git
- release repository: https://github.com/Playfish/cht10_node_release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## cht10_node

```
* Catkinized
* Contributor: Carl
```
