### PR TITLE
pr2_robot: 1.6.29-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7294,7 +7294,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_robot-release.git
-      version: 1.6.28-0
+      version: 1.6.29-0
     source:
       type: git
       url: https://github.com/pr2/pr2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.29-0`:

- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.6.28-0`

## imu_monitor

- No changes

## pr2_bringup

```
* commented out tests that seem to require PR2 to function properly (timing out jenkins build)
* Contributors: David Feil-Seifer
```

## pr2_camera_synchronizer

```
* commented out tests that seem to require PR2 to function properly (timing out jenkins build)
* Contributors: David Feil-Seifer
```

## pr2_computer_monitor

- No changes

## pr2_controller_configuration

- No changes

## pr2_ethercat

- No changes

## pr2_robot

- No changes

## pr2_run_stop_auto_restart

- No changes
