### PR TITLE
pr2_metapackages: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9768,6 +9768,25 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.0-0
     status: maintained
+  pr2_metapackages:
+    doc:
+      type: git
+      url: https://github.com/PR2-prime/pr2_metapackages.git
+      version: indigo-devel
+    release:
+      packages:
+      - pr2
+      - pr2_base
+      - pr2_desktop
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/PR2-prime/pr2_metapackages-release.git
+      version: 1.1.2-0
+    source:
+      type: git
+      url: https://github.com/PR2-prime/pr2_metapackages.git
+      version: indigo-devel
+    status: maintained
   pr2_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_metapackages` to `1.1.2-0`:

- upstream repository: https://github.com/PR2-prime/pr2_metapackages.git
- release repository: https://github.com/PR2-prime/pr2_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## pr2

```
* fixed spelling of hokuyo
* Contributors: David Feil-Seifer
```

## pr2_base

- No changes

## pr2_desktop

- No changes
