### PR TITLE
mcl_3dl: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5036,6 +5036,21 @@ repositories:
       url: https://github.com/mavlink/mavros.git
       version: master
     status: developed
+  mcl_3dl:
+    doc:
+      type: git
+      url: https://github.com/at-wat/mcl_3dl.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/at-wat/mcl_3dl-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/at-wat/mcl_3dl.git
+      version: master
+    status: developed
   md49_base_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.1.0-0`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mcl_3dl

```
* Migrate to ROS recommended namespace model (#130 <https://github.com/at-wat/mcl_3dl/issues/130>)
* Minor CI setting updates (#129 <https://github.com/at-wat/mcl_3dl/issues/129>)
* Fix package deps (#127 <https://github.com/at-wat/mcl_3dl/issues/127>)
* Fix dockerfile style (#125 <https://github.com/at-wat/mcl_3dl/issues/125>)
* Load CI cache from docker hub registry (#124 <https://github.com/at-wat/mcl_3dl/issues/124>)
  
    * also add build matrix
  
* Add raycast performance benchmark (#123 <https://github.com/at-wat/mcl_3dl/issues/123>)
* Fix GLOBAL_LOCALIZATION status (#122 <https://github.com/at-wat/mcl_3dl/issues/122>)
* Add localization status output (#120 <https://github.com/at-wat/mcl_3dl/issues/120>)
* Fix nodehandle usage (#121 <https://github.com/at-wat/mcl_3dl/issues/121>)
* Update demo without odometry (#119 <https://github.com/at-wat/mcl_3dl/issues/119>)
  
    * Update demo without odometry
    * Update README
    * Add document of the demo without odometry
  
* Move sample parameters in launch into yamls (#72 <https://github.com/at-wat/mcl_3dl/issues/72>)
* Fix time jump back (#117 <https://github.com/at-wat/mcl_3dl/issues/117>)
  
    * Fix time jump back
    * Add warning of time jump
    * Fix tf error check
  
* Add unit tests for Raycast (#116 <https://github.com/at-wat/mcl_3dl/issues/116>)
  
    * Add unit tests for Raycast
    * Fix raycast grid handling
  
* Chunked kd-tree (#113 <https://github.com/at-wat/mcl_3dl/issues/113>)
  
    * Add chunked kd-tree to remove map truncation
    * Remove unused params
    * Remove unused debug output
    * Add unit test for ChunkedKdtree
  
* Update test reference checksum (#114 <https://github.com/at-wat/mcl_3dl/issues/114>)
* Fix raycast collision tolerance (#112 <https://github.com/at-wat/mcl_3dl/issues/112>)
  
    * Tolerance of the end of the raycast was too small in 1a758c0 because of the increase of the search range.
  
* Add integral angular odometry error constraint (#111 <https://github.com/at-wat/mcl_3dl/issues/111>)
* Fix raycast (#110 <https://github.com/at-wat/mcl_3dl/issues/110>)
  
    * Hit was checked by using range search with (grid/2.0) which make a lot of miss detection. (sqrt(2.0) * grid / 2.0) should be good approximation.
  
* Add rule based expansion resetting (#109 <https://github.com/at-wat/mcl_3dl/issues/109>)
* Fix integral odom error debug output (#108 <https://github.com/at-wat/mcl_3dl/issues/108>)
* Add landmark measurement input (#107 <https://github.com/at-wat/mcl_3dl/issues/107>)
* Fix map update timer (#105 <https://github.com/at-wat/mcl_3dl/issues/105>)
* Fix CI bot (#104 <https://github.com/at-wat/mcl_3dl/issues/104>)
  
    * Fix repository url
    * Use pip version of the bot
  
* Remove spinOnce polling and waitForTransform (#102 <https://github.com/at-wat/mcl_3dl/issues/102>)
  
    * Use ros::Timer instead of ros::spinOnce polling
    * Remove waitForTransform for static transforms
    * Remove waitForTransform for buffered (delayed) objects
  
* Fix particle initialization (#101 <https://github.com/at-wat/mcl_3dl/issues/101>)
* Reset integral odometry error if jumped (#100 <https://github.com/at-wat/mcl_3dl/issues/100>)
* Add constraint on the integral of odometry error (#99 <https://github.com/at-wat/mcl_3dl/issues/99>)
  
    * odom_err_integ_tc: time constant to hold the integral of the odometry error
    * odom_err_integ_sigma: acceptable range of the integral of the odometry error
  
* Visualize sampled points and raycasting result (#97 <https://github.com/at-wat/mcl_3dl/issues/97>)
  
    * Visualize sampled points and raycasting result
    * Remove duplicated code around raycasting
  
* Fix raycasting accuracy (#96 <https://github.com/at-wat/mcl_3dl/issues/96>)
* Fix odometry noise function in prediction (#95 <https://github.com/at-wat/mcl_3dl/issues/95>)
* Add global localization (#91 <https://github.com/at-wat/mcl_3dl/issues/91>)
* Fix particle resize (#92 <https://github.com/at-wat/mcl_3dl/issues/92>)
  
    * same fix as #90 <https://github.com/at-wat/mcl_3dl/issues/90>
  
* Fix resampling for huge particle size (#90 <https://github.com/at-wat/mcl_3dl/issues/90>)
  
    * All-zero particles have appeared on resampling if the particle size is very large.
    * Also, add iterator.
  
* Add test for pf::ParticleFilter. (#89 <https://github.com/at-wat/mcl_3dl/issues/89>)
* Build test with -Wall -Werror. (#88 <https://github.com/at-wat/mcl_3dl/issues/88>)
  
    * Build test with -Wall -Werror.
    * Workaround for invalid macro name bug in PCL(<1.8.1).
  
* Fix odometry noise function. (#87 <https://github.com/at-wat/mcl_3dl/issues/87>)
  
    * wrong: nd(mean = 1.0, sigma = sigma_trans_trans) * nd(mean = 1.0, sigma = sigma_rot_trans)
    * corrected: nd(mean = 0.0, sigma = sigma_trans_trans) + nd(mean = 0.0, sigma = sigma_rot_trans)
  
* Skip random points sampling if all points are filtered out. (#86 <https://github.com/at-wat/mcl_3dl/issues/86>)
* Fix build on indigo. (#84 <https://github.com/at-wat/mcl_3dl/issues/84>)
* Add map_clip_far param. (#85 <https://github.com/at-wat/mcl_3dl/issues/85>)
* Support variable particle size. (#78 <https://github.com/at-wat/mcl_3dl/issues/78>)
  
    * Support variable particle size.
    * Add service to change particle size.
    * Add test for resizeParticle.
  
* Check input cloud size. (#82 <https://github.com/at-wat/mcl_3dl/issues/82>)
  
    * Check for empty cloud to avoid failure on kdtree build.
    * Fix usage of point size of pcl::PointCloud.
  
* Remove debug outputs. (#81 <https://github.com/at-wat/mcl_3dl/issues/81>)
* Use online version of test result comment bot. (#80 <https://github.com/at-wat/mcl_3dl/issues/80>)
* Fix const function attributes. (#77 <https://github.com/at-wat/mcl_3dl/issues/77>)
* Remove dummy dep to system_lib. (#76 <https://github.com/at-wat/mcl_3dl/issues/76>)
* Add unit tests for mathematical classes. (#74 <https://github.com/at-wat/mcl_3dl/issues/74>)
  
    * Add unit tests for Vec3, Quat, NormalLikelihood, Filter classes.
    * Fix scaling of the NormalLikelihood distribution.
    * Fix Filter::set in angle mode.
  
* Fix naming styles. (#73 <https://github.com/at-wat/mcl_3dl/issues/73>)
  
    * Names of the classes and their members now get compatible with ROS recommended coding styles.
    * Public member variables are kept without underscore postfix.
  
* Fix package install. (#71 <https://github.com/at-wat/mcl_3dl/issues/71>)
* Fix assert of sampled point amount check. (#70 <https://github.com/at-wat/mcl_3dl/issues/70>)
* Fix quaternion average and use expectation as estimation result. (#67 <https://github.com/at-wat/mcl_3dl/issues/67>)
* Fix bot's test result posting on fail. (#68 <https://github.com/at-wat/mcl_3dl/issues/68>)
* Include test result on bot post. (#66 <https://github.com/at-wat/mcl_3dl/issues/66>)
* Fix a bug where all particle probabilities get zero. (#65 <https://github.com/at-wat/mcl_3dl/issues/65>)
  
    * fix number of selected points for likelihood calculation
    * add error recovering / asserts
  
* fixes coding styles (#64 <https://github.com/at-wat/mcl_3dl/issues/64>)
* adds parameter to accumulate input clouds (#60 <https://github.com/at-wat/mcl_3dl/issues/60>)
* syncs tf timestamp with last odometry (#61 <https://github.com/at-wat/mcl_3dl/issues/61>)
* adds example without odometry (#57 <https://github.com/at-wat/mcl_3dl/issues/57>)
* updates default params and demo (#55 <https://github.com/at-wat/mcl_3dl/issues/55>)
* adds option to disable tf publish and test for tf output (#46 <https://github.com/at-wat/mcl_3dl/issues/46>)
* adds test result notifier bot (#53 <https://github.com/at-wat/mcl_3dl/issues/53>)
* fixes possibly invalid memory access (#52 <https://github.com/at-wat/mcl_3dl/issues/52>)
* changes docker storage driver to overlay2 (#51 <https://github.com/at-wat/mcl_3dl/issues/51>)
* adds pcd file output of all pointcloud (#50 <https://github.com/at-wat/mcl_3dl/issues/50>)
* limits minimum beam_model likelihood (#49 <https://github.com/at-wat/mcl_3dl/issues/49>)
* separates point ranges of beam model and fixes total ref reduction (#48 <https://github.com/at-wat/mcl_3dl/issues/48>)
* makes acc measurement variance configurable (#47 <https://github.com/at-wat/mcl_3dl/issues/47>)
* fixes published tf timestamps to have a future date (#45 <https://github.com/at-wat/mcl_3dl/issues/45>)
* fixes docker caching on travis (#43 <https://github.com/at-wat/mcl_3dl/issues/43>)
* updates default parameters (#42 <https://github.com/at-wat/mcl_3dl/issues/42>)
* adds debug visualization output of casted ray (#41 <https://github.com/at-wat/mcl_3dl/issues/41>)
* fixes total reflection reduction (#40 <https://github.com/at-wat/mcl_3dl/issues/40>)
* rejects total reflection points in beam_model (#37 <https://github.com/at-wat/mcl_3dl/issues/37>)
* fixes test result handling and playback rate (#38 <https://github.com/at-wat/mcl_3dl/issues/38>)
* ignores travis run on non-master branch (#36 <https://github.com/at-wat/mcl_3dl/issues/36>)
* caches test dataset outside of docker (#34 <https://github.com/at-wat/mcl_3dl/issues/34>)
  
    * caches test dataset outside docker
    * changes script path
  
* adds travis settings for a test in docker container (#33 <https://github.com/at-wat/mcl_3dl/issues/33>)
* adds localization accuracy test (#32 <https://github.com/at-wat/mcl_3dl/issues/32>)
* makes beam_model likelihood configurable (#30 <https://github.com/at-wat/mcl_3dl/issues/30>)
* removes ad-hoc map filter (#27 <https://github.com/at-wat/mcl_3dl/issues/27>)
* updates sample launch file (#28 <https://github.com/at-wat/mcl_3dl/issues/28>)
  
    * The commit enables:
      
        * IMU measurement
        * loading map from pcd file
      
  
* adds imu measurement (#26 <https://github.com/at-wat/mcl_3dl/issues/26>)
* adds hysteresis on final estimation (#24 <https://github.com/at-wat/mcl_3dl/issues/24>)
* updates parameters in sample launch file (#23 <https://github.com/at-wat/mcl_3dl/issues/23>)
  
    * removes map offset parameters
    * specifies jump detection distance
  
* fixes axis-angle value range (#22 <https://github.com/at-wat/mcl_3dl/issues/22>)
* updates parameters in sample launch file (#19 <https://github.com/at-wat/mcl_3dl/issues/19>)
* fixes odometry error parameter handling (#18 <https://github.com/at-wat/mcl_3dl/issues/18>)
* fixes beam_model raycast origin (#17 <https://github.com/at-wat/mcl_3dl/issues/17>)
* adds parameter to specify odometry error
* adds sample launch file (#14 <https://github.com/at-wat/mcl_3dl/issues/14>)
  
    * This fixes #3 <https://github.com/at-wat/mcl_3dl/issues/3>.
    * A dataset for testing will be supplied in future.
  
* adds documentation (#10 <https://github.com/at-wat/mcl_3dl/issues/10>)
* fixes init_yaw/pitch/roll setting (#12 <https://github.com/at-wat/mcl_3dl/issues/12>)
* ad hoc fix to a bug on PCL-1.7 with C++11
  
    * fixes #9 <https://github.com/at-wat/mcl_3dl/issues/9>
  
* adds matched/unmatched pointclouds output (#7 <https://github.com/at-wat/mcl_3dl/issues/7>)
* fixes filter resetting in angular mode
  
    * This commit fixes #2 <https://github.com/at-wat/mcl_3dl/issues/2>.
  
* makes map clipping parameters configurable
* fixes roll and pitch motion in prediction phase
* adds /amcl_pose output
  
    * This commit fixes #1 <https://github.com/at-wat/mcl_3dl/issues/1>.
  
* applies LPF on debugging output pointcloud coordinate
* changes default map frame to 'map' instead of 'map_ground'
* outsources map update
* adds beam model
* makes z clipping parameters configurable
* adds parameter to skip measurement
* reduces almost invisible points in map
* checks localization covariance on map update
* detects pose jump and reset LPF
* makes some parameters configurable
* adds covariance calculation
* uses rpy variance instead of quat
* supports jump back
* fixes PointRepresentation dimension
* speed up by using radiusSearch instead of nearestKSearch
* improves prediction phase
* adds flexible particle operators
* removes garbage semicolons
* makes matching related parameters configurable
* makes several parameters configurable
* adds output filter
* adds weight in matching
* adds some parameters
* reduces number of points of updated map cloud
* adds particleBase::operator+
* clips and updates maps
* adds vec3::operator*
* adds arg to specify sigma to resampling
* avoids memory access error in max()
* supports tf and initialpose
* supports quat::inverse
* supports vec3::operator-
* updates test parameters
* update map cloud
* accumulates clouds
* fixes resampling
* first test version
* Contributors: Atsushi Watanabe
```
