### PR TITLE
web_interface: 1.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12479,6 +12479,31 @@ repositories:
       url: https://github.com/jihoonl/waypoint.git
       version: master
     status: developed
+  web_interface:
+    doc:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/web_interface.git
+      version: indigo-devel
+    release:
+      packages:
+      - image_stream
+      - launchman
+      - pyclearsilver
+      - ros_apache2
+      - rosjson
+      - rosweb
+      - web_interface
+      - web_msgs
+      - webui
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/UNR-RoboticsResearchLab/web_interface-release.git
+      version: 1.0.7-0
+    source:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/web_interface.git
+      version: indigo-devel
+    status: maintained
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_interface` to `1.0.7-0`:

- upstream repository: https://github.com/UNR-RoboticsResearchLab/web_interface.git
- release repository: https://github.com/UNR-RoboticsResearchLab/web_interface-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## image_stream

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## launchman

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## pyclearsilver

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## ros_apache2

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## rosjson

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## rosweb

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## web_interface

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## web_msgs

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```

## webui

```
* ros_apache2: updated dependencies to include necessary apache2 mod-python
* Contributors: David Feil-Seifer
```
