### PR TITLE
rc_visard: 2.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10783,7 +10783,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboception/rc_visard-release.git
-      version: 2.0.0-0
+      version: 2.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.1.0-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception/rc_visard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.0.0-0`

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

```
* add ptp_enabled dynamic_reconfigure parameter (to enable PrecisionTimeProtocol Slave on rc_visard)
* add reset service for SLAM
* README updates
* use 'rc_visard' as default device name (works with one rc_visard with factory settings connected)
```
