### PR TITLE
Adding raspimouse_sim to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7765,6 +7765,16 @@ repositories:
       url: https://github.com/ryuichiueda/raspimouse_ros.git
       version: master
     status: maintained
+  raspimouse_sim:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: kinetic-devel
+    status: developed
   razor_imu_9dof:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspimouse_sim for ROS Kinetic to be doc'd and indexed.