### PR TITLE
Adding kinect_autonomy to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5889,6 +5889,14 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/kinect_2d_scanner.git
       version: master
     status: maintained
+  kinect_autonomy:
+    doc:
+        type: python
+        url: https://github.com/GunnerPatterson/ROS-Kinect-Autonomy
+        version: indigo
+        depends:
+        -openni
+        -openni_tracker
   kinect_aux:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repo to be indexed and documented on ros.org.