### PR TITLE
tracetools: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1784,6 +1784,17 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  tracetools:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/bosch-robotics-cr/tracetools-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/bosch-robotics-cr/tracetools.git
+      version: devel
+    status: developed
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools` to `0.1.0-0`:

- upstream repository: https://github.com/bosch-robotics-cr/tracetools
- release repository: https://github.com/bosch-robotics-cr/tracetools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
