### PR TITLE
Fix python-bson to pull pymongo in Gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -496,7 +496,7 @@ python-bs4:
 python-bson:
   debian: [python-bson]
   fedora: [python-bson]
-  gentoo: [dev-python/bson]
+  gentoo: [dev-python/pymongo]
   osx:
     pip:
       packages: [bson]


### PR DESCRIPTION
Apparently for the other distros the `bson` dependency has been generated into a different package from the main `pymongo` package. For example, Ubuntu Xenial: https://packages.ubuntu.com/xenial/python-bson comes from the same source than all pymongo.

And the library `python-bson` says it is stripped from pymongo bson and made a package itself but is not compatible with who uses it... in our case `rosbridge_library`.

Also `python-bson` seems to be in a unstable state currently, they seem to be changing the name of the library itself (to py-bson):
https://github.com/py-bson/bson/issues/41

And `rosbridge_library` (who actually depends on it) checks for the _correct_ library here:
https://github.com/RobotWebTools/rosbridge_suite/blob/develop/rosbridge_library/src/rosbridge_library/util/__init__.py#L19-L27

There are plenty of issues with things that are different from the `pymongo` `bson`: https://github.com/py-bson/bson/issues

Until this `py-bson` doesn't become a real alternative, or Gentoo, or someone in ros-overlay with more time to dedicate to this headache fixes it... I think this is quite a good workaround.

As a note, I noticed all this when actually running `rosbrige_server` in Gentoo. I never was able to run it until today, so I could find all this only today. What a mess.

Sorry for all the noise.
