### PR TITLE
pyros_common: 0.5.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7442,7 +7442,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-common-rosrelease.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     status: developed
   pyros_config:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_common` to `0.5.4-0`:

- upstream repository: https://github.com/pyros-dev/pyros-common.git
- release repository: https://github.com/asmodehn/pyros-common-rosrelease.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.3-0`

## pyros_common

```
* Relaxing dependencies version requirements to work cross distros.
  [AlexV]
```
