### PR TITLE
rosmon: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9433,7 +9433,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/xqms/rosmon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.2-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.1-0`

## rosmon

```
* node_monitor: don't collect core dumps from launch-prefixed nodes
* node_monitor: fix error message on failed execvp()
  Previously, the error message was not printed to the screen, as log() is
  not useful in the child process. Rather, use the intended communication
  channel (stdout/stderr) to print log messages.
* Contributors: Max Schwarz
```
