### PR TITLE
srdfdom: 0.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1763,7 +1763,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
-      version: 0.4.2-0
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1758,7 +1758,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/srdfdom.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -1767,7 +1767,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   std_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.5.0-0`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.2-0`

## srdfdom

```
* Switch to std::shared_ptr of C++11 (#36 <https://github.com/ros-planning/srdfdom/issues/36>)
* Change log{Error,Warn} -> CONSOLE_BRIDGE_log{Error,Warn} (#37 <https://github.com/ros-planning/srdfdom/issues/37>)
* Contributors: Chris Lalancette, Ian McMahon
```
