### PR TITLE
denso: 2.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1781,7 +1781,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/start-jsk/denso-release.git
-      version: 2.0.2-0
+      version: 2.0.3-0
     source:
       type: git
       url: https://github.com/start-jsk/denso.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso` to `2.0.3-0`:

- upstream repository: https://github.com/start-jsk/denso.git
- release repository: https://github.com/start-jsk/denso-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.0.2-0`

## denso

- No changes

## denso_launch

- No changes

## denso_ros_control

- No changes

## vs060

```
* check CMake version rather than ROS version (#99 <https://github.com/start-jsk/denso/issues/99>)
* Add c++11 compile option
* Contributors: Mikael Arguedas, Ryosuke Tajima
```

## vs060_gazebo

- No changes

## vs060_moveit_config

- No changes
