### PR TITLE
mcl_3dl: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6875,6 +6875,21 @@ repositories:
       type: git
       url: https://github.com/mikeferguson/maxwell.git
       version: indigo-devel
+  mcl_3dl:
+    doc:
+      type: git
+      url: https://github.com/at-wat/mcl_3dl.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/at-wat/mcl_3dl-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/at-wat/mcl_3dl.git
+      version: master
+    status: developed
   md49_base_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.1.1-0`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mcl_3dl

```
* Update CI settings (#136 <https://github.com/at-wat/mcl_3dl/issues/136>)
* Remove CMake warning message (#134 <https://github.com/at-wat/mcl_3dl/issues/134>)
* Contributors: Atsushi Watanabe
```
