### PR TITLE
Fix twisted dependences for Gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3680,18 +3680,19 @@ python-twisted-bin:
   arch: [python2-twisted]
   debian: [python-twisted-bin]
   fedora: [python-twisted-core]
+  gentoo: [dev-python/twisted]
   ubuntu: [python-twisted-bin]
 python-twisted-core:
   arch: [python2-twisted]
   debian: [python-twisted-core]
   fedora: [python-twisted-core]
-  gentoo: [dev-python/twisted-core]
+  gentoo: [dev-python/twisted]
   ubuntu: [python-twisted-core]
 python-twisted-web:
   arch: [python2-twisted]
   debian: [python-twisted-web]
   fedora: [python-twisted-web]
-  gentoo: [dev-python/twisted-web]
+  gentoo: [dev-python/twisted]
   ubuntu: [python-twisted-web]
 python-twitter:
   debian:


### PR DESCRIPTION
Depend on the main `twisted` package, which provides everything, not in the split packages `twisted-*`.

After a conversation via email with Brian Dolbec @dol-sen who authored the commits on the ebuilds for Gentoo for Twisted [commit](https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-python/twisted/twisted-17.9.0.ebuild?id=8015b0a9993dbfd6fa9eccee0e80bd814e3aa3ac) where he stated:

> It is quite simple really, some years ago twisted went to a split release system.  So it went from a single twisted package to the twisted-* packages.  Then they switched back to single all inclusive releases again.  They no longer support the old twisted-* packages.
> The reason for the blocks is due to file collisions between the old split twisted pkgs and the new single package.

The last line about the blocks is because if a package depends on one of the `twisted-*` splitted packages, it blocks the installation of `twisted`. And `twisted` blocks the installation of the splitted packages. Given that we are supposed to use the main package, well, that's what I propose here.

I tried to fix it locally in the ROS overlay (https://github.com/ros/ros-overlay/pull/578) but seems I can't.

Also, for a bit of software archeology, [splitted versions in ebuilds in Gentoo](https://github.com/gentoo/gentoo/tree/master/dev-python/twisted-core) are (from [NEWS in twisted repo](https://github.com/twisted/twisted/blob/trunk/NEWS.rst)):
* 13.2.0 which dates to 29/10/2013
* 15.2.1 which dates to 23/05/2015

And now we are in an all-included 17.9.0 version.

This all came to be cause [rosbridge_server](https://github.com/RobotWebTools/rosbridge_suite/blob/develop/rosbridge_server/package.xml) depends on `python-tornado` which, on Gentoo, pulls [twisted as a dependence](https://github.com/gentoo/gentoo/blob/master/www-servers/tornado/tornado-4.5.1.ebuild#L25-L28). And then, `rosbridge_server` also depends on `python-twisted-core`, which clashes in that blocking dependence.