### PR TITLE
add map_merge_3d documentation + source

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1605,6 +1605,16 @@ repositories:
       url: https://github.com/hrnr/m-explore.git
       version: lunar-devel
     status: developed
+  map_merge:
+    doc:
+      type: git
+      url: https://github.com/hrnr/map-merge.git
+      version: lunar-devel
+    source:
+      type: git
+      url: https://github.com/hrnr/map-merge.git
+      version: lunar-devel
+    status: developed
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
For now just doc and CI. The repo contains new package `map_merge_3d`.