### PR TITLE
astuff_sensor_msgs: 2.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -535,6 +535,20 @@ repositories:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: release
+    release:
+      packages:
+      - astuff_sensor_msgs
+      - delphi_esr_msgs
+      - delphi_srr_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
+      - pacmod_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/astuff/astuff_sensor_msgs-release.git
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `2.0.1-0`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
