### PR TITLE
network_interface: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8183,6 +8183,11 @@ repositories:
       type: git
       url: https://github.com/astuff/network_interface.git
       version: release
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/astuff/network_interface-release.git
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/astuff/network_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_interface` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/network_interface.git
- release repository: https://github.com/astuff/network_interface-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
