### PR TITLE
Remove ridgeback_simulator from kinetic builds due most packages failing to build

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8217,7 +8217,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
-      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_simulator.git


### PR DESCRIPTION
Ticketed at: https://github.com/ridgeback/ridgeback_simulator/issues/3

mechanum_gazebo_plugin does appear to build wihtout error but doesn't actually build the plugin so removing it too.