### PR TITLE
Remove failing semantic_point_annotator and dependencies

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7318,15 +7318,12 @@ repositories:
       packages:
       - laser_tilt_controller_filter
       - pr2_move_base
-      - pr2_navigation
       - pr2_navigation_config
       - pr2_navigation_global
       - pr2_navigation_local
-      - pr2_navigation_perception
       - pr2_navigation_self_filter
       - pr2_navigation_slam
       - pr2_navigation_teleop
-      - semantic_point_annotator
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_navigation-release.git


### PR DESCRIPTION
They are failing to build on Kinetic

https://github.com/PR2/pr2_navigation/issues/33

Partial rollback of #17422 FYI @k-okada

Dependencies:
pr2_navigation
pr2_navigation_perception