### PR TITLE
removing camera1394stereo from kinetic due to it not building

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -867,7 +867,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/srv/camera1394stereo-release.git
-      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/srv/camera1394stereo.git


### PR DESCRIPTION
Partial rollback of #17001 @miquelmassot

Ticketed upstream at: https://github.com/srv/camera1394stereo/issues/8