### PR TITLE
astuff_pacmod: 2.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -752,6 +752,13 @@ repositories:
       type: git
       url: https://github.com/astuff/ros_pacmod.git
       version: release
+    release:
+      packages:
+      - pacmod
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/astuff/ros_pacmod-release.git
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/astuff/ros_pacmod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_pacmod` to `2.0.2-0`:

- upstream repository: https://github.com/astuff/ros_pacmod.git
- release repository: https://github.com/astuff/ros_pacmod-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
