### PR TITLE
astuff_pacmod_game_control: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -764,6 +764,13 @@ repositories:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git
       version: release
+    release:
+      packages:
+      - pacmod_game_control
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/astuff/pacmod_game_control-release.git
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_pacmod_game_control` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/pacmod_game_control.git
- release repository: https://github.com/astuff/pacmod_game_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
