### PR TITLE
Updating Package Names from AutonomouStuff

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -745,30 +745,6 @@ repositories:
       url: https://github.com/orbbec/ros_astra_launch.git
       version: master
     status: developed
-  astuff_pacmod:
-    doc:
-      depends:
-      - astuff_sensor_msgs
-      type: git
-      url: https://github.com/astuff/ros_pacmod.git
-      version: release
-    source:
-      type: git
-      url: https://github.com/astuff/ros_pacmod.git
-      version: release
-    status: maintained
-  astuff_pacmod_game_control:
-    doc:
-      depends:
-      - astuff_sensor_msgs
-      type: git
-      url: https://github.com/astuff/pacmod_game_control.git
-      version: release
-    source:
-      type: git
-      url: https://github.com/astuff/pacmod_game_control.git
-      version: release
-    status: developed
   astuff_sensor_msgs:
     doc:
       type: git
@@ -9032,6 +9008,30 @@ repositories:
       type: git
       url: https://github.com/ros-industrial-consortium/packml.git
       version: indigo-devel
+    status: developed
+  pacmod:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: release
+    status: maintained
+  pacmod_game_control:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
     status: developed
   pal_msgs:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -745,6 +745,40 @@ repositories:
       url: https://github.com/orbbec/ros_astra_launch.git
       version: master
     status: developed
+  astuff_pacmod:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/ros_pacmod.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/ros_pacmod.git
+      version: release
+    status: maintained
+  astuff_pacmod_game_control:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
+    status: developed
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: release
+    status: developed
   async_web_server_cpp:
     doc:
       type: git
@@ -6096,6 +6130,16 @@ repositories:
       type: git
       url: https://github.com/uos/kurt_navigation.git
       version: indigo
+  kvaser_interface:
+    doc:
+      type: git
+      url: https://github.com/astuff/kvaser_interface.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/kvaser_interface.git
+      version: release
+    status: maintained
   lama:
     doc:
       type: git
@@ -8105,6 +8149,16 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
       version: master
     status: maintained
+  network_interface:
+    doc:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    status: maintained
   nmea_comms:
     doc:
       type: git
@@ -9365,6 +9419,16 @@ repositories:
       url: https://github.com/amineHorseman/pioneer_teleop.git
       version: master
     status: maintained
+  platform_automation_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/platform_automation_msgs.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/platform_automation_msgs.git
+      version: release
+    status: developed
   play_motion:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -506,6 +506,40 @@ repositories:
       url: https://github.com/orbbec/ros_astra_launch.git
       version: master
     status: developed
+  astuff_pacmod:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/ros_pacmod.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/ros_pacmod.git
+      version: release
+    status: maintained
+  astuff_pacmod_game_control:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
+    status: developed
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: release
+    status: developed
   async_web_server_cpp:
     release:
       tags:
@@ -4375,6 +4409,16 @@ repositories:
       url: https://github.com/ros-industrial/kuka_experimental.git
       version: indigo-devel
     status: developed
+  kvaser_interface:
+    doc:
+      type: git
+      url: https://github.com/astuff/kvaser_interface.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/kvaser_interface.git
+      version: release
+    status: maintained
   kvh_drivers:
     doc:
       type: git
@@ -5993,6 +6037,16 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
       version: master
     status: maintained
+  network_interface:
+    doc:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    status: maintained
   nmea_comms:
     doc:
       type: git
@@ -6972,6 +7026,16 @@ repositories:
       url: https://github.com/amineHorseman/pioneer_teleop.git
       version: master
     status: maintained
+  platform_automation_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/platform_automation_msgs.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/platform_automation_msgs.git
+      version: release
+    status: developed
   plotjuggler:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -506,30 +506,6 @@ repositories:
       url: https://github.com/orbbec/ros_astra_launch.git
       version: master
     status: developed
-  astuff_pacmod:
-    doc:
-      depends:
-      - astuff_sensor_msgs
-      type: git
-      url: https://github.com/astuff/ros_pacmod.git
-      version: release
-    source:
-      type: git
-      url: https://github.com/astuff/ros_pacmod.git
-      version: release
-    status: maintained
-  astuff_pacmod_game_control:
-    doc:
-      depends:
-      - astuff_sensor_msgs
-      type: git
-      url: https://github.com/astuff/pacmod_game_control.git
-      version: release
-    source:
-      type: git
-      url: https://github.com/astuff/pacmod_game_control.git
-      version: release
-    status: developed
   astuff_sensor_msgs:
     doc:
       type: git
@@ -6729,6 +6705,30 @@ repositories:
       type: git
       url: https://github.com/ros-industrial-consortium/packml.git
       version: kinetic-devel
+    status: developed
+  pacmod:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: release
+    status: maintained
+  pacmod_game_control:
+    doc:
+      depends:
+      - astuff_sensor_msgs
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod_game_control.git
+      version: release
     status: developed
   parameter_pa:
     doc:


### PR DESCRIPTION
@mikaelarguedas mentioned some significant inconsistencies in package/repo/package entry naming for at least two of our packages. These have now been renamed and the repo URLs changed to be more consistent.