### PR TITLE
pacmod: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6732,6 +6732,11 @@ repositories:
       type: git
       url: https://github.com/astuff/pacmod.git
       version: release
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/astuff/pacmod-release.git
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/astuff/pacmod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/pacmod.git
- release repository: https://github.com/astuff/pacmod-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
