### PR TITLE
ridgeback_simulator: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8238,6 +8238,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.0.3-0`:

- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mecanum_gazebo_plugin

- No changes

## ridgeback_gazebo

- No changes

## ridgeback_gazebo_plugins

```
* Fixed deps for kinetic.
* Contributors: Tony Baltovski
```

## ridgeback_simulator

- No changes
