### PR TITLE
[dep] Add python-sh.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3119,6 +3119,15 @@ python-setuptools:
     xenial_python3: [python3-setuptools]
     yakkety: [python-setuptools]
     zesty: [python-setuptools]
+python-sh:
+  debian: [python-sh]
+  fedora: [python-sh]
+  gentoo: [dev-python/sh]
+  ubuntu:
+    '*': [python-sh]
+    trusty:
+      pip:
+        packages: [sh]
 python-shapely:
   debian: [python-shapely]
   fedora: [python-shapely]


### PR DESCRIPTION
- Debian https://packages.debian.org/sid/python/python-sh
- Fedora https://admin.fedoraproject.org/pkgdb/package/rpms/python-sh/
- Gentoo https://packages.gentoo.org/packages/dev-python/sh
- Ubuntu https://packages.ubuntu.com/search?keywords=python-sh
  - It's tricky to me that the apt pkg seems to have become available since Xenial and on Trusty it's only available via `pip`. Assuming it'll remain available onward, it there a way to describe the rule cleanly so that we won't have to populate for each distro?