### PR TITLE
ros_control: 0.13.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2981,7 +2981,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.13.2-1
+      version: 0.13.3-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.13.3-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.13.2-1`

## combined_robot_hw

```
* Introduce shared_ptr typedefs
* Update maintainers
* Contributors: Bence Magyar
```

## combined_robot_hw_tests

```
* Update maintainers
* Fix catkin_lint errors and warnings
* Contributors: Bence Magyar
```

## controller_interface

```
* Introduce shared_ptr typedefs
* Update maintainers
* Contributors: Bence Magyar
```

## controller_manager

```
* Introduce shared_ptr typedefs
* Update maintainers
* Fix catkin_lint errors and warnings
* Remove unused imports, comment and executable flag
* Remove realtime_tools dependency
* Contributors: Bence Magyar
```

## controller_manager_msgs

```
* Update maintainers
* Contributors: Bence Magyar
```

## controller_manager_tests

```
* Update maintainers
* Fix catkin_lint errors and warnings
* Contributors: Bence Magyar
```

## hardware_interface

```
* Introduce shared_ptr typedefs
* Update maintainers
* Fix catkin_lint errors and warnings
* Contributors: Bence Magyar
```

## joint_limits_interface

```
* Update maintainers
* Fix catkin_lint errors and warnings
* Contributors: Bence Magyar
```

## ros_control

```
* Update maintainers
* Contributors: Bence Magyar
```

## rqt_controller_manager

```
* Update maintainers
* Fix catkin_lint errors and warnings
* Contributors: Bence Magyar
```

## transmission_interface

```
* Introduce shared_ptr typedefs
* Update maintainers
* Fix catkin_lint errors and warnings
* fix license string
* Update transmission parser to parse the joint role
* Contributors: Bence Magyar, Patrick Holthaus, jlack1987
```
