### PR TITLE
pr2_navigation: 0.1.28-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7336,8 +7336,8 @@ repositories:
   pr2_navigation:
     doc:
       type: git
-      url: https://github.com/pr2/pr2_navigation.git
-      version: hydro-devel
+      url: https://github.com/PR2-prime/pr2_navigation.git
+      version: kinetic-devel
     release:
       packages:
       - laser_tilt_controller_filter
@@ -7353,12 +7353,12 @@ repositories:
       - semantic_point_annotator
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/pr2-gbp/pr2_navigation-release.git
+      url: https://github.com/PR2-prime/pr2_navigation-release.git
       version: 0.1.28-0
     source:
       type: git
-      url: https://github.com/pr2/pr2_navigation.git
-      version: hydro-devel
+      url: https://github.com/PR2-prime/pr2_navigation.git
+      version: kinetic-devel
     status: unmaintained
   pr2_power_drivers:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7342,16 +7342,19 @@ repositories:
       packages:
       - laser_tilt_controller_filter
       - pr2_move_base
+      - pr2_navigation
       - pr2_navigation_config
       - pr2_navigation_global
       - pr2_navigation_local
+      - pr2_navigation_perception
       - pr2_navigation_self_filter
       - pr2_navigation_slam
       - pr2_navigation_teleop
+      - semantic_point_annotator
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_navigation-release.git
-      version: 0.1.27-0
+      version: 0.1.28-0
     source:
       type: git
       url: https://github.com/pr2/pr2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.28-0`:

- upstream repository: https://github.com/PR2-prime/pr2_navigation.git
- release repository: https://github.com/pr2-gbp/pr2_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.27-0`

## laser_tilt_controller_filter

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Merge pull request #31 <https://github.com/PR2-prime/pr2_navigation/issues/31> from mikaelarguedas/update_pluginlib_macros
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Contributors: Austin, David Feil-Seifer, Mikael Arguedas
```

## pr2_move_base

```
* updated changelogs
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
```

## pr2_navigation

```
* updated changelogs
* updated maintainer
* Update package.xml
* Contributors: David Feil-Seifer, Devon Ash
* updated maintainer
* Update package.xml
* Contributors: David Feil-Seifer, Devon Ash
```

## pr2_navigation_config

```
* updated changelogs
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
```

## pr2_navigation_global

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
```

## pr2_navigation_local

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
```

## pr2_navigation_perception

```
* updated maintainer
* Merge pull request #31 <https://github.com/PR2-prime/pr2_navigation/issues/31> from mikaelarguedas/update_pluginlib_macros
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Contributors: Austin, David Feil-Seifer, Mikael Arguedas
```

## pr2_navigation_self_filter

```
* updated changelogs
* updated maintainer
* fixed CMake files for compile in kinetic
* Merge pull request #24 <https://github.com/PR2-prime/pr2_navigation/issues/24> from wkentaro/self_filter-timestamp
  Set correct timestamp for self filtered cloud
* Set correct timestamp for self filtered cloud
  This is needed because pcl drops some value of timestamp.
  So pcl::fromROSMsg and pcl::toROSMsg does not work to get correct timestamp.
* Contributors: David Feil-Seifer, Devon Ash, Kentaro Wada
* updated maintainer
* fixed CMake files for compile in kinetic
* Merge pull request #24 <https://github.com/PR2-prime/pr2_navigation/issues/24> from wkentaro/self_filter-timestamp
  Set correct timestamp for self filtered cloud
* Set correct timestamp for self filtered cloud
  This is needed because pcl drops some value of timestamp.
  So pcl::fromROSMsg and pcl::toROSMsg does not work to get correct timestamp.
* Contributors: David Feil-Seifer, Devon Ash, Kentaro Wada
```

## pr2_navigation_slam

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
```

## pr2_navigation_teleop

```
* updated changelogs
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer
```

## semantic_point_annotator

```
* updated maintainer
* fixed CMake files for compile in kinetic
* Merge pull request #34 <https://github.com/PR2-prime/pr2_navigation/issues/34> from PR2/pr-fix-catkin-includes
  fix typo in catkin_INCLUDE_DIRS
* fix typo in catkin_INCLUDE_DIRS
  Fixes #33 <https://github.com/PR2-prime/pr2_navigation/issues/33>
* Merge pull request #25 <https://github.com/PR2-prime/pr2_navigation/issues/25> from gheorghelisca/patch-1
  sac_inc_ground_removal_node instalation location fixed
* sac_inc_ground_removal_node instalation location fixed
  sac_inc_ground_removal_node would be installed in "/opt/ros/indigo/bin/" directory and roslaunch couldn't find it.
  now sac_inc_ground_removal_node will go into "/opt/ros/indigo/bin/sac_inc_ground_removal_node" directory.
* Contributors: David Feil-Seifer, Devon Ash, Gheorghe Lisca, Kei Okada, Michael Gorner
```
