### PR TITLE
cartographer_ros: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -953,6 +953,25 @@ repositories:
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 0.2.0-2
     status: developed
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: 0.2.0
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer_ros-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: 0.2.0
+    status: developed
   catch_ros:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -967,10 +967,6 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
       version: 0.2.0-0
-    source:
-      type: git
-      url: https://github.com/googlecartographer/cartographer_ros.git
-      version: 0.2.0
     status: developed
   catch_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `0.2.0-0`:

- upstream repository: https://github.com/googlecartographer/cartographer_ros.git
- release repository: https://github.com/ros-gbp/cartographer_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## cartographer_ros

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```

## cartographer_ros_msgs

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```

## cartographer_rviz

```
* https://github.com/googlecartographer/cartographer/compare/0.1.0...0.2.0
```
