### PR TITLE
darknet_ros: 1.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1722,7 +1722,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/leggedrobotics/darknet_ros-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `darknet_ros` to `1.1.3-0`:

- upstream repository: https://github.com/leggedrobotics/darknet_ros
- release repository: https://github.com/leggedrobotics/darknet_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.1.2-0`

## darknet_ros

```
* Fixed iteration through detection boxes.
* Merge pull request #80 <https://github.com/leggedrobotics/darknet_ros/issues/80> from leggedrobotics/feature/yolo3
  Feature/yolo3
* Fixed publishers.
* Applied first changes for yolo v3.
* Updated darknet and added launch files for yolov3.
* Merge pull request #73 <https://github.com/leggedrobotics/darknet_ros/issues/73> from leggedrobotics/fix/weights
  Fix/weights
* Fixed weights.
* Fix test.
* Fixed formatting part 2.
* Fixed naming.
* Merge branch 'firephinx-master'
* Merge branch 'master' of https://github.com/firephinx/darknet_ros into firephinx-master
* Merge pull request #62 <https://github.com/leggedrobotics/darknet_ros/issues/62> from warp1337/master
  Reduced window size to reasonable values
* Reduced window size to reasonable values
* Added rgb_image_header to BoundingBoxes msg.
* Updated to the latest darknet version.
* Merge pull request #57 <https://github.com/leggedrobotics/darknet_ros/issues/57> from leggedrobotics/devel/threads
  Devel/threads
* Rearranged.
* Fixed action with new threads.
* Adapted package description.
* Added publisher.
* Merge branch 'master' into devel/threads
* Rearranged code.
* Update package.xml
* Fixed image_view if x11 is not running.
* COmment runYolo().
* Update object_detector_demo.cpp
* Changed ros config.
* Node is shutting down properly.
* Rearranged code and added threads.
* Contributors: Kevin Zhang, Marko Bjelonic, fl
```

## darknet_ros_msgs

```
* Fixed formatting part 2.
* Merge branch 'firephinx-master'
* Merge branch 'master' of https://github.com/firephinx/darknet_ros into firephinx-master
* Added rgb_image_header to BoundingBoxes msg.
* Merge pull request #57 <https://github.com/leggedrobotics/darknet_ros/issues/57> from leggedrobotics/devel/threads
  Devel/threads
* Adapted package description.
* Merge branch 'master' into devel/threads
* Update package.xml
* Contributors: Kevin Zhang, Marko Bjelonic