### PR TITLE
pacmod: 2.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9018,7 +9018,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/astuff/pacmod-release.git
-      version: 2.0.0-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/astuff/pacmod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod` to `2.0.2-0`:

- upstream repository: https://github.com/astuff/pacmod.git
- release repository: https://github.com/astuff/pacmod-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.0.0-0`
