### PR TITLE
moveit_resources: 0.6.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1900,7 +1900,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.3-0`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.2-0`

## moveit_resources

```
* [enhance] Update param scope (#17 <https://github.com/ros-planning/moveit_resources/issues/17>)
* [enhance] Use the "Hybrid" collision checker and created a sample config file for parameters (#16 <https://github.com/ros-planning/moveit_resources/issues/16>)
* Contributors: Simon Schmeisser, Will Baker
```
