### PR TITLE
moveit_resources: 0.6.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5422,7 +5422,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.3-0`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.2-0`

## moveit_resources

```
* [enhance] Update param scope (#17 <https://github.com/ros-planning/moveit_resources/issues/17>)
* [enhance] Use the "Hybrid" collision checker and created a sample config file for parameters (#16 <https://github.com/ros-planning/moveit_resources/issues/16>)
* Contributors: Simon Schmeisser, Will Baker
```
