### PR TITLE
jsk_planning: 0.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5699,7 +5699,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_planning-release.git
-      version: 0.1.10-0
+      version: 0.1.11-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
     status: developed
   jsk_pr2eus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.11-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_planning
- release repository: https://github.com/tork-a/jsk_planning-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.10-0`

## jsk_planning

- No changes

## pddl_msgs

- No changes

## pddl_planner

```
* pddl_planner: pddl.py: remove (REACH-GOAL) on action which emerges occasionally (#61 <https://github.com/jsk-ros-pkg/jsk_planning/issues/61>)
* Contributors: Yuki Furuta
```

## pddl_planner_viewer

- No changes

## task_compiler

- No changes
