### PR TITLE
pr2_navigation: 0.1.28-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9912,7 +9912,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_navigation-release.git
-      version: 0.1.27-0
+      version: 0.1.28-0
     source:
       type: git
       url: https://github.com/pr2/pr2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation` to `0.1.28-0`:

- upstream repository: https://github.com/PR2/pr2_navigation.git
- release repository: https://github.com/pr2-gbp/pr2_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.1.27-0`

## laser_tilt_controller_filter

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Merge pull request #31 <https://github.com/pr2/pr2_navigation/issues/31> from mikaelarguedas/update_pluginlib_macros
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Contributors: Austin, David Feil-Seifer, Kei Okada, Mikael Arguedas
```

## pr2_move_base

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer, Kei Okada
```

## pr2_navigation

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* Update package.xml
* Contributors: David Feil-Seifer, Devon Ash, Kei Okada
```

## pr2_navigation_config

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer, Kei Okada
```

## pr2_navigation_global

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer, Kei Okada
```

## pr2_navigation_local

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer, Kei Okada
```

## pr2_navigation_perception

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* Merge pull request #27 <https://github.com/pr2/pr2_navigation/issues/27> from v4hn/pr-hydro-fix-broken-filters-plugin
  specify prefix for filter plugins
* Merge pull request #35 <https://github.com/pr2/pr2_navigation/issues/35> from k-okada/hydro-devel
  use arg for all parameters for ground filtering
* fix layout
* enable to use args for all params
* Merge pull request #28 <https://github.com/pr2/pr2_navigation/issues/28> from v4hn/pr-hydro-filter-machine
  spawn laser filter on c2 (where the rest of the pipeline runs)
* Merge pull request #31 <https://github.com/pr2/pr2_navigation/issues/31> from mikaelarguedas/update_pluginlib_macros
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* spawn laser filter on c2 (where the rest of the pipeline runs)
  Without this, all tilt laserscans are sent back and forth between
  c1 and c2 for no reason, adding to the general delays...
* specify prefix for filter plugins
  The missing prefix has hazardous consequences due
  to a series of unfortunate events involving the filters and the
  laser_filters package..
* Contributors: Austin, David Feil-Seifer, Kei Okada, Mikael Arguedas, v4hn
```

## pr2_navigation_self_filter

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Merge pull request #24 <https://github.com/pr2/pr2_navigation/issues/24> from wkentaro/self_filter-timestamp
  Set correct timestamp for self filtered cloud
* Set correct timestamp for self filtered cloud
  This is needed because pcl drops some value of timestamp.
  So pcl::fromROSMsg and pcl::toROSMsg does not work to get correct timestamp.
* Contributors: David Feil-Seifer, Devon Ash, Kei Okada, Kentaro Wada
```

## pr2_navigation_slam

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer, Kei Okada
```

## pr2_navigation_teleop

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Contributors: David Feil-Seifer, Kei Okada
```

## semantic_point_annotator

```
* Merge pull request #36 <https://github.com/pr2/pr2_navigation/issues/36> from k-okada/fix_catkin_depends
  fixed CMake files for compile in kinetic
* updated maintainer
* fixed CMake files for compile in kinetic
* Merge pull request #34 <https://github.com/pr2/pr2_navigation/issues/34> from PR2/pr-fix-catkin-includes
  fix typo in catkin_INCLUDE_DIRS
* fix typo in catkin_INCLUDE_DIRS
  Fixes #33 <https://github.com/pr2/pr2_navigation/issues/33>
* Merge pull request #25 <https://github.com/pr2/pr2_navigation/issues/25> from gheorghelisca/patch-1
  sac_inc_ground_removal_node instalation location fixed
* sac_inc_ground_removal_node instalation location fixed
  sac_inc_ground_removal_node would be installed in "/opt/ros/indigo/bin/" directory and roslaunch couldn't find it.
  now sac_inc_ground_removal_node will go into "/opt/ros/indigo/bin/sac_inc_ground_removal_node" directory.
* Contributors: David Feil-Seifer, Devon Ash, Gheorghe Lisca, Kei Okada, Michael Görner
```
