### PR TITLE
ros_controllers: 0.14.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1256,6 +1256,25 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git
       version: melodic-devel
+    release:
+      packages:
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_controller
+      - forward_command_controller
+      - four_wheel_steering_controller
+      - gripper_action_controller
+      - imu_sensor_controller
+      - joint_state_controller
+      - joint_trajectory_controller
+      - position_controllers
+      - ros_controllers
+      - rqt_joint_trajectory_controller
+      - velocity_controllers
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_controllers-release.git
+      version: 0.14.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.14.0-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## diff_drive_controller

```
* add dynamic_reconf to diff_drive_controller
* migrate to new pluginlib headers
* per wheel radius multiplier
* fix xacro macro warning
* [DiffDrive] Fix time-sensitive tests of diff_drive_controller
* separate include_directories as SYSTEM to avoid unrelated compilation warnings
* Contributors: Jeremie Deray, Mathias Lüdtke
```

## effort_controllers

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## force_torque_sensor_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* migrate to new pluginlib headers
* fix warning un/signed comparison
* [4ws tests] simulation clock
* [4ws tests] Increase position tolerance
* Contributors: Bence Magyar, Jeremie Deray, Mathias Lüdtke, Vincent Rousseau
```

## gripper_action_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## imu_sensor_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## joint_state_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## joint_trajectory_controller

```
* Make the compiler happy in the test.
* migrate to new pluginlib headers
* TrajectoryController: Use desired state to calculate hold trajectory (#297 <https://github.com/ros-controls/ros_controllers/issues/297>)
* Add velocity feedforward term to velocity HardwareInterfaceAdapter (#227 <https://github.com/ros-controls/ros_controllers/issues/227>)
* Contributors: Chris Lalancette, Mathias Lüdtke, Miguel Prada, agutenkunst
```

## position_controllers

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

```
* fix license string
* Contributors: Patrick Holthaus
```

## velocity_controllers

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```
