### PR TITLE
ros_controllers: 0.13.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9107,7 +9107,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.13.2-0
+      version: 0.13.3-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.13.3-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.13.2-0`

## diff_drive_controller

```
* add dynamic_reconf to diff_drive_controller
* migrate to new pluginlib headers
* typo in odometry.h
* fix doc
* per wheel radius multiplier
* fix xacro macro warning
* [DiffDrive] Test fixing (#318 <https://github.com/ros-controls/ros_controllers/issues/318>)
* separate include_directories as SYSTEM to avoid unrelated compilation warnings
* Contributors: Jeremie Deray, Mathias Lüdtke
```

## effort_controllers

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## force_torque_sensor_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* migrate to new pluginlib headers
* fix warning un/signed comparison
* [4ws tests] simulation clock
* [4ws tests] Increase position tolerance
* Contributors: Bence Magyar, Jeremie Deray, Mathias Lüdtke, Vincent Rousseau
```

## gripper_action_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## imu_sensor_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## joint_state_controller

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## joint_trajectory_controller

```
* migrate to new pluginlib headers
* TrajectoryController: Use desired state to calculate hold trajectory (#297 <https://github.com/ros-controls/ros_controllers/issues/297>)
* Add velocity feedforward term to velocity HardwareInterfaceAdapter (#227 <https://github.com/ros-controls/ros_controllers/issues/227>)
* Contributors: Mathias Lüdtke, Miguel Prada, agutenkunst
```

## position_controllers

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

```
* fix license string
* Contributors: Patrick Holthaus
```

## velocity_controllers

```
* migrate to new pluginlib headers
* Contributors: Mathias Lüdtke
```
