### PR TITLE
Add libdw-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1572,6 +1572,12 @@ libdrm-dev:
   fedora: [libdrm-devel]
   gentoo: [x11-libs/libdrm]
   ubuntu: [libdrm-dev]
+libdw-dev:
+  arch: [libelf]
+  debian: [libdw-dev]
+  fedora: [elfutils-devel]
+  gentoo: [dev-libs/elfutils]
+  ubuntu: [libdw-dev]
 libesd0-dev:
   debian: [libesd0-dev]
   fedora: [esound-devel]


### PR DESCRIPTION
This library is required for releasing https://github.com/pal-robotics/backward_ros which is a ROS flavored port of https://github.com/bombela/backward-cpp.