### PR TITLE
stage: 4.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1802,6 +1802,21 @@ repositories:
       url: https://github.com/ros-planning/srdfdom.git
       version: melodic-devel
     status: maintained
+  stage:
+    doc:
+      type: git
+      url: https://github.com/ros-gbp/stage-release.git
+      version: release/kinetic/stage
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/stage-release.git
+      version: 4.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-gbp/stage-release.git
+      version: release/kinetic/stage
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.3.0-0`:

- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
