### PR TITLE
bond_core: 1.8.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -73,7 +73,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.8.1-0
+      version: 1.8.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.2-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.8.1-0`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* uuid dependency fixup (#36 <https://github.com/ros/bond_core/issues/36>)
  * dont export uuid dependency as this isnt anywhere in the public api
  * fixx uuid dependency in test_bond as well
* Contributors: Mikael Arguedas
```

## bondpy

- No changes

## smclib

- No changes
