### PR TITLE
pluginlib: 1.12.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -946,7 +946,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.12.0-0
+      version: 1.12.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.12.1-0`:

- upstream repository: https://github.com/ros/pluginlib
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.0-0`

## pluginlib

```
* [warning fix] remove deprecation warning until users are required to change code (#115 <https://github.com/ros/pluginlib/issues/115>)
* [warning fix] move catkinFindLib implementation from anonymous namespace to getCatkinLibraryPaths (#113 <https://github.com/ros/pluginlib/issues/113>)
* Contributors: Mikael Arguedas
```
