### PR TITLE
rqt_top: 0.4.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1757,6 +1757,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_tf_tree.git
       version: master
     status: maintained
+  rqt_top:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_top-release.git
+      version: 0.4.8-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: master
+    status: maintained
   rqt_topic:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_top` to `0.4.8-0`:

- upstream repository: https://github.com/ros-visualization/rqt_top.git
- release repository: https://github.com/ros-gbp/rqt_top-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rqt_top

- No changes
