### PR TITLE
class_loader: 0.4.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -116,7 +116,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.4.0-1
+      version: 0.4.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.4.1-0`:

- upstream repository: https://github.com/ros/class_loader
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.0-1`

## class_loader

```
* Provide std::shared_ptr interface (#95 <https://github.com/ros/class_loader/issues/95>)
* Windows compat and style fixups (#90 <https://github.com/ros/class_loader/issues/90>)
  * add visibility macros to public functions
  * rename private namespace 'class_loader_private' to 'impl' to match ros2 branch
* use new headers to build library (#93 <https://github.com/ros/class_loader/issues/93>)
* Contributors: Mikael Arguedas
```
