### PR TITLE
nodelet_core: 1.9.16-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.9.15-0
+      version: 1.9.16-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.9.16-0`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.9.15-0`

## nodelet

```
* uuid dependency fixup (#74 <https://github.com/ros/nodelet_core/issues/74>)
  * don't export uuid library
  * wrap for readability
* Contributors: Mikael Arguedas
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
