### PR TITLE
rviz: 1.12.16-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10548,7 +10548,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.15-0
+      version: 1.12.16-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.16-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.12.15-0`

## rviz

```
* Fixed use of LineSpacing, horizontal alignment and AABB calculation in MovableText (#1200 <https://github.com/ros-visualization/rviz/issues/1200>)
* Disable dock widget text eliding (#1168 <https://github.com/ros-visualization/rviz/issues/1168>)
* Updated include statements to use new pluginlib and class_loader headers (#1217 <https://github.com/ros-visualization/rviz/issues/1217>)
* Updated camera_display plugin to take roi in cameraInfo into consideration (#1158 <https://github.com/ros-visualization/rviz/issues/1158>)
* Fixed bug where help.html wasn't being installed (#1218 <https://github.com/ros-visualization/rviz/issues/1218>)
* Fixed compiler warning due to mismached new/delete in MapDisplay Swatch (#1211 <https://github.com/ros-visualization/rviz/issues/1211>)
* Factored out marker creation from ROS msg into new createMarker() (#1183 <https://github.com/ros-visualization/rviz/issues/1183>)
* Fixed crash if display-config parameter was fewer than 4 characters (#1189 <https://github.com/ros-visualization/rviz/issues/1189>)
* Contributors: Daniel Seifert, Johannes Meyer, Mikael Arguedas, Robert Haschke, Tomáš Černík, Victor Lamoine, dhood, ecazaubon
```
