### PR TITLE
rviz: 1.13.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1802,6 +1802,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_web.git
       version: master
     status: maintained
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rviz-release.git
+      version: 1.13.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rviz.git
+      version: melodic-devel
+    status: maintained
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.0-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rviz

```
* Created a new Preferences window, and added PromptSaveOnExit option (#1216 <https://github.com/ros-visualization/rviz/issues/1216>)
* Allowed classes inheriting from image display access to more state (#1221 <https://github.com/ros-visualization/rviz/issues/1221>)
* Updated additional include statement to use new pluginlib and class_loader headers (#1231 <https://github.com/ros-visualization/rviz/issues/1231>)
* Fixed crash when robot model not loaded before processing JointState msg (#1229 <https://github.com/ros-visualization/rviz/issues/1229>)
* Contributors: William Woodall, dhood, daiz, ahoarau, MasterEric
```
