### PR TITLE
Try to clarify where the "folded blocks" are

### DIFF
--- a/test/fold_block.py
+++ b/test/fold_block.py
@@ -14,7 +14,7 @@ class Fold(object):
         if os.environ.get('TRAVIS') == 'true':
             if msg:
                 msg += ', '
-            msg += "see folded block '%s' in the travis log for details" % self.get_block_name()
+            msg += "see folded block '%s' above for details" % self.get_block_name()
         return msg
 
     def get_block_name(self):

--- a/test/fold_block.py
+++ b/test/fold_block.py
@@ -14,7 +14,7 @@ class Fold(object):
         if os.environ.get('TRAVIS') == 'true':
             if msg:
                 msg += ', '
-            msg += "see folded block '%s' for details" % self.get_block_name()
+            msg += "see folded block '%s' in the travis log for details" % self.get_block_name()
         return msg
 
     def get_block_name(self):

--- a/test/rosdistro_check_urls_test.py
+++ b/test/rosdistro_check_urls_test.py
@@ -26,4 +26,4 @@ If this fails you can run 'scripts/check_rosdistro_urls.py file://`pwd`/%s %s' t
             if not check_rosdistro_urls(index_url, distro_name):
                 failed_distros.append(distro_name)
                 fold_blocks.append(fold.get_block_name())
-    assert not failed_distros, "There were problems with urls in the distribution files for these distros: %s, see folded blocks for details: %s" % (failed_distros, fold_blocks)
+    assert not failed_distros, "There were problems with urls in the distribution files for these distros: %s, see folded blocks in the travis log for details: %s" % (failed_distros, fold_blocks)

--- a/test/rosdistro_check_urls_test.py
+++ b/test/rosdistro_check_urls_test.py
@@ -26,4 +26,4 @@ If this fails you can run 'scripts/check_rosdistro_urls.py file://`pwd`/%s %s' t
             if not check_rosdistro_urls(index_url, distro_name):
                 failed_distros.append(distro_name)
                 fold_blocks.append(fold.get_block_name())
-    assert not failed_distros, "There were problems with urls in the distribution files for these distros: %s, see folded blocks in the travis log for details: %s" % (failed_distros, fold_blocks)
+    assert not failed_distros, "There were problems with urls in the distribution files for these distros: %s, see folded blocks above for details: %s" % (failed_distros, fold_blocks)


### PR DESCRIPTION
Based on https://github.com/ros/rosdistro/pull/17633#issuecomment-384746831 it is not obvious to users where to find the details of why the job failed.

This PR tries to clarify it, feedback and suggestions on the wording are welcome.

2 suggestions in this PR, one commit for each:
- "see folded block N in the travis log for details"
- "see folded block above for details"

I think the second one is more readable but I'm not sure if that clarifies a lot.
@130s FYI