### PR TITLE
minas: 1.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5233,7 +5233,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/minas-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/tork-a/minas.git


### PR DESCRIPTION
Increasing version of package(s) in repository `minas` to `1.0.10-0`:

- upstream repository: https://github.com/tork-a/minas
- release repository: https://github.com/tork-a/minas-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.9-0`

## ethercat_manager

- No changes

## minas

- No changes

## minas_control

```
* Add dependency on realtime_tools(#72 <https://github.com/tork-a/minas/issues/72>)
* Contributors: Ryosuke Tajima, Tokyo Opensource Robotics Developer 534
```

## tra1_bringup

- No changes

## tra1_description

- No changes

## tra1_moveit_config

- No changes
