### PR TITLE
moveit_pr2: 0.7.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5402,6 +5402,25 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: jade-devel
     status: maintained
+  moveit_pr2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_pr2.git
+      version: kinetic-devel
+    release:
+      packages:
+      - moveit_pr2
+      - pr2_moveit_config
+      - pr2_moveit_plugins
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_pr2-release.git
+      version: 0.7.0-2
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_pr2.git
+      version: kinetic-devel
+    status: maintained
   moveit_python:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.7.0-2`:

- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## moveit_pr2

```
* Migrate to format2
* Add Bence as maintainer
* Remove moveit-tutorials dependency
* Contributors: Bence Magyar, Dave Coleman, Isaac I.Y. Saito
* [fix] Remove obsolete dependency on moveit-tutorials #92 <https://github.com/ros-planning/moveit_pr2/issues/92>
* Contributors: Dave Coleman
```

## pr2_moveit_config

```
* Migrate to format2
* Fix xacro warnings
* [moveit.rviz] Fix always showing init pose. (#89 <https://github.com/ros-planning/moveit_pr2/issues/89>)
  Init pose would always be shown in addition to the current {start, goal} poses. This is useless and confusing.
  Although only thing I did was to remove RobotState panel, and save as to overwrite the same .rviz file, there are some changes that seem unrelated. I do not know what happened but if some of those changes should be reverted let me know.
* allow to open pr2_moveit_config in setup_assistant
  The temp-file does not exist and the moveit_config
  already run_depends on pr2_description anyway.
* add arms_and_torso group
* Contributors: Bence Magyar, Christian Dornhege, Isaac I.Y. Saito, tarukosu, v4hn
```

## pr2_moveit_plugins

```
* Maintainer update & order dependencies
* pluginlib headers migration
* Migrate to format2
* Add Bence as maintainer
* GetKinematicSolverInfo -> KinematicSolverInfo
* compile with c++11
* Explicitly convert shared_ptr to bool for c++11 compatibility.
* Contributors: Bence Magyar, Christian Dornhege, Dave Coleman, Isaac I.Y. Saito, Maarten de Vries, v4hn
```
