### PR TITLE
Melodic release: rqt_runtime_monitor, rqt_nav_view

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1605,6 +1605,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_msg.git
       version: master
     status: maintained
+  rqt_nav_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_nav_view.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_nav_view-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_nav_view.git
+      version: master
+    status: maintained
   rqt_plot:
     doc:
       type: git
@@ -1709,6 +1724,21 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: master
+    status: maintained
+  rqt_runtime_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_runtime_monitor-release.git
+      version: 0.5.7-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
       version: master
     status: maintained
   rqt_service_caller:


### PR DESCRIPTION
Got a "KeyError - u'gmail" error when trying to auto open PRs via bloom (maybe my 2 factor?)

Either way here is a copy of the patch text from both rqt_runtime_monitor & rqt_nav_view

