### PR TITLE
backward_ros: 0.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -624,6 +624,12 @@ repositories:
       url: https://github.com/ros-drivers/axis_camera.git
       version: master
     status: unmaintained
+  backward_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/backward_ros-release.git
+      version: 0.1.5-0
   baldor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `0.1.5-0`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## backward_ros

```
* Fixed version for finding libraries for catkin_make
* Resolve relative paths generated by catkin_make
* Merge branch 'fix_typos' into 'master'
  Fix typos in README.md
  See merge request qa/backward_ros!1
* Fix typos in README.md
* Change Readme.md so we put backward_ros specific information.
* Force backward lib to link with backward targets
* Contributors: Jordan Palacios, Victor, Victor Lopez
```
