### PR TITLE
perception_pcl: 1.6.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -947,6 +947,26 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: indigo-devel
     status: maintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: melodic-devel
+    release:
+      packages:
+      - pcl_conversions
+      - pcl_ros
+      - perception_pcl
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/perception_pcl-release.git
+      version: 1.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: melodic-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.6.0-0`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
