### PR TITLE
vision_opencv: 1.13.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2033,6 +2033,26 @@ repositories:
       type: git
       url: https://github.com/Kukanani/vision_msgs.git
       version: melodic-devel
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: melodic
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/vision_opencv-release.git
+      version: 1.13.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: melodic
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.13.0-0`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## cv_bridge

```
* Use rosdep OpenCV and not ROS one.
  We defintely don't need the whole OpenCV.
  We need to clean the rosdep keys.
* Contributors: Vincent Rabaud
```

## image_geometry

```
* Use rosdep OpenCV and not ROS one.
  We defintely don't need the whole OpenCV.
  We need to clean the rosdep keys.
* Contributors: Vincent Rabaud
```

## vision_opencv

- No changes
