### PR TITLE
wu_ros_tools: 0.2.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4583,6 +4583,27 @@ repositories:
       url: https://github.com/ksatyaki/wts_driver-release.git
       version: 1.0.4-2
     status: maintained
+  wu_ros_tools:
+    doc:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: kinetic
+    release:
+      packages:
+      - easy_markers
+      - joy_listener
+      - kalman_filter
+      - rosbaglive
+      - wu_ros_tools
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/wu-robotics/wu_ros_tools.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: kinetic
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.2.4-0`:

- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
