### PR TITLE
catkin: 0.7.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -100,7 +100,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.11-0
+      version: 0.7.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.12-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.7.11-0`

## catkin

```
* add CMake option for symlink install (#929 <https://github.com/ros/catkin/issues/929>)
* use verbatim on test target to fix testing with Ninja (#935 <https://github.com/ros/catkin/issues/935>)
* do not add_library() gmock and gtest if targets already exist (#927 <https://github.com/ros/catkin/issues/927>)
* modernize Python 2 code to get ready for Python 3 (#928 <https://github.com/ros/catkin/issues/928>)
* remove Python 3.3 specific code because it is end of life (#924 <https://github.com/ros/catkin/issues/924>)
* fix an error in the comment. (#930 <https://github.com/ros/catkin/issues/930>)
* fix typos (#934 <https://github.com/ros/catkin/issues/934>)
```
