### PR TITLE
rtabmap/rtabmap_ros: 0.17.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3897,7 +3897,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.13.2-3
+      version: 0.17.0-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -3912,7 +3912,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.13.2-0
+      version: 0.17.0-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap`/`rtabmap_ros` to `0.17.0-0`:

- upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.13.2`