### PR TITLE
ros: 1.14.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1191,7 +1191,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.14.3-0
+      version: 1.14.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.14.4-0`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.14.3-0`

## mk

- No changes

## rosbash

```
* rosrun: array is now properly expanded in debug-echo (#176 <https://github.com/ros/ros/issues/176>)
* rosbash: replaced ... with $(...) (#177 <https://github.com/ros/ros/issues/177>)
* rosrun: replaced ... with $(...) (#175 <https://github.com/ros/ros/issues/175>)
* rosfish: fix syntax error (#171 <https://github.com/ros/ros/issues/171>)
* fix zsh tab completion for symlinks (#169 <https://github.com/ros/ros/issues/169>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

- No changes
