### PR TITLE
Add mrpt1 and mrpt2 libs as ROS pkgs.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5513,26 +5513,37 @@ repositories:
       url: https://github.com/groove-x/mqtt_bridge.git
       version: master
     status: developed
+  mrpt1:
+    source:
+      type: git
+      url: https://github.com/mrpt/mrpt.git
+      version: mrpt-1.5
+    status: maintained
+  mrpt_bridge:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
+      version: master
+    status: maintained
+  mrpt_msgs:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    status: maintained
   mrpt_navigation:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: master
-    release:
-      packages:
-      - mrpt_bridge
-      - mrpt_local_obstacles
-      - mrpt_localization
-      - mrpt_map
-      - mrpt_msgs
-      - mrpt_navigation
-      - mrpt_rawlog
-      - mrpt_reactivenav2d
-      - mrpt_tutorials
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.18-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -759,6 +759,22 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: maintained
+  mrpt2:
+    source:
+      type: git
+      url: https://github.com/mrpt/mrpt.git
+      version: master
+    status: maintained
+  mrpt_bridge:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
+      version: master
+    status: maintained
   mrpt_msgs:
     doc:
       type: git
@@ -767,6 +783,26 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    status: maintained
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: master
+    status: maintained
+  mrpt_slam:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
       version: master
     status: maintained
   navigation_msgs:


### PR DESCRIPTION
Needed as a ROS-way of specifying more recent MRPT versions (than those in the Ubuntu repos) as a package dependency; much like opencv3 and such.

Also, reflect that two packages (mrpt_msgs and mrpt_bridge) now do live
in independent repos, off "mrpt_navigation" (this is now needed to avoid
circular deps).

To avoid conflicts of duplicated names, I have also manually removed the entire
"release:" section of "mrpt_navigation", so there will be neither conflicts (after
the first releases of those two pkgs) nor packages without all their dependencies
satisfied.