### PR TITLE
backward_ros: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -629,7 +629,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pal-gbp/backward_ros-release.git
-      version: 0.1.5-0
+      version: 0.1.6-0
   baldor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `0.1.6-0`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.5-0`

## backward_ros

```
* Replace #warning with #pragma message
* Update backward to the latest version
* Fx wrong LIBRARIES variable concatenation
* Contributors: Victor Lopez
```
