### PR TITLE
sick_scan: 0.0.13-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4051,7 +4051,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `0.0.13-0`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.12-0`

## sick_scan

```
* moved some cpp files to ensure Debian compatibility
* Contributors: Unknown
```
