### PR TITLE
mongodb_store: 0.3.8-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7243,7 +7243,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.3.6-1
+      version: 0.3.8-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.3.8-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.6-1`

## libmongocxx_ros

- No changes

## mongodb_log

- No changes

## mongodb_store

```
* Merge pull request #220 <https://github.com/strands-project/mongodb_store/issues/220> from furushchev/replication-with-query
  Replication with query
* mongodb_store: support filter by query on moving entries
* Merge pull request #218 <https://github.com/strands-project/mongodb_store/issues/218> from furushchev/test-replicator
  Test replication functionality
* mongodb_store: avoid to use rosrun in test code
* mongodb_store: test replication
* mongodb_server: minor bugfix
* Merge pull request #213 <https://github.com/strands-project/mongodb_store/issues/213> from furushchev/fix/encode-utf8
  mongodb_store: encode utf-8 on filling rosmsg
* Merge remote-tracking branch 'origin/kinetic-devel' into fix/encode-utf8
* Import connection failure
* Merge pull request #214 <https://github.com/strands-project/mongodb_store/issues/214> from furushchev/option-query-extra
  mongodb_store: message_store_node.py: deprecate using extra servers
* Merge remote-tracking branch 'origin/kinetic-devel' into option-query-extra
  Conflicts:
  mongodb_store/scripts/message_store_node.py
* Merge pull request #215 <https://github.com/strands-project/mongodb_store/issues/215> from furushchev/remove-dup-projection
  mongodb_store: Remove duplicated codes for projection
* mongodb_store: use launch for test
* mongodb_store: remove duplicated codes for querying with projection
* mongodb_store: message_store_node.py: deprecate using extra servers
* mongodb_store: encode utf-8 on filling rosmsg
* Merge pull request #212 <https://github.com/strands-project/mongodb_store/issues/212> from furushchev/fix-query-extra
  fix error on querying extra servers
* fix error on querying extra servers
* Contributors: Furushchev, Nick Hawes, Yuki Furuta
```

## mongodb_store_msgs

```
* Merge pull request #220 <https://github.com/strands-project/mongodb_store/issues/220> from furushchev/replication-with-query
  Replication with query
* mongodb_store_msgs: add query slot to MoveEntries action
* Merge remote-tracking branch 'origin/kinetic-devel' into fix/encode-utf8
* Merge remote-tracking branch 'origin/kinetic-devel' into option-query-extra
  Conflicts:
  mongodb_store/scripts/message_store_node.py
* Merge pull request #215 <https://github.com/strands-project/mongodb_store/issues/215> from furushchev/remove-dup-projection
  mongodb_store: Remove duplicated codes for projection
* mongodb_store: remove duplicated codes for querying with projection
* Contributors: Furushchev, Nick Hawes
```
