### PR TITLE
teleop_twist_keyboard: 0.6.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1990,6 +1990,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_keyboard.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_keyboard.git
+      version: master
+    status: maintained
   tracetools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `0.6.1-0`:

- upstream repository: https://github.com/ros-teleop/teleop_twist_keyboard.git
- release repository: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## teleop_twist_keyboard

```
* Merge pull request #11 <https://github.com/ros-teleop/teleop_twist_keyboard/issues/11> from MatthijsBurgh/patch-1
  Correct exception handling; Python3 print compatible
* import print from future
* Print python3 compatible
* correct Exception handling
* Merge pull request #7 <https://github.com/ros-teleop/teleop_twist_keyboard/issues/7> from lucasw/speed_params
  set linear and turn speed via rosparams
* Using tabs instead of spaces to match rest of file
* set linear and turn speed via rosparams
* Contributors: Austin, Lucas Walter, Matthijs van der Burgh
```
