### PR TITLE
audio_common: 0.2.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -835,7 +835,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.2.12-0
+      version: 0.2.13-0
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.2.13-0`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.12-0`

## audio_capture

```
* [sound_play] add option to select audio device to play / record (#87 <https://github.com/ros-drivers/audio_common/issues/87>)
  * [sound_play] add option to select audio device to play
  * [sound_play] reformat README to markdown; add usage to set device via rosparam
  * audio_capture: add option for selecting device to use
  * audio_play: add option to select device for playing audio
  * add device argument to launch files
* Contributors: Yuki Furuta
```

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

```
* [sound_play] add option to select audio device to play / record (#87 <https://github.com/ros-drivers/audio_common/issues/87>)
  * [sound_play] add option to select audio device to play
  * [sound_play] reformat README to markdown; add usage to set device via rosparam
  * audio_capture: add option for selecting device to use
  * audio_play: add option to select device for playing audio
  * add device argument to launch files
* Contributors: Yuki Furuta
```

## sound_play

```
* [sound_play] add option to select audio device to play / record (#87 <https://github.com/ros-drivers/audio_common/issues/87>)
  * [sound_play] add option to select audio device to play
  * [sound_play] reformat README to markdown; add usage to set device via rosparam
  * audio_capture: add option for selecting device to use
  * audio_play: add option to select device for playing audio
  * add device argument to launch files
* Contributors: Yuki Furuta
```
