### PR TITLE
audio_common: 0.3.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -58,6 +58,27 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  audio_common:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: master
+    release:
+      packages:
+      - audio_capture
+      - audio_common
+      - audio_common_msgs
+      - audio_play
+      - sound_play
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/audio_common-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: master
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.2-0`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## audio_capture

```
* [sound_play] add option to select audio device to play / record (#87 <https://github.com/ros-drivers/audio_common/issues/87>)
  * [sound_play] add option to select audio device to play
  * [sound_play] reformat README to markdown; add usage to set device via rosparam
  * audio_capture: add option for selecting device to use
  * audio_play: add option to select device for playing audio
  * add device argument to launch files
  Conflicts:
  audio_capture/launch/capture.launch
  audio_capture/launch/capture_to_file.launch
  audio_capture/src/audio_capture.cpp
  audio_play/launch/play.launch
  sound_play/scripts/soundplay_node.py
* Merge pull request #102 <https://github.com/ros-drivers/audio_common/issues/102> from EndPointCorp/fix_capture_leak
  Fix audio_capture leak
* Fix audio_capture sample/buffer leak
* Merge pull request #90 <https://github.com/ros-drivers/audio_common/issues/90> from prarobo/master
  Error checking code and improvements to launch files
* Bug fix
* fix(audio_capture): capturing wave using gst1.0
  0.10-style raw audio caps were being created, according to GStreamer warning. Should be audio/x-raw,format=(string).. now.
* Merge pull request #1 <https://github.com/ros-drivers/audio_common/issues/1> from prarobo/fixes
  Error checking code and improvements to launch files
* Removed default device
* Added error checking code
* Added parameters to launch files
* Contributors: Austin, Matt Vollrath, Prasanna Kannappan, Rokus, Yuki Furuta, prarobo
```

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

```
* [sound_play] add option to select audio device to play / record (#87 <https://github.com/ros-drivers/audio_common/issues/87>)
  * [sound_play] add option to select audio device to play
  * [sound_play] reformat README to markdown; add usage to set device via rosparam
  * audio_capture: add option for selecting device to use
  * audio_play: add option to select device for playing audio
  * add device argument to launch files
  Conflicts:
  audio_capture/launch/capture.launch
  audio_capture/launch/capture_to_file.launch
  audio_capture/src/audio_capture.cpp
  audio_play/launch/play.launch
  sound_play/scripts/soundplay_node.py
* Merge pull request #101 <https://github.com/ros-drivers/audio_common/issues/101> from EndPointCorp/audio_play_dont_pause_pipeline
  audio_play: Fix mp3 clip overlap by never pausing the pipeline
* audio_play: Don't pause the pipeline
  This prevents glitches when playing short mp3 clips.
* Merge pull request #90 <https://github.com/ros-drivers/audio_common/issues/90> from prarobo/master
  Error checking code and improvements to launch files
* Merge pull request #1 <https://github.com/ros-drivers/audio_common/issues/1> from prarobo/fixes
  Error checking code and improvements to launch files
* Added parameters to launch files
* Contributors: Austin, Matt Vollrath, Prasanna Kannappan, Yuki Furuta, prarobo
```

## sound_play

```
* [sound_play] add option to select audio device to play / record (#87 <https://github.com/ros-drivers/audio_common/issues/87>)
  * [sound_play] add option to select audio device to play
  * [sound_play] reformat README to markdown; add usage to set device via rosparam
  * audio_capture: add option for selecting device to use
  * audio_play: add option to select device for playing audio
  * add device argument to launch files
  Conflicts:
  audio_capture/launch/capture.launch
  audio_capture/launch/capture_to_file.launch
  audio_capture/src/audio_capture.cpp
  audio_play/launch/play.launch
  sound_play/scripts/soundplay_node.py
* Merge pull request #95 <https://github.com/ros-drivers/audio_common/issues/95> from yujinrobot/volume_check
  [sound_play] volume check for cached sounds
* [sound_play] checks if sound's Gst instance's volume has changed and resets it
* Contributors: Austin, Naveed Usmani, Yuki Furuta
```
