### PR TITLE
diagnostics: 1.9.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -566,7 +566,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.9.2-0
+      version: 1.9.3-0
     source:
       type: git
       url: https://github.com/ros/diagnostics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.9.3-0`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.9.2-0`

## diagnostic_aggregator

```
* Merge pull request #79 <https://github.com/ros/diagnostics/issues/79> from nlamprian/indigo-devel
  Fixed base_path handling
* Merge pull request #82 <https://github.com/ros/diagnostics/issues/82> from moriarty/fix-pluginlib-deprecated-headers
  [Aggregator] Fixes C++ Warnings (pluginlib)
* [Aggregator] Fixes C++ Warnings (pluginlib)
  This fixes the following warnings:
  warning: Including header <pluginlib/class_list_macros.h>
  is deprecated,include <pluginlib/class_list_macros.hpp> instead. [-Wcpp]
  warning: Including header <pluginlib/class_loader.h>
  is deprecated, include <pluginlib/class_loader.hpp> instead. [-Wcpp]
  The .hpp files have been backported to indigo
* Fixed base_path handling
* Upstream missing changes to add_analyzers
* Contributors: Alexander Moriarty, Austin, Nick Lamprianidis, trainman419
```

## diagnostic_analysis

- No changes

## diagnostic_common_diagnostics

- No changes

## diagnostic_updater

```
* Merge pull request #73 <https://github.com/ros/diagnostics/issues/73> from tue-robotics/indigo-devel
  Add a simple Heartbeat-DiagnosticTask
* Add Python version of Heartbeat DiagnosticTask
* Add a very very simple Heartbeat DiagnosticTask
* Contributors: Austin, Loy van Beek, loy
```

## diagnostics

- No changes

## rosdiagnostic

- No changes

## self_test

- No changes

## test_diagnostic_aggregator

- No changes
