### PR TITLE
rtabmap/rtabmap_ros updated package version (indigo/kinetic/lunar) 

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13643,7 +13643,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.0-0
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -13658,7 +13658,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.0-0
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10377,7 +10377,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.0-0
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -10392,7 +10392,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.0-0
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3918,7 +3918,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.0-0
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -3933,7 +3933,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.0-0
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
from `0.17.0-0` to `0.17.0-1` on indigo, kinetic and lunar. New dependency `libg2o` added to `rtabmap`. Fixed `rtabmap_ros`'s `rgbd_sync` backward compatibility problem.