### PR TITLE
cartographer_ros: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -112,6 +112,21 @@ repositories:
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 0.3.0-1
     status: developed
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: 0.3.0
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/cartographer_ros-release.git
+      version: 0.3.0-0
+    status: developed
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `0.3.0-0`:

- upstream repository: https://github.com/googlecartographer/cartographer_ros.git
- release repository: https://github.com/ros-gbp/cartographer_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## cartographer_ros

```
* https://github.com/googlecartographer/cartographer_ros/compare/0.2.0...0.3.0
```

## cartographer_ros_msgs

```
* https://github.com/googlecartographer/cartographer_ros/compare/0.2.0...0.3.0
```

## cartographer_rviz

```
* https://github.com/googlecartographer/cartographer_ros/compare/0.2.0...0.3.0
```
