### PR TITLE
geometry: 1.12.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -543,7 +543,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.11.9-0
+      version: 1.12.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.12.0-0`:

- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.11.9-0`

## eigen_conversions

```
* Remove dependency on cmake_modules (#157 <https://github.com/ros/geometry/issues/157>)
  This is not needed anymore with the move from Eigen to Eigen3 in 707eb41.
* Contributors: Jochen Sprickerhof
```

## geometry

- No changes

## kdl_conversions

- No changes

## tf

```
* Adapt to new xmlrpcpp header location (#164 <https://github.com/ros/geometry/issues/164>)
* Maintain & expose tf2 Buffer in shared_ptr for tf (#163 <https://github.com/ros/geometry/issues/163>)
  - Adds a tf2_ros::Buffer via a public accessor
  method to expose to customers of Transformer
  - Maintains the tf2_ros::Buffer in a shared_ptr
  to safely share access to the Buffer object
  - As this is targeting Melodic, adds c++11 compile
  flags to grant access to std::shared_ptr's
  - Reorders the include_directories in the CMakeLists
  to ensure the headers exposed in this package are
  read *before* the system installed catkin_INCLUDE_DIRS
  (otherwise changes to tf source headers are never detected
  during a catkin_make on a system with ros-*-geometry
  installed)
* Prevent rates that result in core dump (0.0) or no limit on update rate at all (<0.0) #159 <https://github.com/ros/geometry/issues/159> (#160 <https://github.com/ros/geometry/issues/160>)
* Fix empty yaml parsing (#153 <https://github.com/ros/geometry/issues/153>)
  Fixes #152 <https://github.com/ros/geometry/issues/152>
  The empty yaml was coming through as a list not a dict so was breaking the expectations.
  I used the shorthand or {} since I know any valid data won't evaluate to zero. A more complete solution is described here: https://stackoverflow.com/a/35777649/604099
* Make python scripts Python3 compatible. (#151 <https://github.com/ros/geometry/issues/151>)
  * Python 3 fixes
  * Prefer str.format over operator % and small python3 fixes.
* Contributors: Ian McMahon, Lucas Walter, Maarten de Vries, Tully Foote
```

## tf_conversions

```
* Remove dependency on cmake_modules (#157 <https://github.com/ros/geometry/issues/157>)
  This is not needed anymore with the move from Eigen to Eigen3 in 707eb41.
* Make python scripts Python3 compatible. (#151 <https://github.com/ros/geometry/issues/151>)
  * Python 3 fixes
  * Prefer str.format over operator % and small python3 fixes.
* Contributors: Jochen Sprickerhof, Maarten de Vries
```
