### PR TITLE
geometry2: 0.6.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -571,7 +571,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.6.2-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.1-0`

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

```
* Adds toMsg & fromMsg for Eigen Vector3 (#294 <https://github.com/ros/geometry2/issues/294>)
  - Adds toMsg for geometry_msgs::Vector3&  with dual argument syntax to
  avoid an overload conflict with
  geometry_msgs::Point& toMsg(contst Eigen::Vector3d& in)
  - Adds corresponding fromMsg for Eigen Vector3d and
  geometry_msgs::Vector3
  - Fixed typos in description of fromMsg for Twist and Eigen 6x1 Matrix
* Adds additional conversions for tf2, KDL, Eigen (#292 <https://github.com/ros/geometry2/issues/292>)
  - adds non-stamped Eigen to Transform function
  - converts Eigen Matrix Vectors to and from geometry_msgs::Twist
  - adds to/from message for geometry_msgs::Pose and KDL::Frame
* Contributors: Ian McMahon
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

```
* Adds additional conversions for tf2, KDL, Eigen (#292 <https://github.com/ros/geometry2/issues/292>)
  - adds non-stamped Eigen to Transform function
  - converts Eigen Matrix Vectors to and from geometry_msgs::Twist
  - adds to/from message for geometry_msgs::Pose and KDL::Frame
* Contributors: Ian McMahon
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* update buffer_server_name (#296 <https://github.com/ros/geometry2/issues/296>)
  * use nodename as namespace
  * Update #209 <https://github.com/ros/geometry2/issues/209> to provide backwards compatibility.
* Contributors: Jihoon Lee, Tully Foote
```

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Tf2 tools echo (#289 <https://github.com/ros/geometry2/issues/289>)
  * tf2_tools echo is working but not yet printing the rotation #287 <https://github.com/ros/geometry2/issues/287>
  * install echo.py
  * Added quaternion output but importing from tf1 for euler_from_quaternion seems wrong (#222 <https://github.com/ros/geometry2/issues/222>) so not doing that yet.  Also made count exit after n counts even if exceptions occurred, also printing time of lookup for exceptions #287 <https://github.com/ros/geometry2/issues/287>
  * Fixed time query option, also changing message text to be more clear #287 <https://github.com/ros/geometry2/issues/287>
  * Added bsd license, code from transform3d transformations.py #287 <https://github.com/ros/geometry2/issues/287>
  * Get rid of tabs
  * docstring for each function
* Contributors: Lucas Walter
```
