### PR TITLE
marker_msgs: 0.0.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -744,6 +744,12 @@ repositories:
       type: git
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
+  marker_msgs:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tuw-robotics/marker_msgs-release.git
+      version: 0.0.5-0
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.5-0`:

- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## marker_msgs

```
* new msgs
* Removed MarkerCandidate messages. Use Fiducial.msg and FiducialDetection.msg instead.
* Changed MarkerCandidate* to Fiducial*
* Fiducial msg added
* Fiducial msg added
* gitignore added
* Merge branch 'master' into devel
* header to msg/MarkerCandidate.msg added
* merge
* Added MarkerCandidate/Array messages.
* marker_msg type added
* Contributors: Markus Bader, Markus Bader @ munin, doctorseus
```
