### PR TITLE
tuw_msgs: 0.0.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2092,6 +2092,21 @@ repositories:
       url: https://github.com/bosch-robotics-cr/tracetools.git
       version: devel
     status: developed
+  tuw_msgs:
+    release:
+      packages:
+      - tuw_airskin_msgs
+      - tuw_gazebo_msgs
+      - tuw_geometry_msgs
+      - tuw_msgs
+      - tuw_multi_robot_msgs
+      - tuw_nav_msgs
+      - tuw_object_msgs
+      - tuw_vehicle_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_msgs-release.git
+      version: 0.0.5-0
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_msgs` to `0.0.5-0`:

- upstream repository: https://github.com/tuw-robotics/tuw_msgs.git
- release repository: https://github.com/tuw-robotics/tuw_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
