### PR TITLE
tuw_msgs: 0.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11957,7 +11957,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_msgs-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_msgs` to `0.0.6-0`:

- upstream repository: https://github.com/tuw-robotics/tuw_msgs.git
- release repository: https://github.com/tuw-robotics/tuw_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.5-0`

## tuw_geometry_msgs

- No changes
