### PR TITLE
rviz: 1.11.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13895,7 +13895,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.11.18-0
+      version: 1.11.19-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.11.19-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.11.18-0`

## rviz

```
* Indigo backports from kinetic-devel
  * Fixed bug where help.html wasn't being installed (#1218 <https://github.com/ros-visualization/rviz/issues/1218>)
  * Fixed crash when unchecking options of "triangle list" markers (#1164 <https://github.com/ros-visualization/rviz/issues/1164>)
  * Fixed crash when robot model not loaded before processing JointState msg (#1229 <https://github.com/ros-visualization/rviz/issues/1229>)
* Fixed BOOST_JOIN moc error with Qt 4 and Boost 1.58 (#1149 <https://github.com/ros-visualization/rviz/issues/1149>)
* Contributors: Antoine Hoarau, Johannes Meyer, Lucas Walter, dhood
```
