### PR TITLE
catkin_virtualenv: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1029,7 +1029,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.1.4-1
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.2.0-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.4-1`

## catkin_virtualenv

```
* Fixup python 3 dependencies
* Merge pull request #16 <https://github.com/locusrobotics/catkin_virtualenv/issues/16> from locusrobotics/system-site-packages
  Provide more CMake flags to customize behaviour
* Make sure we find python exectuable
* Implement ISOLATE_REQUIREMENTS and add docs
* Make flags more flexible to support disabling system site packages
* Merge pull request #14 <https://github.com/locusrobotics/catkin_virtualenv/issues/14> from locusrobotics/fix-pip
  Fix issues due to pip 10 release
* Review comments
* Lock down pip version
* Make logging optional
* Contributors: Paul Bovbel
```
