### PR TITLE
catkin_virtualenv: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -143,6 +143,21 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: kinetic-devel
     status: maintained
+  catkin_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: devel
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.2.0-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## catkin_virtualenv

```
* Fixup python 3 dependencies
* Merge pull request #16 <https://github.com/locusrobotics/catkin_virtualenv/issues/16> from locusrobotics/system-site-packages
  Provide more CMake flags to customize behaviour
* Make sure we find python exectuable
* Implement ISOLATE_REQUIREMENTS and add docs
* Make flags more flexible to support disabling system site packages
* Merge pull request #14 <https://github.com/locusrobotics/catkin_virtualenv/issues/14> from locusrobotics/fix-pip
  Fix issues due to pip 10 release
* Review comments
* Lock down pip version
* Make logging optional
* Contributors: Paul Bovbel
```
