### PR TITLE
rqt_rviz: 0.5.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1904,6 +1904,12 @@ repositories:
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git
       version: master
     status: maintained
+  rqt_rviz:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_rviz-release.git
+      version: 0.5.9-0
   rqt_service_caller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_rviz` to `0.5.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_rviz.git
- release repository: https://github.com/ros-gbp/rqt_rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## rqt_rviz

- No changes
