### PR TITLE
ros_canopen: 0.7.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2929,7 +2929,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.7-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.7.6-0`

## can_msgs

- No changes

## canopen_402

```
* Added state_switch_timeout parameter to motor.
* added types for all function objects
* pull make_shared into namespaces
* added types for all shared_ptrs
* migrate to new classloader headers
* address catkin_lint errors/warnings
* Contributors: Alexander Gutenkunst, Mathias Lüdtke
```

## canopen_chain_node

```
* added types for all function objects
* pull make_shared into namespaces
* added types for all shared_ptrs
* migrate to new classloader headers
* address catkin_lint errors/warnings
* removed IPC/SHM based sync masters
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* added types for all function objects
* pull make_shared into namespaces
* added types for all shared_ptrs
* migrate to new classloader headers
* throw bad_cast if datatype is not supported
* special handling of std::bad_cast
* address catkin_lint errors/warnings
* removed IPC/SHM based sync masters
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

```
* added types for all function objects
* added types for all shared_ptrs
* error if muparser is not available
* address catkin_lint errors/warnings
* Contributors: Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

```
* pull make_shared into namespaces
* added types for all shared_ptrs
* address catkin_lint errors/warnings
* protect tests from accessing front() or back() of empty list
* added checkMaskFilter for socketcan_bridge
* remove isValid work-around
* added unit test for can id pass filter
* add CAN filter to socketcan_bridge nodes
* Contributors: Benjamin Maidel, Mathias Lüdtke
```

## socketcan_interface

```
* pull make_shared into namespaces
* added types for all shared_ptrs
* fix catkin_lint warnings in filter tests
* migrate to new classloader headers
* find and link the thread library properly
* compile also with boost >= 1.66.0
* explicitly include iostream to compile with boost >= 1.65.0
* address catkin_lint errors/warnings
* added test for FilteredFrameListener
* fix string parsers
* default to relaxed filter handling
  works for standard and extended frames
* fix string handling of extended frames
* added filter parsers
  should work for vector<unsigned int>, vector<string> and custom vector-like classes
* implemented mask and range filters for can::Frame
* Contributors: Lukas Bulwahn, Mathias Lüdtke
```
