### PR TITLE
ompl: 1.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6501,7 +6501,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.2.1-1
+      version: 1.2.3-0
     status: maintained
   omronsentech_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.2.3-0`:

- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.2.1-1`
