### PR TITLE
ros_canopen: 0.7.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2929,7 +2929,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.7-0
+      version: 0.7.8-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.8-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.7.7-0`

## can_msgs

- No changes

## canopen_402

```
* Revert "pull make_shared into namespaces"
  This reverts commit 9b2cd05df76d223647ca81917d289ca6330cdee6.
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

```
* Revert "pull make_shared into namespaces"
  This reverts commit 9b2cd05df76d223647ca81917d289ca6330cdee6.
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* Revert "pull make_shared into namespaces"
  This reverts commit 9b2cd05df76d223647ca81917d289ca6330cdee6.
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

- No changes

## ros_canopen

- No changes

## socketcan_bridge

```
* Revert "pull make_shared into namespaces"
  This reverts commit 9b2cd05df76d223647ca81917d289ca6330cdee6.
* Contributors: Mathias Lüdtke
```

## socketcan_interface

```
* Revert "pull make_shared into namespaces"
  This reverts commit 9b2cd05df76d223647ca81917d289ca6330cdee6.
* Contributors: Mathias Lüdtke
```
