### PR TITLE
[dep] build-essential.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -307,6 +307,10 @@ box2d-dev:
   debian: [libbox2d-dev]
   fedora: [Box2D-devel]
   ubuntu: [libbox2d-dev]
+build-essential:
+  debian: [build-essential]
+  opensuse: [build-essentials-packages]
+  ubuntu: [build-essential]
 bullet:
   arch: [bullet]
   debian: [libbullet-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -309,6 +309,8 @@ box2d-dev:
   ubuntu: [libbox2d-dev]
 build-essential:
   debian: [build-essential]
+  fedora: [development-tools]
+  gentoo: []
   opensuse: [build-essentials-packages]
   ubuntu: [build-essential]
 bullet:


### PR DESCRIPTION
- debian, opensuse, Ubuntu can be found via https://pkgs.org/download/build-essential

For some Linux distros that look commonly registered, such as gentoo, fedora, this pkg isn't found. Also confirmed individually:
- gentoo https://packages.gentoo.org/packages/search?q=build-essential
- fedora https://apps.fedoraproject.org/packages/s/build-essential