### PR TITLE
rosmon: 1.0.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3332,7 +3332,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.3-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.2-0`

## rosmon

```
* launch_config: ignore empty YAML data in <rosparam> tags
  See #12 <https://github.com/xqms/rosmon/issues/12> for discussion as to why this is necessary.
  TL;DR: roslaunch does it.
  Co-authored-by: Lucas Coelho Figueiredo <mailto:lucascoelhof@gmail.com>
* launch_config: simplify whitespace inside ParseContext::evaluate()
  This should fix problems with whitespace such as #1 <https://github.com/xqms/rosmon/issues/1>,
  #16 <https://github.com/xqms/rosmon/issues/16>, #22 <https://github.com/xqms/rosmon/issues/22>.
* ui: calculate node name padding correctly on 32 bit architectures
  Fixes #19 <https://github.com/xqms/rosmon/issues/19>.
* add LICENSE file
* address clang-tidy warnings
* launch_config: handle relative params with tilde + validate names
  This also prints a more informative error message on malformed parameter
  names.
* launch_config: support pass_all_args
* Contributors: Max Schwarz
```
