### PR TITLE
gazebo_ros_pkgs: 2.8.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -428,6 +428,29 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: master
     status: maintained
+  gazebo_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: melodic-devel
+    release:
+      packages:
+      - gazebo_dev
+      - gazebo_msgs
+      - gazebo_plugins
+      - gazebo_ros
+      - gazebo_ros_control
+      - gazebo_ros_pkgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
+      version: 2.8.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: melodic-devel
+    status: developed
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.8.1-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## gazebo_dev

```
* Replace gazebo7 by gazebo9 in gazebo_dev. Gazebo9 is the official version supported in Melodic
* Contributors: Jose Luis Rivero
```

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Update version to 2.8.0
* Fix sensors after time reset (lunar-devel) (#705 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/705>)
  * camera plugin keeps publishing after negative sensor update interval
  World resets result in a negative time differences between current world
  time and the last recorded sensor update time, preventing the plugin
  from publishing new frames. This commit detects such events and resets
  the internal sensor update timestamp.
  * block_laser, range, and joint_state_publisher keep publishing after clock reset
  * p3d keeps publishing after clock reset
* Support 16-bit cameras (lunar-devel) (#700 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/700>)
  * extend camera util to support 16 bit rgb image encoding
  * support 16 bit mono
  * add test for 16-bit camera
  * update skip_
  * move camera test to camera.h, add camera16bit.cpp
* Fix #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612> for Gazebo9 (lunar-devel) (#699 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/699>)
  * Fix #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612> for Gazebo9
  This commit fixes #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>, but only for Gazebo9. Fixing it for Gazebo7 (the version used in ROS Kinetic) requires the following PR to be backported to Gazebo 7 and 8:
* gazebo_plugins: unique names for distortion tests (lunar-devel) (#686 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/686>)
  * gazebo_plugins: unique names for distortion tests
  * Missing test files
* Contributors: Jose Luis Rivero
```

## gazebo_ros

```
* Parameter to disable ROS network interaction from/to Gazebo (lunar-devel) (#704 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/704>)
* Load the libgazebo_ros_api_plugin when starting gzclient so that the ROS event loop will turn over, which is required when you have a client-side Gazebo plugin that uses ROS. (#676 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/676>)
* Pass verbose argument to gzclient (#677 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/677>)
* strip comments from parsed urdf (#698 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/698>)
  Remove comments from urdf before trying to find packages. Otherwise non-existant packages will produce a fatal error, even though they are not used.
* Contributors: Jose Luis Rivero
```

## gazebo_ros_control

```
* Don't ignore robotNamespace in gazebo_ros_control nodes (lunar-devel) (#706 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/706>)
  This commit restores the intended behavior, i.e., the parameters will now read from <robot_name>/..., where <robot_name> is specified via the robotNamespace plugin parameter or the parent name.
* add physics type for dart with joint velocity interface (#701 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/701>)
* Contributors: Jose Luis Rivero
```

## gazebo_ros_pkgs

- No changes
