### PR TITLE
Drop test_pull_requests: true from perception_pcl

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1113,7 +1113,6 @@ repositories:
       url: https://github.com/ros-gbp/perception_pcl-release.git
       version: 1.6.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
       version: melodic-devel

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1113,6 +1113,7 @@ repositories:
       url: https://github.com/ros-gbp/perception_pcl-release.git
       version: 1.6.0-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
       version: melodic-devel


### PR DESCRIPTION
## Why?

- It is already tested on Travis.
- It fails because of compiler warnings in PCL code, and they cannot
be solved in the ROS package.

It is described in https://github.com/ros-perception/perception_pcl/pull/197#issuecomment-386824502.