### PR TITLE
rosdep: Add python-setuptools for Ubuntu Artful and Bionic.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3111,6 +3111,8 @@ python-setuptools:
     pip:
       packages: [setuptools]
   ubuntu:
+    artful: [python-setuptools]
+    bionic: [python-setuptools]
     lucid: [python-setuptools]
     maverick: [python-setuptools]
     natty: [python-setuptools]


### PR DESCRIPTION
Required to release MAVLink for Melodic.