### PR TITLE
pid: 0.0.24-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1118,6 +1118,21 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: melodic-devel
     status: maintained
+  pid:
+    doc:
+      type: git
+      url: https://bitbucket.org/AndyZe/pid.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/AndyZe/pid-release.git
+      version: 0.0.24-0
+    source:
+      type: git
+      url: https://bitbucket.org/AndyZe/pid.git
+      version: master
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.24-0`:

- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZe/pid-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
