### PR TITLE
mavlink: 2018.5.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -799,6 +799,21 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/tuw-robotics/marker_msgs-release.git
       version: 0.0.5-0
+  mavlink:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/melodic/mavlink
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: 2018.5.7-0
+    source:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/melodic/mavlink
+    status: maintained
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2018.5.7-0`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
