### PR TITLE
Add python-gitlab package to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4083,7 +4083,7 @@ python3-gitlab:
     '*': [python3-gitlab]
     jessie:
       pip:
-        packages: [python3-gitlab]
+        packages: [python-gitlab]
   ubuntu:
     '*': [python3-gitlab]
     trusty:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1227,8 +1227,22 @@ python-github-pip:
     pip:
       packages: [PyGithub]
 python-gitlab:
-  debian: [python-gitlab]
-  ubuntu: [python-gitlab]
+  debian:
+    buster: [python-gitlab]
+    jessie:
+      pip:
+        packages: [python-gitlab]
+    stretch: [python-gitlab]
+  ubuntu:
+    artful: [python-gitlab]
+    bionic: [python-gitlab]
+    cosmic: [python-gitlab]
+    trusty:
+      pip:
+        packages: [python-gitlab]
+    xenial: [python-gitlab]
+    yakkety: [python-gitlab]
+    zesty: [python-gitlab]
 python-gitpython-pip:
   ubuntu:
     pip:
@@ -4071,9 +4085,22 @@ python3-flake8:
   gentoo: [dev-python/flake8]
   ubuntu: [python3-flake8]
 python3-gitlab:
-  debian: [python3-gitlab]
+  debian:
+    buster: [python3-gitlab]
+    jessie:
+      pip:
+        packages: [python-gitlab]
+    stretch: [python3-gitlab]
   ubuntu:
+    artful: [python3-gitlab]
     bionic: [python3-gitlab]
+    cosmic: [python3-gitlab]
+    trusty:
+      pip:
+        packages: [python-gitlab]
+    xenial: [python3-gitlab]
+    yakkety: [python3-gitlab]
+    zesty: [python3-gitlab]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1219,6 +1219,10 @@ python-git:
   fedora: [GitPython]
   gentoo: [dev-python/git-python]
   ubuntu: [python-git]
+python-gitlab-pip:
+  ubuntu:
+    pip:
+      packages: [python-gitlab]
 python-github-pip:
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1226,10 +1226,9 @@ python-github-pip:
   ubuntu:
     pip:
       packages: [PyGithub]
-python-gitlab-pip:
-  ubuntu:
-    pip:
-      packages: [python-gitlab]
+python-gitlab:
+  debian: [python-gitlab]
+  ubuntu: [python-gitlab]
 python-gitpython-pip:
   ubuntu:
     pip:
@@ -4071,6 +4070,10 @@ python3-flake8:
     stretch: [python3-flake8]
   gentoo: [dev-python/flake8]
   ubuntu: [python3-flake8]
+python3-gitlab:
+  debian: [python3-gitlab]
+  ubuntu:
+    bionic: [python3-gitlab]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1228,21 +1228,15 @@ python-github-pip:
       packages: [PyGithub]
 python-gitlab:
   debian:
-    buster: [python-gitlab]
+    '*': [python-gitlab]
     jessie:
       pip:
         packages: [python-gitlab]
-    stretch: [python-gitlab]
   ubuntu:
-    artful: [python-gitlab]
-    bionic: [python-gitlab]
-    cosmic: [python-gitlab]
+    '*': [python-gitlab]
     trusty:
       pip:
         packages: [python-gitlab]
-    xenial: [python-gitlab]
-    yakkety: [python-gitlab]
-    zesty: [python-gitlab]
 python-gitpython-pip:
   ubuntu:
     pip:
@@ -4086,21 +4080,15 @@ python3-flake8:
   ubuntu: [python3-flake8]
 python3-gitlab:
   debian:
-    buster: [python3-gitlab]
+    '*': [python3-gitlab]
     jessie:
       pip:
-        packages: [python-gitlab]
-    stretch: [python3-gitlab]
+        packages: [python3-gitlab]
   ubuntu:
-    artful: [python3-gitlab]
-    bionic: [python3-gitlab]
-    cosmic: [python3-gitlab]
+    '*': [python3-gitlab]
     trusty:
       pip:
         packages: [python-gitlab]
-    xenial: [python3-gitlab]
-    yakkety: [python3-gitlab]
-    zesty: [python3-gitlab]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1219,10 +1219,6 @@ python-git:
   fedora: [GitPython]
   gentoo: [dev-python/git-python]
   ubuntu: [python-git]
-python-gitlab-pip:
-  ubuntu:
-    pip:
-      packages: [python-gitlab]
 python-github-pip:
   osx:
     pip:
@@ -1230,6 +1226,10 @@ python-github-pip:
   ubuntu:
     pip:
       packages: [PyGithub]
+python-gitlab-pip:
+  ubuntu:
+    pip:
+      packages: [python-gitlab]
 python-gitpython-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Add **Python Gitlab** ([github](https://github.com/python-gitlab/python-gitlab), [read-the-docs](http://python-gitlab.readthedocs.io/en/stable/index.html)) to `python.yaml`

> `python-gitlab` is a Python package providing access to the GitLab server API.
> It supports the v3 and v4 APIs of GitLab, and provides a CLI tool (gitlab).

