### PR TITLE
Adding rr_swiftnav_piksi to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10345,6 +10345,16 @@ repositories:
       url: https://github.com/stonier/rqt_wrapper.git
       version: devel
     status: developed
+  rr_swiftnav_piksi:
+    doc:
+      type: git
+      url: https://github.com/roverrobotics/rr_swiftnav_piksi.git
+      version: devel
+    source:
+      type: git
+      url: https://github.com/roverrobotics/rr_swiftnav_piksi.git
+      version: devel
+    status: developed
   rrt_exploration:
     doc:
       type: git


### PR DESCRIPTION
I'd like rr_swiftnav_piksi to be indexed and documented on ros.org