### PR TITLE
perception_pcl: 1.6.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1148,7 +1148,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.6.0-0
+      version: 1.6.1-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.6.1-0`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.6.0-0`

## pcl_conversions

```
* Add 1.6.0 section to CHANGELOG.rst
* Use foreach + string regex to implement list(filter on old cmake
* Downgrade the required cmake version for backward compatibility
* update package.xml links to point to new repository
* CMake 3.6.3 is sufficient
* Fix a bug building on artful.
* Fixup pcl_conversions test
* Contributors: Chris Lalancette, Kentaro Wada, Mikael Arguedas, Paul Bovbel
```

## pcl_ros

```
* Add 1.6.0 section to CHANGELOG.rst
* Fix the use of Eigen3 in cmake
* Contributors: Kentaro Wada
```

## perception_pcl

```
* Add 1.6.0 section to CHANGELOG.rst
* Contributors: Kentaro Wada
```
