### PR TITLE
catch_ros: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -348,6 +348,11 @@ repositories:
       type: git
       url: https://github.com/AIS-Bonn/catch_ros.git
       version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/AIS-Bonn/catch_ros-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/AIS-Bonn/catch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros` to `0.2.0-0`:

- upstream repository: https://github.com/AIS-Bonn/catch_ros
- release repository: https://github.com/AIS-Bonn/catch_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## catch_ros

```
* adapt ROSReporter to Catch2
* upgrade to Catch v2.2.2
* Contributors: Max Schwarz
```
