### PR TITLE
collada_urdf: 1.12.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1485,7 +1485,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/collada_urdf-release.git
-      version: 1.12.11-0
+      version: 1.12.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `collada_urdf` to `1.12.12-0`:

- upstream repository: https://github.com/ros/collada_urdf.git
- release repository: https://github.com/ros-gbp/collada_urdf-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.11-0`

## collada_parser

```
* add exec_depend to package.xml of collada_parser for loading by pluginlib (#27 <https://github.com/ros/collada_urdf/issues/27>)
* Contributors: Yohei Kakiuchi
```

## collada_urdf

- No changes
