### PR TITLE
collada_urdf: 1.12.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -218,7 +218,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/collada_urdf-release.git
-      version: 1.12.11-0
+      version: 1.12.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `collada_urdf` to `1.12.12-0`:

- upstream repository: https://github.com/ros/collada_urdf.git
- release repository: https://github.com/ros-gbp/collada_urdf-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.11-0`

## collada_parser

```
* add exec_depend to package.xml of collada_parser for loading by pluginlib (#27 <https://github.com/ros/collada_urdf/issues/27>)
* Contributors: Yohei Kakiuchi
```

## collada_urdf

- No changes
