### PR TITLE
Kinetic, perception_pcl: test_commits: false

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7033,6 +7033,7 @@ repositories:
       url: https://github.com/ros-gbp/perception_pcl-release.git
       version: 1.4.3-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
       version: kinetic-devel


### PR DESCRIPTION
Because of the cmake warnings caused by upstream (PCL).

For more details: https://github.com/ros-perception/perception_pcl/issues/202

cc @paulbovbel