### PR TITLE
pr2_common: 1.12.2-0 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -4688,7 +4688,7 @@ repositories:
       tags:
         release: release/jade/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_common-release.git
-      version: 1.11.9-0
+      version: 1.12.2-0
     source:
       type: git
       url: https://github.com/pr2/pr2_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.2-0`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.11.9-0`

## pr2_common

- No changes

## pr2_dashboard_aggregator

- No changes

## pr2_description

```
* Merge pull request #269 <https://github.com/pr2/pr2_common/issues/269> from bmagyar/kinetic-devel
  Fix pr2_description warnings
* Remove playerstage xml schemas
* xacro.py -> xacro
* Contributors: Bence Magyar
```

## pr2_machine

- No changes

## pr2_msgs

- No changes
