### PR TITLE
urdf_tutorial: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2299,6 +2299,21 @@ repositories:
       url: https://github.com/ros-controls/urdf_geometry_parser.git
       version: kinetic-devel
     status: developed
+  urdf_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_tutorial-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: master
+    status: maintained
   urdfdom_py:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.4.0-0`:

- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
