### PR TITLE
rqt_robot_dashboard: 0.5.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1961,6 +1961,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_reconfigure.git
       version: master
     status: maintained
+  rqt_robot_dashboard:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
+      version: 0.5.7-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: master
+    status: maintained
   rqt_robot_monitor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_dashboard` to `0.5.7-0`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_robot_dashboard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rqt_robot_dashboard

- No changes
