### PR TITLE
urdf_sim_tutorial: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2360,6 +2360,21 @@ repositories:
       url: https://github.com/ros-controls/urdf_geometry_parser.git
       version: kinetic-devel
     status: developed
+  urdf_sim_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: master
+    status: maintained
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_sim_tutorial` to `0.4.0-0`:

- upstream repository: https://github.com/ros/urdf_sim_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## urdf_sim_tutorial

```
* Add README.md.
* 0.3.0
* Remove r2d2.xacro
* Split Control Tutorials (#31 <https://github.com/ros/urdf_sim_tutorial/issues/31>)
  * Saved Splits
  * Publish Joints
  * 10
  * Gripper
  * Diff drive
* Install Fixes (#30 <https://github.com/ros/urdf_sim_tutorial/issues/30>)
* Split Gazebo Features to New Package urdf_tutorial2 (#28 <https://github.com/ros/urdf_sim_tutorial/issues/28>)
  * Move everything to subfolder
  * New Package
  * Rename to urdf_sim_tutorial
* Contributors: Chris Lalancette, David V. Lu, David V. Lu!!
```
