### PR TITLE
gazebo_ros_pkgs: 2.8.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -460,7 +460,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.8.1-0
+      version: 2.8.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.8.2-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.8.1-0`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Fix the build on Ubuntu Artful. (#715 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/715>)
  Artful has some bugs in its cmake files for Simbody that
  cause it to fail the build.  If we are on artful, remove
  the problematic entries.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## gazebo_ros

```
* Fix the build on Ubuntu Artful. (#715 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/715>)
  Artful has some bugs in its cmake files for Simbody that
  cause it to fail the build.  If we are on artful, remove
  the problematic entries.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## gazebo_ros_control

```
* Fix the build on Ubuntu Artful. (#715 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/715>)
  Artful has some bugs in its cmake files for Simbody that
  cause it to fail the build.  If we are on artful, remove
  the problematic entries.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## gazebo_ros_pkgs

- No changes
