### PR TITLE
visualization_tutorials: 0.10.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2440,6 +2440,29 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: melodic
     status: maintained
+  visualization_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    release:
+      packages:
+      - interactive_marker_tutorials
+      - librviz_tutorial
+      - rviz_plugin_tutorials
+      - rviz_python_tutorial
+      - visualization_marker_tutorials
+      - visualization_tutorials
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/visualization_tutorials-release.git
+      version: 0.10.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.3-0`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## interactive_marker_tutorials

- No changes

## librviz_tutorial

- No changes

## rviz_plugin_tutorials

```
* Fixed a warning due to a publisher which did not use the keyword argument 'queue_size' (#43 <https://github.com/ros-visualization/visualization_tutorials/issues/43>)
* Changed manifest.xml to package.xml in documentation (#42 <https://github.com/ros-visualization/visualization_tutorials/issues/42>)
* Contributors: Zihan Chen
```

## rviz_python_tutorial

```
* Fixed QWidget not defined bug in rviz_python_tutorial (#41 <https://github.com/ros-visualization/visualization_tutorials/issues/41>)
* Contributors: Zihan Chen
```

## visualization_marker_tutorials

- No changes

## visualization_tutorials

- No changes
