### PR TITLE
visualization_tutorials: 0.10.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12602,7 +12602,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.10.2-0
+      version: 0.10.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.3-0`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.10.2-0`

## interactive_marker_tutorials

- No changes

## librviz_tutorial

- No changes

## rviz_plugin_tutorials

```
* Fixed a warning due to a publisher which did not use the keyword argument 'queue_size' (#43 <https://github.com/ros-visualization/visualization_tutorials/issues/43>)
* Changed manifest.xml to package.xml in documentation (#42 <https://github.com/ros-visualization/visualization_tutorials/issues/42>)
* Contributors: Zihan Chen
```

## rviz_python_tutorial

```
* Fixed QWidget not defined bug in rviz_python_tutorial (#41 <https://github.com/ros-visualization/visualization_tutorials/issues/41>)
* Contributors: Zihan Chen
```

## visualization_marker_tutorials

- No changes

## visualization_tutorials

- No changes
