### PR TITLE
image_pipeline: 1.12.23-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -699,6 +699,26 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  image_pipeline:
+    release:
+      packages:
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/image_pipeline-release.git
+      version: 1.12.23-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: indigo
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.12.23-0`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## camera_calibration

```
* camera_checker: Ensure cols + rows are in correct order (#319 <https://github.com/ros-perception/image_pipeline/issues/319>)
  Without this commit, specifying a smaller column than row size lead to
  huge reported errors:
  ```
  $ rosrun camera_calibration cameracheck.py --size 6x7 --square 0.0495
  Linearity RMS Error: 13.545 Pixels      Reprojection RMS Error: 22.766 Pixels
  $ rosrun camera_calibration cameracheck.py --size 7x6 --square 0.0495
  Linearity RMS Error: 0.092 Pixels      Reprojection RMS Error: 0.083 Pixels
  ```
  This commit switches columns and rows around if necessary.
* Contributors: Martin Günther
```

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

```
* fix 'VideoCapture' undefined symbol error (#318 <https://github.com/ros-perception/image_pipeline/issues/318>)
  * fix 'VideoCapture' undefined symbol error
  The following error occured when trying to run image_publisher:
  [...]/devel/lib/image_publisher/image_publisher: symbol lookup error: [...]/devel/lib//libimage_publisher.so: undefined symbol: _ZN2cv12VideoCaptureC1Ev
  Probably, changes in cv_bridge reducing the OpenCV component dependencies led to the error. See
  https://github.com/ros-perception/vision_opencv/commit/8b5bbcbc1ce65734dc600695487909e0c67c1033
  This is fixed by manually finding OpenCV with the required components and adding the dependencies to the library, not just the node.
  * add image_publisher opencv 2 compatibility
* Contributors: hannometer
```

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

```
* Removed unused mutable scratch buffers (#315 <https://github.com/ros-perception/image_pipeline/issues/315>)
  The uint32_t buffers conflicted with newer release of OpenCV3, as explained here https://github.com/ros-perception/image_pipeline/issues/310
* Contributors: Miquel Massot
```
