### PR TITLE
image_transport_plugins: 1.9.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -718,6 +718,25 @@ repositories:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: indigo-devel
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: 1.9.5-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: indigo-devel
     status: maintained
   interactive_markers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.9.5-0`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros-gbp/image_transport_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## compressed_depth_image_transport

```
* disable -Werr
* Contributors: Vincent Rabaud
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

- No changes
