### PR TITLE
metapackages: 1.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -936,6 +936,30 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: groovy-devel
     status: maintained
+  metapackages:
+    doc:
+      type: git
+      url: https://github.com/ros/metapackages.git
+      version: melodic-devel
+    release:
+      packages:
+      - desktop
+      - desktop_full
+      - perception
+      - robot
+      - ros_base
+      - ros_core
+      - simulators
+      - viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/metapackages-release.git
+      version: 1.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros/metapackages.git
+      version: melodic-devel
+    status: maintained
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.4.0-0`:

- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
