### PR TITLE
rviz: 1.13.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2261,7 +2261,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.0-0
+      version: 1.13.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.1-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.13.0-0`

## rviz

```
* Added API option to disable keyboard focus being set on mouse move (#1174 <https://github.com/ros-visualization/rviz/issues/1174>)
* Deprecated tf API's in favor of new tf2 API alternatives (#1236 <https://github.com/ros-visualization/rviz/issues/1236>)
* Added a boolean property to the wrench visualization to make hiding small forces/torques optional (#1196 <https://github.com/ros-visualization/rviz/issues/1196>)
* Converted all of rviz to tinyxml2 from tinyxml, partially to avoid newly deprecated interfaces in urdf (#1237 <https://github.com/ros-visualization/rviz/issues/1237>)
* Added TF Prefix to effort plugin (#1213 <https://github.com/ros-visualization/rviz/issues/1213>)
* Contributors: Antoine Hoarau, Simon Schmeisser, William Woodall, jgueldenstein
```
