### PR TITLE
Update distribution.yaml

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1869,6 +1869,15 @@ repositories:
       url: https://github.com/ros-visualization/executive_smach_visualization.git
       version: indigo-devel
     status: developed
+  exploration_planning:
+    doc:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/exploration_planning.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/exploration_planning.git
+      version: indigo-devel
   fanuc:
     doc:
       type: git
@@ -2796,6 +2805,15 @@ repositories:
       url: https://github.com/open-rdc/icart_mini.git
       version: indigo-devel
     status: developed
+  IG_exploration:
+    doc:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/IG_exploration.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/ZhuangYanDLUT/IG_exploration.git
+      version: indigo-devel
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Add IG_exploration and exploration_planning while are used in autonomous environment exploration.
I'd like IG_exploration and exploration_planning to be indexed and documented on ros.org