### PR TITLE
Added ros_ips to package index of kinetic distribution.yaml

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9207,6 +9207,15 @@ repositories:
       url: https://github.com/jstnhuang/ros_explorer.git
       version: kinetic-devel
     status: developed
+  ros_ips:
+    doc:
+      type: git
+      url: https://github.com/metratec/ros_ips.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/metratec/ros_ips.git
+      version: master
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
I would like my ROS package (ros_ips) to be indexed to run prerelease tests and eventually release it as a binary.