### PR TITLE
marti_messages: 0.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -873,6 +873,29 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/tuw-robotics/marker_msgs-release.git
       version: 0.0.5-0
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: master
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: master
+    status: developed
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.5.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## marti_can_msgs

- No changes

## marti_common_msgs

```
* Add Matrix3x3Stamped message (#90 <https://github.com/swri-robotics/marti_messages/issues/90>)
* Contributors: Jerry Towler
```

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
