### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1933,6 +1933,11 @@ repositories:
       url: https://github.com/piraka9011/dialogflow_ros.git
       version: kinetic-devel
     status: developed
+  dmu_ros:
+    doc:
+      type: git
+      url: https://github.com/leo-muhendislik/dmu_ros.git
+      version: kinetic-devel
   dnn_detect:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1933,6 +1933,12 @@ repositories:
       url: https://github.com/piraka9011/dialogflow_ros.git
       version: kinetic-devel
     status: developed
+  dmu_ros:
+	doc:
+		type: git
+		url: https://github.com/leo-muhendislik/dmu_ros.git
+		version: kinetic-devel
+	status: developed
   dnn_detect:
     doc:
       type: git


### PR DESCRIPTION
I would like my repo to be indexed and documented on ros.org