### PR TITLE
mavros: 0.25.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5085,7 +5085,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.24.0-0
+      version: 0.25.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.25.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.24.0-0`

## libmavconn

```
* lib: console-bridge uses macroses...
* lib: fixing console-bridge now prefixed
* Contributors: Vladimir Ermakov
```

## mavros

```
* wind plugin: uncrustify
* use eigen and tf conversions (fix conventions), sync timestamp, fix typos
* add wind estimation plugin
* launch: fix style and keep apm.launch consistent with px4.launch
* Updated apm.launch to forward new fcu_protocol parameter
* glob pos plugin: correct gps velocity convention (NEU->ENU)
* Split temperature publisher.
* setpoint_raw: correct yaw transform; remove yaw transform methods
* extras: odom: improve way frame naming is handled
* extras: update odom plugin to send ODOMETRY msgs
* lib: enum_to_string: update enums
* setpoint_attitude: rename topic from target_attitude to attitude
* imu plugin: fix pressure units
* imu plugin: publish differential pressure (#1001 <https://github.com/mavlink/mavros/issues/1001>)
  * imu plugin: publish differential pressure
  * imu plugin: fix doxygen snippets
* lib: add PX4 mode AUTO.PRECLAND
* extras: add covariance parsing to vision_speed_estimate (#996 <https://github.com/mavlink/mavros/issues/996>)
* Contributors: Anthony Lamping, Nuno Marques, Oleg Kalachev, Sondre Engebråten, TSC21, Thomas Stastny, Timo Hinzmann, Vladimir Ermakov
```

## mavros_extras

```
* extras: Refactor Trajectory handle cb
* extras: Refactor Trajectory subscription callbacks
* trajectory: use lambda functions
* trajectory: add time_horizon for trajectory type Bezier
* trajectory: add time_horizon field
* trajectory: fix wrap_pi to have constant time execution
* trajectory: fix email
* trajectory: when receiving mavlink trajectory msg distinguish between types
  to fill correctly the mavros message
* trajectory: add path callback to support nav_msgs Path
* trajectory: update trajectory_call back so that it distinguish between
  trajectory types in copy the values
* rename ObstacleAvoidance plugin to Trajectory
* obstacle_avoidance: use cog to fill mavlink and ros messages
* obstacle_avoidance: uncrustify
* mavros_plugins: add obstacle avoidance plugin
* add obstacle_avoidance plugin
* CMakeLists: add obstacle_avoidance plugin
* extras: odom: explicitly set the lambda expression arg types
* extras: odom: use lambda expression to set the transform for twist
* extras: odom: change the way the rotation matrices are init
* extras: odom: set the frame_id to local frame only
* extras: odom: respect the Odometry msg frame spec
* extras: redo odom param processing
* extras: odom: remove unnecessary eigen_conversions/eigen_msg.h include
* extras: odom: fix underlying_type assignment
* extras: odom: update msg spec link
* extras: odom: move frame parsing to init()
* extras: odom: change tf exception handler
* extras: odom: improve way frame naming is handled
* extras: update odom plugin to send ODOMETRY msgs
* extras: smal style fix in vision pose est
* extras: add covariance parsing to vision_speed_estimate (#996 <https://github.com/mavlink/mavros/issues/996>)
* Contributors: Martina, Nuno Marques, TSC21, Vladimir Ermakov
```

## mavros_msgs

```
* trajectory: add time_horizon field
* change message name from ObstacleAvoidance to Trajectory since it is
  general enough to support any type of trajectory
* CMakeLists: add ObstacleAvoidance message
* add ObstacleAvoidance message
* msgs: Update message doc link
* CommandCode: update list of available commands on MAV_CMD enum (#995 <https://github.com/mavlink/mavros/issues/995>)
* Contributors: Martina, Nuno Marques, Vladimir Ermakov
```

## test_mavros

- No changes
