### PR TITLE
Adding dmu_ros to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1933,6 +1933,16 @@ repositories:
       url: https://github.com/piraka9011/dialogflow_ros.git
       version: kinetic-devel
     status: developed
+  dmu_ros:
+    doc:
+      type: git
+      url: https://github.com/leo-muhendislik/dmu_ros.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/leo-muhendislik/dmu_ros.git
+      version: master
+    status: developed
   dnn_detect:
     doc:
       type: git


### PR DESCRIPTION
I would like to add dmu_ros to be indexed and documented on ros.org