### PR TITLE
marti_common: 2.2.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1708,7 +1708,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.2.0-0
+      version: 2.2.1-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.2.1-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.2.0-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Initialize image before drawing on it. (#512 <https://github.com/swri-robotics/marti_common/issues/512>)
* Contributors: Marc Alban
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

```
* Support ROS Melodic (#514 <https://github.com/swri-robotics/marti_common/issues/514>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

```
* Catch and fix NaNs in the fillOrientations function (#513 <https://github.com/swri-robotics/marti_common/issues/513>)
* Contributors: kriskozak
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Support ROS Melodic (#514 <https://github.com/swri-robotics/marti_common/issues/514>)
* Contributors: P. J. Reed
```

## swri_yaml_util

- No changes
