### PR TITLE
marti_common: 2.2.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -873,6 +873,39 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/tuw-robotics/marker_msgs-release.git
       version: 0.0.5-0
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: master
+    release:
+      packages:
+      - marti_data_structures
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_nodelet
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_rospy
+      - swri_route_util
+      - swri_serial_util
+      - swri_string_util
+      - swri_system_util
+      - swri_transform_util
+      - swri_yaml_util
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 2.2.1-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: master
+    status: developed
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.2.1-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Initialize image before drawing on it. (#512 <https://github.com/swri-robotics/marti_common/issues/512>)
* Contributors: Marc Alban
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

```
* Support ROS Melodic (#514 <https://github.com/swri-robotics/marti_common/issues/514>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

```
* Catch and fix NaNs in the fillOrientations function (#513 <https://github.com/swri-robotics/marti_common/issues/513>)
* Contributors: kriskozak
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Support ROS Melodic (#514 <https://github.com/swri-robotics/marti_common/issues/514>)
* Contributors: P. J. Reed
```

## swri_yaml_util

- No changes
