### PR TITLE
swri_console: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11269,7 +11269,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_console-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `1.1.0-0`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.0-0`

## swri_console

```
* Added simple rosout_agg_recorder (#15 <https://github.com/pjreed/swri_console/issues/15>)
* Change logger levels from within swri_console (#20 <https://github.com/pjreed/swri_console/issues/20>)
* Load ROS logs and directories of ROS logs
* Fix compiler warnings found with Clang
* Add search bar
* Contributors: Edward Venator, P. J. Reed, Phil Westhart, Victor Murray, elliotjo, jgassaway
```
