### PR TITLE
swri_console: 1.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4226,7 +4226,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_console-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `1.1.0-0`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.0-0`

## swri_console

```
* Added simple rosout_agg_recorder (#15 <https://github.com/pjreed/swri_console/issues/15>)
* Change logger levels from within swri_console (#20 <https://github.com/pjreed/swri_console/issues/20>)
* Load ROS logs and directories of ROS logs
* Fix compiler warnings found with Clang
* Add search bar
* Contributors: Edward Venator, P. J. Reed, Phil Westhart, Victor Murray, elliotjo, jgassaway
```
