### PR TITLE
radar_omnipresense: 0.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2702,21 +2702,11 @@ repositories:
       version: kinetic-devel
     status: maintained
   radar_omnipresense:
-    doc:
-      type: git
-      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
-      version: 0.1.0
     release:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
       version: 0.1.0-0
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
-      version: 0.1.0
-    status: developed
   random_numbers:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2701,6 +2701,22 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
+  radar_omnipresense:
+    doc:
+      type: git
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
+      version: 0.1.0
+    status: developed
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_omnipresense` to `0.1.0-0`:

- upstream repository: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
- release repository: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## radar_omnipresense

```
* commiting the 2011 api version of the code. The branch RapidJSON_preserve contians 2015 api version. That branch should not be modified at all
* altered findrapidjson
* deleted old findrapidjson
* updated CMakeLists and utest to 'pass'
* adding files for very simple 'unit testing'
* Updated the readme to no longer say that you need to download and install LinuxCommConnection for the package
* modified change log
* Added the lib file so that linuxcommconnection is no longer a depedency issue
* Added lib file so that linnux comm connection is no longer a dependency issue
* address RapidJSON dependency
* added raw msgs
* Prepping for ros package submittal
* Contributors: Garren Hendricks, Jim Whitfield
* Added the lib file so that linuxcommconnection is no longer a depedency issue
* address RapidJSON dependency
* added raw msgs
* Contributors: Garren Hendricks, Jim Whitfield
```
