### PR TITLE
imagezero_transport: 0.2.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -757,6 +757,25 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: indigo-devel
     status: maintained
+  imagezero_transport:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
+    release:
+      packages:
+      - imagezero
+      - imagezero_image_transport
+      - imagezero_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/imagezero_transport.git
+      version: master
+    status: developed
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imagezero_transport` to `0.2.4-0`:

- upstream repository: https://github.com/swri-robotics/imagezero_transport.git
- release repository: https://github.com/swri-robotics-gbp/imagezero_transport-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## imagezero

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_image_transport

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```

## imagezero_ros

```
* Add documentation; build on Lunar (#12 <https://github.com/pjreed/imagezero_transport/issues/12>)
* Contributors: P. J. Reed
```
