### PR TITLE
mrpt1: 1.5.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1099,6 +1099,17 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: maintained
+  mrpt1:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt1-release.git
+      version: 1.5.7-0
+    source:
+      type: git
+      url: https://github.com/mrpt/mrpt.git
+      version: mrpt-1.5
+    status: maintained
   mrpt2:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt1` to `1.5.7-0`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt1-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
