### PR TITLE
Roll back mavros to 0.24.0

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5095,7 +5095,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.25.0-0
+      version: 0.24.0-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Due to https://github.com/mavlink/mavros/issues/1026

This reverts #17813
@vooon FYI