### PR TITLE
adding publish_trace to documentation index for indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9,6 +9,10 @@ release_platforms:
   ubuntu:
   - trusty
 repositories:
+  aaa:
+    doc:
+    release:
+    source:
   aau_multi_robot:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10,9 +10,6 @@ release_platforms:
   - trusty
 repositories:
   aaa:
-    doc:
-    release:
-    source:
   aau_multi_robot:
     doc:
       type: git
@@ -10162,6 +10159,15 @@ repositories:
       url: https://github.com/ros-drivers/prosilica_gige_sdk.git
       version: hydro-devel
     status: maintained
+  publish_trace:
+    doc:
+      type: git
+      url: https://github.com/wlfws/publish_trace.git
+      version: indigo
+    source:
+      type: git
+      url: https://github.com/wlfws/publish_trace.git
+      version: indigo
   pugixml:
     doc:
       type: git


### PR DESCRIPTION
I'd like publish_trace to be indexed and documented on ros.org.