### PR TITLE
Adding odometry_serialcom to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8583,6 +8583,15 @@ repositories:
       url: https://github.com/xaxxontech/oculusprime_ros.git
       version: master
     status: developed
+  odometry_serialcom:
+    doc:
+      type: git
+      url: https://github.com/wlfws/odometry_serialcom.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/wlfws/odometry_serialcom.git
+      version: indigo-devel
   odva_ethernetip:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8587,11 +8587,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/wlfws/odometry_serialcom.git
-      version: indigo-devel
+      version: master
     source:
       type: git
       url: https://github.com/wlfws/odometry_serialcom.git
-      version: indigo-devel
+      version: master
   odva_ethernetip:
     doc:
       type: git


### PR DESCRIPTION
I'd like odometry_serialcom to be indexed and documented on ros.org