### PR TITLE
nerian_stereo: 2.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1237,6 +1237,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jade-devel
     status: maintained
+  nerian_stereo:
+    doc:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nerian-vision/nerian_stereo-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo.git
+      version: master
+    status: developed
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `2.2.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## nerian_stereo

```
* Added support for RGB point cloud output
* Contributors: Konstantin Schauwecker
```
