### PR TITLE
Add dependencies for Melodic that rospilot needs

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4079,10 +4079,10 @@ postgresql:
   ubuntu: [postgresql, postgresql-contrib]
 postgresql-9.x-postgis:
   debian:
-    buster: [postgresql-9.6-postgis-2.3]
-    jessie: [postgresql-9.4-postgis-2.1]
-    stretch: [postgresql-9.6-postgis-2.3]
-    wheezy: [postgresql-9.4-postgis-2.1]
+    buster: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
+    jessie: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
+    stretch: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
+    wheezy: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
   fedora: [postgis]
   gentoo: [dev-db/postgis,'=dev-db/postgresql-9*']
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1907,15 +1907,10 @@ libgphoto-dev:
   fedora: [libgphoto2-devel]
   gentoo: [media-gfx/gphoto2]
   ubuntu:
-    lucid: [libgphoto2-dev]
+    '*': [libgphoto2-dev]
     precise: [libgphoto2-2-dev]
     raring: [libgphoto2-2-dev]
     saucy: [libgphoto2-6-dev]
-    trusty: [libgphoto2-dev]
-    utopic: [libgphoto2-dev]
-    vivid: [libgphoto2-dev]
-    wily: [libgphoto2-dev]
-    xenial: [libgphoto2-dev]
 libgps:
   arch: [gpsd]
   debian: [libgps-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4104,6 +4104,18 @@ postgresql-client:
   fedora: [postgresql-client]
   gentoo: [dev-db/postgresql]
   ubuntu: [postgresql-client]
+postgresql-postgis:
+  debian:
+    buster: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
+    jessie: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
+    stretch: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
+  fedora: [postgis]
+  gentoo: [dev-db/postgis,'=dev-db/postgresql-9*']
+  ubuntu:
+    artful: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
+    bionic: [postgresql-10-postgis-2.4, postgresql-contrib, postgresql-server-dev-all]
+    trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
+    xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib, postgresql-server-dev-all]
 procps:
   arch: [procps-ng]
   debian: [procps]


### PR DESCRIPTION
Description: PostGIS adds support for geographic objects to the PostgreSQL object-relational
database.

Links:
* https://admin.fedoraproject.org/pkgdb/package/rpms/postgis/
* https://packages.debian.org/stretch/postgresql-9.6-postgis-2.3
* https://packages.ubuntu.com/bionic/postgresql-10-postgis-2.4