### PR TITLE
geometric_shapes: 0.5.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2914,7 +2914,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.5.4-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.3-1`

## geometric_shapes

```
* gracefully handle negative cylinder height: #64 <https://github.com/ros-planning/geometric_shapes/issues/64>, #80 <https://github.com/ros-planning/geometric_shapes/issues/80>
* clang-formatting of whole repo: #79 <https://github.com/ros-planning/geometric_shapes/issues/79>
* operator<< for ShapeType: #80 <https://github.com/ros-planning/geometric_shapes/issues/80>
* adaption to new CONSOLE_BRIDGE_logXXX API: #75 <https://github.com/ros-planning/geometric_shapes/issues/75>, #72 <https://github.com/ros-planning/geometric_shapes/issues/72>
* [fix] box-ray intersection: #73 <https://github.com/ros-planning/geometric_shapes/issues/73>
* Contributors: Dave Coleman, Leroy Rügemer, Malcolm Mielle, Mike Purvis, Robert Haschke, Michael Goerner
```
