### PR TITLE
update python-gitlab

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -135,30 +135,6 @@ pika:
     pip:
       packages: [pika]
   ubuntu: [python-pika]
-pyapi-gitlab:
-  debian:
-    '*':
-      pip:
-        packages: [pyapi-gitlab]
-    stretch: [python-gitlab]
-  ubuntu:
-    '*':
-      pip:
-        packages: [pyapi-gitlab]
-    artful: [python-gitlab]
-    xenial: [python-gitlab]
-pyapi3-gitlab:
-  debian:
-    '*':
-      pip:
-        packages: [python-gitlab]
-    stretch: [python3-gitlab]
-  ubuntu:
-    '*':
-      pip:
-        packages: [python-gitlab]
-    artful: [python3-gitlab]
-    xenial: [python3-gitlab]
 pydocstyle:
   debian:
     buster: [pydocstyle]
@@ -1254,17 +1230,15 @@ python-github-pip:
       packages: [PyGithub]
 python-gitlab:
   debian:
-    '*':
+    jessie:
       pip:
         packages: [python-gitlab]
     buster: [python-gitlab]
-    sid: [python-gitlab]
   ubuntu:
+    '*': [python-gitlab]
     artful:
       pip:
         packages: [python-gitlab]
-    bionic: [python-gitlab]
-    cosmic: [python-gitlab]
     trusty:
       pip:
         packages: [python-gitlab]
@@ -4114,15 +4088,8 @@ python3-flake8:
   ubuntu: [python3-flake8]
 python3-gitlab:
   debian:
-    '*':
-      pip:
-        packages: [python3-gitlab]
     buster: [python3-gitlab]
-    sid: [python3-gitlab]
   ubuntu:
-    '*':
-      pip:
-        packages: [python3-gitlab]
     bionic: [python3-gitlab]
     cosmic: [python3-gitlab]
 python3-nose:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1230,10 +1230,13 @@ python-github-pip:
       packages: [PyGithub]
 python-gitlab:
   debian:
+    '*': [python-gitlab]
+    stretch:
+      pip:
+        packages: [python-gitlab]
     jessie:
       pip:
         packages: [python-gitlab]
-    buster: [python-gitlab]
   ubuntu:
     '*': [python-gitlab]
     artful:
@@ -4088,10 +4091,24 @@ python3-flake8:
   ubuntu: [python3-flake8]
 python3-gitlab:
   debian:
-    buster: [python3-gitlab]
+    '*': [python3-gitlab]
+    jessie:
+      pip:
+        package: [python-gitlab]
+    stretch:
+      pip:
+        package: [python-gitlab]
   ubuntu:
-    bionic: [python3-gitlab]
-    cosmic: [python3-gitlab]
+    '*': [python3-gitlab]
+    artful:
+      pip:
+        package: [python-gitlab]
+    trusty:
+      pip:
+        package: [python-gitlab]
+    xenial:
+      pip:
+        package: [python-gitlab]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1231,10 +1231,10 @@ python-github-pip:
 python-gitlab:
   debian:
     '*': [python-gitlab]
-    stretch:
+    jessie:
       pip:
         packages: [python-gitlab]
-    jessie:
+    stretch:
       pip:
         packages: [python-gitlab]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4094,21 +4094,21 @@ python3-gitlab:
     '*': [python3-gitlab]
     jessie:
       pip:
-        package: [python-gitlab]
+        packages: [python-gitlab]
     stretch:
       pip:
-        package: [python-gitlab]
+        packages: [python-gitlab]
   ubuntu:
     '*': [python3-gitlab]
     artful:
       pip:
-        package: [python-gitlab]
+        packages: [python-gitlab]
     trusty:
       pip:
-        package: [python-gitlab]
+        packages: [python-gitlab]
     xenial:
       pip:
-        package: [python-gitlab]
+        packages: [python-gitlab]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -135,6 +135,30 @@ pika:
     pip:
       packages: [pika]
   ubuntu: [python-pika]
+pyapi-gitlab:
+  debian:
+    '*':
+      pip:
+        packages: [pyapi-gitlab]
+    stretch: [python-gitlab]
+  ubuntu:
+    '*':
+      pip:
+        packages: [pyapi-gitlab]
+    artful: [python-gitlab]
+    xenial: [python-gitlab]
+pyapi3-gitlab:
+  debian:
+    '*':
+      pip:
+        packages: [python-gitlab]
+    stretch: [python3-gitlab]
+  ubuntu:
+    '*':
+      pip:
+        packages: [python-gitlab]
+    artful: [python3-gitlab]
+    xenial: [python3-gitlab]
 pydocstyle:
   debian:
     buster: [pydocstyle]
@@ -1230,13 +1254,21 @@ python-github-pip:
       packages: [PyGithub]
 python-gitlab:
   debian:
-    '*': [python-gitlab]
-    jessie:
+    '*':
       pip:
         packages: [python-gitlab]
+    buster: [python-gitlab]
+    sid: [python-gitlab]
   ubuntu:
-    '*': [python-gitlab]
+    artful:
+      pip:
+        packages: [python-gitlab]
+    bionic: [python-gitlab]
+    cosmic: [python-gitlab]
     trusty:
+      pip:
+        packages: [python-gitlab]
+    xenial:
       pip:
         packages: [python-gitlab]
 python-gitpython-pip:
@@ -4082,15 +4114,17 @@ python3-flake8:
   ubuntu: [python3-flake8]
 python3-gitlab:
   debian:
-    '*': [python3-gitlab]
-    jessie:
+    '*':
       pip:
-        packages: [python-gitlab]
+        packages: [python3-gitlab]
+    buster: [python3-gitlab]
+    sid: [python3-gitlab]
   ubuntu:
-    '*': [python3-gitlab]
-    trusty:
+    '*':
       pip:
-        packages: [python-gitlab]
+        packages: [python3-gitlab]
+    bionic: [python3-gitlab]
+    cosmic: [python3-gitlab]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]


### PR DESCRIPTION
@mikaelarguedas 
I had to make several changes to the `python-gitlab` packages, because the package name is ambiguous depending on the release version (e.g. **xenial**: `python-gitlab` --> `pyapi-gitlab` (7.5.0) [link](https://github.com/pyapi-gitlab/pyapi-gitlab) but **cosmic**: `python-gitlab` --> `python-gitlab` (1.3.0) [link](https://github.com/python-gitlab/python-gitlab)).
The same problem occurs with debian.
Changes:
- `python-gitlab`/`python3-gitlab` native if possible / pip otherwise
- new pkg `pyapi-gitlab`/`pyapi3-gitlab` native if possible / pip otherwise