### PR TITLE
robotnik_msgs: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8680,7 +8680,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_msgs` to `0.2.3-0`:

- upstream repository: https://github.com/RobotnikAutomation/robotnik_msgs.git
- release repository: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.2-0`

## robotnik_msgs

```
* adding mantaineirs for the package
* added SetElevator action
* completing alarms
* removed set_kuka_pose.srv
* Cartesian euler pose msg and srv added
* robotnik_msgs: adding string array
* Kuka pose msg and set kuka pose srv added
* added set_named_input to CMakeLists
* msg changed to digital_inputs and digital_outputs
* alarms with display number
* Added named_input_output msg and srv
* added GetBool service
```
