### PR TITLE
ecl_manipulation: 0.60.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -441,6 +441,25 @@ repositories:
       url: https://github.com/stonier/ecl_lite.git
       version: release/0.61-melodic
     status: maintained
+  ecl_manipulation:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_manipulation.git
+      version: release/0.60-melodic
+    release:
+      packages:
+      - ecl
+      - ecl_manipulation
+      - ecl_manipulators
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
+      version: 0.60.2-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_manipulation.git
+      version: release/0.60-melodic
+    status: maintained
   ecl_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation` to `0.60.2-0`:

- upstream repository: https://github.com/stonier/ecl_manipulation.git
- release repository: https://github.com/yujinrobot-release/ecl_manipulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
