### PR TITLE
mavros: 0.25.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1767,7 +1767,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.25.0-0
+      version: 0.25.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.25.1-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.25.0-0`

## libmavconn

```
* lib #1026 <https://github.com/mavlink/mavros/issues/1026>: fix logInform compat
* lib #1026 <https://github.com/mavlink/mavros/issues/1026>: add compat header for older console-bridge
* Contributors: Vladimir Ermakov
```

## mavros

- No changes

## mavros_extras

- No changes

## mavros_msgs

- No changes

## test_mavros

- No changes
