### PR TITLE
summit_xl_sim: 1.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11244,7 +11244,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/summit_xl_sim-release.git
-      version: 1.0.9-2
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/summit_xl_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `summit_xl_sim` to `1.1.1-0`:

- upstream repository: https://github.com/RobotnikAutomation/summit_xl_sim.git
- release repository: https://github.com/RobotnikAutomation/summit_xl_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.9-2`

## summit_xl_control

- No changes

## summit_xl_gazebo

- No changes

## summit_xl_robot_control

- No changes

## summit_xl_sim

- No changes

## summit_xl_sim_bringup

- No changes
