### PR TITLE
frame_editor: 1.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2597,7 +2597,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
-      version: 1.0.2-0
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frame_editor` to `1.0.2-1`:

- upstream repository: https://github.com/ipa320/rqt_frame_editor_plugin.git
- release repository: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.2-0`

## frame_editor

```
* Fix: import rospkg
  Add rviz view to headless demo launch
* headless version
* during close, save_as proposes to save as current yaml
* added Duplicate Frame button
* Installing tags for frameeditor
* package.xml v2
* Ask for automatic mesh version path update if possible.
* fix legacy yaml loading, if you want to change to rospackages+path you have to reselect your mesh and save again
* Warning Widget if saved with absolute pathes
* resolve mesh pathes with rospackages if possible, fall back to absolute pathes if not possible.
* ugly qt5-slots workaround to make meshes and forms work
* Contributors: ipa-frn, ipa-lth, ipa-pgt
```
