### PR TITLE
warthog_desktop: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12707,6 +12707,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog.git
       version: kinetic-devel
     status: maintained
+  warthog_desktop:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_desktop
+      - warthog_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_desktop-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    status: maintained
   waypoint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_desktop` to `0.0.1-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_desktop.git
- release repository: https://github.com/clearpath-gbp/warthog_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## warthog_desktop

```
* Initial commit.
* Contributors: Tony Baltovski
```

## warthog_viz

```
* Initial commit.
* Contributors: Tony Baltovski
```
