### PR TITLE
kobuki_msgs: 0.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -962,6 +962,17 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_core.git
       version: melodic
     status: maintained
+  kobuki_msgs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_msgs.git
+      version: release/0.7-melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
+      version: 0.7.0-1
+    status: maintained
   laser_assembler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs` to `0.7.0-1`:

- upstream repository: https://github.com/yujinrobot/kobuki_msgs.git
- release repository: https://github.com/yujinrobot-release/kobuki_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
