### PR TITLE
jsk_control: 0.1.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5650,7 +5650,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.14-0
+      version: 0.1.15-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.15-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.14-0`

## cmd_vel_smoother

- No changes

## contact_states_observer

- No changes

## eus_nlopt

- No changes

## eus_qp

- No changes

## eus_qpoases

- No changes

## joy_mouse

- No changes

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

```
* Merge pull request #692 <https://github.com/jsk-ros-pkg/jsk_control/issues/692> from orikuma/replace-footstep-state-to-state-ptr
  Replace FootstepState::Ptr to StatePtr in footstep_astar_solver to be used with a GraphT which has different state type
* [jsk_footstep_planner] Replace FootstepState::Ptr -> StatePtr in footstep_astar_solver to be used with a GraphT which has different state type
* Contributors: Iori Kumagai, Yohei Kakiuchi
```

## jsk_ik_server

- No changes

## jsk_teleop_joy

```
* Merge pull request #693 <https://github.com/jsk-ros-pkg/jsk_control/issues/693> from k-okada/fix_apt_slow
  remove unused build_depends
* remove unused build_depends
* Contributors: Kei Okada
```
