### PR TITLE
perception_pcl: 1.4.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7041,7 +7041,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.4.3-0
+      version: 1.4.4-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.4.4-0`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.4.3-0`

## pcl_ros

```
* Use nested foreach for the filtered patterns
* Filter include dirs that does not exist
  Close https://github.com/ros-perception/perception_pcl/issues/172
  Close https://github.com/ros-perception/perception_pcl/issues/206
* Remove dependencies on not existing target
* Fix use of Eigen3
* Revert "Increase limits on CropBox filter parameters"
  This reverts commit e007128e41b189092a3311775a28c8ebbd8f13ad.
* Increase limits on CropBox filter parameters
  Min and max of CropBox filter was +/- 5m. For a pointcloud from a Velodyne, for example, this is not enough.
  Increased to +/- 1000m.
* Contributors: James Ward, Kentaro Wada
```

## perception_pcl

- No changes
