### PR TITLE
costmap_converter: 0.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1613,7 +1613,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.8-0`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.7-0`

## costmap_converter

```
* Standalone converter subscribes now to costmap updates. Fixes #1 <https://github.com/rst-tu-dortmund/costmap_converter/issues/1>
* Adds radius field for circular obstacles to ObstacleMsg
* Stacked costmap conversion (#7 <https://github.com/rst-tu-dortmund/costmap_converter/issues/7>).
  E.g., it is now possible combine a dynamic obstacle and static obstacle converter plugin.
* Contributors: Christoph Rösmann, Franz Albers
```
