### PR TITLE
Adding hls-lfcd-lds2-driver to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3075,6 +3075,23 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: kinetic-devel
     status: maintained
+  hls-lfom-tof-driver:
+    doc:
+      type: git
+      url: https://github.com/HLDS-GIT/hls_lfom_tof_driver.git
+      version: kinetic-devel
+    release:
+      packages:
+      - hls_lfom_tof_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/HLDS-GIT-release/hls-lfom-tof-driver-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/HLDS-GIT/hls_lfom_tof_driver.git
+      version: kinetic-devel
+    status: maintained
   hokuyo3d:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3079,18 +3079,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/HLDS-GIT/hls_lfom_tof_driver.git
-      version: kinetic-devel
-    release:
-      packages:
-      - hls_lfom_tof_driver
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/HLDS-GIT-release/hls-lfom-tof-driver-release.git
-      version: 1.0.0-0
+      version: master
     source:
       type: git
       url: https://github.com/HLDS-GIT/hls_lfom_tof_driver.git
-      version: kinetic-devel
+      version: master
     status: maintained
   hokuyo3d:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3075,6 +3075,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: kinetic-devel
     status: maintained
+  hls-lfcd-lds2-driver:
+    doc:
+      type: git
+      url: https://github.com/HLDS-GIT/hls_lfcd_lds2_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/HLDS-GIT/hls_lfcd_lds2_driver.git
+      version: master
+    status: maintained
   hls-lfom-tof-driver:
     doc:
       type: git


### PR DESCRIPTION
I'd like hls-lfcd-lds2-driver to be indexed and documented on ros.org.