### PR TITLE
swri_profiler: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15288,6 +15288,25 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  swri_profiler:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: master
+    release:
+      packages:
+      - swri_profiler
+      - swri_profiler_msgs
+      - swri_profiler_tools
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: master
+    status: developed
   talos_audio:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.0.3-0`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
