### PR TITLE
swri_profiler: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11275,6 +11275,25 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  swri_profiler:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: kinetic-devel
+    release:
+      packages:
+      - swri_profiler
+      - swri_profiler_msgs
+      - swri_profiler_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: kinetic-devel
+    status: developed
   sync_params:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.1.0-0`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## swri_profiler

- No changes

## swri_profiler_msgs

- No changes

## swri_profiler_tools

```
* Kinetic compatibility
* Contributors: Matthew Bries, P. J. Reed
```
