### PR TITLE
Adding slam_constructor to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10935,6 +10935,16 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
       version: 0.2.2-0
     status: developed
+  slam_constructor:
+    doc:
+      type: git
+      url: https://github.com/OSLL/slam-constructor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/OSLL/slam-constructor.git
+      version: master
+    status: developed
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
I'd like 'slam_constructor' to be indexed  and documented on ros.org.