### PR TITLE
slam_constructor: 0.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10940,6 +10940,11 @@ repositories:
       type: git
       url: https://github.com/OSLL/slam-constructor.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OSLL/slam_constructor-release.git
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/OSLL/slam-constructor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_constructor` to `0.9.0-0`:

- upstream repository: https://github.com/OSLL/slam-constructor.git
- release repository: https://github.com/OSLL/slam_constructor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## slam_constructor

```
* Initial release
* Contributors: Artur Huletski, Dmitriy Kartashov, Kirill Krinkin, RomanDegtyar, art32fil
```
