### PR TITLE
Package rename from ros_ips to indoor_positioning

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3745,6 +3745,15 @@ repositories:
       url: https://github.com/ccny-ros-pkg/imu_tools.git
       version: kinetic
     status: developed
+  indoor_positioning:
+    doc:
+      type: git
+      url: https://github.com/metratec/indoor_positioning.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/metratec/indoor_positioning.git
+      version: master
   industrial_calibration:
     doc:
       type: git
@@ -9217,15 +9226,6 @@ repositories:
       url: https://github.com/jstnhuang/ros_explorer.git
       version: kinetic-devel
     status: developed
-  ros_ips:
-    doc:
-      type: git
-      url: https://github.com/metratec/ros_ips.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/metratec/ros_ips.git
-      version: master
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
Renaming because 'ros' in the package name is redundant and 'ips' is not obviously interpretable or searchable.
As per recommendation by Tully Foote: https://github.com/ros/rosdistro/pull/17807#issuecomment-389363739