### PR TITLE
map_merge: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1032,6 +1032,23 @@ repositories:
       type: git
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
+  map_merge:
+    doc:
+      type: git
+      url: https://github.com/hrnr/map-merge.git
+      version: melodic-devel
+    release:
+      packages:
+      - map_merge_3d
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/hrnr/map-merge-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/hrnr/map-merge.git
+      version: melodic-devel
+    status: developed
   marker_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `map_merge` to `0.1.0-0`:

- upstream repository: https://github.com/hrnr/map-merge.git
- release repository: https://github.com/hrnr/map-merge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## map_merge_3d

```
* Initial release
* Contributors: Jiri Horner
```
