### PR TITLE
remove map_merge from lunar

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1651,16 +1651,6 @@ repositories:
       url: https://github.com/hrnr/m-explore.git
       version: lunar-devel
     status: developed
-  map_merge:
-    doc:
-      type: git
-      url: https://github.com/hrnr/map-merge.git
-      version: lunar-devel
-    source:
-      type: git
-      url: https://github.com/hrnr/map-merge.git
-      version: lunar-devel
-    status: developed
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
I have decided to do binary release only for upcoming melodic via #17882. This removes the doc job from lunar to avoid confusion on the wiki.