### PR TITLE
common_msgs: 1.12.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -474,7 +474,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.12.5-0
+      version: 1.12.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.6-0`:

- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.5-0`

## actionlib_msgs

- No changes

## common_msgs

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

```
* Return default value to prevent missing return warning.
* Add function to convert PointCloud2 to namedtuples
  Add new function read_points_list that converts a PointCloud2 to a list of named tuples.
  It works on top of read_points, which generates lists containing the values.
  In consequence read_points_list is slower than read_points.
* Added equidistant distortion model const
* Added test_depend on rosunit in sensor_msgs
* fix catkin_lint warnings
* add mingration rule, copied from common_msgs-1.6
* Add missing include for atoi.
  Fixes #97 <https://github.com/ros/common_msgs/issues/97>
* Contributors: 2scholz, Adam Allevato, Ivor Wanders, Kei Okada, Tully Foote, alexzzhu
```

## shape_msgs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
