### PR TITLE
Adding pioneer_mrs to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7139,6 +7139,16 @@ repositories:
       url: https://github.com/amineHorseman/pioneer_bringup.git
       version: master
     status: maintained
+  pioneer_mrs:
+    doc:
+      type: git
+      url: https://github.com/hanzheteng/pioneer_mrs.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/hanzheteng/pioneer_mrs.git
+      version: master
+    status: maintained
   pioneer_teleop:
     doc:
       type: git


### PR DESCRIPTION
I'd like pioneer_mrs repository to be indexed and documented on ros.org.