### PR TITLE
map_merge: 0.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1043,7 +1043,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/hrnr/map-merge-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/hrnr/map-merge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `map_merge` to `0.1.1-0`:

- upstream repository: https://github.com/hrnr/map-merge.git
- release repository: https://github.com/hrnr/map-merge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.0-0`

## map_merge_3d

```
* workaround build issues in Debian Stretch and Ubuntu Artful
* Contributors: Jiri Horner
```
