### PR TITLE
mrpt_bridge: 0.1.22-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1269,6 +1269,11 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
+      version: 0.1.22-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_bridge` to `0.1.22-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mrpt_bridge

```
* Release as an independent repository outside of "mrpt_navigation"
```
