### PR TITLE
Adding hls-lfcd-lds2-driver to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3361,6 +3361,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: kinetic-devel
     status: developed
+  hls-lfcd-lds2-driver:
+    doc:
+      type: git
+      url: https://github.com/HLDS-GIT/hls_lfcd_lds2_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/HLDS-GIT/hls_lfcd_lds2_driver.git
+      version: master
+    status: maintained
   hls-lfom-tof-driver:
     doc:
       type: git


### PR DESCRIPTION
I'd like hls-lfcd-lds2-driver to be indexed and documented on ros.org.