### PR TITLE
libg2o: 2018.3.23-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1032,6 +1032,13 @@ repositories:
       type: git
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
+  libg2o:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/libg2o-release.git
+      version: 2018.3.23-0
+    status: maintained
   map_merge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libg2o` to `2018.3.23-0`:

- upstream repository: https://github.com/RainerKuemmerle/g2o.git
- release repository: https://github.com/ros-gbp/libg2o-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
