### PR TITLE
libg2o: 2018.3.24-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1037,7 +1037,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/libg2o-release.git
-      version: 2018.3.23-0
+      version: 2018.3.24-0
     status: maintained
   map_merge:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `libg2o` to `2018.3.24-0`:

- upstream repository: https://github.com/RainerKuemmerle/g2o.git
- release repository: https://github.com/ros-gbp/libg2o-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2018.3.23-0`
