### PR TITLE
find_object_2d: 0.6.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -544,6 +544,21 @@ repositories:
       url: https://github.com/ros/filters.git
       version: lunar-devel
     status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.6.2-0
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: melodic-devel
+    status: maintained
   four_wheel_steering_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.6.2-0`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
