### PR TITLE
ros_control: 0.9.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12125,7 +12125,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.9.6-0
+      version: 0.9.7-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.9.7-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.9.6-0`

## controller_interface

```
* Introduce shared_ptr typedefs
* Contributors: Bence Magyar
```

## controller_manager

```
* Introduce shared_ptr typedefs
* Contributors: Bence Magyar
```

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

```
* Introduce shared_ptr typedefs
* Contributors: Bence Magyar
```

## joint_limits_interface

```
* Add urdf dependency, use urdf_compatibility & update urdf include
* Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr
* Contributors: Bence Magyar
```

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Introduce shared_ptr typedefs
* Contributors: Bence Magyar
```
