### PR TITLE
rgbd_launch: 2.2.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1764,6 +1764,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
     status: maintained
+  rgbd_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rgbd_launch-release.git
+      version: 2.2.2-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: jade-devel
+    status: maintained
   robot_activity:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.2.2-0`:

- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rgbd_launch

```
* [capability] add rgb prefix, rectify_ir to node name
* [maintenance] enable rostest upon build.
* [maintenance] Remove Indigo. Enable Kinetic from Travis conf. #32 <https://github.com/ros-drivers/rgbd_launch/issues/32>
* Contributors: Yuki Furuta, Isaac I.Y. Saito
```
