### PR TITLE
Updating 'slam_constructor' doc and source branches for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10935,6 +10935,16 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
       version: 0.2.2-0
     status: developed
+  slam_constructor:
+    doc:
+      type: git
+      url: https://github.com/OSLL/slam-constructor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/OSLL/slam-constructor.git
+      version: master
+    status: developed
   slam_gmapping:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10966,7 +10966,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/OSLL/slam-constructor.git
-      version: master
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -10975,7 +10975,7 @@ repositories:
     source:
       type: git
       url: https://github.com/OSLL/slam-constructor.git
-      version: master
+      version: kinetic-devel
     status: developed
   slam_gmapping:
     doc:


### PR DESCRIPTION
Hello! I wish to switch my package sources to another branch and release a new version of the package. Do I need to specify some options when running bloom-release (e.g. `--edit`), or a normal run (i.e. `bloom-release foo --track kinetic --rosdistro kinetic`) is enough? Thanks!