### PR TITLE
perception_pcl: 1.6.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1559,7 +1559,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/perception_pcl-release.git
-      version: 1.6.1-0
+      version: 1.6.2-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.6.2-0`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.6.1-0`

## pcl_conversions

- No changes

## pcl_ros

```
* Fix exported includes in Ubuntu Artful
* Increase limits on CropBox filter parameters
* Contributors: James Ward, Jiri Horner
```

## perception_pcl

- No changes
