### PR TITLE
pose_cov_ops: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1612,6 +1612,11 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.2.0-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## pose_cov_ops

```
* Made compatible with MRPT 1.x and 2.x
* Contributors: Jose Luis Blanco Claraco
```
