### PR TITLE
Adding  my_repo "dlut_path_planner" to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2699,15 +2699,6 @@ repositories:
       type: git
       url: https://github.com/ZhuangYanDLUT/dlut_laser.git
       version: indigo-devel
-  dlut_path_planner:
-    doc:
-      type: git
-      url: https://github.com/DS921020/Hexagon_map.git
-      version: indigo-devel
-    source:
-      type: git
-      url: https://github.com/DS921020/Hexagon_map.git
-      version: indigo-devel
   dlut_smartrob:
     doc:
       type: git
@@ -4552,6 +4543,15 @@ repositories:
       url: https://github.com/heron/heron_desktop.git
       version: indigo-devel
     status: maintained
+  hexagon_map:
+    doc:
+      type: git
+      url: https://github.com/DS921020/Hexagon_map.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/DS921020/Hexagon_map.git
+      version: master
   hironx_rpc:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2699,6 +2699,15 @@ repositories:
       type: git
       url: https://github.com/ZhuangYanDLUT/dlut_laser.git
       version: indigo-devel
+  dlut_path_planner:
+    doc:
+      type: git
+      url: https://github.com/DS921020/Hexagon_map.git
+      version: indigo-devel
+    source:
+      type: git
+      url: https://github.com/DS921020/Hexagon_map.git
+      version: indigo-devel
   dlut_smartrob:
     doc:
       type: git


### PR DESCRIPTION
I'd like to my_repo "dlut_path_planner" to be indexed and documented on ros.org