### PR TITLE
ar_track_alvar: 0.7.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -106,7 +106,6 @@ repositories:
       url: https://github.com/ros-gbp/ar_track_alvar-release.git
       version: 0.7.1-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/ar_track_alvar.git
       version: kinetic-devel

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -58,6 +58,24 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  ar_track_alvar:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/ar_track_alvar.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ar_track_alvar
+      - ar_track_alvar_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ar_track_alvar-release.git
+      version: 0.7.1-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/ar_track_alvar.git
+      version: kinetic-devel
+    status: maintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ar_track_alvar` to `0.7.1-0`:

- upstream repository: https://github.com/ros-perception/ar_track_alvar
- release repository: https://github.com/ros-gbp/ar_track_alvar-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ar_track_alvar

```
* [maintenance] Remove unnecessary metapkg.
* [fix][build][CMakeLists] Prevent rosdep errors that only occur when running tests with catkin_make_isolated. See http://answers.ros.org/question/262558/buildfarm-missing-package-dependencies-pkg_namepackagexml/
* [test] Relax tf test criteria #39 <https://github.com/ros-perception/ar_track_alvar/pull/39>
* Contributors: Isaac I.Y. Saito
```

## ar_track_alvar_msgs

```
* [maintenance] Remove unnecessary metapkg.
```
