### PR TITLE
ros_comm: 1.14.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2061,6 +2061,22 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosconsole:
+    doc:
+      type: git
+      url: https://github.com/ros/rosconsole.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rosconsole-release.git
+      version: 1.13.7-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/rosconsole.git
+      version: melodic-devel
+    status: maintained
   rosconsole_bridge:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1897,7 +1897,6 @@ repositories:
       - ros_comm
       - rosbag
       - rosbag_storage
-      - rosconsole
       - roscpp
       - rosgraph
       - roslaunch
@@ -1917,7 +1916,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.6-2
+      version: 1.14.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.14.0-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.13.6-2`

## message_filters

```
* change invocation to add to conform template syntax (#1388 <https://github.com/ros/ros_comm/issues/1388>)
* fix sphinx warning (#1371 <https://github.com/ros/ros_comm/issues/1371>)
```

## ros_comm

- No changes

## rosbag

```
* keep connection header info in rosbag filter/compress (#1372 <https://github.com/ros/ros_comm/issues/1372>)
* implement bag encryption/decryption (#1206 <https://github.com/ros/ros_comm/issues/1206>)
* add TransportHint options --tcpnodelay and --udp (#1295 <https://github.com/ros/ros_comm/issues/1295>)
* fix check for header first in rosbag play for rate control topic (#1352 <https://github.com/ros/ros_comm/issues/1352>)
```

## rosbag_storage

```
* specialize BagCallbackT for MessageInstance (#1374 <https://github.com/ros/ros_comm/issues/1374>)
* fix compiler warning of test_aes_encryptor (#1376 <https://github.com/ros/ros_comm/issues/1376>)
* implement bag encryption/decryption (#1206 <https://github.com/ros/ros_comm/issues/1206>)
* use boost::shared_ptr to fix memory leak (#1373 <https://github.com/ros/ros_comm/issues/1373>)
```

## roscpp

```
* force a rebuild of the pollset on flag changes (#1393 <https://github.com/ros/ros_comm/issues/1393>)
* fix integer overflow for oneshot timers (#1382 <https://github.com/ros/ros_comm/issues/1382>)
* convert the period standard deviation in StatisticsLogger to Duration at the end (#1361 <https://github.com/ros/ros_comm/issues/1361>)
* add time when timer expired to timer events (#1130 <https://github.com/ros/ros_comm/issues/1130>)
* replace DCL pattern with static variable (#1365 <https://github.com/ros/ros_comm/issues/1365>)
* add parameter to stop clients from generating rosout topics list (#1241 <https://github.com/ros/ros_comm/issues/1241>)
```

## rosgraph

```
* use HTTP/1.1 in XMLRPC Server (#1287 <https://github.com/ros/ros_comm/issues/1287>)
```

## roslaunch

```
* fix "pass_all_args" for roslaunch-check, add nosetest (#1368 <https://github.com/ros/ros_comm/issues/1368>)
* add --log option to roslaunch (#1330 <https://github.com/ros/ros_comm/issues/1330>)
* add substitution when loading yaml files (#1354 <https://github.com/ros/ros_comm/issues/1354>)
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

```
* allow disabling rosout file logging (to rosout.log) (#1381 <https://github.com/ros/ros_comm/issues/1381>)
```

## rosparam

- No changes

## rospy

```
* add API to suppress sequential identical messages (#1309 <https://github.com/ros/ros_comm/issues/1309>)
* add parameter to stop clients from generating rosout topics list (#1241 <https://github.com/ros/ros_comm/issues/1241>)
* add rosconsole echo (#1324 <https://github.com/ros/ros_comm/issues/1324>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

```
* add public get_topic_list() function for use in other scripts (#1154 <https://github.com/ros/ros_comm/issues/1154>)
```

## roswtf

```
* warn if ROS_IP contains whitespace (#1379 <https://github.com/ros/ros_comm/issues/1379>)
```

## topic_tools

```
* throttling when rostime jump backward (#1397 <https://github.com/ros/ros_comm/issues/1397>)
* check that output topic is valid in demux (#1367 <https://github.com/ros/ros_comm/issues/1367>)
* add latch functionality to topic_tools/transform (#1341 <https://github.com/ros/ros_comm/issues/1341>)
```

## xmlrpcpp

```
* fixes for OSX (#1402 <https://github.com/ros/ros_comm/issues/1402>)
* take XmlRpcValue by *const* ref. in operator<< (#1350 <https://github.com/ros/ros_comm/issues/1350>)
* fix various compiler warnings on bionic (#1325 <https://github.com/ros/ros_comm/issues/1325>)
```
