### PR TITLE
metapackages: 1.4.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1251,7 +1251,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/metapackages-release.git
-      version: 1.4.0-0
+      version: 1.4.1-0
     source:
       type: git
       url: https://github.com/ros/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.4.1-0`:

- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.4.0-0`
