### PR TITLE
grasping_msgs: 0.3.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1104,6 +1104,21 @@ repositories:
       url: https://github.com/davetcoleman/graph_msgs-release.git
       version: 0.1.0-0
     status: maintained
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/mikeferguson/grasping_msgs-gbp.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: master
+    status: maintained
   grid_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grasping_msgs` to `0.3.1-0`:

- upstream repository: git@github.com:mikeferguson/grasping_msgs.git
- release repository: https://github.com/mikeferguson/grasping_msgs-gbp.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## grasping_msgs

```
* update email
* update description in package.xml
* Contributors: Michael Ferguson
```
