### PR TITLE
mrpt_navigation: 0.1.22-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1339,6 +1339,19 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: master
+    release:
+      packages:
+      - mrpt_local_obstacles
+      - mrpt_localization
+      - mrpt_map
+      - mrpt_navigation
+      - mrpt_rawlog
+      - mrpt_reactivenav2d
+      - mrpt_tutorials
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
+      version: 0.1.22-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.22-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mrpt_local_obstacles

```
* fix all catkin_lint errors
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_localization

```
* fix all catkin_lint errors
* remove exec +x flag to cfg files
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_map

```
* fix all catkin_lint errors
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_navigation

```
* fix all catkin_lint errors
* remove pkgs from metapkg list
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_rawlog

```
* fix all catkin_lint errors
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* fix all catkin_lint errors
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

```
* fix all catkin_lint errors
* Contributors: Jose Luis Blanco-Claraco
```
