### PR TITLE
indoor_positioning: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3760,10 +3760,16 @@ repositories:
       type: git
       url: https://github.com/metratec/indoor_positioning.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/metratec/indoor_positioning-release.git
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/metratec/indoor_positioning.git
       version: master
+    status: maintained
   industrial_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `indoor_positioning` to `1.0.2-0`:

- upstream repository: https://github.com/metratec/indoor_positioning.git
- release repository: https://github.com/metratec/indoor_positioning-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## indoor_positioning

```
* Renamed package from ros_ips to indoor_positioning
```
