### PR TITLE
Add svg.path to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1377,8 +1377,8 @@ python-gridfs:
 python-gst:
   arch: [gstreamer0.10-python]
   debian:
-    jessie:  [python-gst0.10]
-    wheezy:  [python-gst0.10]
+    jessie: [python-gst0.10]
+    wheezy: [python-gst0.10]
   fedora: [gstreamer-python]
   gentoo: [dev-python/gst-python]
   ubuntu:
@@ -1395,9 +1395,9 @@ python-gst:
     vivid: [python-gst0.10]
 python-gst-1.0:
   debian:
-    buster:  [python-gst-1.0]
-    jessie:  [python-gst-1.0]
-    stretch:  [python-gst-1.0]
+    buster: [python-gst-1.0]
+    jessie: [python-gst-1.0]
+    stretch: [python-gst-1.0]
   gentoo: ['dev-python/gst-python:1.0']
   ubuntu: [python-gst-1.0]
 python-gtk2:
@@ -1973,7 +1973,7 @@ python-numpydoc:
 python-oauth2:
   arch: [python-oauth2]
   debian:
-    wheezy:  [python-oauth2]
+    wheezy: [python-oauth2]
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
   ubuntu:
@@ -3449,6 +3449,14 @@ python-support:
     pip:
       packages: []
   ubuntu: [python-support]
+python-svg.path:
+  debian: [python-svg.path]
+  fedora: [python-svg-path]
+  ubuntu:
+    '*': [python-svg.path]
+    trusty:
+      pip:
+        packages: [svg.path]
 python-svn:
   debian: [python-svn]
   fedora: [pysvn]
@@ -3797,7 +3805,7 @@ python-ujson:
     yakkety: [python-ujson]
     zesty: [python-ujson]
 python-urlgrabber:
-  arch:   [urlgrabber]
+  arch: [urlgrabber]
   debian: [python-urlgrabber]
   fedora: [python-urlgrabber]
   gentoo: [dev-python/urlgrabber]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3450,7 +3450,11 @@ python-support:
       packages: []
   ubuntu: [python-support]
 python-svg.path:
-  debian: [python-svg.path]
+  debian:
+    '*': [python-svg.path]
+    jessie:
+      pip:
+        packages: [svg.path]
   fedora: [python-svg-path]
   ubuntu:
     '*': [python-svg.path]


### PR DESCRIPTION
* ubuntu: https://packages.ubuntu.com/search?keywords=python-svg.path
* debian: https://packages.debian.org/sid/python/python-svg.path
* fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/python-svg-path

Add this package for implementing some feature about picture
drawing which using svg files as input.

There's some spacing modification by `scrips/clean_rosdep_yaml.py`.