### PR TITLE
teraranger_array: 1.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11470,7 +11470,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git
-      version: 1.3.0-0
+      version: 1.3.1-1
     status: maintained
   teraranger_array_converter:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `1.3.1-1`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.3.0-0`

## teraranger_array

```
* Change default modes
* Re-add line removed by mistake
* Correct typo in example launch files
* Contributors: Pierre-Louis Kabaradjian
```
