### PR TITLE
Adding ftm_msgs to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2662,6 +2662,12 @@ repositories:
       url: https://github.com/paulbovbel/frontier_exploration.git
       version: indigo-devel
     status: maintained
+  ftm_msgs:
+    source:
+      type: git
+      url: https://github.com/guykhazma/ftm_msgs.git
+      version: master
+    status: unmaintained
   fzi_icl_can:
     doc:
       type: git


### PR DESCRIPTION
I would like to be indexed and documented on ros.org