### PR TITLE
Revert "realtime_tools: 1.12.0-0 in 'melodic/distribution.yaml'"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1785,7 +1785,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.12.0-0
+      version: 1.11.0-0
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Reverts ros/rosdistro#17924.  This caused breakage with downstream consumers of these packages.