### PR TITLE
audio_common: 0.3.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -130,7 +130,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.2-0
+      version: 0.3.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.3-0`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.2-0`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

- No changes

## sound_play

```
* Fix gstreamer errors. Fixes #108 <https://github.com/ros-drivers/audio_common/issues/108>
* Contributors: trainman419
```
