### PR TITLE
moveit: 0.10.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1272,6 +1272,48 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: melodic-devel
     status: maintained
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: melodic-devel
+    release:
+      packages:
+      - chomp_motion_planner
+      - moveit
+      - moveit_commander
+      - moveit_controller_manager_example
+      - moveit_core
+      - moveit_experimental
+      - moveit_fake_controller_manager
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_chomp
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_manipulation
+      - moveit_ros_move_group
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_setup_assistant
+      - moveit_simple_controller_manager
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit-release.git
+      version: 0.10.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: melodic-devel
+    status: developed
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.10.0-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## chomp_motion_planner

```
* [fix] for chomp fixed base joint bug (#870 <https://github.com/ros-planning/moveit/issues/870>)
* [maintenance] MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [maintenance] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* Contributors: Bence Magyar, Dave Coleman, Ian McMahon, Mike Lautman, Xiaojian Ma
```

## moveit

- No changes

## moveit_commander

```
* Merge pull request #861 <https://github.com/ros-planning/moveit/issues/861> from BryceStevenWilley/patch-1
  Fix and Test for #842 <https://github.com/ros-planning/moveit/issues/842>
* Added a test for PlanningSceneInterface
  Ensures that you can construct a PlanningSceneInterface without having to pass an explicit namespace.
* Fix #842 <https://github.com/ros-planning/moveit/issues/842>
  Adds a optional namespace argument to the python side of planning_scene_interface and passes it to the wrapped C++, which expects a namespace after #835 <https://github.com/ros-planning/moveit/issues/835>.
* Remove trailing whitespace from py, xml, launch files (#837 <https://github.com/ros-planning/moveit/issues/837>)
* Feature/markers and states (#836 <https://github.com/ros-planning/moveit/issues/836>)
  * Add python goodies
  * Update planning interface tests for namespace arg
  * Add namespace tests
  * Update moveit commander for namespacing
  * Add moveit commander tests
  * Add movegroup test in namespace
  * Update param scopes in template and launch files
  * Code formatting
  * Add functionality to get robot markers and plan from state
  * is None is not None
* Add namespace capabilities to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
  * Add python goodies
  * Update planning interface tests for namespace arg
  * Add namespace tests
  * Update moveit commander for namespacing
  * Add moveit commander tests
  * Add movegroup test in namespace
  * Update param scopes in template and launch files
  * Code formatting
  * Add BSD License and name
  * Add description
  * Fix joy test
* Constrained Cartesian planning using moveit commander (#805 <https://github.com/ros-planning/moveit/issues/805>)
  * Add constraints to cartesian planning with moveit commander
  * clang formatting
  * Formatting, add comments
  * Add demo script
  * Fix minor typos in comments
* Handle robot_description parameter in RobotCommander (#782 <https://github.com/ros-planning/moveit/issues/782>)
* support TrajectoryConstraints in MoveGroupInterface + MoveitCommander (#793 <https://github.com/ros-planning/moveit/issues/793>)
* Add API to get planner_id (#788 <https://github.com/ros-planning/moveit/issues/788>)
  * Add a member function to get the current planner_id
  * Add python method to get planner_id
* Contributors: Akiyoshi Ochiai, Bence Magyar, Bryce Willey, Dave Coleman, Michael Görner, Ryan Keating, Will Baker, srsidd
```

## moveit_controller_manager_example

```
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* Contributors: Mikael Arguedas
```

## moveit_core

```
* Merge pull request #906 <https://github.com/ros-planning/moveit/issues/906> from ubi-agni/compile-fixes
  various fixes for melodic build
* adapt unittests after update to tf2
* KDL solvers: provide dummy updateInternalDataStructures()
  ... for new abstract method in KDL 1.4.0 of Melodic
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* Fix allocator type to pass GCC8 static assert. (#888 <https://github.com/ros-planning/moveit/issues/888>)
* testAbsoluteJointSpaceJump: improve readability of code (#864 <https://github.com/ros-planning/moveit/issues/864>)
* code clean up of moveit_core (#882 <https://github.com/ros-planning/moveit/issues/882>)
  * code clean up of moveit_core
  * code clean up of moveit_core
* fixup! do not always print visible messages when attaching (#878 <https://github.com/ros-planning/moveit/issues/878>)
* fixup! fix printf conversion specifiers for logging  (#876 <https://github.com/ros-planning/moveit/issues/876>)
* do not always print visible messages when attaching (#878 <https://github.com/ros-planning/moveit/issues/878>)
  This should not be a public message.
  Especially annoying because the RViz display calls this
  function quite often when displaying trajectories with attached objects.
* fix printf conversion specifiers for logging  (#876 <https://github.com/ros-planning/moveit/issues/876>)
  * printf size_t values with %zu
* [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
  * [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE
  * [Fix] clang format
  * [Fix] manually fix bad clang-formatting in strings
* robot_state/test: remove introduced dependency to moveit_ros_planning/rdf_loader (#850 <https://github.com/ros-planning/moveit/issues/850>)
* Remove variable name KinematicConstraint::print() to avoid compilation warning (#849 <https://github.com/ros-planning/moveit/issues/849>)
* Add ability to request detailed distance information from fcl (#662 <https://github.com/ros-planning/moveit/issues/662>)
  Expose the ability to request detailed distance information from FCL. New virtual methods distanceXXX(DistanceRequest&, DistanceResult&) are provided in CollisionRobot and CollisionWorld. Existing methods were adapted to use the new underlying infrastructure of DistanceRequests.
* improved checking for joint-space jumps of Cartesian path (#843 <https://github.com/ros-planning/moveit/issues/843>)
  * adding absolute jump threshold capability in parallel, also adding test coverage
  * formatting of comments, reduce redundancy
  * inline definition of convienency methods
  * improve readability: always call testJointSpaceJump()
  * reduce redundancy, improve efficiency
  * restore old code were applicable
  * cleanup tests
  * changing struct variable names to be less redundant, improving tests, removing throw error from abs jump test
  * revert test changes
  * relax testing conditions
  - test for both, relative and absolute jumps (if corresponding thresholds > 0)
  - skip revolute/prismatic if threshold is <= 0
  * cherry-pick reworked log messages
  * cherry-pick test changes: use default joint pose
  * extend unittests: test both direct and indirect methods
  * consistent order: 1st: revolute, 2nd: prismatic
  * fixup! extend unittests: test both direct and indirect methods
  * computeCartesianPath: only test for jump if there's something to check
  If the trajectory consists only of the first (current) robot state,
  there is no need to test for joint space jumps and thus we avoid
  printing the new warning "too few points to test" in this case.
* code clean up of robot_model (#820 <https://github.com/ros-planning/moveit/issues/820>)
  mostly remove explicit moveit::core namespaces everywhere
* code clean up of robot_state.cpp (#815 <https://github.com/ros-planning/moveit/issues/815>)
  * code clean up of robot_state.cpp
  * updated with clang-format
* Simplify adding CollisionObjects with colors (#810 <https://github.com/ros-planning/moveit/issues/810>)
  To facilitate assignment of object colors in addCollisionObjects() and applyCollisionObjects(),
  the object id of the CollisionObject is reused for ObjectColors if not specified.
* fixed typo
* fix RobotState::computeCartesianPath
  - consider both, translational and rotational distance to compute number interpolation of steps
  - ensure that quaternions are on same half sphere before doing quaternion slerp
* cleanup jump threshold test in computeCartesianPath (#784 <https://github.com/ros-planning/moveit/issues/784>)
  Issue a warning if too few trajectory waypoints are available for jump threshold test.
  This would result in unreliable testing.
* Merge pull request #768 <https://github.com/ros-planning/moveit/issues/768> from ubi-agni/fix-mimic-joint-updates
  fix updateMimicJoint()
* mark updated mimic joints as dirty
* test mimic joint updates
* unittests: simplify verification of Eigen matrices
* replace deprecated logging macros with CONSOLE_BRIDGE macros (#787 <https://github.com/ros-planning/moveit/issues/787>)
  - replace log* macros with CONSOLE_BRIDGE_log* macros
  - replace printf commands for size_t: %u -> %zu
* updateMimicJoint(group->getMimicJointModels()) -> updateMimicJoints(group)
  Clearly indicate the fact, that the functions
  updateMimicJoint(group->getMimicJointModels()) and
  markDirtyJointTransforms(group)
  need to be called together!
* Merge pull request #765 <https://github.com/ros-planning/moveit/issues/765> from ubi-agni/warp-link
  improve RobotState::updateStateWithLinkAt()
* extended documentation
* fix computation of shape_extents_ of links w/o shapes (#766 <https://github.com/ros-planning/moveit/issues/766>)
* Merge pull request #769 <https://github.com/ros-planning/moveit/issues/769> from ubi-agni/improve-eef-mapping
  improve association of IK solvers to groups
* fix updateMimicJoint()
  Although the joint transform was marked dirty, the corresponding link transforms were not!
* improve comments associating kinematics solvers to groups
* updateStateWithLinkAt(backward=true): mark all collision body transforms dirty
* improve doc for updateStateWithLinkAt()
* reduce code bloat
* RobotModel::getRigidlyConnectedParentLinkModel()
  ... to compute earliest parent link that is rigidly connected to a given link
* Iterative cubic spline (#441 <https://github.com/ros-planning/moveit/issues/441>)
  * adding iterative spline time parameterization
  * add 2nd and 2nd-last points
  * move added points near endpoints, but not exactly the same.  Fix math error.
  * add jerk comment
  * clang-formatting
  * prevent divide-by-zero. Fix out-of-bounds array write
  * fix variables
  * off by one error.  change default limits
  * comments
  * fix for setting waypoint durations
  * comments
  * add time parameterization unit test
  * styling
  * add compile-time option to disable jerk
  * allow jerk to be enabled/disabled at runtime
  * make requested changes, the biggest of which is allowing for min and max constraints
  * add duration check to unit test
  * set default acceleration to 1.0
  * fix class name
  * add migration notes
  * whitespace styling
  * set waypoint velocities/accelerations when unset.  Increase default jerk limit.  Modify test case to catch this.
  * improved handling of unspecified initial/final velocities/accelerations
  * change 0.01 constant to epsilon()
  * simplify tests
  * styling
  * Remove jerk, as it causes oscillations
* Merge pull request #703 <https://github.com/ros-planning/moveit/issues/703> from tradr-project/fix_bbox-kinetic
  Fixed bugs in computation of AABB in LinkModel and RobotState.
* Addressed rhaschke's comments.
* Added a test for the AABB of a specific rotated link on the PR2.
* Fixed buggy AABB computation.
  Also added a way to visualize both AABBs and OBBs in RViz to verify.
* Merge pull request #731 <https://github.com/ros-planning/moveit/issues/731> from ros-planning/pr-clang-tidy-collision
  As per #28 <https://github.com/ros-planning/moveit/issues/28>, I setup and documented how to run clang-tidy on the codebase, and tested it on the collision_detection and collision_detection_fcl folders. I chose these two because they were small, so I could get feedback on what to change before applying to the entire repo.
  The clang-tidy config file is based on https://github.com/davetcoleman/rviz_visual_tools/blob/kinetic-devel/.clang-tidy and adds some more checks to the code.
* Better naming for clang-changed variables.
* Changed shared pointer in constructor back and added NOLINT.
* Little fixes following Dave Colemans' suggestions.
* clang-format run
* Fixed computation of a the AABB of links and models.
* Ran clang-format.
* Fixed more modernize issues.
* Moved clang-tidy docs to the website.
* Forgot to format the include files.
* Stopped reusing an existing name and clang-format on collision_dection.
* Ran clang-tidy and clang-format on collision_dection and collision_detection_fcl.
* Documented how to clang-tidy with run-clang-tidy-3.8.py
* Fixed a deprecated call to console bridge.
* Contributors: 2scholz, Bryce Willey, Ian McMahon, Ken Anderson, Levi Armstrong, Maarten de Vries, Martin Pecka, Michael Görner, Mike Lautman, Patrick Holthaus, Robert Haschke, Victor Lamoine, Xiaojian Ma, bailaC
```

## moveit_experimental

```
* Merge pull request #906 <https://github.com/ros-planning/moveit/issues/906> from ubi-agni/compile-fixes
  various fixes for melodic build
* boost::shared_ptr to std::shared_ptr
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* fix printf conversion specifiers for logging  (#876 <https://github.com/ros-planning/moveit/issues/876>)
  * printf size_t values with %zu
* [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
  * [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE
  * [Fix] clang format
  * [Fix] manually fix bad clang-formatting in strings
* Merge pull request #863 <https://github.com/ros-planning/moveit/issues/863> from ubi-agni/fix-buid-farm-issues
  * fix various cmake warnings
  * remove not required test dependency
  * replaced 2nd find_package(catkin ...)
* fix various cmake warnings
* Add ability to request detailed distance information from fcl (#662 <https://github.com/ros-planning/moveit/issues/662>)
  Expose the ability to request detailed distance information from FCL. New virtual methods distanceXXX(DistanceRequest&, DistanceResult&) are provided in CollisionRobot and CollisionWorld. Existing methods were adapted to use the new underlying infrastructure of DistanceRequests.
* Contributors: Bence Magyar, Ian McMahon, Levi Armstrong, Mikael Arguedas, Robert Haschke, Xiaojian Ma
```

## moveit_fake_controller_manager

```
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
  * [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE
  * [Fix] clang format
  * [Fix] manually fix bad clang-formatting in strings
* Contributors: Mikael Arguedas, Xiaojian Ma
```

## moveit_kinematics

```
* Merge pull request #906 <https://github.com/ros-planning/moveit/issues/906> from ubi-agni/compile-fixes
  various fixes for melodic build
* KDL solvers: provide dummy updateInternalDataStructures()
  ... for new abstract method in KDL 1.4.0 of Melodic
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
  * [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE
  * [Fix] clang format
  * [Fix] manually fix bad clang-formatting in strings
* Merge pull request #863 <https://github.com/ros-planning/moveit/issues/863> from ubi-agni/fix-buid-farm-issues
  * fix various cmake warnings
  * remove not required test dependency
  * replaced 2nd find_package(catkin ...)
* fix various cmake warnings
* Improve ikfast kinematics plugin (#808 <https://github.com/ros-planning/moveit/issues/808>)
  * Initialize constant num_joints_ in constructor.
  * Check size of input array in getPositionFK.
  * Fix implementation error.
  * Add name variable to ikfast plugin.
* Cached ik kinematics plugin (#612 <https://github.com/ros-planning/moveit/issues/612>)
  add caching wrapper for IK solvers
  * - Remove OMPL dependency, add slightly modified versions of OMPL code to this repo
  - Change camelCase variable names to underscore_names
  - Use /** ... */ for doxygen comments instead of /// ...
  - Fix memory leak
  - Various small fixes
  * handle optional TRAC-IK dependency a different way
  * remove OMPL_INCLUDE_DIRS
  * include trac_ik headers optionally *after* moveit includes
  Sorting dependency-includes via catkin breaks either way around
  with multiple find_package calls and can always break
  overlaying workspaces.
  However, ${catkin_INCLUDE_DIRS} contains many more dependencies
  than ${trac_ik_kinematics_plugin_INCLUDE_DIRS}, so avoid more
  breakage than necessary by including catkin_INCLUDE_DIRS first.
  * add missing include
  * Don't write configured file to build dir. Can't write to src dir either since it might be read-only. Instead, just comment out the parts that are for development / testing purposes only.
  * ik cache: use lookupParam for plugin parameters
* Contributors: Ian McMahon, Mark Moll, Mikael Arguedas, Robert Haschke, Xiaojian Ma, martiniil
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* [fix] dependencies for chomp interface test (#778 <https://github.com/ros-planning/moveit/issues/778>)
* [maintenance][chomp_motion_planner] MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [capability] namespace to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
* Contributors: Bence Magyar, Dave Coleman, Ian McMahon, Mikael Arguedas, Robert Haschke, Stephan, Will Baker
```

## moveit_planners_ompl

```
* Merge pull request #906 <https://github.com/ros-planning/moveit/issues/906> from ubi-agni/compile-fixes
  various fixes for melodic build
* ompl's cmake file uses lowercase
* adaptions for OMPL 1.4 (#903 <https://github.com/ros-planning/moveit/issues/903>)
  Defined an OMPLProjection that is typedef'd to work with versions <= 1.4 of OMPL
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
  * [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE
  * [Fix] clang format
  * [Fix] manually fix bad clang-formatting in strings
* Make trajectory interpolation in MoveIt consistent to OMPL (#869 <https://github.com/ros-planning/moveit/issues/869>)
  Adapt final path simplification to match latest OMPL changes:
  As optimizing planners, like RRT*, consume all planning time, there should be at least one final simplification step. If more time is available OMPL will continue simplifying the path. No need for checking the time in MoveIt anymore.
  Resolved redundancy of parameters longest_valid_segment_fraction and max_waypoint_distance, only passing the most conservative to OMPL.
* Contributors: Bryce Willey, Ian McMahon, Mikael Arguedas, Robert Haschke, Xiaojian Ma
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* Contributors: Ian McMahon, Mikael Arguedas
```

## moveit_ros_control_interface

```
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* fixed a small typo in README (#794 <https://github.com/ros-planning/moveit/issues/794>)
* Contributors: Mikael Arguedas, Mohmmad Ayman
```

## moveit_ros_manipulation

```
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* Contributors: Ian McMahon, Mikael Arguedas
```

## moveit_ros_move_group

```
* Merge pull request #833 <https://github.com/ros-planning/moveit/issues/833> from davetcoleman-melodic-execute-service
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* Remove deprecated ExecuteTrajectoryServiceCapability in Melodic
  - Add MIGRATION.md file
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* Cleanup source of execute trajectory action capability (#834 <https://github.com/ros-planning/moveit/issues/834>)
* Add namespace capabilities to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
  * Add python goodies
  * Update planning interface tests for namespace arg
  * Add namespace tests
  * Update moveit commander for namespacing
  * Add moveit commander tests
  * Add movegroup test in namespace
  * Update param scopes in template and launch files
  * Code formatting
  * Add BSD License and name
  * Add description
  * Fix joy test
* disable flaky unittest (#771 <https://github.com/ros-planning/moveit/issues/771>)
  ... introduced in #756 <https://github.com/ros-planning/moveit/issues/756>
* MoveAction capability can drop cancel request if it is sent shortly after goal is sent (#756 <https://github.com/ros-planning/moveit/issues/756>)
  * add unittests to check for dropped cancelling of move action
  * prevent cancelling of move actionstarts to be dropped
* Contributors: Dave Coleman, Ian McMahon, Mikael Arguedas, Robert Haschke, Will Baker, khupilz
```

## moveit_ros_perception

```
* Merge pull request #906 <https://github.com/ros-planning/moveit/issues/906> from ubi-agni/compile-fixes
  various fixes for melodic build
* boost::shared_ptr to std::shared_ptr
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* cleanup typo in perception CMakeLists.txt (#825 <https://github.com/ros-planning/moveit/issues/825>)
* moveit_ros_perception: make OpenGL parts optional (#698 <https://github.com/ros-planning/moveit/issues/698>)
  But build everything by default.
  This commit is motivated by the work on the OpenEmbedded layer
  for ROS, a cross-compilation tool chain environment for ROS
  packages. We would like to allow to use moveit_ros_perception
  in embedded systems without OpenGL support.
  Signed-off-by: Dmitry Rozhkov <mailto:dmitry.rozhkov@linux.intel.com>
  [Ported Dmitry's patch from indigo to current kinetic branch,
  renamed build config, elaborated commit message]
  Signed-off-by: Lukas Bulwahn <mailto:lukas.bulwahn@gmail.com>
* Contributors: Bence Magyar, Ian McMahon, Lukas Bulwahn, Michael Görner, Mikael Arguedas, Robert Haschke
```

## moveit_ros_planning

```
* Fix multi dof validate trajectory (#905 <https://github.com/ros-planning/moveit/issues/905>)
  bugfix: correctly check names of multidof trajectory
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* explicitly enforce updateSceneWithCurrentState() in waitForCurrentRobotState() (#824 <https://github.com/ros-planning/moveit/issues/824>)
* execution manager: use variable for named logging (#838 <https://github.com/ros-planning/moveit/issues/838>)
* Support static TFs for multi-DOF joints in CurrentStateMonitor (#799 <https://github.com/ros-planning/moveit/issues/799>)
* Merge pull request #796 <https://github.com/ros-planning/moveit/issues/796> from ubi-agni/msa-xacro-args
  msa: added support for xacro args
* rdf_loader: remove --inorder xacro argument
  this should be provided in xacro_args
* CSM: wait for *active* joint states only (#792 <https://github.com/ros-planning/moveit/issues/792>)
  We don't expect that drivers publish the transforms for fixed joints
  Fixup for 739a85a4820ec68fecd31f51519ecc92a50f8c7e
  It wasn't a problem before because the checks used variable names
  and fixed joints do not have variables. So nothing was checked.
* Merge pull request #769 <https://github.com/ros-planning/moveit/issues/769> from ubi-agni/improve-eef-mapping
  improve association of IK solvers to groups
* add warning about undefined kinematics plugins
* cherry-pick #753 <https://github.com/ros-planning/moveit/issues/753>: skip non-actuated joints for execution (#754 <https://github.com/ros-planning/moveit/issues/754>)
* clang-format fix
* Allow wait time to be specified for getCurrentState() (#685 <https://github.com/ros-planning/moveit/issues/685>)
  Expose wait_time argument to MoveGroupInterface::getCurrentState()
* fix newly introduced error (#758 <https://github.com/ros-planning/moveit/issues/758>)
* Iterative cubic spline (#441 <https://github.com/ros-planning/moveit/issues/441>)
  * adding iterative spline time parameterization
  * add 2nd and 2nd-last points
  * move added points near endpoints, but not exactly the same.  Fix math error.
  * add jerk comment
  * clang-formatting
  * prevent divide-by-zero. Fix out-of-bounds array write
  * fix variables
  * off by one error.  change default limits
  * comments
  * fix for setting waypoint durations
  * comments
  * add time parameterization unit test
  * styling
  * add compile-time option to disable jerk
  * allow jerk to be enabled/disabled at runtime
  * make requested changes, the biggest of which is allowing for min and max constraints
  * add duration check to unit test
  * set default acceleration to 1.0
  * fix class name
  * add migration notes
  * whitespace styling
  * set waypoint velocities/accelerations when unset.  Increase default jerk limit.  Modify test case to catch this.
  * improved handling of unspecified initial/final velocities/accelerations
  * change 0.01 constant to epsilon()
  * simplify tests
  * styling
  * Remove jerk, as it causes oscillations
* Floating Joint Support in CurrentStateMonitor (#748 <https://github.com/ros-planning/moveit/issues/748>)
  * allow CSM to update any multi-dof joint via TF
  Previously this was limited to the root link of the robot.
  * change key of time map from string to JointModel*
  * remove obsolete private method isPassiveOrMimicDOF
* validate multi-dof trajectories before execution (#713 <https://github.com/ros-planning/moveit/issues/713>)
  * validate multi-dof trajectories before execution
  * addressed Dave's comments
* Contributors: Bruno Brito, Dave Coleman, Ian McMahon, Ken Anderson, Michael Görner, Mikael Arguedas, Phil, Robert Haschke
```

## moveit_ros_planning_interface

```
* [maintenance] Remove deprecated ExecuteTrajectoryServiceCapability in Melodic #833 <https://github.com/ros-planning/moveit/issues/833>
* [maintenance] MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [maintenance] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* [capability] namespace to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
* Constrained Cartesian planning using moveit commander (#805 <https://github.com/ros-planning/moveit/issues/805>)
* Simplify adding CollisionObjects with colors (#810 <https://github.com/ros-planning/moveit/issues/810>)
* support TrajectoryConstraints in MoveGroupInterface + MoveitCommander (#793 <https://github.com/ros-planning/moveit/issues/793>)
* Add API to get planner_id (#788 <https://github.com/ros-planning/moveit/issues/788>)
* Allow wait time to be specified for getCurrentState() (#685 <https://github.com/ros-planning/moveit/issues/685>)
* Contributors: 2scholz, Akiyoshi Ochiai, Bence Magyar, Dave Coleman, Ian McMahon, Robert Haschke, Will Baker, Xiaojian Ma, srsidd
```

## moveit_ros_robot_interaction

```
* [fix] interaction with planar joints (#767 <https://github.com/ros-planning/moveit/issues/767>)
* [maintenance] boost::shared_ptr to std::shared_ptr
* [maintenance] MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [enhance] association of IK solvers to groups #769 <https://github.com/ros-planning/moveit/issues/769>
* Contributors: Bence Magyar, Ian McMahon, Michael Görner, Robert Haschke
```

## moveit_ros_visualization

```
* Merge pull request #906 <https://github.com/ros-planning/moveit/issues/906> from ubi-agni/compile-fixes
  various fixes for melodic build
* moveit_ros_visualization: build_depend on qt-dev + ogre-dev
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* rviz plugin: set start/goal RobotState from external (#823 <https://github.com/ros-planning/moveit/issues/823>)
  - /rviz/moveit/update_custom_start_state
  - /rviz/moveit/update_custom_goal_state
  stopping from external:
  - /rviz/moveit/stop
* Save and resume approximate_IK UI setting for easier usage (#841 <https://github.com/ros-planning/moveit/issues/841>)
* Remove trailing whitespace from py, xml, launch files (#837 <https://github.com/ros-planning/moveit/issues/837>)
* Add namespace capabilities to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
  * Add python goodies
  * Update planning interface tests for namespace arg
  * Add namespace tests
  * Update moveit commander for namespacing
  * Add moveit commander tests
  * Add movegroup test in namespace
  * Update param scopes in template and launch files
  * Code formatting
  * Add BSD License and name
  * Add description
  * Fix joy test
* consider shape transform for OcTree
* MotionPlanningDisplay: check for parent widget (#801 <https://github.com/ros-planning/moveit/issues/801>)
* show/hide panel if display is enabled/disabled (#760 <https://github.com/ros-planning/moveit/issues/760>)
* fix realtime trajectory display (#761 <https://github.com/ros-planning/moveit/issues/761>)
  Don't reset current_state_time_ to zero, but continously increment it based on wall_dt.
  This ensures that waypoints are displayed in realtime.
* Contributors: Alexander Rössler, Dave Coleman, Ian McMahon, Mikael Arguedas, Pan Hy, Phy, Robert Haschke, Will Baker
```

## moveit_ros_warehouse

```
* [maintenance][warehouse] MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
* Contributors: Ian McMahon
```

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* MoveIt! tf2 migration (#830 <https://github.com/ros-planning/moveit/issues/830>)
  migration from tf to tf2 API, resolves issue #745 <https://github.com/ros-planning/moveit/issues/745>
  - All type conversions now depend on geometry2 ROS packages, rather than geometry
  (see https://github.com/ros/geometry2/pull/292 and
  https://github.com/ros/geometry2/pull/294 for details of the new conversions)
  - Removes all boost::shared_ptr<tf::TransformListener> from the API,
  and replaced them with std::shared_ptr<tf2_ros::Buffer>'s
  - Utilize new tf2 API in the tf::Transformer library to access the internal tf2::Buffer of RViz
  (see https://github.com/ros/geometry/pull/163 for details of the new API)
  - Removes prepending of forward slashes ('/') for transforms frames as this is deprecated in tf2
  - Replaced deprecated tf2 _getLatestCommonTime
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* Remove trailing whitespace from py, xml, launch files (#837 <https://github.com/ros-planning/moveit/issues/837>)
* Add namespace capabilities to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
  * Add python goodies
  * Update planning interface tests for namespace arg
  * Add namespace tests
  * Update moveit commander for namespacing
  * Add moveit commander tests
  * Add movegroup test in namespace
  * Update param scopes in template and launch files
  * Code formatting
  * Add BSD License and name
  * Add description
  * Fix joy test
* Merge pull request #795 <https://github.com/ros-planning/moveit/issues/795> from ubi-agni/msa-yaml-parsing
  msa: cleanup yaml parsing
* simplify YAML parsing
  - using utility function parse()
  - removing yaml-cpp 0.3 support
* cleanup yaml parsing
  - limit findValue to std::string key
  using templates for char[N] is ineffient, as every literal of new
  length N requires a new template instance
  - use boost::optional constructor to return value
* actually use found yaml-cpp
* Merge pull request #796 <https://github.com/ros-planning/moveit/issues/796> from ubi-agni/msa-xacro-args
  msa: added support for xacro args
* allow to edit xacro args
* cleanup LoadPathWidget API
  - use QString were suitable
  - pass parent before bool options
* report about xacro errors
* Merge pull request #769 <https://github.com/ros-planning/moveit/issues/769> from ubi-agni/improve-eef-mapping
  improve association of IK solvers to groups
* jmg is also considered for collision checking
* clarify that joints and links always go in pairs
* 'or' to indicate config methods are alternative options
* MSA: extended explanation of planning group + end effector
* MSA: fix setting of group states (#762 <https://github.com/ros-planning/moveit/issues/762>)
  * allow same pose name in different groups
  * only consider active joints when defining named poses
* cherry-pick #753 <https://github.com/ros-planning/moveit/issues/753>: skip non-actuated joints for execution (#754 <https://github.com/ros-planning/moveit/issues/754>)
* Contributors: Dave Coleman, Ian McMahon, Michael Görner, Mikael Arguedas, Robert Haschke, Will Baker
```

## moveit_simple_controller_manager

```
* update include statements to use new pluginlib and class_loader headers (#827 <https://github.com/ros-planning/moveit/issues/827>)
* [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
  * [Fix] switch to ROS_LOGGER from CONSOLE_BRIDGE
  * [Fix] clang format
  * [Fix] manually fix bad clang-formatting in strings
* Contributors: Mikael Arguedas, Xiaojian Ma
```
