### PR TITLE
ros_canopen: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12062,7 +12062,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.6.9-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.8-0`

## can_msgs

- No changes

## canopen_402

```
* fix initialization bug in ProfiledPositionMode
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

- No changes

## canopen_master

- No changes

## canopen_motor_node

- No changes

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

```
* explicitly include iostream to compile with boost >= 1.65.0
* Contributors: Lukas Bulwahn
```
