### PR TITLE
ros_canopen: 0.7.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2933,7 +2933,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.8-0
+      version: 0.7.9-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.9-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.7.8-0`

## can_msgs

- No changes

## canopen_402

```
* fix initialization bug in ProfiledPositionMode
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

- No changes

## canopen_master

```
* provided KeyHash
  for use with unordered containers
* added c_array access functons to can::Frame
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

```
* introduced HandleLayerSharedPtr
* Contributors: Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

```
* compare can_msgs::Frame and can::Frame properly
* Contributors: Mathias Lüdtke
```

## socketcan_interface

```
* introduced ROSCANOPEN_MAKE_SHARED
* added c_array access functons to can::Frame
* Contributors: Mathias Lüdtke
```
