### PR TITLE
smp_ros: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11026,6 +11026,18 @@ repositories:
       url: https://github.com/larics/smartek_camera.git
       version: master
     status: maintained
+  smp_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ksatyaki/smp_ros-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ksatyaki/smp_ros.git
+      version: master
+    status: developed
   sns-ik:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `smp_ros` to `1.0.0-0`:

- upstream repository: https://github.com/ksatyaki/smp_ros.git
- release repository: https://github.com/ksatyaki/smp_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
