### PR TITLE
rosdep: Add python django

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4721,12 +4721,6 @@ vrep:
     trusty:
       source:
         uri: 'https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest'
-werkzeug:
-  arch: [python-werkzeug]
-  debian: [python-werkzeug]
-  fedora: [python-werkzeug]
-  gentoo: [dev-python/werkzeug]
-  ubuntu: [python-werkzeug]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4721,6 +4721,12 @@ vrep:
     trusty:
       source:
         uri: 'https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest'
+werkzeug:
+  arch: [python-werkzeug]
+  debian: [python-werkzeug]
+  fedora: [python-werkzeug]
+  gentoo: [dev-python/werkzeug]
+  ubuntu: [python-werkzeug]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3828,6 +3828,7 @@ python-webtest:
   gentoo: [dev-python/webtest]
   ubuntu: [python-webtest]
 python-werkzeug:
+  arch: [python-werkzeug]
   debian: [python-werkzeug]
   fedora: [python-werkzeug]
   gentoo: [dev-python/werkzeug]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -882,7 +882,7 @@ python-defusedxml:
       packages: [defusedxml]
   ubuntu: [python-defusedxml]
 python-django:
-  arch: [python-django]
+  arch: [python2-django]
   debian: [python-django]
   fedora: [python-django]
   gentoo: [dev-python/django]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -881,6 +881,15 @@ python-defusedxml:
     pip:
       packages: [defusedxml]
   ubuntu: [python-defusedxml]
+python-django:
+  arch: [python-django]
+  debian: [python-django]
+  fedora: [python-django]
+  gentoo: [dev-python/django]
+  ubuntu: [python-django]
+python-django-extra-views:
+  debian: [python-django-extra-views]
+  ubuntu: [python-django-extra-views]
 python-dlib:
   debian:
     pip: [dlib]


### PR DESCRIPTION
Adding `python-django` and `python-django-extra-views` to `python.yaml`. Found packages for the following distributions where the generic name works for all OS versions I could find:

Arch:
  * https://www.archlinux.org/packages/?sort=&q=python-django&maintainer=&flagged=
  * Nothing for python-django-extra-views.

Debian:
  * https://packages.debian.org/search?keywords=python-django&searchon=names&suite=all&section=all
  * https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python-django-extra-views

Fedora:
  * https://apps.fedoraproject.org/packages/python-django
  * Nothing for python-django-extra-views.                                                                                  

Gentoo:
  * https://packages.gentoo.org/packages/dev-python/django
  * Nothing for python-django-extra-views.

Ubuntu:
  * https://packages.ubuntu.com/search?keywords=python-django&searchon=names&suite=all&section=all
  * https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python-django-extra-views&searchon=names

I successfully tested all of those distributions with `rosdep resolve` using my forked repo/branch of rosdep as spelled out in the [Contributing rosdep rules](http://docs.ros.org/independent/api/rosdep/html/contributing_rules.html) documentation.