### PR TITLE
rosdep: Add sparsehash bionic rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4721,12 +4721,6 @@ vrep:
     trusty:
       source:
         uri: 'https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest'
-werkzeug:
-  arch: [python-werkzeug]
-  debian: [python-werkzeug]
-  fedora: [python-werkzeug]
-  gentoo: [dev-python/werkzeug]
-  ubuntu: [python-werkzeug]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4721,6 +4721,12 @@ vrep:
     trusty:
       source:
         uri: 'https://raw.githubusercontent.com/peci1/vrep_ros_bridge/rdmanifest/vrep.rdmanifest'
+werkzeug:
+  arch: [python-werkzeug]
+  debian: [python-werkzeug]
+  fedora: [python-werkzeug]
+  gentoo: [dev-python/werkzeug]
+  ubuntu: [python-werkzeug]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4421,6 +4421,7 @@ sparsehash:
   gentoo: [dev-cpp/sparsehash]
   ubuntu:
     artful: [libsparsehash-dev]
+    bionic: [libsparsehash-dev]
     precise: [sparsehash]
     saucy: [sparsehash]
     trusty: [sparsehash]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3828,6 +3828,7 @@ python-webtest:
   gentoo: [dev-python/webtest]
   ubuntu: [python-webtest]
 python-werkzeug:
+  arch: [python-werkzeug]
   debian: [python-werkzeug]
   fedora: [python-werkzeug]
   gentoo: [dev-python/werkzeug]


### PR DESCRIPTION
Added entry to `base.yaml` for `sparsehash` to include Ubuntu Bionic. I successfully tested my branch as spelled out in the [Contributing rosdep rules](http://docs.ros.org/independent/api/rosdep/html/contributing_rules.html) documentation.

    $ rosdep resolve sparsehash --os=ubuntu:bionic
    #apt
    libsparsehash-dev
