### PR TITLE
robot_upstart: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8519,7 +8519,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.3.0-0`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.2-0`

## robot_upstart

```
* Add a dependency onto network-online.target (#67 <https://github.com/clearpathrobotics/robot_upstart/issues/67>)
* Clarify the reason of the error due to wrong pkgpath passed. (#57 <https://github.com/clearpathrobotics/robot_upstart/issues/57>)
* Allow ROS_HOME to be set previously by env file. (#54 <https://github.com/clearpathrobotics/robot_upstart/issues/54>)
* Contributors: Isaac I.Y. Saito, Thomas Furfaro, mhosmar-cpr
```
