### PR TITLE
robot_upstart: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1928,6 +1928,22 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: kinetic-devel
     status: maintained
+  robot_upstart:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/robot_upstart-release.git
+      version: 0.3.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/clearpathrobotics/robot_upstart.git
+      version: kinetic-devel
+    status: maintained
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.3.0-0`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## robot_upstart

```
* Add a dependency onto network-online.target (#67 <https://github.com/clearpathrobotics/robot_upstart/issues/67>)
* Clarify the reason of the error due to wrong pkgpath passed. (#57 <https://github.com/clearpathrobotics/robot_upstart/issues/57>)
* Allow ROS_HOME to be set previously by env file. (#54 <https://github.com/clearpathrobotics/robot_upstart/issues/54>)
* Contributors: Isaac I.Y. Saito, Thomas Furfaro, mhosmar-cpr
```
