### PR TITLE
mongodb_store: 0.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7252,7 +7252,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.3.8-1
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.4.0-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.8-1`

## libmongocxx_ros

```
* if compiler supports it use C++11
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_log

```
* if compiler supports it use C++11
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_store

```
* if compiler supports it use C++11
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_store_msgs

- No changes
