### PR TITLE
Melodic metapackages doc job workaround

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1252,7 +1252,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/metapackages.git
-      version: melodic-devel
+      version: melodic-workaround-doc-job
     release:
       packages:
       - desktop


### PR DESCRIPTION
See https://github.com/ros/metapackages/commit/9f1bebf6d06ea753c27aa9731896f175735e94ea for more info on why we are temporarily doing this; it will be reverted once we have a successful doc job build for metapackages.