### PR TITLE
ompl: 1.2.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6541,7 +6541,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.2.3-0
+      version: 1.2.3-1
     status: maintained
   omron_os32c_driver:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.2.3-1`:

- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.2.3-0`
