### PR TITLE
rosmon: 1.0.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3357,7 +3357,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.4-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.3-0`

## rosmon

```
* Merge pull request #30 <https://github.com/xqms/rosmon/issues/30> from xqms/feature/global_remap
  Support <remap> in other scopes than <node>. Fixes #28 <https://github.com/xqms/rosmon/issues/28>.
* Merge pull request #29 <https://github.com/xqms/rosmon/issues/29> from xqms/feature/fmt
  Port all string formatting to fmt
* update README.md, refer to ROS wiki
  Otherwise we duplicate the information.
* launch: keep pointer to current element in ParseContext
  This is in preparation for a refactoring of the error handling code. This
  way, we don't have to explicitly pass line number information around - we
  can instead pull it from the ParseContext when the error is generated.
* Merge pull request #27 <https://github.com/xqms/rosmon/issues/27> from xqms/feature/spec_tests
  roslaunch/XML spec unit tests
* launch: launch_config: error on <include clear_params="true" />
  Even the roslaunch/XML spec says this is "extremely dangerous". We will
  explicitly *not* support that one for now.
* launch: substitution_python: fix type deduction
  py::extract actually includes automatic conversion, so it is not
  appropriate for checking the returned object type. Use Python API instead.
* launch: handle <node clear_params="true"> attribute
* launch: launch_config: add support for <node cwd="..." />
* launch: launch_config: node uniqueness check should consider namespaces
* launch: substitution_python: report python exceptions more completely
* launch: launch_config: error if node name is not unique
* launch: launch_config: accept True/False as boolean values as well
  We are lenient here and accept the pythonic forms "True" and "False"
  as well, since roslaunch seems to do the same. Even the roslaunch/XML
  spec mentions True/False in the examples, even though they are not
  valid options for if/unless and other boolean attributes...
  http://wiki.ros.org/roslaunch/XML/rosparam
* launch_config: add check for invalid <param> combinations
* xml: param: test robustness against malformed tags
* launch: launch_config: propagate exceptions from lazy param threads
  .. to main thread.
* launch: launch_config: check if <param> commands exit normally
* launch_config: handle binfile
* launch: handle type "yaml" parameters (new in roslaunch since Lunar)
  This is actually a bit complicated, since this breaks a previous assumption
  we made: Our lazy evaluation of parameters depend on a 1:1 mapping of
  parameter names to jobs - this is not the case with YAML parameters, since
  one YAML file can turn into multiple params on the parameter server.
  So we handle YAML parameters separately from "ordinary" parameters, i.e.
  here our lazy evaluation does not prevent multiple loadings of the same
  parameters.
* cmake: basic rostest depends on rosmon target
  This makes sure that "make run_tests" also (re-)builds rosmon.
* launch: larger refactoring of param parsing
  Simplifies the forced type logic and applies it to "command" and "textfile"
  results as well.
* launch: split off as shared library and offer string parsing interface
  Preparation for more specific unit tests on roslaunch XML loading.
* CMakeLists.txt: option to create clang source-based coverage builds
* Contributors: Max Schwarz, Matthias Nieuwenhuisen
```
