### PR TITLE
rqt_dep: 0.4.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2348,7 +2348,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_dep-release.git
-      version: 0.4.8-0
+      version: 0.4.9-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_dep.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_dep` to `0.4.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_dep.git
- release repository: https://github.com/ros-gbp/rqt_dep-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.8-0`

## rqt_dep

```
* catch exceptions caused by threading to prevent crashing UI (#4 <https://github.com/ros-visualization/rqt_dep/issues/4>)
```
