### PR TITLE
network_interface: 2.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2133,6 +2133,21 @@ repositories:
       url: https://github.com/nerian-vision/nerian_stereo.git
       version: master
     status: developed
+  network_interface:
+    doc:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/astuff/network_interface-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    status: developed
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_interface` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/network_interface.git
- release repository: https://github.com/astuff/network_interface-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
