### PR TITLE
network_interface: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1486,6 +1486,21 @@ repositories:
       url: https://github.com/nerian-vision/nerian_stereo.git
       version: master
     status: developed
+  network_interface:
+    doc:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/astuff/network_interface-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: release
+    status: developed
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_interface` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/network_interface.git
- release repository: https://github.com/astuff/network_interface-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
