### PR TITLE
astuff_sensor_msgs: 2.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -115,6 +115,30 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_msgs.git
       version: master
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: release
+    release:
+      packages:
+      - astuff_sensor_msgs
+      - delphi_esr_msgs
+      - delphi_srr_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
+      - pacmod_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/astuff/astuff_sensor_msgs-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: release
+    status: developed
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `2.0.1-0`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
