### PR TITLE
openni2_camera: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1641,6 +1641,24 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.4.0-0
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
+    release:
+      packages:
+      - openni2_camera
+      - openni2_launch
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_camera-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: indigo-devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.3.0-0`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## openni2_camera

- No changes

## openni2_launch

```
* Move openni2_launch package into openni2_camera repository #55 <https://github.com/ros-drivers/openni2_camera/issues/55>
* Add rosdoc-based document.
* Contributors: Isaac I.Y. Saito
```
