### PR TITLE
axis_camera: 0.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -199,7 +199,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/axis_camera-release.git
-      version: 0.2.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/axis_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.3.0-0`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/ros-drivers-gbp/axis_camera-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.1-0`

## axis_camera

```
* Merge pull request #49 <https://github.com/ros-drivers/axis_camera/issues/49> from rossctaylor/feature/support_for_f34
  Add: support for Axis F34 multicamera switch
* Merge pull request #48 <https://github.com/ros-drivers/axis_camera/issues/48> from tonybaltovski/pan-tilt-parms
  Added ROS params for the pan and tilt axis.
* Contributors: Ross Taylor, Tony Baltovski
```
