### PR TITLE
pid: 0.0.25-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1738,7 +1738,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AndyZe/pid-release.git
-      version: 0.0.24-0
+      version: 0.0.25-0
     source:
       type: git
       url: https://bitbucket.org/AndyZe/pid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.25-0`:

- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZe/pid-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.24-0`
