### PR TITLE
sick_tim: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14386,7 +14386,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.13-0`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.12-0`

## sick_tim

```
* First release into melodic
* Fix mrs1000 frame_id parameter (#61 <https://github.com/uos/sick_tim/issues/61>)
  If frame_id parameter was defined to something other than "laser", the node would not publish the /scan topic and the /cloud header.frame_id would always be "laser" even if a different one was defined. This fixes both issues.
* Add min/max angle and range parameters to URDF macros (#60 <https://github.com/uos/sick_tim/issues/60>)
* catkin test-flag around roslaunch_add_file_check (#59 <https://github.com/uos/sick_tim/issues/59>)
  Eval CATKIN_ENABLE_TESTING prior to call roslaunch_add_file_check to ensure the function is defined.
* Contributors: Jacob Perron, Jeremie Deray, Patrick Hussey
```
