### PR TITLE
imu_tools: 1.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1323,7 +1323,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.1.5-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.0-0`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.1.5-0`

## imu_complementary_filter

```
* Add std dev parameter to orientation estimate from filter (#85 <https://github.com/ccny-ros-pkg/imu_tools/issues/85>)
  Similar to #41 <https://github.com/ccny-ros-pkg/imu_tools/issues/41>, but not using dynamic_reconfigure as not implemented for complementary filter
* Contributors: Stefan Kohlbrecher
```

## imu_filter_madgwick

```
* Remove outdated Makefile
* Add warning when IMU time stamp is zero
  Closes #82 <https://github.com/ccny-ros-pkg/imu_tools/issues/82>.
* update to use non deprecated pluginlib macro (#77 <https://github.com/ccny-ros-pkg/imu_tools/issues/77>)
* Contributors: Martin Günther, Mikael Arguedas
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
