### PR TITLE
ftm_msgs: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2667,6 +2667,11 @@ repositories:
       type: git
       url: https://github.com/guykhazma/ftm_msgs.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/guykhazma/ftm_msgs-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/guykhazma/ftm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ftm_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/guykhazma/ftm_msgs.git
- release repository: https://github.com/guykhazma/ftm_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
