### PR TITLE
robot_localization 2.5.2-1

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1998,6 +1998,22 @@ repositories:
       url: https://github.com/snt-robotics/robot_activity.git
       version: master
     status: developed
+  robot_localization:
+    doc:
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/cra-ros-pkg/robot_localization-release.git
+      version: 2.5.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: melodic-devel
+    status: developed
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
`bloom` threw a GitHub API error for the rosdistro PR.