### PR TITLE
marti_common: 2.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6826,7 +6826,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.2.1-0
+      version: 2.3.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.3.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.2.1-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Only calculate statistics when messages arrive in order (#516 <https://github.com/swri-robotics/marti_common/issues/516>)
* Contributors: David Anthony
```

## swri_rospy

- No changes

## swri_route_util

```
* Fill in route id of route positions when possible. (#517 <https://github.com/swri-robotics/marti_common/issues/517>)
* Contributors: Marc Alban
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Initialize transform timestamp to 0 instead of ros::Time::now() (#515 <https://github.com/swri-robotics/marti_common/issues/515>)
* Contributors: Marc Alban
```

## swri_yaml_util

- No changes
