### PR TITLE
rosmon: 1.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9675,7 +9675,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://github.com/xqms/rosmon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.6-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.5-0`

## rosmon

```
* test/xml: replace more multiline string Catch captures
  Sorry, somehow these slipped through - and I didn't have a good way of
  testing these locally without the buildfarm. I'm testing with gcc 4.8
  on trusty now, which seems to have matching behavior.
* Contributors: Max Schwarz
```
