### PR TITLE
xiaoqiang: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13076,6 +13076,14 @@ repositories:
       type: git
       url: https://github.com/bluewhalerobot/xiaoqiang.git
       version: kinetic-devel
+    release:
+      packages:
+      - xiaoqiang
+      - xiaoqiang_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/bluewhalerobot/xiaoqiang.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xiaoqiang` to `0.0.2-0`:

- upstream repository: https://github.com/bluewhalerobot/xiaoqiang
- release repository: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## xiaoqiang

```
* add description
* Contributors: xiaoqiang
```

## xiaoqiang_description

```
* add description
* Contributors: xiaoqiang
```
