### PR TITLE
rosdep: Add setserial

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13071,13 +13071,6 @@ repositories:
       type: git
       url: https://github.com/bluewhalerobot/xiaoqiang.git
       version: kinetic-devel
-    release:
-      packages:
-      - xiaoqiang_description
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/bluewhalerobot-release/xiaoqiang-release.git
-      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/bluewhalerobot/xiaoqiang.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13066,6 +13066,23 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: kinetic-devel
     status: developed
+  xiaoqiang:
+    doc:
+      type: git
+      url: https://github.com/bluewhalerobot/xiaoqiang.git
+      version: kinetic-devel
+    release:
+      packages:
+      - xiaoqiang_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/bluewhalerobot-release/xiaoqiang-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/bluewhalerobot/xiaoqiang.git
+      version: kinetic-devel
+    status: developed
   xpp:
     doc:
       type: git

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4362,6 +4362,9 @@ sdl2-ttf:
   fedora: [SDL2_ttf-devel]
   gentoo: [media-libs/sdl2-ttf]
   ubuntu: [libsdl2-ttf-dev]
+setserial:
+  debian: [setserial]
+  ubuntu: [setserial]
 sfml-dev:
   arch: [sfml]
   debian: [libsfml-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4364,6 +4364,8 @@ sdl2-ttf:
   ubuntu: [libsdl2-ttf-dev]
 setserial:
   debian: [setserial]
+  fedora: [setserial]
+  gentoo: [setserial]
   ubuntu: [setserial]
 sfml-dev:
   arch: [sfml]


### PR DESCRIPTION
Debian: https://packages.debian.org/stretch/setserial
Fedora: https://apps.fedoraproject.org/packages/setserial
Gentoo: https://packages.gentoo.org/packages/sys-apps/setserial
Ubuntu: https://packages.ubuntu.com/bionic/setserial

In some cases, the speed of the serial port is slow by default, which affects the use of serial devices. The tool can change the parameters of the serial port easily and make devices work properly.