### PR TITLE
rosmon: 1.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9675,7 +9675,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/xqms/rosmon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.7-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.6-0`

## rosmon

```
* Support Python 3 & select appropriate Python version.
  This fixes a mismatch on Debian Jessie, where rospack is linked against
  Python 2.7 and we would link against Python 3.4.
* launch: substitution_python: support Python 3
* Contributors: Max Schwarz
```
