### PR TITLE
[rosdep] fix setserial gentoo rosdep rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4365,7 +4365,7 @@ sdl2-ttf:
 setserial:
   debian: [setserial]
   fedora: [setserial]
-  gentoo: [setserial]
+  gentoo: [sys-apps/setserial]
   ubuntu: [setserial]
 sfml-dev:
   arch: [sfml]


### PR DESCRIPTION
Adds the missing `sys-apps` category to the `setserial` rosdep gentoo rule.
Gentoo: https://packages.gentoo.org/packages/sys-apps/setserial
Follow up of https://github.com/ros/rosdistro/pull/18006