### PR TITLE
ros_control: 0.15.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2150,7 +2150,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.14.2-0
+      version: 0.15.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.15.0-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.14.2-0`

## combined_robot_hw

```
* CreateInstance -> CreateUniqueInstance
* boost::shared_ptr -> std::shared_ptr
* Introduce shared_ptr typedefs
* Contributors: Bence Magyar
```

## combined_robot_hw_tests

- No changes

## controller_interface

```
* boost::shared_ptr -> std::shared_ptr
* Introduce shared_ptr typedefs
* remove forward declaration of InterfaceResources
* Contributors: Bence Magyar, Mathias Lüdtke
```

## controller_manager

```
* boost::shared_ptr -> std::shared_ptr
* Introduce shared_ptr typedefs
* Add controller_group script that allows switching groups easily
* Contributors: Bence Magyar, Enrique Fernández Perdomo, Yong Li
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Add controller_group script that allows switching groups easily
* Contributors: Enrique Fernández Perdomo, Yong Li
```

## hardware_interface

```
* boost::shared_ptr -> std::shared_ptr
* Introduce shared_ptr typedefs
* Contributors: Bence Magyar
```

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Remove deprecated typedef
* BOOST_FOREACH -> C++11 for
* boost::shared_ptr -> std::shared_ptr
* Introduce shared_ptr typedefs
* Contributors: Bence Magyar, Mathias Lüdtke
```
