### PR TITLE
costmap_converter: 0.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1613,7 +1613,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.9-0`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.8-0`

## costmap_converter

```
* Moved plugin loader for static costmap conversion to BaseCostmapToDynamicObstacles.
  The corresponding ROS parameter static_converter_plugin is now defined in the CostmapToDynamicObstacles namespace.
* Contributors: Christoph Rösmann
```
