### PR TITLE
fcl_catkin: 0.5.92-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2455,7 +2455,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.91-2
+      version: 0.5.92-0
     status: developed
   feed_the_troll:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl_catkin` to `0.5.92-0`:

- upstream repository: https://github.com/wxmerkt/fcl_catkin.git
- release repository: https://github.com/wxmerkt/fcl_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.91-2`
