### PR TITLE
ompl: 1.3.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2339,7 +2339,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.3.4-0
+      version: 1.3.5-0
     status: maintained
   omronsentech_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.3.5-0`:

- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.3.4-0`
