### PR TITLE
mongodb_store: 0.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5328,7 +5328,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.4.1-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.0-0`

## libmongocxx_ros

```
* check if env. var. exists if not decide based on OS version
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_log

```
* check if env. var. exists if not decide based on OS version
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_store

```
* check if env. var. exists if not decide based on OS version
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_store_msgs

- No changes
