### PR TITLE
smp_ros: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11049,7 +11049,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ksatyaki/smp_ros-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smp_ros` to `1.0.1-0`:

- upstream repository: https://github.com/ksatyaki/smp_ros.git
- release repository: https://github.com/ksatyaki/smp_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.0-0`

## smp_ros

```
* Add mrpt as a dependency in package.xml
* Contributors: Chittaranjan Swaminathan
```
