### PR TITLE
turtlebot3_applications_msgs: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11845,6 +11845,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
       version: kinetic-devel
     status: developed
+  turtlebot3_applications_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications_msgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
+      version: kinetic-devel
+    status: developed
   turtlebot3_autorace:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## turtlebot3_applications_msgs

```
* separated turtlebot3_msgs and applications related messages
* Contributors: Darby Lim
```
