### PR TITLE
play_motion: 0.4.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7207,6 +7207,15 @@ repositories:
       url: https://github.com/astuff/platform_automation_msgs.git
       version: release
     status: developed
+  play_motion:
+    release:
+      packages:
+      - play_motion
+      - play_motion_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/play_motion-release2.git
+      version: 0.4.5-0
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion` to `0.4.5-0`:

- upstream repository: https://github.com/pal-robotics/play_motion.git
- release repository: https://github.com/pal-gbp/play_motion-release2.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## play_motion

```
* fixed merge
* 0.4.4
* updated changelog
* added missing joint trajectory controller for test
* added missing position_controllers test
* added missing xacro test depend
* migration to kinetic
* added extra test dependencies
* added gitignore and update new ros_control kinetic compatibility
* Contributors: Hilario Tome, Hilario Tomé
```

## play_motion_msgs

```
* fixed merge
* 0.4.4
* updated changelog
* Contributors: Hilario Tome
```
