### PR TITLE
turtlebot3_msgs: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11890,7 +11890,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release.git
-      version: 0.1.5-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.5-0`

## turtlebot3_msgs

```
* added sensors
* deleted unused msg and srv
* separated turtlebot3_msgs and applications related messages
* merged pull request #10 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/10> #9 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/9> #8 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/8> #7 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/7>
* Contributors: Darby Lim, Gilbert, Pyo
```
