### PR TITLE
hls-lfcd-lds-driver: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3370,7 +3370,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
-      version: 0.1.5-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls-lfcd-lds-driver` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.5-0`

## hls_lfcd_lds_driver

```
* modified max-range to avoid fencepost error.
* merged pull request #27 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/27> from skasperski/master
  Corrected max-range to avoid fencepost error.
* merged pull request #29 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/29> #28 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/28> #24 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/24>
* Contributors: Gilbert, Sebastian Kasperski, Pyo
```
