### PR TITLE
slam_constructor: 0.9.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11008,7 +11008,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OSLL/slam_constructor-release.git
-      version: 0.9.2-0
+      version: 0.9.3-0
     source:
       type: git
       url: https://github.com/OSLL/slam-constructor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_constructor` to `0.9.3-0`:

- upstream repository: https://github.com/OSLL/slam-constructor.git
- release repository: https://github.com/OSLL/slam_constructor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.9.2-0`

## slam_constructor

```
* Minor fixes
```
