### PR TITLE
xiaoqiang: 0.0.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13115,11 +13115,21 @@ repositories:
     release:
       packages:
       - xiaoqiang
+      - xiaoqiang_bringup
+      - xiaoqiang_controller
       - xiaoqiang_description
+      - xiaoqiang_driver
+      - xiaoqiang_freenect
+      - xiaoqiang_freenect_camera
+      - xiaoqiang_freenect_launch
+      - xiaoqiang_monitor
+      - xiaoqiang_msgs
+      - xiaoqiang_navigation
+      - xiaoqiang_server
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
-      version: 0.0.2-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/bluewhalerobot/xiaoqiang.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xiaoqiang` to `0.0.5-0`:

- upstream repository: https://github.com/bluewhalerobot/xiaoqiang
- release repository: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.2-0`

## xiaoqiang

- No changes

## xiaoqiang_bringup

- No changes

## xiaoqiang_controller

- No changes

## xiaoqiang_description

- No changes

## xiaoqiang_driver

- No changes

## xiaoqiang_freenect

```
* change email
* Contributors: xiaoqiang
```

## xiaoqiang_freenect_camera

```
* change email
* Contributors: xiaoqiang
```

## xiaoqiang_freenect_launch

```
* change email
* Contributors: xiaoqiang
```

## xiaoqiang_monitor

- No changes

## xiaoqiang_msgs

- No changes

## xiaoqiang_navigation

- No changes

## xiaoqiang_server

- No changes
