### PR TITLE
moveit: 0.9.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5438,7 +5438,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.12-0
+      version: 0.9.12-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.12-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.9.12-0`

## moveit

- No changes

## moveit_commander

```
* Get robot markers from state (#836 <https://github.com/ros-planning/moveit/issues/836>)
* Add namespace capabilities to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
* Constrained Cartesian planning using moveit commander (#805 <https://github.com/ros-planning/moveit/issues/805>)
* Handle robot_description parameter in RobotCommander (#782 <https://github.com/ros-planning/moveit/issues/782>)
* support TrajectoryConstraints in MoveGroupInterface + MoveitCommander (#793 <https://github.com/ros-planning/moveit/issues/793>)
* API to get planner_id (#788 <https://github.com/ros-planning/moveit/issues/788>)
* Contributors: Akiyoshi Ochiai, Bence Magyar, Bryce Willey, Dave Coleman, Michael Görner, Ryan Keating, Will Baker
```

## moveit_controller_manager_example

- No changes

## moveit_core

```
* consider max linear+rotational eef step in computeCartesianPath() (#884 <https://github.com/ros-planning/moveit/issues/884>)
* clang-tidy moveit_core (#880 <https://github.com/ros-planning/moveit/issues/880>) (#911 <https://github.com/ros-planning/moveit/issues/911>)
* Allow to retrieve Jacobian of a child link of a move group. (#877 <https://github.com/ros-planning/moveit/issues/877>)
* Contributors: Bryce Willey, Dave Coleman, Michael Görner
* migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* Switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* Add ability to request detailed distance information from fcl (#662 <https://github.com/ros-planning/moveit/issues/662>)
* allow checking for absolute joint-space jumps in Cartesian path (#843 <https://github.com/ros-planning/moveit/issues/843>)
* Simplify adding colored CollisionObjects (#810 <https://github.com/ros-planning/moveit/issues/810>)
* updateMimicJoint(group->getMimicJointModels()) -> updateMimicJoints(group)
* improve RobotState::updateStateWithLinkAt() (#765 <https://github.com/ros-planning/moveit/issues/765>)
* fix computation of shape_extents_ of links w/o shapes (#766 <https://github.com/ros-planning/moveit/issues/766>)
* RobotModel::getRigidlyConnectedParentLinkModel()
  ... to compute earliest parent link that is rigidly connected to a given link
* Iterative cubic spline interpolation (#441 <https://github.com/ros-planning/moveit/issues/441>)
* Contributors: Bryce Willey, Ian McMahon, Ken Anderson, Levi Armstrong, Maarten de Vries, Martin Pecka, Michael Görner, Mike Lautman, Patrick Holthaus, Robert Haschke, Victor Lamoine, Xiaojian Ma
```

## moveit_fake_controller_manager

```
* switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* Contributors: Mikael Arguedas, Xiaojian Ma
```

## moveit_kinematics

```
* migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* fixes to ikfast kinematics plugin (#808 <https://github.com/ros-planning/moveit/issues/808>)
* Cached ik kinematics plugin (#612 <https://github.com/ros-planning/moveit/issues/612>)
  add caching wrapper for IK solvers
* Contributors: Ian McMahon, Mark Moll, Mikael Arguedas, Robert Haschke, Xiaojian Ma
```

## moveit_planners

- No changes

## moveit_planners_ompl

```
* forward OMPL logging to rosconsole (#916 <https://github.com/ros-planning/moveit/issues/916>)
* migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* Make trajectory interpolation in MoveIt consistent to OMPL (#869 <https://github.com/ros-planning/moveit/issues/869>)
* Contributors: Bryce Willey, Ian McMahon, Mikael Arguedas, Robert Haschke, Xiaojian Ma, Zachary Kingston
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* Contributors: Ian McMahon
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [maintenance] migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* Contributors: Ian McMahon
```

## moveit_ros_move_group

```
* disable waitForCurrentRobotState() for PlanService capability (#923 <https://github.com/ros-planning/moveit/issues/923>), fixing (#868 <https://github.com/ros-planning/moveit/issues/868>)
* Remove deprecated ExecuteTrajectoryServiceCapability (#833 <https://github.com/ros-planning/moveit/issues/833>)
* migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* Add namespace capabilities to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
* [fix] MoveAction capability can drop cancel request if it is sent shortly after goal is sent (#756 <https://github.com/ros-planning/moveit/issues/756>)
* Contributors: Dave Coleman, Ian McMahon, Mikael Arguedas, Robert Haschke, Will Baker
```

## moveit_ros_perception

```
* boost::shared_ptr -> std::shared_ptr
* migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [fix] make OpenGL parts optional (#698 <https://github.com/ros-planning/moveit/issues/698>)
* Contributors: Bence Magyar, Ian McMahon, Lukas Bulwahn, Michael Görner, Mikael Arguedas, Robert Haschke
```

## moveit_ros_planning

```
* CSM: copy dynamics to output if enabled (#922 <https://github.com/ros-planning/moveit/issues/922>)
* move PlanExecution::executeAndMonitor() into public API (#812 <https://github.com/ros-planning/moveit/issues/812>)
* [fix] explicitly enforce updateSceneWithCurrentState() in waitForCurrentRobotState() (#824 <https://github.com/ros-planning/moveit/issues/824>)
* Support static TFs for multi-DOF joints in CurrentStateMonitor (#799 <https://github.com/ros-planning/moveit/issues/799>)
* support xacro args (#796 <https://github.com/ros-planning/moveit/issues/796>)
* CSM: wait for *active* joint states only (#792 <https://github.com/ros-planning/moveit/issues/792>)
* skip non-actuated joints for execution (#754 <https://github.com/ros-planning/moveit/issues/754>)
* Iterative cubic spline interpolation (#441 <https://github.com/ros-planning/moveit/issues/441>)
* Floating Joint Support in CurrentStateMonitor (#748 <https://github.com/ros-planning/moveit/issues/748>)
* validate multi-dof trajectories before execution (#713 <https://github.com/ros-planning/moveit/issues/713>)
* Contributors: 2scholz, Bruno Brito, Dave Coleman, Ian McMahon, Ken Anderson, Michael Görner, Mikael Arguedas, Robert Haschke
```

## moveit_ros_planning_interface

```
* [maintenance] Remove deprecated ExecuteTrajectoryServiceCapability (#833 <https://github.com/ros-planning/moveit/issues/833>)
* [maintenance] migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [maintenance] switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* [capability] namespace to moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
* Constrained Cartesian planning using moveit commander (#805 <https://github.com/ros-planning/moveit/issues/805>)
* Simplify adding CollisionObjects with colors (#810 <https://github.com/ros-planning/moveit/issues/810>)
* support TrajectoryConstraints in MoveGroupInterface + MoveitCommander (#793 <https://github.com/ros-planning/moveit/issues/793>)
* Add API to get planner_id (#788 <https://github.com/ros-planning/moveit/issues/788>)
* Allow wait time to be specified for getCurrentState() (#685 <https://github.com/ros-planning/moveit/issues/685>)
* Contributors: 2scholz, Akiyoshi Ochiai, Bence Magyar, Dave Coleman, Ian McMahon, Robert Haschke, Will Baker, Xiaojian Ma, srsidd
```

## moveit_ros_robot_interaction

```
* [fix] interaction with planar joints (#767 <https://github.com/ros-planning/moveit/issues/767>)
* [maintenance] boost::shared_ptr -> std::shared_ptr
* [maintenance] migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [enhance] association of IK solvers to groups #769 <https://github.com/ros-planning/moveit/issues/769>
* Contributors: Bence Magyar, Ian McMahon, Michael Görner, Robert Haschke
```

## moveit_ros_visualization

```
* [maintenance] Reduce vertical size of Rviz MotionPlanning Window (#891 <https://github.com/ros-planning/moveit/issues/891>)
* [maintenance] migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [feature] rviz plugin: set start/goal RobotState from external (#823 <https://github.com/ros-planning/moveit/issues/823>)
  - /rviz/moveit/update_custom_start_state
  - /rviz/moveit/update_custom_goal_state
  stopping from external:
  - /rviz/moveit/stop
* [feature] namespace capabilities for moveit_commander (#835 <https://github.com/ros-planning/moveit/issues/835>)
* [fix] consider shape transform for OcTree
* [fix] realtime trajectory display (#761 <https://github.com/ros-planning/moveit/issues/761>)
* Contributors: Alexander Rössler, Dave Coleman, Ian McMahon, Mikael Arguedas, Pan Hy, Phy, Robert Haschke, Will Baker
```

## moveit_ros_warehouse

```
* [maintenance] migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* Contributors: Ian McMahon
```

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [maintenance] trim group + link names (#921 <https://github.com/ros-planning/moveit/issues/921>)
* [feature] combo box to choose default planner (#658 <https://github.com/ros-planning/moveit/issues/658>)
* [maintenance] migration from tf to tf2 API (#830 <https://github.com/ros-planning/moveit/issues/830>)
* [maintenance] cleanup yaml parsing, remove yaml-cpp 0.3 support (#795 <https://github.com/ros-planning/moveit/issues/795>)
* [feature] allow editing of xacro args (#796 <https://github.com/ros-planning/moveit/issues/796>)
* Contributors: Mohmmad Ayman, Dave Coleman, Ian McMahon, Michael Görner, Mikael Arguedas, Robert Haschke, Will Baker
```

## moveit_simple_controller_manager

```
* switch to ROS_LOGGER from CONSOLE_BRIDGE (#874 <https://github.com/ros-planning/moveit/issues/874>)
* Contributors: Mikael Arguedas, Xiaojian Ma
```
