### PR TITLE
add python-transforms3d-pip, python-control-pip, python-slycot-pip to 'rosdep/python.yaml'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -700,6 +700,13 @@ python-concurrent.futures:
   fedora: [python-futures]
   gentoo: [virtual/python-futures]
   ubuntu: [python-concurrent.futures]
+python-control-pip:
+  ubuntu:
+    pip:
+      packages: [control]
+  debian:
+    pip:
+      packages: [control]
 python-cookiecutter:
   debian:
     buster: [python-cookiecutter]
@@ -3416,6 +3423,13 @@ python-slacker-cli:
   ubuntu:
     pip:
       packages: [slacker-cli]
+python-slycot-pip:
+  ubuntu:
+    pip:
+      packages: [slycot]
+  debian:
+    pip:
+      packages: [slycot]
 python-smbus:
   debian: [python-smbus]
   ubuntu: [python-smbus]
@@ -3810,6 +3824,13 @@ python-tqdm:
         packages: [tqdm]
     yakkety: [python-tqdm]
     zesty: [python-tqdm]
+python-transforms3d-pip:
+  ubuntu:
+    pip:
+      packages: [transforms3d]
+  debian:
+    pip:
+      packages: [transforms3d]
 python-trep:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -701,10 +701,10 @@ python-concurrent.futures:
   gentoo: [virtual/python-futures]
   ubuntu: [python-concurrent.futures]
 python-control-pip:
-  ubuntu:
+  debian:
     pip:
       packages: [control]
-  debian:
+  ubuntu:
     pip:
       packages: [control]
 python-cookiecutter:
@@ -3424,10 +3424,10 @@ python-slacker-cli:
     pip:
       packages: [slacker-cli]
 python-slycot-pip:
-  ubuntu:
+  debian:
     pip:
       packages: [slycot]
-  debian:
+  ubuntu:
     pip:
       packages: [slycot]
 python-smbus:
@@ -3825,10 +3825,10 @@ python-tqdm:
     yakkety: [python-tqdm]
     zesty: [python-tqdm]
 python-transforms3d-pip:
-  ubuntu:
+  debian:
     pip:
       packages: [transforms3d]
-  debian:
+  ubuntu:
     pip:
       packages: [transforms3d]
 python-trep:


### PR DESCRIPTION
Add transforms3d (https://pypi.org/project/transforms3d/) for easy geometric transformations conversions in python
Add control (https://pypi.org/project/control/) for control system design
Add slycot (https://pypi.org/project/slycot/), which is a wrapper to the SLICOT control library (http://slicot.org/)