### PR TITLE
epson_g364_imu_driver: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2343,6 +2343,14 @@ repositories:
       url: https://github.com/ensenso/ros_driver.git
       version: master
     status: developed
+  epson_g364_imu_driver:
+    release:
+      packages:
+      - epson_imu_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@bitbucket.org:castacks/epson_g364_imu_driver-release.git
+      version: 0.0.2-0
   ethercat_grant:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2349,8 +2349,16 @@ repositories:
       - epson_imu_driver
       tags:
         release: release/kinetic/{package}/{version}
-      url: git@bitbucket.org:castacks/epson_g364_imu_driver-release.git
+      url: https://bitbucket.org/castacks/epson_g364_imu_driver-release.git
       version: 0.0.2-0
+    doc:
+      type: git
+      url: https://bitbucket.org/castacks/epson_g364_imu_driver.git
+      version: master
+    source:
+      type: git
+      url: https://bitbucket.org/castacks/epson_g364_imu_driver.git
+      version: master
   ethercat_grant:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2344,6 +2344,10 @@ repositories:
       version: master
     status: developed
   epson_g364_imu_driver:
+    doc:
+      type: git
+      url: https://bitbucket.org/castacks/epson_g364_imu_driver.git
+      version: master
     release:
       packages:
       - epson_imu_driver
@@ -2351,10 +2355,6 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/castacks/epson_g364_imu_driver-release.git
       version: 0.0.2-0
-    doc:
-      type: git
-      url: https://bitbucket.org/castacks/epson_g364_imu_driver.git
-      version: master
     source:
       type: git
       url: https://bitbucket.org/castacks/epson_g364_imu_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `epson_g364_imu_driver` to `0.0.2-0`:

- upstream repository: git@bitbucket.org:castacks/epson_g364_imu_driver.git
- release repository: git@bitbucket.org:castacks/epson_g364_imu_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
