### PR TITLE
marker_msgs: 0.0.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1158,11 +1158,15 @@ repositories:
       version: melodic-devel
     status: developed
   marker_msgs:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tuw-robotics/marker_msgs-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.6-0`:

- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.5-0`
