### PR TITLE
remove hexagon_map

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4543,15 +4543,6 @@ repositories:
       url: https://github.com/heron/heron_desktop.git
       version: indigo-devel
     status: maintained
-  hexagon_map:
-    doc:
-      type: git
-      url: https://github.com/DS921020/Hexagon_map.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/DS921020/Hexagon_map.git
-      version: master
   hironx_rpc:
     doc:
       type: git


### PR DESCRIPTION
Revert #17917.

@DS921020 FYI. The recent build of the repository failed and the job sends notification emails to an "invalid" email address. Therefore we will remove the repository for now. Please address the comments from the original PR and then feel free to re-add the repository again. Thanks,