### PR TITLE
novatel_gps_driver: 3.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1600,6 +1600,24 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: master
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
+      version: 3.4.0-0
+    source:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: master
+    status: developed
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.4.0-0`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## novatel_gps_driver

```
* Fixes RPY orientation in IMU output (based on testing).
* Add service to novatel_gps_nodelet that issues a FRESET command on the indicated target, or STANDARD if none is provided
* Use find_library to look up the location of libpcap.so
* Contributors: Joshua Whitley, Matthew Bries, P. J. Reed
```

## novatel_gps_msgs

```
* Add service to novatel_gps_nodelet that issues a FRESET command on the indicated target, or STANDARD if none is provided
* Contributors: Matthew Bries, P. J. Reed
```
