### PR TITLE
qb_device: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7825,10 +7825,11 @@ repositories:
       - qb_device_hardware_interface
       - qb_device_msgs
       - qb_device_srvs
+      - qb_device_utils
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 1.2.2-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `2.0.0-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.2.2-0`

## qb_device

- No changes

## qb_device_bringup

```
* Refactor launch files
* Fix minors
* Add a blocking setCommands method
* Fix until ros_comm#889 is fixed
* Refactor launch files and fix controllers spawner
```

## qb_device_control

```
* Update doxygen documentation
* Refactor launch files
* Add method to temporarily change PID parameters
* Add asynchronous requests for sporadic get/set
* Add a unique control node
* Fix minors
* Fix thread spinning
* Add basic trajectory builder methods
* Refactor yaml waypoint trajectory parsing
* Refactor Actions to match given hardware interfaces
* Switch to CombinedRobotHW
* Fix minors
* Fix waypoints parsing source
* Add a control loop frequency publisher
* Refactor launch files and fix controllers spawner
* Fix destructor calls on ROS shutdown
* Fix minors
```

## qb_device_description

```
* Refactor launch files
* Refactor launch files and fix controllers spawner
```

## qb_device_driver

```
* Move sleep at low level (next to API)
* Add method to temporarily change PID parameters
* Fix doxygen documentation
* Fix communication errors with asynchronous reads
* Refactor node registration
* Add method to get currents and positions together
* Fix minors
* Fix repetitions reliablity check
* Add a blocking setCommands method
* Fix destructor calls on ROS shutdown
* Fix minors
* Fix unexpected fault with std::unordered_set
* Add parallelization with several USB connected
* Let the user decide whether to read/write or not
* Add an alert if maximum repetitions is set to zero
* Refactor node registration
* Add a real isConnected method
* Refactor device scan method with repetitions
* Retrieve control and input mode device settings
* Implement repetitions also for getMeasurements
* Add repetitions while reading from serial
* Move error checks in ROS service callbacks
```

## qb_device_hardware_interface

```
* Add device configuration to the state topic info
* Fix recovery on service server fault
* Refactor node registration
* Fix accidental repetitions with namespace prefix
* Refactor initialization by extending the base init
* Add method to get currents and positions together
* Fix repetitions reliablity check
* Add a blocking setCommands method
* Refactor launch files and fix controllers spawner
* Fix minors
* Let the user decide whether to read/write or not
* Refactor node registration
* Add repetitions while reading from serial
```

## qb_device_msgs

```
* Add device configuration to the state topic info
* Add repetitions while reading from serial
```

## qb_device_srvs

```
* Add method to temporarily change PID parameters
* Refactor node registration
* Add method to get currents and positions together
* Add a blocking setCommands method
* Let the user decide whether to read/write or not
* Refactor node registration
* Add repetitions while reading from serial
```

## qb_device_utils

```
* Add SIGINT and shutdown RPC handlers
```
