### PR TITLE
qb_hand: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7848,7 +7848,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
-      version: 1.0.6-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbhand-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_hand` to `2.0.0-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbhand-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.6-0`

## qb_hand

- No changes

## qb_hand_control

```
* Update README
* Refactor launch files
* Remove control node
* Add blocking setCommands method support
* Refactor launch files
* Fix destructor calls on ROS shutdown
```

## qb_hand_description

```
* Update README
* Update xacro models
* Refactor launch files
* Refactor launch files
```

## qb_hand_hardware_interface

```
* Refactor transmission initialization
* Refactor initialization
* Prepare for CombinedRobotHW compatibility
```
