### PR TITLE
qb_hand: 2.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2706,6 +2706,26 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  qb_hand:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbhand-ros.git
+      version: production-lunar
+    release:
+      packages:
+      - qb_hand
+      - qb_hand_control
+      - qb_hand_description
+      - qb_hand_hardware_interface
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbhand-ros.git
+      version: production-lunar
+    status: developed
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_hand` to `2.0.0-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbhand-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbhand-ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## qb_hand

- No changes

## qb_hand_control

```
* Update README
* Refactor launch files
* Remove control node
* Add blocking setCommands method support
* Refactor launch files
* Fix destructor calls on ROS shutdown
```

## qb_hand_description

```
* Update README
* Update xacro models
* Refactor launch files
* Refactor launch files
```

## qb_hand_hardware_interface

```
* Refactor transmission initialization
* Refactor initialization
* Prepare for CombinedRobotHW compatibility
```
