### PR TITLE
qb_move: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1849,6 +1849,26 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  qb_move:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbmove-ros.git
+      version: production-melodic
+    release:
+      packages:
+      - qb_move
+      - qb_move_control
+      - qb_move_description
+      - qb_move_hardware_interface
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbmove-ros.git
+      version: production-melodic
+    status: developed
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `2.0.0-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## qb_move

- No changes

## qb_move_control

```
* Update README
* Refactor launch files
* Remove control node
* Add blocking setCommands method support
* Refactor launch files
* Fix destructor calls on ROS shutdown
```

## qb_move_description

```
* Update xacro models
* Refactor launch files
* Add flange meshes and few basic configurations
* Add qbmove meshes
* Refactor launch files
```

## qb_move_hardware_interface

```
* Refactor transmission initialization
* Refactor initialization
* Prepare for CombinedRobotHW compatibility
```
