### PR TITLE
graph_msgs: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -873,6 +873,21 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: master
     status: developed
+  graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/graph_msgs.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/davetcoleman/graph_msgs-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/davetcoleman/graph_msgs.git
+      version: jade-devel
+    status: maintained
   grasping_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.1.0-0`:

- upstream repository: https://github.com/davetcoleman/graph_msgs
- release repository: https://github.com/davetcoleman/graph_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## graph_msgs

```
* Added header / timestamp
* Contributors: Dave Coleman
```
