### PR TITLE
catkin: 0.7.13-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -205,7 +205,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.12-0
+      version: 0.7.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.13-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.7.12-0`

## catkin

```
* add separate option CATKIN_INSTALL_INTO_PREFIX_ROOT (#940 <https://github.com/ros/catkin/issues/940>)
* find the Python version specified in ROS_PYTHON_VERSION (#939 <https://github.com/ros/catkin/issues/939>)
* move catkin_prepare_release script as well as dependencies to catkin_pkg (#941 <https://github.com/ros/catkin/issues/941>)
```
