### PR TITLE
rosparam_shortcuts: 0.2.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2422,6 +2422,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rosparam_shortcuts:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/rosparam_shortcuts.git
+      version: melodic-devel
+    status: developed
   rqt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.2.1-0`:

- upstream repository: https://github.com/PickNikRobotics/rosparam_shortcuts.git
- release repository: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rosparam_shortcuts

```
* Fix Eigen3 include
* Fix C++11 compiling method
* Update Travis for Kinetic
* Updated README
* Contributors: Dave Coleman
```
