### PR TITLE
cartesian_msgs: 0.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -154,6 +154,21 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
     status: maintained
+  cartesian_msgs:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/cartesian_msgs.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PickNikRobotics/cartesian_msgs-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/cartesian_msgs.git
+      version: jade-devel
+    status: maintained
   cartographer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_msgs` to `0.0.3-0`:

- upstream repository: https://github.com/PickNikRobotics/cartesian_msgs.git
- release repository: https://github.com/PickNikRobotics/cartesian_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## cartesian_msgs

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
