### PR TITLE
ros_control_boilerplate: 0.4.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2228,6 +2228,21 @@ repositories:
       url: https://github.com/ros-controls/ros_control.git
       version: melodic-devel
     status: maintained
+  ros_control_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/ros_control_boilerplate.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
+      version: 0.4.1-0
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros_control_boilerplate.git
+      version: melodic-devel
+    status: developed
   ros_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.4.1-0`:

- upstream repository: https://github.com/PickNikRobotics/ros_control_boilerplate.git
- release repository: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ros_control_boilerplate

```
* Changed boost::shared_ptr to typedef for Lunar support
* Implemented simulated velocity control
* Contributors: Dave Coleman
```
