### PR TITLE
open_manipulator_msgs: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6620,6 +6620,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git
       version: kinetic-devel
     status: developed
+  open_manipulator_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_msgs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
+      version: kinetic-devel
+    status: developed
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## open_manipulator_msgs

```
* Package reconfiguration for OpenManipulator
* Contributors: Darby Lim, Pyo
```
