### PR TITLE
open_manipulator_simulations: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6635,6 +6635,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
       version: kinetic-devel
     status: developed
+  open_manipulator_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
+      version: kinetic-devel
+    release:
+      packages:
+      - open_manipulator_gazebo
+      - open_manipulator_simulations
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
+      version: kinetic-devel
+    status: developed
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_simulations` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## open_manipulator_gazebo

```
* package reconfiguration for OpenManipulator
* Contributors: Darby Lim
```

## open_manipulator_simulations

```
* package reconfiguration for OpenManipulator
* Contributors: Darby Lim
```
