### PR TITLE
open_manipulator_perceptions: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6635,6 +6635,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
       version: kinetic-devel
     status: developed
+  open_manipulator_perceptions:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_perceptions.git
+      version: kinetic-devel
+    release:
+      packages:
+      - open_manipulator_ar_markers
+      - open_manipulator_perceptions
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_perceptions-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_perceptions.git
+      version: kinetic-devel
+    status: developed
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_perceptions` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_perceptions.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_perceptions-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## open_manipulator_ar_markers

```
* added new open_manipulator_perceptions package
* added perception packages as AR marker, Object recognition and so on
* Contributors: Darby Lim
```

## open_manipulator_perceptions

```
* added new open_manipulator_perceptions package
* added perception packages as AR marker, Object recognition and so on
* Contributors: Darby Lim
```
