### PR TITLE
open_manipulator_with_tb3_msgs: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6653,6 +6653,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
       version: kinetic-devel
     status: developed
+  open_manipulator_with_tb3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_msgs-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
+      version: kinetic-devel
+    status: developed
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_with_tb3_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## open_manipulator_with_tb3_msgs

```
* package reconfiguration for OpenManipulator
* added msgs for open_manipulator and turtlebot3
* Contributors: Darby Lim, Pyo
```
