### PR TITLE
open_manipulator_with_tb3: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6671,6 +6671,27 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
       version: kinetic-devel
     status: developed
+  open_manipulator_with_tb3:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git
+      version: kinetic-devel
+    release:
+      packages:
+      - open_manipulator_with_tb3
+      - open_manipulator_with_tb3_description
+      - open_manipulator_with_tb3_tools
+      - open_manipulator_with_tb3_waffle_moveit
+      - open_manipulator_with_tb3_waffle_pi_moveit
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git
+      version: kinetic-devel
+    status: developed
   open_manipulator_with_tb3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_with_tb3` to `1.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## open_manipulator_with_tb3

```
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_description

```
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_tools

```
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_waffle_moveit

```
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_waffle_pi_moveit

```
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Pyo
```
