### PR TITLE
qb_device: 2.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2725,7 +2725,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `2.0.1-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.0.0-0`

## qb_device

- No changes

## qb_device_bringup

- No changes

## qb_device_control

```
* Fix dependencies
```

## qb_device_description

- No changes

## qb_device_driver

- No changes

## qb_device_hardware_interface

- No changes

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes

## qb_device_utils

- No changes
