### PR TITLE
qb_device: 2.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1879,6 +1879,31 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  qb_device:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
+      version: production-melodic
+    release:
+      packages:
+      - qb_device
+      - qb_device_bringup
+      - qb_device_control
+      - qb_device_description
+      - qb_device_driver
+      - qb_device_hardware_interface
+      - qb_device_msgs
+      - qb_device_srvs
+      - qb_device_utils
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
+      version: production-melodic
+    status: developed
   qb_hand:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `2.0.1-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## qb_device

- No changes

## qb_device_bringup

- No changes

## qb_device_control

```
* Fix dependencies
```

## qb_device_description

- No changes

## qb_device_driver

- No changes

## qb_device_hardware_interface

- No changes

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes

## qb_device_utils

- No changes
