### PR TITLE
cartographer: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -178,7 +178,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
-      version: 0.3.0-1
+      version: 1.0.0-0
     status: developed
   cartographer_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `1.0.0-0`:

- upstream repository: https://github.com/googlecartographer/cartographer.git
- release repository: https://github.com/ros-gbp/cartographer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.0-1`
