### PR TITLE
qb_chain: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7925,7 +7925,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
-      version: 1.0.4-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbchain-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `2.0.0-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.4-0`

## qb_chain

- No changes

## qb_chain_control

```
* Refactor xacro models and relative launch files
```

## qb_chain_description

```
* Refactor xacro models and relative launch files
```
