### PR TITLE
qb_chain: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1879,6 +1879,25 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kinetic-devel
     status: maintained
+  qb_chain:
+    doc:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbchain-ros.git
+      version: production-melodic
+    release:
+      packages:
+      - qb_chain
+      - qb_chain_control
+      - qb_chain_description
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbchain-ros.git
+      version: production-melodic
+    status: developed
   qb_device:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `2.0.0-0`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## qb_chain

- No changes

## qb_chain_control

```
* Refactor xacro models and relative launch files
```

## qb_chain_description

```
* Refactor xacro models and relative launch files
```
