### PR TITLE
moveit_sim_controller: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1431,6 +1431,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: maintained
+  moveit_sim_controller:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/moveit_sim_controller.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PickNikRobotics/moveit_sim_controller-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/moveit_sim_controller.git
+      version: melodic-devel
+    status: maintained
   mrpt1:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.1.0-0`:

- upstream repository: https://github.com/PickNikRobotics/moveit_sim_controller.git
- release repository: https://github.com/PickNikRobotics/moveit_sim_controller-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## moveit_sim_controller

```
* Add C++11 support
* Fixed occational Nan
* Minor formatting
* added roslint and roslint changes
* Contributors: Dave Coleman
```
