### PR TITLE
radar_omnipresense: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8059,7 +8059,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
-      version: 0.1.0-1
+      version: 0.2.0
     status: developed
   random_numbers:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8055,11 +8055,20 @@ repositories:
       version: kinetic-devel
     status: maintained
   radar_omnipresense:
+    doc:
+      type: git
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
+      version: 0.2.0
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
+      version: 0.2.0
     status: developed
   random_numbers:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8055,20 +8055,11 @@ repositories:
       version: kinetic-devel
     status: maintained
   radar_omnipresense:
-    doc:
-      type: git
-      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
-      version: 0.2.0
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
       version: 0.1.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
-      version: 0.2.0
     status: developed
   random_numbers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_omnipresense` to `0.1.0-1`:

- upstream repository: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
- release repository: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.0-0`

## radar_omnipresense

```
* commiting the 2011 api version of the code. The branch RapidJSON_preserve contians 2015 api version. That branch should not be modified at all
* altered findrapidjson
* deleted old findrapidjson
* updated CMakeLists and utest to 'pass'
* adding files for very simple 'unit testing'
* Updated the readme to no longer say that you need to download and install LinuxCommConnection for the package
* modified change log
* Added the lib file so that linuxcommconnection is no longer a depedency issue
* Added lib file so that linnux comm connection is no longer a dependency issue
* address RapidJSON dependency
* added raw msgs
* Prepping for ros package submittal
* Contributors: Garren Hendricks, Jim Whitfield
* Added the lib file so that linuxcommconnection is no longer a depedency issue
* address RapidJSON dependency
* added raw msgs
* Contributors: Garren Hendricks, Jim Whitfield
```
