### PR TITLE
add Python 3 key for catkin-pkg-modules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4188,6 +4188,11 @@ python3-babeltrace:
   ubuntu:
     wily: [python3-babeltrace]
     xenial: [python3-babeltrace]
+python3-catkin-pkg-modules:
+  debian: [python3-catkin-pkg]
+  fedora: [python3-catkin_pkg]
+  gentoo: [dev-python/catkin_pkg]
+  ubuntu: [python3-catkin-pkg-modules]
 python3-dev:
   debian: [python3-dev]
   gentoo: [=dev-lang/python-3*]


### PR DESCRIPTION
* Debian: https://packages.debian.org/search?searchon=names&keywords=python3-catkin-pkg
* Fedora: http://rpmfind.net/linux/rpm2html/search.php?query=python3-catkin_pkg
* Gentoo: same as Python 2 key
* Ubuntu: imported from bootstrap repo

Used in ros2/ros2cli#94.