### PR TITLE
raspi_temperature: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8076,6 +8076,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspi_temperature:
+    doc:
+      type: git
+      url: https://github.com/bberrevoets/raspi_temperature.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/bberrevoets/raspi_temperature-release.git
+      version: 0.1.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/bberrevoets/raspi_temperature.git
+      version: 0.1.1
+    status: maintained
   raspigibbon_apps:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8080,7 +8080,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/bberrevoets/raspi_temperature.git
-      version: 0.1.1
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -8090,7 +8090,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/bberrevoets/raspi_temperature.git
-      version: 0.1.1
+      version: master
     status: maintained
   raspigibbon_apps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `raspi_temperature` to `0.1.1-0`:

- upstream repository: https://github.com/bberrevoets/raspi_temperature.git
- release repository: https://github.com/bberrevoets/raspi_temperature-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## raspi_temperature

```
* Release
* Corrected a little error
* Contributors: B.N.Berrevoets
```
