### PR TITLE
open_manipulator_with_tb3: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6686,7 +6686,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3-release.git
-      version: 1.0.0-1
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_with_tb3` to `1.0.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.0-1`

## open_manipulator_with_tb3

```
* added dependency package option
* Contributors: Pyo
```

## open_manipulator_with_tb3_description

```
* added dependency package option
* Contributors: Pyo
```

## open_manipulator_with_tb3_tools

```
* added dependency package option
* Contributors: Pyo
```

## open_manipulator_with_tb3_waffle_moveit

```
* added dependency package option
* Contributors: Pyo
```

## open_manipulator_with_tb3_waffle_pi_moveit

```
* added dependency package option
* Contributors: Pyo
```
