### PR TITLE
dynamixel-workbench: 0.3.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -423,7 +423,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `0.3.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.0-0`

## dynamixel_workbench

```
* updated Qt5 and delete Qt4 config
* deleted rqt_plugin header
* merged pull request #154 <https://github.com/ROBOTIS-GIT/dynamixel-workbench/issues/154> #153 <https://github.com/ROBOTIS-GIT/dynamixel-workbench/issues/153>
* Contributors: Darby Lim
```

## dynamixel_workbench_controllers

```
* none
```

## dynamixel_workbench_operators

```
* None
```

## dynamixel_workbench_single_manager

```
* None
```

## dynamixel_workbench_single_manager_gui

```
* updated Qt5 and delete Qt4 config
* deleted rqt_plugin header
* merged pull request #154 <https://github.com/ROBOTIS-GIT/dynamixel-workbench/issues/154> #153 <https://github.com/ROBOTIS-GIT/dynamixel-workbench/issues/153>
* Contributors: Darby Lim
```

## dynamixel_workbench_toolbox

```
* None
```
