### PR TITLE
gazebo_ros_pkgs: 2.4.16-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3752,7 +3752,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.4.15-0
+      version: 2.4.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.4.16-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.4.15-0`

## gazebo_msgs

- No changes

## gazebo_plugins

```
* ROS UTILS: initialize rosnode_ in alternative constructor to avoid segfault #478 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/478> (#722 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/722>)
* Contributors: Jose Luis Rivero
```

## gazebo_ros

```
* gazebo_ros_api_plugin: improve plugin xml parsing (#731 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/731>)
  An xml comment that start with plugin causes a seg-fault:
  <!--plugin-->
  or
  <!--plugin filename="lib.so"/-->
  This fixes the xml parsing to not try to add child elements
  to xml comments.
* Contributors: Jose Luis Rivero
```

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
