### PR TITLE
gazebo_ros_pkgs: 2.5.16-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2762,7 +2762,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.14-1
+      version: 2.5.16-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.16-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.5.14-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Add publishOdomTF flag (#692 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/692>) (#716 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/716>)
* ROS UTILS: prevent segfault when using alternative GazeboRos constructor (kinetic-devel) (#721 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/721>)
* Triggered camera / multicamera plugins (#687 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/687>)
* Fix sensors after time reset (#683 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/683>)
  World resets result in a negative time differences between current world
  time and the last recorded sensor update time, preventing the plugin
  from publishing new frames. This commit detects such events and resets
  the internal sensor update timestamp.
  * block_laser, range, and joint_state_publisher keep publishing after clock reset
  * p3d keeps publishing after clock reset
* Support 16-bit cameras (#675 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/675>)
  * extend camera util to support 16 bit rgb image encoding:  support 16 bit mono
* Add warnings when the user is affected by gazebo not preserving world velocity when set positions (#691 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/691>)
  Issue #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>. Workaround at https://github.com/mintar/mimic_joint_gazebo_tutorial
* Fix for preserving world velocity when set positions for Gazebo9: #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>
  This commit fixes #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>, but only for Gazebo9.
  Fixing it for Gazebo7 (the version used in ROS Kinetic) requires the
  following PR to be backported to Gazebo 7 and 8:
  https://bitbucket.org/osrf/gazebo/pull-requests/2814/fix-issue-2111-by-providing-options-to/diff
* gazebo_plugins: unique names for distortion tests (#685 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/685>)
* Fix tests and compiler warnings on kinetic-devel #678 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/678>
* fix gazebo9 warnings by removing Set.*Accel calls
* gazebo_plugins: don't use -r in tests
* Contributors: Jose Luis Rivero, Julian Kooij, Kevin Allen, Martin Günther, Steven Peters, krzysztof-zurad
```

## gazebo_ros

```
* Use generic SIGINT parameter in kill command for gazebo script (kinetic-devel) (#723 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/723>)
  * Use generic SIGINT parameter in kill command for gazebo script
  * redirect to kill command to std_err
* strip comments from parsed urdf (#695 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/695>)
  Remove comments from urdf before trying to find packages. Otherwise non-existant packages will produce a fatal error, even though they are not used.
* Merge pull request #672 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/672> from ros-simulation/gzclient_verbose
  Pass verbose argument to gzclient
* Merge pull request #670 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/670> from ros-simulation/add_ros_api_plugin_to_gzclient
  Load the libgazebo_ros_api_plugin when starting gzclient
* Pass verbose argument to gzclient
* Load the libgazebo_ros_api_plugin when starting gzclient so that the ROS event loop will turn over, which is required when you have a client-side Gazebo plugin that uses ROS.
* Contributors: Brian Gerkey, Jose Luis Rivero, Steven Peters, azhural, chapulina
```

## gazebo_ros_control

```
* add physics type for dart with joint velocity interface (#693 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/693>)
* Add warnings when the user is affected by gazebo not preserving world velocity when set positions (#691 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/691>)
  Issue #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>. Workaround at https://github.com/mintar/mimic_joint_gazebo_tutorial
* Fix for preserving world velocity when set positions for Gazebo9: #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>
  This commit fixes #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>, but only for Gazebo9.
  Fixing it for Gazebo7 (the version used in ROS Kinetic) requires the
  following PR to be backported to Gazebo 7 and 8:
  https://bitbucket.org/osrf/gazebo/pull-requests/2814/fix-issue-2111-by-providing-options-to/diff
* Contributors: Jack Liu, Martin Günther
```

## gazebo_ros_pkgs

- No changes
