### PR TITLE
ohm_rrl_perception: 0.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8607,6 +8607,20 @@ repositories:
       url: https://github.com/ros-drivers/odva_ethernetip.git
       version: indigo-devel
     status: maintained
+  ohm_rrl_perception:
+    release:
+      packages:
+      - ohm_rrl_cdetection
+      - ohm_rrl_motiondetection
+      - ohm_rrl_perception
+      - ohm_rrl_perception_launch
+      - ohm_rrl_perception_utility
+      - ohm_rrl_qrdetection
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/autonohm/ohm_rrl_perception.git
+      version: 0.0.1-1
+    status: developed
   ohm_tsd_slam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ohm_rrl_perception` to `0.0.1-1`:

- upstream repository: https://github.com/autonohm/ohm_rrl_perception.git
- release repository: https://github.com/autonohm/ohm_rrl_perception.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
