### PR TITLE
gazebo_ros_pkgs: 2.7.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -863,7 +863,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.7.3-0
+      version: 2.7.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.7.5-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.7.3-0`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Triggered camera / multicamera plugins (lunar-devel) (#714 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/714>)
  * adds triggered cameras and multicameras
* fix gazebo9 warnings by removing Set.*Accel calls (#728 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/728>)
  * fix gazebo9 warnings by removing Set.*Accel calls
  * gazebo_plugins: don't use -r in tests
* Fix model_state_test. -v means --version not --verbose (#710 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/710>)
* ROS UTILS: prevent segfault when using alternative GazeboRos constructor (lunar-devel) (#720 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/720>)
* Fix sensors after time reset (lunar-devel) (#705 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/705>)
  * camera plugin keeps publishing after negative sensor update interval
  World resets result in a negative time differences between current world
  time and the last recorded sensor update time, preventing the plugin
  from publishing new frames. This commit detects such events and resets
  the internal sensor update timestamp.
  * block_laser, range, and joint_state_publisher keep publishing after clock reset
  * p3d keeps publishing after clock reset
* Support 16-bit cameras (lunar-devel) (#700 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/700>)
  * extend camera util to support 16 bit rgb image encoding
  * support 16 bit mono
  * add test for 16-bit camera
  * update skip_
  * move camera test to camera.h, add camera16bit.cpp
* Fix for preserving world velocity when set positions for Gazebo9: #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>
  This commit fixes #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>, but only for Gazebo9.
  Fixing it for Gazebo7 (the version used in ROS Kinetic) requires the
  following PR to be backported to Gazebo 7 and 8:
  https://bitbucket.org/osrf/gazebo/pull-requests/2814/fix-issue-2111-by-providing-options-to/diff
* gazebo_plugins: unique names for distortion tests (lunar-devel) (#686 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/686>)
  * gazebo_plugins: unique names for distortion tests
  * Missing test files
* Contributors: Jose Luis Rivero, Kevin Allen, Steven Peters
```

## gazebo_ros

```
* Use generic SIGINT parameter in kill command for gazebo script (#711 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/711>)
  * Use generic SIGINT parameter in kill command for gazebo script
  * redirect to kill command to std_err
* Parameter to disable ROS network interaction from/to Gazebo (lunar-devel) (#704 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/704>)
  * Merge initial part of 585 PR
  * Missing parts from the port to lunar
  * Fix last remaining code from merge
* Load the libgazebo_ros_api_plugin when starting gzclient so that the ROS event loop will turn over, which is required when you have a client-side Gazebo plugin that uses ROS. (#676 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/676>)
* Pass verbose argument to gzclient (#677 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/677>)
* strip comments from parsed urdf (#698 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/698>)
  Remove comments from urdf before trying to find packages. Otherwise non-existant packages will produce a fatal error, even though they are not used.
* Contributors: Jose Luis Rivero
```

## gazebo_ros_control

```
* Don't ignore robotNamespace in gazebo_ros_control nodes (lunar-devel) (#706 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/706>)
  * Don't ignore robotNamespace
  When creating the NodeHandle for reading the PID parameters, the model_nh was always ignored. Instead, all parameters were read from /gazebo_ros_control/pid_gains/<joint_name>/* instead of /<robot_name>/gazebo_ros_control/pid_gains/<joint_name>/*.
  This commit restores the intended behavior, i.e., the parameters will now read from <robot_name>/..., where <robot_name> is specified via the robotNamespace plugin parameter or the parent name.
* add physics type for dart with joint velocity interface (#701 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/701>)
* Fix for preserving world velocity when set positions for Gazebo9: #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>
  This commit fixes #612 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612>, but only for Gazebo9.
  Fixing it for Gazebo7 (the version used in ROS Kinetic) requires the
  following PR to be backported to Gazebo 7 and 8:
  https://bitbucket.org/osrf/gazebo/pull-requests/2814/fix-issue-2111-by-providing-options-to/diff
* Contributors: Jose Luis Rivero
```

## gazebo_ros_pkgs

- No changes
