### PR TITLE
Adding raspimouse_sim to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2053,6 +2053,16 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspimouse_sim:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: melodic-devel
+    status: developed
   rc_dynamics_api:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspimouse_sim for ROS Melodic to be doc'd and indexed.