### PR TITLE
Added rosdeps for glfw3.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -965,12 +965,6 @@ gksu:
 glc:
   arch: [glc]
   gentoo: [media-libs/quesoglc]
-glfw3:
-  debian: [libglfw3-dev]
-  gentoo: [media-libs/glfw]
-  ubuntu:
-    '*': [libglfw3-dev]
-    trusty: null
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]
@@ -1843,6 +1837,12 @@ libglew-dev:
     xenial: [libglew-dev]
     yakkety: [libglew-dev]
     zesty: [libglew-dev]
+libglfw3-dev:
+  debian: [libglfw3-dev]
+  gentoo: [media-libs/glfw]
+  ubuntu:
+    '*': [libglfw3-dev]
+    trusty: null
 libglib-dev:
   arch: [glib2]
   debian: [libglib2.0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -967,7 +967,9 @@ glc:
   gentoo: [media-libs/quesoglc]
 glfw3:
   debian: [libglfw3-dev]
-  ubuntu: [libglfw3-dev]
+  ubuntu:
+    '*': [libglfw3-dev]
+    trusty: null
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -965,6 +965,9 @@ gksu:
 glc:
   arch: [glc]
   gentoo: [media-libs/quesoglc]
+glfw3:
+  debian: [libglfw3-dev]
+  ubuntu: [libglfw3-dev]
 glut:
   arch: [freeglut]
   debian: [freeglut3-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -967,6 +967,7 @@ glc:
   gentoo: [media-libs/quesoglc]
 glfw3:
   debian: [libglfw3-dev]
+  gentoo: [media-libs/glfw]
   ubuntu:
     '*': [libglfw3-dev]
     trusty: null


### PR DESCRIPTION
This adds a rosdep key for [glfw3](http://www.glfw.org/).

- debian: https://packages.debian.org/jessie/libglfw3-dev
- ubuntu: https://packages.ubuntu.com/xenial/libdevel/libglfw3-dev

I am using this dependency to compile [librealsense](https://github.com/IntelRealSense/librealsense) as a catkin package. Tested on Ubuntu 16.04.

I am not sure whether the key shall be `glfw` or `glfw3`. On Ubuntu 16.04, the following packages are available:

- libglfw2
- libglfw3
- libglfw3-dev
- libglfw-dev (installs libglfw2)

For compiling librealsense, I need libglfw3-dev, therefore `glfw3` would more specific. However, on some the distributions I googled (e.g. gentoo: https://packages.gentoo.org/packages/media-libs/glfw), it seems that it is not possible to select the version to install and you just get the latest.

