### PR TITLE
support null package list as per REP 111

### DIFF
--- a/scripts/check_rosdep.py
+++ b/scripts/check_rosdep.py
@@ -113,6 +113,8 @@ def check_brackets(buf):
     def fun(i, l, o):
         m = re.match(r'^(?:' + indent_atom + r')*([^:]*):\s*(\w.*)$', l)
         if m is not None and m.groups()[0] not in excepts:
+            if m.groups()[1] == 'null':
+                return True
             print_err("list not in square brackets line %u" % (i+1))
             return False
         return True


### PR DESCRIPTION
Tests currently don't accept the `null` os version [defined in REP111](https://github.com/ros-infrastructure/rep/blob/master/rep-0111.rst#allow-package_argument-to-be-explicitly-null)

This makes CI fails if we try to add such a rule to the rosdep database: https://travis-ci.org/ros/rosdistro/builds/388261517?utm_source=github_status&utm_medium=notification