### PR TITLE
Adding raspi_temperature to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8076,6 +8076,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspi_temperature:
+    doc:
+      type: git
+      url: https://github.com/bberrevoets/raspi_temperature.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/bberrevoets/raspi_temperature-release.git
+      version: 0.1.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/bberrevoets/raspi_temperature.git
+      version: master
+    status: maintained
   raspigibbon_apps:
     doc:
       type: git


### PR DESCRIPTION
I'd like raspi_temperature to be indexed and documented on ros.org.