### PR TITLE
radar_omnipresense: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2833,7 +2833,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
-      version: 0.1.0-1
+      version: 0.2.0-0
     status: developed
   random_numbers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_omnipresense` to `0.2.0-0`:

- upstream repository: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
- release repository: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.0-1`

## radar_omnipresense

```
* serialconnection folder
* added rapidjson, which has all needed header files
* added rapidjson folder in lib folder
* added rapidjson include the lib folder and 'wrapped' it in a radar_omnipresense namespace
* Contributors: Garren Hendricks, Jim Whitfield
```
