### PR TITLE
radar_omnipresense: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2038,6 +2038,13 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
+  radar_omnipresense:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
+      version: 0.2.0-0
+    status: developed
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_omnipresense` to `0.2.0-0`:

- upstream repository: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
- release repository: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## radar_omnipresense

```
* serialconnection folder
* added rapidjson, which has all needed header files
* added rapidjson folder in lib folder
* added rapidjson include the lib folder and 'wrapped' it in a radar_omnipresense namespace
* Contributors: Garren Hendricks, Jim Whitfield
```
