### PR TITLE
added pyqt5.qsci and sysv-ipc packages as ubuntu xenial rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2812,6 +2812,9 @@ python-qt5-bindings-gl:
     xenial: [python-pyqt5.qtopengl]
     yakkety: [python-pyqt5.qtopengl]
     zesty: [python-pyqt5.qtopengl]
+python-qt5-bindings-qsci:
+  ubuntu:
+    xenial: [python-pyqt5.qsci]
 python-qt5-bindings-webkit:
   arch: [python2-pyqt5]
   debian:
@@ -3574,6 +3577,9 @@ python-sympy:
     wily_python3: [python3-sympy]
     xenial: [python-sympy]
     xenial_python3: [python3-sympy]
+python-sysv-ipc:
+  ubuntu:
+    xenial: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]
   fedora: [python-tablib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3580,7 +3580,7 @@ python-sympy:
     xenial_python3: [python3-sympy]
 python-sysv-ipc:
   debian: [python-sysv-ipc]
-  fedora: [python-sysv-ipc]
+  fedora: [python2-sysv-ipc]
   ubuntu: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2813,8 +2813,9 @@ python-qt5-bindings-gl:
     yakkety: [python-pyqt5.qtopengl]
     zesty: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
-  ubuntu:
-    xenial: [python-pyqt5.qsci]
+  debian: [python-pyqt5.qsci]
+  fedora: [python2-qscintilla-qt5]
+  ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-webkit:
   arch: [python2-pyqt5]
   debian:
@@ -3578,8 +3579,9 @@ python-sympy:
     xenial: [python-sympy]
     xenial_python3: [python3-sympy]
 python-sysv-ipc:
-  ubuntu:
-    xenial: [python-sysv-ipc]
+  debian: [python-sysv-ipc]
+  fedora: [python-sysv-ipc]
+  ubuntu: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]
   fedora: [python-tablib]


### PR DESCRIPTION
We are working on JdeRobot/VisualStates (https://github.com/JdeRobot/VisualStates) project to release it as a ros package. In the project, we have two python dependencies that are not part of rosdep.
- `python-qt5.qsci` is a python bindings of QScintilla source code editor library. We use this package to provide a source code editor to the users.
- `python-sysv-ipc` is a python package to provide system v inter process communication functionality. We use this package to communicate python and c++ programs.