### PR TITLE
Revert "gazebo_ros_pkgs: 2.5.16-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2762,7 +2762,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.16-0
+      version: 2.5.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#18106

@j-rivero ticketed https://github.com/ros-simulation/gazebo_ros_pkgs/issues/739

@mikaelarguedas @clalancette FYI this is likely affecting lunar #18108 and melodic #18109 also but they don't have downstream packages released yet.