### PR TITLE
Revert "gazebo_ros_pkgs: 2.7.5-0 in 'lunar/distribution.yaml' [bloom]"

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -863,7 +863,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.7.5-0
+      version: 2.7.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#18108

Similar to https://github.com/ros/rosdistro/pull/18124, more details at https://github.com/ros-simulation/gazebo_ros_pkgs/issues/739
@j-rivero FYI