### PR TITLE
mavros: 0.26.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1795,7 +1795,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.25.1-0
+      version: 0.26.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.26.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.25.1-0`

## libmavconn

```
* libmavconn: add scheme for permanent UDP broadcasting
* test python 3 f-string formatting
* Contributors: Oleg Kalachev, Vladimir Ermakov
```

## mavros

```
* lib: add tunable timeout to gcs_quiet_mode
* udp bridge: pass only HEARTBEATs when GCS is offline
* sys_time : add advanced timesync algorithm
* libmavconn: add scheme for permanent UDP broadcasting
* GPS accuracy wo approximations (#1034 <https://github.com/mavlink/mavros/issues/1034>)
  * GPS horizontal and vertical accuracy are based now on h_acc, v_acc of GPS_RAW_INT.
  * GPS horizontal and vertical accuracy are based now on h_acc, v_acc of GPS_RAW_INT if on mavlink v2.0,
  or on DOP values otherwise.
  * GPS accuracy update.
* Contributors: Mohammed Kabir, Oleg Kalachev, Pavlo Kolomiiets, Vladimir Ermakov
```

## mavros_extras

```
* odom: fix mapping for body frame
* Contributors: TSC21
```

## mavros_msgs

```
* mavros_msgs : add timesync status message
* Contributors: Mohammed Kabir
```

## test_mavros

- No changes
