### PR TITLE
Adding topics_rviz_plugin to documentation index for melodic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11904,7 +11904,7 @@ repositories:
       type: git
       url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
       version: kinetic
-    status: developed
+    status: maintained
   towr:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3232,6 +3232,12 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  topics_rviz_plugin:
+    doc:
+      type: git
+      url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
+      version: melodic
+    status: maintained
   tracetools:
     release:
       tags:


### PR DESCRIPTION
I have also changed the status of the package to `maintained` on `kinetic`.