### PR TITLE
catkin: 0.7.14-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -220,7 +220,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.13-0
+      version: 0.7.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.14-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.7.13-0`

## catkin

```
* terminal_color is now in catkin_pkg, regression from 0.7.13 (#943 <https://github.com/ros/catkin/issues/943>)
* fix permission of CMake file (#942 <https://github.com/ros/catkin/issues/942>)
```
