### PR TITLE
ros_comm: 1.14.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2300,7 +2300,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.14.1-0
+      version: 1.14.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.14.2-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.14.1-0`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

- No changes

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

```
* import rosbag locally instead of at module level (#1424 <https://github.com/ros/ros_comm/issues/1424>)
```

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* fix some errors in some probably not frequented code paths (#1415 <https://github.com/ros/ros_comm/issues/1415>)
* fix thread problem with get_topics() (#1416 <https://github.com/ros/ros_comm/issues/1416>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

```
* fix the count of subscribers, regression from 1.14.0 (#1407 <https://github.com/ros/ros_comm/issues/1407>)
```

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

- No changes
