### PR TITLE
ypspur_ros: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13435,7 +13435,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/ypspur_ros-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/openspur/ypspur_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.2.0-0`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.0-0`

## ypspur_ros

```
* Add CI build for melodic (#37 <https://github.com/openspur/ypspur_ros/issues/37>)
  
    * Also rename ci script directory
  
* Add encrypted token for image caching (#35 <https://github.com/openspur/ypspur_ros/issues/35>)
* Migrate to ROS recommended namespace model (#31 <https://github.com/openspur/ypspur_ros/issues/31>)
* Fix --enable-get-digital-io arg to ypspur-coordinator (#33 <https://github.com/openspur/ypspur_ros/issues/33>)
* Fix installation of nodes (#30 <https://github.com/openspur/ypspur_ros/issues/30>)
* Fix variable and class naming styles (#29 <https://github.com/openspur/ypspur_ros/issues/29>)
* Contributors: Atsushi Watanabe
```
