### PR TITLE
ypspur_ros: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3528,5 +3528,20 @@ repositories:
       url: https://github.com/openspur/yp-spur.git
       version: master
     status: developed
+  ypspur_ros:
+    doc:
+      type: git
+      url: https://github.com/openspur/ypspur_ros.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/openspur/ypspur_ros-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/openspur/ypspur_ros.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.2.0-0`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ypspur_ros

```
* Add CI build for melodic (#37 <https://github.com/openspur/ypspur_ros/issues/37>)
  
    * Also rename ci script directory
  
* Add encrypted token for image caching (#35 <https://github.com/openspur/ypspur_ros/issues/35>)
* Migrate to ROS recommended namespace model (#31 <https://github.com/openspur/ypspur_ros/issues/31>)
* Fix --enable-get-digital-io arg to ypspur-coordinator (#33 <https://github.com/openspur/ypspur_ros/issues/33>)
* Fix installation of nodes (#30 <https://github.com/openspur/ypspur_ros/issues/30>)
* Fix variable and class naming styles (#29 <https://github.com/openspur/ypspur_ros/issues/29>)
* Contributors: Atsushi Watanabe
```
