### PR TITLE
gazebo_ros_pkgs: 2.7.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -863,7 +863,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.7.3-0
+      version: 2.7.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.7.6-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.7.3-0`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* gazebo_plugins: install triggered camera plugins (#741 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/741>)
  Fixes #739 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/739>.
* Contributors: Jose Luis Rivero
```

## gazebo_ros

- No changes

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
