### PR TITLE
gazebo_ros_pkgs: 2.5.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2762,7 +2762,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.14-1
+      version: 2.5.17-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.17-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `2.5.14-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* gazebo_plugins: install triggered camera plugins (#740 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/740>)
  Fixes #739 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/739>.
* Contributors: Steven Peters
```

## gazebo_ros

- No changes

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
