### PR TITLE
grizzly_simulator: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3158,6 +3158,24 @@ repositories:
       url: https://github.com/g/grizzly.git
       version: kinetic-devel
     status: maintained
+  grizzly_simulator:
+    doc:
+      type: git
+      url: https://github.com/g/grizzly_simulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - grizzly_gazebo
+      - grizzly_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/grizzly_simulator-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/g/grizzly_simulator.git
+      version: kinetic-devel
+    status: maintained
   grpc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_simulator` to `0.3.0-0`:

- upstream repository: https://github.com/g/grizzly_simulator.git
- release repository: https://github.com/clearpath-gbp/grizzly_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## grizzly_gazebo

```
* Upgrading simulation to kinetic
* Rename control.launch to localization.launch
* Contributors: Mohamed Elshatshat, Shokoofeh Pourmehr
```

## grizzly_simulator

```
* Upgrading simulation to kinetic
* Contributors: Mohamed Elshatshat
```
