### PR TITLE
grizzly_desktop: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3158,6 +3158,24 @@ repositories:
       url: https://github.com/g/grizzly.git
       version: kinetic-devel
     status: maintained
+  grizzly_desktop:
+    doc:
+      type: git
+      url: https://github.com/g/grizzly_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - grizzly_desktop
+      - grizzly_viz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/grizzly_desktop-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/g/grizzly_desktop.git
+      version: kinetic-devel
+    status: maintained
   grizzly_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_desktop` to `0.3.1-0`:

- upstream repository: https://github.com/g/grizzly_desktop
- release repository: https://github.com/clearpath-gbp/grizzly_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## grizzly_desktop

```
* Removed un-needed deps and updated maintainer.
* 0.3.0
* Changes.
* Contributors: Tony Baltovski
```

## grizzly_viz

```
* Removed un-needed deps and updated maintainer.
* 0.3.0
* Changes.
* cleaning up package.xml and cmakelists
* Contributors: Mohamed Elshatshat, Tony Baltovski
```
