### PR TITLE
Remove EOL Release platforms Debian Jessie, Fedora 23 and 24

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3,11 +3,6 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
-  debian:
-  - jessie
-  fedora:
-  - '23'
-  - '24'
   ubuntu:
   - xenial
 repositories:


### PR DESCRIPTION
This is a follow on to https://github.com/ros-infrastructure/ros_buildfarm_config/pull/118

Holding until we've confirmed jessie is shutdown cleanly. 