### PR TITLE
rqt_joint_trajectory_plot: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10191,7 +10191,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/tork-a/rqt_joint_trajectory_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_joint_trajectory_plot` to `0.0.2-0`:

- upstream repository: https://github.com/tork-a/rqt_joint_trajectory_plot.git
- release repository: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.1-0`

## rqt_joint_trajectory_plot

```
* Add script/rqt_joint_trajectory_plot(#7 <https://github.com/tork-a/rqt_joint_trajectory_plot/issues/7>)
* Update to visualize FollowJointTrajectoryActionGoal(#6 <https://github.com/tork-a/rqt_joint_trajectory_plot/issues/6>)
* Contributors: Kei Okada, Ryosuke Tajima
```
