### PR TITLE
cartographer_ros: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -193,7 +193,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     status: developed
   catch_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.0-1`:

- upstream repository: https://github.com/googlecartographer/cartographer_ros.git
- release repository: https://github.com/ros-gbp/cartographer_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.0-0`

## cartographer_ros

```
* https://github.com/googlecartographer/cartographer_ros/compare/0.3.0...1.0.0
```
