### PR TITLE
teb_local_planner: 0.6.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11635,7 +11635,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.6.9-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.8-0`

## teb_local_planner

```
* Adds the possibility to provide via-points via a topic.
  Currently, the user needs to decide whether to receive via-points from topic or to obtain them from the global reference plan
  (e.g., activate the latter by setting global_plan_viapoint_sep>0 as before).
  A small test script publish_viapoints.py is provided to demonstrate the feature within test_optim_node.
* Contributors: Christoph Rösmann
```
