### PR TITLE
grizzly_desktop: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3170,7 +3170,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly_desktop-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/g/grizzly_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_desktop` to `0.3.2-0`:

- upstream repository: https://github.com/g/grizzly_desktop
- release repository: https://github.com/clearpath-gbp/grizzly_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.1-0`

## grizzly_desktop

- No changes

## grizzly_viz

```
* Removed unused args in launch file.
* Contributors: Tony Baltovski
```
