### PR TITLE
grizzly_simulator: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3188,7 +3188,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly_simulator-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/g/grizzly_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly_simulator` to `0.3.1-0`:

- upstream repository: https://github.com/g/grizzly_simulator.git
- release repository: https://github.com/clearpath-gbp/grizzly_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.0-0`

## grizzly_gazebo

```
* Removed un-used args and multimaster.  Updated maintainer.
* Contributors: Tony Baltovski
```

## grizzly_simulator

```
* Removed un-used args and multimaster.  Updated maintainer.
* Contributors: Tony Baltovski
```
