### PR TITLE
moveit_visual_tools: 3.2.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1474,6 +1474,21 @@ repositories:
       url: https://github.com/PickNikRobotics/moveit_sim_controller.git
       version: melodic-devel
     status: maintained
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/moveit_visual_tools.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PickNikRobotics/moveit_visual_tools-release.git
+      version: 3.2.1-2
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/moveit_visual_tools.git
+      version: melodic-devel
+    status: developed
   mrpt1:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.2.1-2`:

- upstream repository: https://github.com/PickNikRobotics/moveit_visual_tools.git
- release repository: https://github.com/PickNikRobotics/moveit_visual_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## moveit_visual_tools

```
* New publishTrajectoryPath() functions
* New publishTrajectoryLine() functions
* getRobotState() return by reference
* Trajectory path has smaller vertices
* IMarkerRobotState: added isStateValid()
* Contributors: Dave Coleman
```
