### PR TITLE
xiaoqiang: 0.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13320,6 +13320,7 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - addwa_local_planner
       - xiaoqiang
       - xiaoqiang_bringup
       - xiaoqiang_controller
@@ -13331,11 +13332,13 @@ repositories:
       - xiaoqiang_freenect_launch
       - xiaoqiang_monitor
       - xiaoqiang_msgs
+      - xiaoqiang_navigation
+      - xiaoqiang_navigation_example
       - xiaoqiang_server
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/bluewhalerobot/xiaoqiang.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xiaoqiang` to `0.0.10-0`:

- upstream repository: https://github.com/bluewhalerobot/xiaoqiang
- release repository: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.9-0`

## addwa_local_planner

```
* add navigation and add fix depth image dependency
* Contributors: xiaoqiang
```

## xiaoqiang

- No changes

## xiaoqiang_bringup

```
* add navigation and add fix depth image dependency
* Contributors: xiaoqiang
```

## xiaoqiang_controller

- No changes

## xiaoqiang_depth_image_proc

```
* add navigation and add fix depth image dependency
* Contributors: xiaoqiang
```

## xiaoqiang_description

- No changes

## xiaoqiang_driver

- No changes

## xiaoqiang_freenect

- No changes

## xiaoqiang_freenect_camera

- No changes

## xiaoqiang_freenect_launch

- No changes

## xiaoqiang_monitor

- No changes

## xiaoqiang_msgs

- No changes

## xiaoqiang_navigation

```
* add navigation and add fix depth image dependency
* Contributors: xiaoqiang
```

## xiaoqiang_navigation_example

```
* add navigation and add fix depth image dependency
* Contributors: xiaoqiang
```

## xiaoqiang_server

- No changes
