### PR TITLE
mrpt_bridge: 0.1.23-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5660,7 +5660,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
-      version: 0.1.23-0
+      version: 0.1.23-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_bridge` to `0.1.23-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.23-0`

## mrpt_bridge

```
* make catkin_lint clean
* ROS build farm badges and links
* Contributors: Jose Luis Blanco-Claraco
```
