### PR TITLE
create_autonomy: 1.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2349,6 +2349,17 @@ repositories:
       type: git
       url: https://github.com/AutonomyLab/create_autonomy.git
       version: indigo-devel
+    release:
+      packages:
+      - ca_description
+      - ca_driver
+      - ca_msgs
+      - ca_tools
+      - create_autonomy
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/AutonomyLab/create_autonomy-release.git
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/AutonomyLab/create_autonomy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `create_autonomy` to `1.3.0-0`:

- upstream repository: https://github.com/AutonomyLab/create_autonomy.git
- release repository: https://github.com/AutonomyLab/create_autonomy-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ca_description

```
* Migrate to package.xml format 2
  
  Minor linting to package files.
* Update install rules
* Refactor launch files and expose robot base and odometry frame IDs as parameters
* Refactor CMakeLists.txt and package.xml files and add missing install rules
* Contributors: Jacob Perron
```

## ca_driver

```
* Add explicit dependency on catkin_EXPORTED_TARGETS
  
  This ensures ca_msgs is built before ca_driver.
* Migrate to package.xml format 2
  
  Minor linting to package files.
* Add roslint test and fix lint issues
* find_package libcreate instead of downloading as external project
* Add support for defining and playing songs
* Update install rules
* Refactor launch files and expose robot base and odometry frame IDs as parameters
* Refactor CMakeLists.txt and package.xml files and add missing install rules
* Contributors: Clyde McQueen, Jacob Perron
```

## ca_msgs

```
* Migrate to package.xml format 2
  
  Minor linting to package files.
* Add support for defining and playing songs
* Refactor CMakeLists.txt and package.xml files and add missing install rules
* Contributors: Clyde McQueen, Jacob Perron
```

## ca_tools

```
* Migrate to package.xml format 2
  
  Minor linting to package files.
* Update install rules
* Refactor launch files and expose robot base and odometry frame IDs as parameters
* Refactor CMakeLists.txt and package.xml files and add missing install rules
* Contributors: Jacob Perron
```

## create_autonomy

```
* Migrate to package.xml format 2
  
  Minor linting to package files.
* Contributors: Jacob Perron
```
