### PR TITLE
mrpt1: 1.5.7-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5645,7 +5645,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt1-release.git
-      version: 1.5.7-2
+      version: 1.5.7-3
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt1` to `1.5.7-3`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt1-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.5.7-2`
