### PR TITLE
rosdep/python: add python-pytest-qt

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2672,6 +2672,16 @@ python-pytest:
   fedora: [python-pytest]
   gentoo: [dev-python/pytest]
   ubuntu: [python-pytest]
+python-pytest-qt-pip:
+  debian:
+    pip:
+      packages: [pytest-qt]
+  fedora:
+    pip:
+      packages: [pytest-qt]
+  ubuntu:
+    pip:
+      packages: [pytest-qt]
 python-pytz-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Add the [pytest-qt](https://pypi.org/project/pytest-qt/) pytest extension.