### PR TITLE
video_stream_opencv: 1.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16451,7 +16451,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-drivers/video_stream_opencv-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/video_stream_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_stream_opencv` to `1.1.2-0`:

- upstream repository: https://github.com/ros-drivers/video_stream_opencv.git
- release repository: https://github.com/ros-drivers/video_stream_opencv-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.1.1-0`

## video_stream_opencv

```
* Fix empty frame id in camera info header when providing a calibration file.
* Contributors: tim-fan
```
