### PR TITLE
joystick_drivers: 1.12.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1082,6 +1082,27 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: master
+    release:
+      packages:
+      - joy
+      - joystick_drivers
+      - ps3joy
+      - spacenav_node
+      - wiimote
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/joystick_drivers-release.git
+      version: 1.12.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: master
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.12.0-0`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## joy

```
* Update timestamp when using autorepeat_rate
* Added dev_name parameter to select joystick by name
* Added Readme for joy package with description of new device name parameter
* Fixed numerous outstanding PRs.
* Added sticky buttons
* Changed package xml to format 2
* Fixed issue when the joystick data did not got send until changed.
* Changed messaging to better reflect what the script is doing
* Contributors: Dino Hüllmann, Jonathan Bohren, Joshua Whitley, Miklos Marton, Naoki Mizuno, jprod123, psimona
```

## joystick_drivers

```
* Addressed numerous outstanding PRs.
* Changed package xml to format 2
* Contributors: Jonathan Bohren, jprod123
```

## ps3joy

```
* Addressed numerous outstanding PRs.
* Created bluetooth_devices.md
* Created testing guide for ps3joy.
* Create procedure_test.md
* Let ps3joy_node not quit on inactivity-timeout.
* Refine diagnostics message usage in ps3joy_node
* Improve ps3joy_node with rospy.init_node and .is_shutdown
* Remove quit on failed root level check, part one of issue #53 <https://github.com/ros-drivers/joystick_drivers/issues/53>
* Create README
* Changed package xml to format 2
* Contributors: Alenso Labady, Felix Kolbe, Jonathan Bohren, alab288, jprod123
```

## spacenav_node

```
* Adding tested spacenav scaling
* Added README
* Addressed numerous outstanding PRs.
* Changed package xml to format 2
* Reduce the number of scale params in spacenav_node
* Add a scale parameter to each axis in spacenav_node
  Do not apply the scale to the joy topic.
* Contributors: Gaël Ecorchard, Jonathan Bohren, jprod123
```

## wiimote

```
* Addressed numerous outstanding PRs.
* Fixed issue when nunchuk wasn't connected
* Update README.md
* Added testing proceedures for wiimote
* Resolved div-by-zero error race condition on startup.
* Added testing proceedures for wiimote
* Fixed issue when nunchuk wasn't connected
* Changed package xml to format 2
* Added wiimote testing script
* Add pairing params to wiimote_node
  * bluetooth_addr
  * pair_timeout
* Contributors: Jonathan Bohren, Matt Vollrath, jprod123, psimona
```
