### PR TITLE
pacmod: 2.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2465,6 +2465,21 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: master
     status: developed
+  pacmod:
+    doc:
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: release
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/astuff/pacmod-release.git
+      version: 2.0.2-0
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: release
+    status: developed
   parameter_pa:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod` to `2.0.2-0`:

- upstream repository: https://github.com/astuff/pacmod.git
- release repository: https://github.com/astuff/pacmod-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
