### PR TITLE
Revert "radar_omnipresense: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]"

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2848,7 +2848,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
-      version: 0.2.0-0
+      version: 0.1.0-1
     status: developed
   random_numbers:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#18120

@garrenhendricks FYI: reverting #18120 as discussed in https://github.com/ros/rosdistro/pull/18120#issuecomment-394898121 given that the build is still failing