### PR TITLE
mcl_3dl_msgs: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5228,6 +5228,21 @@ repositories:
       url: https://github.com/at-wat/mcl_3dl.git
       version: master
     status: developed
+  mcl_3dl_msgs:
+    doc:
+      type: git
+      url: https://github.com/at-wat/mcl_3dl_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/at-wat/mcl_3dl_msgs-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/at-wat/mcl_3dl_msgs.git
+      version: master
+    status: developed
   md49_base_controller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl_msgs` to `0.1.2-0`:

- upstream repository: https://github.com/at-wat/mcl_3dl_msgs.git
- release repository: https://github.com/at-wat/mcl_3dl_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mcl_3dl_msgs

```
* Fix runtime dependency (https://github.com/at-wat/mcl_3dl_msgs/issues/3)
* Fix package dependency (https://github.com/at-wat/mcl_3dl_msgs/issues/2)
* Build messages and services
* Initial drop from mcl_3dl package
* Support variable particle size (https://github.com/at-wat/mcl_3dl/issues/78)
  
    * Support variable particle size.
    * Add service to change particle size.
    * Add test for resizeParticle.
  
* Add localization status output (https://github.com/at-wat/mcl_3dl/issues/120)
* Contributors: Atsushi Watanabe
```
