### PR TITLE
lusb: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6666,6 +6666,11 @@ repositories:
       type: hg
       url: https://bitbucket.org/dataspeedinc/lusb
       version: default
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DataspeedInc-release/lusb-release.git
+      version: 1.0.9-0
     source:
       test_commits: false
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `1.0.9-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## lusb

```
* Prioritize the local include folder (there were issues with catkin workspace overlays)
* Contributors: Kevin Hallenbeck
```
