### PR TITLE
lusb: 1.0.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4948,6 +4948,11 @@ repositories:
       type: hg
       url: https://bitbucket.org/dataspeedinc/lusb
       version: default
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/lusb-release.git
+      version: 1.0.9-0
     source:
       test_commits: false
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `1.0.9-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## lusb

```
* Prioritize the local include folder (there were issues with catkin workspace overlays)
* Contributors: Kevin Hallenbeck
```
