### PR TITLE
lusb: 1.0.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1219,6 +1219,21 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
     status: maintained
+  lusb:
+    doc:
+      type: hg
+      url: https://bitbucket.org/dataspeedinc/lusb
+      version: default
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/lusb-release.git
+      version: 1.0.9-0
+    source:
+      type: hg
+      url: https://bitbucket.org/dataspeedinc/lusb
+      version: default
+    status: developed
   map_merge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `1.0.9-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## lusb

```
* Prioritize the local include folder (there were issues with catkin workspace overlays)
* Contributors: Kevin Hallenbeck
```
