### PR TITLE
dataspeed_can: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2468,6 +2468,16 @@ repositories:
       type: hg
       url: https://bitbucket.org/dataspeedinc/dataspeed_can
       version: default
+    release:
+      packages:
+      - dataspeed_can
+      - dataspeed_can_msg_filters
+      - dataspeed_can_tools
+      - dataspeed_can_usb
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
+      version: 1.0.9-0
     source:
       test_commits: false
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.9-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

```
* Added tests for extended IDs, error frames, and RTR frames
* Ported tests from ros_comm/message_filters/approximate_time_policy
* Distinguish between standard and extended IDs with the MSB of the ID
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_tools

```
* Preliminary support for extended IDs
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_usb

```
* Removed the private dataspeed_boot_usb package as an exec dependency
* Contributors: Kevin Hallenbeck
```
