### PR TITLE
Add python inputs package to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1562,6 +1562,19 @@ python-inject-pip:
   ubuntu:
     pip:
       packages: [inject]
+python-inputs-pip:
+  debian:
+    pip:
+      packages: [inputs]
+  fedora:
+    pip:
+      packages: [inputs]
+  osx:
+    pip:
+      packages: [inputs]
+  ubuntu:
+    pip:
+      packages: [inputs]
 python-ipdb:
   debian: [python-ipdb]
   gentoo: [dev-python/ipdb]


### PR DESCRIPTION
Adding support for the [inputs](https://pypi.org/project/inputs/) python module.

From the pip project page: 

> The inputs module provides an easy way for your Python program to listen for user input.

I am currently using this module in a controller ROS package that enables use of a number of gamepads with a computer or RaspberryPi.