### PR TITLE
phidgets_drivers: 0.7.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1911,6 +1911,29 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: melodic-devel
     status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: melodic
+    release:
+      packages:
+      - libphidget21
+      - phidgets_api
+      - phidgets_drivers
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_imu
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
+      version: 0.7.5-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: melodic
+    status: maintained
   pid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.5-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## libphidget21

- No changes

## phidgets_api

```
* Add support for the phidgets_ik (Phidgets Interface Kit)
* Contributors: Russel Howe, James Sarrett, Martin Günther
```

## phidgets_drivers

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

```
* Initial release of the phidgets_ik package for the Phidgets Interface Kit
* Contributors: Russel Howe, James Sarrett, Dorian Goepp, Martin Günther
```

## phidgets_imu

```
* phidgets_imu: Add roslaunch_add_file_check
* phidgets_imu: Add diagnostic_aggregator dependency
* phidgets_imu: Add missing install rule for config
* update to use non deprecated pluginlib macro (#19 <https://github.com/ros-drivers/phidgets_drivers/issues/19>)
* Contributors: Martin Günther, Mikael Arguedas
```
