### PR TITLE
dataspeed_can: 1.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2477,7 +2477,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       test_commits: false
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.10-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.9-0`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

```
* Removed unnecessary rostest dependency
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_tools

- No changes

## dataspeed_can_usb

- No changes
