### PR TITLE
dbw_mkz_ros: 1.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2489,6 +2489,18 @@ repositories:
       type: hg
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
       version: default
+    release:
+      packages:
+      - dbw_mkz
+      - dbw_mkz_can
+      - dbw_mkz_description
+      - dbw_mkz_joystick_demo
+      - dbw_mkz_msgs
+      - dbw_mkz_twist_controller
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
+      version: 1.0.13-0
     source:
       test_commits: false
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_mkz_ros` to `1.0.13-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
- release repository: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## dbw_mkz

- No changes

## dbw_mkz_can

```
* Updated firmware versions
* Added option to enable/disable warnings on received command messages
* Added support for the RES+ and RES- buttons
* Added explicit casts to float
* Added firmware version of separate shifting module
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_description

- No changes

## dbw_mkz_joystick_demo

```
* Warn and suggest fix for incorrect Logitech gamepad X/D switch configuration
* Removed joystick_demo namespace
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_msgs

```
* Added support for the RES+ and RES- buttons
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_twist_controller

```
* Fixed compile error on ROS Melodic and Ubuntu Bionic
* Contributors: Kevin Hallenbeck
```
