### PR TITLE
rqt_joint_trajectory_plot: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13248,6 +13248,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: indigo-devel
     status: maintained
+  rqt_joint_trajectory_plot:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    status: developed
   rqt_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_joint_trajectory_plot` to `0.0.3-0`:

- upstream repository: https://github.com/tork-a/rqt_joint_trajectory_plot.git
- release repository: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rqt_joint_trajectory_plot

```
* Check the qt version in plot_widget.py for indigo release(#9 <https://github.com/tork-a/rqt_joint_trajectory_plot/issues/9>)
* Contributors: Ryosuke Tajima
```
