### PR TITLE
rqt_joint_trajectory_plot: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13257,7 +13257,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/tork-a/rqt_joint_trajectory_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_joint_trajectory_plot` to `0.0.4-0`:

- upstream repository: https://github.com/tork-a/rqt_joint_trajectory_plot.git
- release repository: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.3-0`

## rqt_joint_trajectory_plot

```
* Fix lint problem
* Contributors: Ryosuke Tajima
```
