### PR TITLE
xiaoqiang: 0.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13372,7 +13372,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/bluewhalerobot/xiaoqiang.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xiaoqiang` to `0.0.11-0`:

- upstream repository: https://github.com/bluewhalerobot/xiaoqiang
- release repository: https://github.com/BluewhaleRobot-release/xiaoqiang-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.10-0`

## addwa_local_planner

```
* fix linking error
* Contributors: xiaoqiang
```

## xiaoqiang

- No changes

## xiaoqiang_bringup

- No changes

## xiaoqiang_controller

- No changes

## xiaoqiang_depth_image_proc

```
* fix linking error
* Contributors: xiaoqiang
```

## xiaoqiang_description

- No changes

## xiaoqiang_driver

- No changes

## xiaoqiang_freenect

- No changes

## xiaoqiang_freenect_camera

- No changes

## xiaoqiang_freenect_launch

- No changes

## xiaoqiang_monitor

- No changes

## xiaoqiang_msgs

- No changes

## xiaoqiang_navigation

- No changes

## xiaoqiang_navigation_example

- No changes

## xiaoqiang_server

- No changes
