### PR TITLE
handeye: 0.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4328,7 +4328,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/crigroup/handeye-release.git
-      version: 0.1.0-0
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/crigroup/handeye.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.1-1`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.0-0`

## handeye

```
* Fix np.linalg.lstsq bug
* Add installation rules for python node
* Contributors: fsuarez6
```
