### PR TITLE
handeye: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3273,7 +3273,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/crigroup/handeye-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/crigroup/handeye.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.1-0`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.0-0`

## handeye

```
* Fix np.linalg.lstsq bug
* Add installation rules for python node
* Contributors: fsuarez6
```
