### PR TITLE
criutils: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1692,7 +1692,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/crigroup/criutils-release.git
-      version: 0.1.1-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/crigroup/criutils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.3-0`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.1-0`

## criutils

```
* Add automatic TF broadcaster node
* Add missing dependency to OpenCV
* Add and improve test coverage
* Use baldor package instead of tf.transformations
* Fix documentation generation for ROS indigo (#2)
* Contributors: Francisco, fsuarez6
```
