### PR TITLE
criutils: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2363,7 +2363,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/crigroup/criutils-release.git
-      version: 0.1.1-1
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/crigroup/criutils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.3-0`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.1-1`

## criutils

```
* Add automatic TF broadcaster node
* Add missing dependency to OpenCV
* Add and improve test coverage
* Use baldor package instead of tf.transformations
* Fix documentation generation for ROS indigo (#2)
* Contributors: Francisco, fsuarez6
```
