### PR TITLE
rc_cloud_accumulator: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10927,6 +10927,22 @@ repositories:
       url: https://bitbucket.org/rbdl/rbdl
       version: default
     status: developed
+  rc_cloud_accumulator:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_cloud_accumulator.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_cloud_accumulator-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_cloud_accumulator.git
+      version: master
+    status: developed
   rc_dynamics_api:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_cloud_accumulator` to `1.0.0-0`:

- upstream repository: https://github.com/roboception/rc_cloud_accumulator.git
- release repository: https://github.com/roboception-gbp/rc_cloud_accumulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## rc_cloud_accumulator

```
* initial release
```
