### PR TITLE
teb_local_planner_tutorials: 0.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11703,7 +11703,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner_tutorials` to `0.2.2-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.1-0`

## teb_local_planner_tutorials

```
* Example scripts, configurations and launch files for planning with dynamic obstacles added
* Scripts updated to consider the costmap_converter::ObstacleArrayMsg message
* Contributors: Christoph Rösmann, Franz Albers
```
