### PR TITLE
lusb: 1.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4967,7 +4967,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/lusb-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: hg
       url: https://bitbucket.org/dataspeedinc/lusb


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `1.0.10-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.9-0`

## lusb

```
* Added function to list devices using the class variables for VID and PID
* Contributors: Kevin Hallenbeck
```
