### PR TITLE
Add clang-format for all Ubuntu distros

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -389,8 +389,7 @@ clang-format:
     buster: [clang-format]
     stretch: [clang-format]
   gentoo: [sys-devel/clang]
-  ubuntu:
-    xenial: [clang-format]
+  ubuntu: [clang-format]
 cmake:
   arch: [cmake]
   debian: [cmake]


### PR DESCRIPTION
clang-format is available xenial-onwards. Is it acceptable to provide it like this, or does each distro post xenial need to be specified independently?