### PR TITLE
Add source/doc for mrpt_sensors

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5738,7 +5738,7 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: master
     status: maintained
-mrpt_sensors:
+  mrpt_sensors:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
@@ -5748,7 +5748,7 @@ mrpt_sensors:
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
       version: master
     status: maintained
-mrpt_slam:
+  mrpt_slam:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5736,9 +5736,19 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
-      version: compat-mrpt-1.3
+      version: master
     status: maintained
-  mrpt_slam:
+mrpt_sensors:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: master
+    status: maintained
+mrpt_slam:
     doc:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
@@ -5758,7 +5768,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
-      version: compat-mrpt-1.3
+      version: master
     status: maintained
   msp:
     doc:


### PR DESCRIPTION
Also, update source branch for "dev" builds of mrpt repos to "master", since they now can be build against mrpt-1.5.* via the ROS package `mrpt1` that provides a newer version of MRPT than the available via official Ubuntu repos (mrpt-1.3)