### PR TITLE
yocs_msgs: 0.7.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3621,6 +3621,13 @@ repositories:
       url: https://github.com/rohbotics/xv_11_laser_driver.git
       version: kinetic-devel
     status: maintained
+  yocs_msgs:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/yocs_msgs-release.git
+      version: 0.7.0-0
+    status: maintained
   yp-spur:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yocs_msgs` to `0.7.0-0`:

- upstream repository: https://github.com/yujinrobot/yocs_msgs.git
- release repository: https://github.com/yujinrobot-release/yocs_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
