### PR TITLE
Fedora 26 is EOL

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5,8 +5,6 @@
 release_platforms:
   debian:
   - stretch
-  fedora:
-  - '26'
   ubuntu:
   - xenial
 repositories:


### PR DESCRIPTION
Fedora 26 went EOL on [may 29th, 2018](https://fedoraproject.org/wiki/End_of_life).
