### PR TITLE
python: debian|fedora|ubuntu: add casadi dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -42,6 +42,16 @@ azure-iothub-device-client-pip:
   ubuntu:
     pip:
       packages: [azure-iothub-device-client]
+casadi-pip:
+  debian:
+    pip:
+      packages: [casadi]
+  fedora:
+    pip:
+      packages: [casadi]
+  ubuntu:
+    pip:
+      packages: [casadi]
 catkin_pkg:
   gentoo: [dev-python/catkin_pkg]
 cmakelint-pip:


### PR DESCRIPTION
Adds [CasADi](https://github.com/casadi/casadi) to the dependency list.