### PR TITLE
create_autonomy: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8497,7 +8497,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/jlack/rdl_release.git
-      version: 0.9.5-0
+      version: 0.10.6-1
     source:
       type: git
       url: https://gitlab.com/jlack/rdl.git


### PR DESCRIPTION
Increasing version of package(s) in repository create_autonomy to 0.10.6-1:

upstream repository: https://gitlab.com/jlack/rdl
release repository: https://gitlab.com/jlack/rdl_release
distro file: kinetic/distribution.yaml
bloom version: 0.6.4
previous version for package: 0.9.5