### PR TITLE
Adding hexagon_map to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4563,6 +4563,15 @@ repositories:
       url: https://github.com/heron/heron_desktop.git
       version: indigo-devel
     status: maintained
+  hexagon_map:
+     doc:
+       type: git
+       url: https://github.com/DS921020/hexagon_map.git
+       version: master
+     source:
+       type: git
+       url: https://github.com/DS921020/hexagon_map.git
+       version: master
   hironx_rpc:
     doc:
       type: git


### PR DESCRIPTION
I'd like my_repo hexagon_map to be indexed and documented on ros.org.