### PR TITLE
navigation: 1.12.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8076,7 +8076,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.12.15-0
+      version: 1.12.16-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.12.16-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.12.15-0`

## amcl

- No changes

## base_local_planner

- No changes

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

```
* Merge pull request #695 <https://github.com/ros-planning/navigation/issues/695> from ros-planning/indigo_675
  Fixed race condition with costmaps in LayeredCostmap::resizeMap() (backport #675 <https://github.com/ros-planning/navigation/issues/675>)
  LayeredCostmap::updateMap() and LayeredCostmap::resizeMap() write to the master grid costmap.
  And these two functions can be called by different threads at the same time.
  One example of these cases is a race condition between subscriber callback thread
  dealing with dynamically-size-changing static_layer and periodical updateMap() calls from Costmap2DROS thread.
  Under the situation the master grid costmap is not thread-safe.
  LayeredCostmap::updateMap() already used the master grid costmap's lock.
* Merge pull request #692 <https://github.com/ros-planning/navigation/issues/692> from ros-planning/remove_got_footprint
  remove unused got_footprint_
* Merge pull request #691 <https://github.com/ros-planning/navigation/issues/691> from ros-planning/rehash_620
  initialize all costmap variables
* Contributors: Jaeyoung Lee, Michael Ferguson
```

## dwa_local_planner

- No changes

## fake_localization

- No changes

## global_planner

- No changes

## map_server

- No changes

## move_base

- No changes

## move_base_msgs

- No changes

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## robot_pose_ekf

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
