### PR TITLE
navigation: 1.14.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6135,7 +6135,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.3-0
+      version: 1.14.4-0
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.14.4-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.14.3-0`

## amcl

```
* Merge pull request #731 <https://github.com/ros-planning/navigation/issues/731> from maracuya-robotics/kinetic/amcl-dynamic-reconfigure
  AMCL dynamic reconfigure: Extend parameter range
* In Addition to #696 <https://github.com/ros-planning/navigation/issues/696>, which checks the input arguments, this extends the
  allowed parameter range in dynamic reconfigure. The description for
  "save_pose_rate" says "-1.0 to disable" but allowed only positive values
  previously.
  Also increase maximum value for laser_max_beams for high performance
  systems.
* Merge pull request #668 <https://github.com/ros-planning/navigation/issues/668> from B0gdar/kinetic-devel
  Update laser_model_type enum on AMCL.cfg
  Adding likelihood_field_prob laser model option on AMCL.cfg to be able to control dynamic parameters with this laser sensor model.
* Contributors: Michael Ferguson, Miguel Cordero, maracuya-robotics
```

## base_local_planner

- No changes

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

```
* Merge pull request #693 <https://github.com/ros-planning/navigation/issues/693> from ros-planning/kinetic_691
  costmap variable init & cleanup (forward port of #691 <https://github.com/ros-planning/navigation/issues/691>)
* remove unused got_footprint_
* initialize all costmap variables
* Merge pull request #675 <https://github.com/ros-planning/navigation/issues/675> from stereoboy/kinetic-devel_jylee
  Fixed race condition with costmaps in LayeredCostmap::resizeMap()
  LayeredCostmap::updateMap() and LayeredCostmap::resizeMap() write to the master grid costmap.
  And these two functions can be called by different threads at the same time.
  One example of these cases is a race condition between subscriber callback thread
  dealing with dynamically-size-changing static_layer and periodical updateMap() calls from Costmap2DROS thread.
  Under the situation the master grid costmap is not thread-safe.
  LayeredCostmap::updateMap() already used the master grid costmap's lock.
* Contributors: Jaeyoung Lee, Michael Ferguson
```

## dwa_local_planner

- No changes

## fake_localization

```
* Merge pull request #609 <https://github.com/ros-planning/navigation/issues/609> from vrabaud/more_tf2
  switch fake_localization to tf2.
* Contributors: Michael Ferguson, Vincent Rabaud
```

## global_planner

- No changes

## map_server

```
* Allow specification of free/occupied thresholds for map_saver (#708 <https://github.com/ros-planning/navigation/issues/708>)
  * add occupied threshold command line parameter to map_saver (--occ)
  * add free threshold command line parameter to map_saver (--free)
* Map server wait for a valid time, fix #573 <https://github.com/ros-planning/navigation/issues/573> (#700 <https://github.com/ros-planning/navigation/issues/700>)
  When launching the map_server with Gazebo, the current time is picked
  before the simulation is started and then has a value of 0.
  Later when querying the stamp of the map, a value of has a special
  signification on tf transform for example.
* Contributors: Romain Reignier, ipa-fez
```

## move_base

```
* Merge pull request #711 <https://github.com/ros-planning/navigation/issues/711> from SteveMacenski/costmap_clearing_thread_lock
  adding mutex locks to costmap clearing service
* Contributors: Michael Ferguson, stevemacenski
```

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## robot_pose_ekf

```
* Merge pull request #713 <https://github.com/ros-planning/navigation/issues/713> from garethellis0/kinetic-devel
  Added handling for NaN linear.z components of GPS in robot_pose_ekf
  Added a check in odom_estimation_node.cpp that checks if linear.z
  values in the GPS odom message are NaN (something common in such
  messages), and if so, sets it to 0, and sets the corresponding variance
  to a very high value so we ignore it.
* Contributors: Gareth Ellis, Michael Ferguson
```

## rotate_recovery

- No changes

## voxel_grid

- No changes
