### PR TITLE
neonavigation_msgs: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6225,6 +6225,27 @@ repositories:
       url: https://github.com/ros-planning/navigation_tutorials.git
       version: indigo-devel
     status: maintained
+  neonavigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/at-wat/neonavigation_msgs.git
+      version: master
+    release:
+      packages:
+      - costmap_cspace_msgs
+      - map_organizer_msgs
+      - neonavigation_msgs
+      - planner_cspace_msgs
+      - trajectory_tracker_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/at-wat/neonavigation_msgs-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/at-wat/neonavigation_msgs.git
+      version: master
+    status: developed
   nerian_sp1:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_msgs` to `0.2.0-0`:

- upstream repository: https://github.com/at-wat/neonavigation_msgs.git
- release repository: https://github.com/at-wat/neonavigation_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## costmap_cspace_msgs

```
* Fix package dependencies (#2 <https://github.com/at-wat/neonavigation_msgs/issues/2>)
* Fix package versions (#1 <https://github.com/at-wat/neonavigation_msgs/issues/1>)
* Initial drop from neonavigation meta-package
* Contributors: Atsushi Watanabe
```

## map_organizer_msgs

```
* Fix package dependencies (#2 <https://github.com/at-wat/neonavigation_msgs/issues/2>)
* Initial drop from neonavigation meta-package
* Contributors: Atsushi Watanabe
```

## neonavigation_msgs

```
* Fix package versions (#1 <https://github.com/at-wat/neonavigation_msgs/issues/1>)
* Initial drop from neonavigation meta-package
* Contributors: Atsushi Watanabe
```

## planner_cspace_msgs

```
* Fix package dependencies (#2 <https://github.com/at-wat/neonavigation_msgs/issues/2>)
* Fix package versions (#1 <https://github.com/at-wat/neonavigation_msgs/issues/1>)
* Initial drop from neonavigation meta-package
* Contributors: Atsushi Watanabe
```

## trajectory_tracker_msgs

```
* Fix package dependencies (#2 <https://github.com/at-wat/neonavigation_msgs/issues/2>)
* Initial drop from neonavigation meta-package
* Contributors: Atsushi Watanabe
```
