### PR TITLE
grizzly: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3167,7 +3167,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/grizzly-release.git
-      version: 0.4.0-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/g/grizzly.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grizzly` to `0.4.2-0`:

- upstream repository: https://github.com/g/grizzly.git
- release repository: https://github.com/clearpath-gbp/grizzly-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.4.0-0`

## grizzly_control

- No changes

## grizzly_description

```
* [grizzly_description] Installed env_run script.
* Contributors: Tony Baltovski
```

## grizzly_msgs

- No changes

## grizzly_navigation

- No changes
