### PR TITLE
mcl_3dl: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5260,7 +5260,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.1.1-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.1.3-0`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.1-0`

## mcl_3dl

```
* Fix install of demo launch and config (#164 <https://github.com/at-wat/mcl_3dl/issues/164>)
* Update CI and add test on ROS Melodic (#155 <https://github.com/at-wat/mcl_3dl/issues/155>)
* Ignore gh-pr-comment failure (#162 <https://github.com/at-wat/mcl_3dl/issues/162>)
* Compile with PCL_NO_PRECOMPILE (#161 <https://github.com/at-wat/mcl_3dl/issues/161>)
* Fix rostest dependency (#160 <https://github.com/at-wat/mcl_3dl/issues/160>)
* Fix roslint dependency (#159 <https://github.com/at-wat/mcl_3dl/issues/159>)
* Update install instructions in README (#158 <https://github.com/at-wat/mcl_3dl/issues/158>)
* Update manifest format and fix CMakeLists (#157 <https://github.com/at-wat/mcl_3dl/issues/157>)
* Use mcl_3dl_msgs package (#152 <https://github.com/at-wat/mcl_3dl/issues/152>)
* Test with shadow-fixed repository (#154 <https://github.com/at-wat/mcl_3dl/issues/154>)
* Update CI bot environments (#150 <https://github.com/at-wat/mcl_3dl/issues/150>)
* Add encrypted token for image caching (#149 <https://github.com/at-wat/mcl_3dl/issues/149>)
* Fix migration instruction message (#147 <https://github.com/at-wat/mcl_3dl/issues/147>)
* Fix match ratio min/max check (#146 <https://github.com/at-wat/mcl_3dl/issues/146>)
* Add interfaces to ChunkedKdtree for external usages (#145 <https://github.com/at-wat/mcl_3dl/issues/145>)
* Install headers (#143 <https://github.com/at-wat/mcl_3dl/issues/143>)
* Contributors: Atsushi Watanabe
```
