### PR TITLE
tracetools: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3392,11 +3392,15 @@ repositories:
       version: melodic
     status: maintained
   tracetools:
+    doc:
+      type: git
+      url: https://github.com/bosch-robotics-cr/tracetools.git
+      version: devel
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/bosch-robotics-cr/tracetools-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/bosch-robotics-cr/tracetools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools` to `0.2.0-0`:

- upstream repository: https://github.com/bosch-robotics-cr/tracetools
- release repository: https://github.com/bosch-robotics-cr/tracetools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.0-0`
