### PR TITLE
tracetools: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12100,7 +12100,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/bosch-robotics-cr/tracetools-release.git
-      version: 0.1.0-1
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/bosch-robotics-cr/tracetools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools` to `0.2.0-0`:

- upstream repository: https://github.com/bosch-robotics-cr/tracetools
- release repository: https://github.com/bosch-robotics-cr/tracetools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.0-1`
