### PR TITLE
pointcloud_to_laserscan: 1.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2005,7 +2005,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
-      version: indigo-devel
+      version: lunar-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -2015,7 +2015,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
-      version: indigo-devel
+      version: lunar-devel
     status: maintained
   pose_cov_ops:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2001,6 +2001,22 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
     status: maintained
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
+      version: 1.4.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: indigo-devel
+    status: maintained
   pose_cov_ops:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `1.4.0-0`:

- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `null`

## pointcloud_to_laserscan

```
* Added inf_epsilon parameter that determines the value added to max range when use_infs parameter is set to false
* Merge pull request #11 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/11> from ros-perception/mikaelarguedas-patch-1
  update to use non deprecated pluginlib macro
* Migrate to package format 2; add roslint
* Add sane parameter defaults; fixup lint warnings
* update to use non deprecated pluginlib macro
* Contributors: Mikael Arguedas, Paul Bovbel, Prasanna Kannappan
```
