### PR TITLE
vrpn: 7.34.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3596,6 +3596,21 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: kinetic-devel
     status: maintained
+  vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/vrpn-release.git
+      version: 7.34.0-1
+    source:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.34.0-1`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros-drivers-gbp/vrpn-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `null`
