### PR TITLE
Add keys for ROS 2 DDS vendors

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2384,6 +2384,10 @@ libopenscenegraph:
   fedora: [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
   gentoo: [dev-games/openscenegraph]
   ubuntu: [openscenegraph, libopenscenegraph-dev]
+libopensplice67:
+  ubuntu:
+    bionic: [libopensplice67]
+    xenial: [libopensplice67]
 libopenvdb:
   arch: [openvdb]
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4304,6 +4304,10 @@ rsync:
   gentoo: [net-misc/rsync]
   opensuse: [rsync]
   ubuntu: [rsync]
+rti-connext-dds-5.3.1:
+  ubuntu:
+    bionic: [rti-connext-dds-5.3.1]
+    xenial: [rti-connext-dds-5.3.1]
 rtmidi:
   debian: [librtmidi-dev]
   fedora: [rtmidi-devel]


### PR DESCRIPTION
There's an existing key for `opensplice` which is only resolved for Gentoo. But the key libopensplice67 is in use across ROS 2 bouncy.