### PR TITLE
twist_mux_msgs: 2.1.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3441,6 +3441,21 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_msgs-release.git
       version: 0.0.7-0
+  twist_mux_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux_msgs-release.git
+      version: 2.1.0-3
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: melodic-devel
+    status: maintained
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux_msgs` to `2.1.0-3`:

- upstream repository: https://github.com/ros-teleop/twist_mux_msgs.git
- release repository: https://github.com/ros-gbp/twist_mux_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## twist_mux_msgs

- No changes
