### PR TITLE
Added python-networkx-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1964,6 +1964,25 @@ python-networkx:
     yakkety_python3: [python3-networkx]
     zesty: [python-networkx]
     zesty_python3: [python3-networkx]
+python-networkx-pip:
+  arch:
+    pip:
+      packages: [networkx]
+  debian:
+    pip:
+      packages: [networkx]
+  fedora:
+    pip:
+      packages: [networkx]
+  gentoo:
+    pip:
+      packages: [networkx]
+  osx:
+    pip:
+      packages: [networkx]
+  ubuntu:
+    pip:
+      packages: [networkx]
 python-nose:
   arch: [python2-nose]
   debian: [python-nose]


### PR DESCRIPTION
Added `python-networkx-pip` as the OS package manager `python-networkx` packages are all on the 1.x release series, whereas pip is on the 2.x series, which came out last September.