### PR TITLE
magni_robot: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5038,10 +5038,11 @@ repositories:
       - magni_nav
       - magni_robot
       - magni_teleop
+      - magni_viz
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/magni_robot-release.git
-      version: 0.2.5-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/magni_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `magni_robot` to `0.3.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/magni_robot.git
- release repository: https://github.com/UbiquityRobotics-release/magni_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.5-0`

## magni_bringup

```
* Launch sonars if 'installed', but not by default (#58 <https://github.com/UbiquityRobotics/magni_robot/issues/58>)
* Support getting robot configuration from a file in etc  (#57 <https://github.com/UbiquityRobotics/magni_robot/issues/57>)
* Refactor Launch Files (and fix #50 <https://github.com/UbiquityRobotics/magni_robot/issues/50>)
* launch the core launch from a python script that can do something smart
* start to re-organize the launch files, with base.launch being the boot up launch
  Also move the rosbridge stuff out to magni_teleop to be more modular.
* Contributors: Jim Vaughan, Rohan Agrawal
```

## magni_demos

```
* Add dnn_rotate demo (#52 <https://github.com/UbiquityRobotics/magni_robot/issues/52>)
* Merge pull request #51 <https://github.com/UbiquityRobotics/magni_robot/issues/51> from rohbotics/launch_file_refactor
  Refactor Launch Files (and fix #50 <https://github.com/UbiquityRobotics/magni_robot/issues/50>)
* make joystick and teleop launch aliaises again
* cleanup other demo launch files
* remove old demo launches
* renamed speech commands to simple_navigation
* remove roshub from default launch, make joystick a symlink again
* added roshub stuff
* Contributors: Jim Vaughan, Rohan Agrawal
```

## magni_description

```
* Support getting robot configuration from a file in etc  (#57 <https://github.com/UbiquityRobotics/magni_robot/issues/57>)
* move to a xacro based magni model
* Contributors: Rohan Agrawal
```

## magni_nav

```
* Add footprint (#48 <https://github.com/UbiquityRobotics/magni_robot/issues/48>)
* Remove launch file for old fiducials. (#47 <https://github.com/UbiquityRobotics/magni_robot/issues/47>)
  * Remove launch file for old fiducials.
  * Remove fiducial_detect exec_depend
* Contributors: Jim Vaughan
```

## magni_robot

```
* Add magni_viz package (#49 <https://github.com/UbiquityRobotics/magni_robot/issues/49>)
  * Add magni_viz
* Contributors: Jim Vaughan
```

## magni_teleop

```
* Merge pull request #51 <https://github.com/UbiquityRobotics/magni_robot/issues/51> from rohbotics/launch_file_refactor
  Refactor Launch Files (and fix #50 <https://github.com/UbiquityRobotics/magni_robot/issues/50>)
* start to re-organize the launch files, with base.launch being the boot up launch
  Also move the rosbridge stuff out to magni_teleop to be more modular.
* Contributors: Rohan Agrawal
```

## magni_viz

```
* Add magni_viz package (#49 <https://github.com/UbiquityRobotics/magni_robot/issues/49>)
  * Add magni_viz
* Contributors: Jim Vaughan
```
