### PR TITLE
grpc: 0.0.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -946,6 +946,21 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: master
     status: maintained
+  grpc:
+    doc:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CogRobRelease/catkin_grpc-release.git
+      version: 0.0.9-1
+    source:
+      type: git
+      url: https://github.com/CogRob/catkin_grpc.git
+      version: master
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.9-1`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `null`

## grpc

```
* Fixed missing grpc++_core_stats library. It is a new library generated by gRPC.
* Contributors: Shengye Wang
```
