### PR TITLE
rc_cloud_accumulator: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8430,7 +8430,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_cloud_accumulator-release.git
-      version: 1.0.0-0
+      version: 1.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_cloud_accumulator` to `1.0.2-0`:

- upstream repository: https://github.com/roboception/rc_cloud_accumulator.git
- release repository: https://github.com/roboception-gbp/rc_cloud_accumulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.0-0`

## rc_cloud_accumulator

```
* fixup version numbers in package.xml and CHANGELOG.rst
* Update cmake files from project template
```
