### PR TITLE
twist_mux: 3.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3456,6 +3456,21 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_msgs-release.git
       version: 0.0.7-0
+  twist_mux:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux-release.git
+      version: 3.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: melodic-devel
+    status: maintained
   twist_mux_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `3.1.0-0`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`

## twist_mux

- No changes
