### PR TITLE
Pin version of PyYAML to fix rosdistro checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 # command to install dependencies
 install:
   - easy_install -U pip
-  - pip install PyYAML argparse
+  - pip install PyYAML==3.12 argparse
   - pip install catkin_pkg ros_buildfarm rosdistro nose coverage
   - pip install yamllint
   - pip install unidiff


### PR DESCRIPTION
[PyYAML 4.1](https://pypi.org/project/PyYAML/4.1/) was released today and it looks like there have been some API changes.
I haven't taken the time to investigate them but pinning the last 3.x version will at least let CI continue for now.