### PR TITLE
jsk_common: 2.2.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4206,7 +4206,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.6-0
+      version: 2.2.7-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.7-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `2.2.6-0`

## dynamic_tf_publisher

- No changes

## image_view2

- No changes

## jsk_common

- No changes

## jsk_data

```
* jsk_data: chmod extraced files (#1582 <https://github.com/jsk-ros-pkg/jsk_common/issues/1582>)
* [jsk_data] add option not to save in timestamp dir in data_collection_server.py (#1578 <https://github.com/jsk-ros-pkg/jsk_common/issues/1578>)
* add timer save request in data_collection_server (#1557 <https://github.com/jsk-ros-pkg/jsk_common/issues/1557>)
  * update sample data collection launch
  * add message_filers function in data_collection
  * add timer save request in data_collection_server
* Contributors: Shingo Kitagawa, Yuki Furuta
```

## jsk_network_tools

- No changes

## jsk_tilt_laser

```
* add missing dirs into install command (#1583 <https://github.com/jsk-ros-pkg/jsk_common/issues/1583>)
  * add missing dirs into install command
* Contributors: Yasuhiro Ishiguro
```

## jsk_tools

```
* add missing dirs into install command (#1583 <https://github.com/jsk-ros-pkg/jsk_common/issues/1583>)
  * add missing dirs into install command
* Fix roscore regardless (#1576 <https://github.com/jsk-ros-pkg/jsk_common/issues/1576>)
  * respawn child process if -r is given
  * jsk_tools: roscore_regardless.py: fix to work at more cases
* Contributors: Yuki Furuta, Yasuhiro Ishiguro
```

## jsk_topic_tools

```
* Add warnNoRemap to ConnectionBasedNodelet (#1538 <https://github.com/jsk-ros-pkg/jsk_common/issues/1538>)
  * add version_gte 1.9.11 for nodelet
* jsk_topic_tools: add option to display diagnostic messages on warning level (#1585 <https://github.com/jsk-ros-pkg/jsk_common/issues/1585>)
  * jsk_topic_tools: add option to set diangostic leveljsk_topic_tools: update doc for jsk_topic_tools nodelet classes
* Add #include <boost/format.hpp> (#1584 <https://github.com/jsk-ros-pkg/jsk_common/issues/1584>)
* jsk_topic_tools: add synchronized_throttle (#1579 <https://github.com/jsk-ros-pkg/jsk_common/issues/1579>)
  * jsk_topic_tools: add synchronized_throttle
  * Add warnNoRemap to ConnectionBasedNodelet
* Fix roscore regardless (#1576 <https://github.com/jsk-ros-pkg/jsk_common/issues/1576>)
  * jsk_topic_tools: fix isMasterAlive to work
* Contributors: Yuki Furuta, Kentaro Wada, Laurenz
```

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
