### PR TITLE
rosdep/python: add python-pytest-dependency-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2747,6 +2747,16 @@ python-pytest:
   fedora: [python-pytest]
   gentoo: [dev-python/pytest]
   ubuntu: [python-pytest]
+python-pytest-dependency-pip:
+  debian:
+    pip:
+      packages: [pytest-dependency]
+  fedora:
+    pip:
+      packages: [pytest-dependency]
+  ubuntu:
+    pip:
+      packages: [pytest-dependency]
 python-pytest-qt-pip:
   debian:
     pip:


### PR DESCRIPTION
Adds the [pytest-dependency](https://pypi.org/project/pytest-dependency/) package.
[Docs](http://pytest-dependency.readthedocs.io/en/latest/usage.html)