### PR TITLE
rqt_rviz: 0.6.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4010,7 +4010,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_rviz-release.git
-      version: 0.5.8-0
+      version: 0.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_rviz` to `0.6.0-0`:

- upstream repository: https://github.com/ros-visualization/rqt_rviz.git
- release repository: https://github.com/ros-gbp/rqt_rviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.5.8-0`

## rqt_rviz

```
* Indigo -> Lunar
* Contributors: chapulina
```
