### PR TITLE
mvsim: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5909,7 +5909,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.2.0-0`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `0.1.2-0`

## mvsim

```
* fix build against mrpt1
* update to package XML format 2
* fix build in mrpt 2.0
* use docker in travis
* Allow mvsim to be built w/o ROS again
* Merge pull request #10 <https://github.com/ual-arm-ros-pkg/mvsim/issues/10> from spsancti/master
  GSoC contribution to mvsim
  See discussion thread: https://github.com/MRPT/GSoC2017-discussions/issues/2
* Added description of world files
* Added description of loggers and Ward-Iagnemma friction model
* Added refernce to Torsen-defferntial
* Added desctiption of Ackermann-drivetrain dynamics
* Added Doxyfile
* Added user manual with basic friction model described
* Added text logger for CSV format
* Add mvsim slam demo.
* fix catkin deps: it now requires mrpt_bridge
* LaserScanner: new option to make all fixtures invisible
* Contributors: Borys Tymchenko, Jose Luis Blanco Claraco, Logrus
```
