### PR TITLE
rosdep: Added ruby-dev as a separate key

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -84,11 +84,11 @@ ruby:
     zesty: [ruby, ruby-dev]
 ruby-dev:
   arch: [ruby]
-  debian: [ruby, ruby-dev]
-  fedora: [ruby, ruby-devel, openssl-devel, rubygems]
+  debian: [ruby-dev]
+  fedora: [ruby-devel, openssl-devel, rubygems]
   gentoo: [dev-lang/ruby]
   macports: [ruby]
-  ubuntu: [ruby, ruby-dev]
+  ubuntu: [ruby-dev]
 ruby-sass:
   debian: [ruby-sass]
   fedora: [rubygem-sass]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -82,6 +82,13 @@ ruby:
     xenial: [ruby, ruby-dev]
     yakkety: [ruby, ruby-dev]
     zesty: [ruby, ruby-dev]
+ruby-dev:
+  arch: [ruby]
+  debian: [ruby, ruby-dev]
+  fedora: [ruby, ruby-devel, openssl-devel, rubygems]
+  gentoo: [dev-lang/ruby]
+  macports: [ruby]
+  ubuntu: [ruby, ruby-dev]
 ruby-sass:
   debian: [ruby-sass]
   fedora: [rubygem-sass]


### PR DESCRIPTION
For now it's a copy of key `ruby`, without the specializations for Ubuntu EOL distros.
In the future we would like to split ruby dependencies in run-time and build-time.

Furthermore some Orocos packages (e.g. [typelib](https://github.com/orocos-toolchain/typelib), see also https://github.com/orocos-toolchain/typelib/pull/109) would require the `ruby-dev` key for compatibility with the [AutoProj](https://www.rock-robotics.org/documentation/autoproj/index.html) [package set](https://github.com/rock-core/package_set) used by the Rock community. The `manifest.xml` file was originally supposed to be compatible to ROS/rosdep and AutoProj.