### PR TITLE
libfranka: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4741,7 +4741,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.3.0-0
+      version: 0.4.0-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.4.0-0`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `0.3.0-0`
