### PR TITLE
Update git to use new package name

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -948,13 +948,13 @@ gimp:
   ubuntu: [gimp]
 git:
   arch: [git]
-  debian: [git-core]
+  debian: [git]
   fedora: [git]
   freebsd: [git]
   gentoo: [dev-vcs/git]
   macports: [git-core]
   opensuse: [git-core]
-  ubuntu: [git-core]
+  ubuntu: [git]
 gitg:
   debian: [gitg]
   fedora: [gitg]


### PR DESCRIPTION
git-core is obsolete at least as of trusty and wheezy
https://packages.ubuntu.com/trusty/git-core
https://packages.debian.org/wheezy/git-core

Follow up to: #18272