### PR TITLE
dataspeed_pds: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2483,6 +2483,27 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dataspeed_can
       version: default
     status: developed
+  dataspeed_pds:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dataspeed_pds
+      version: default
+    release:
+      packages:
+      - dataspeed_pds
+      - dataspeed_pds_can
+      - dataspeed_pds_msgs
+      - dataspeed_pds_rqt
+      - dataspeed_pds_scripts
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
+      version: 1.0.1-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dataspeed_pds
+      version: default
+    status: developed
   dbw_mkz_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.1-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `null`

## dataspeed_pds

```
* Removed dataspeed_pds_lcm
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_can

- No changes

## dataspeed_pds_msgs

- No changes

## dataspeed_pds_rqt

```
* Initial release
* Contributors: Eric Myllyoja, Kevin Hallenbeck
```

## dataspeed_pds_scripts

- No changes
