### PR TITLE
Move some release repos to ros-gbp

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11437,7 +11437,7 @@ repositories:
       - robot_calibration_msgs
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
+      url: https://github.com/ros-gbp/robot_calibration-release.git
       version: 0.5.4-0
     source:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14581,7 +14581,7 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
+      url: https://github.com/ros-gbp/simple_grasping-release.git
       version: 0.2.2-0
     source:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11316,7 +11316,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/fetchrobotics-gbp/simple_grasping-release.git
+      url: https://github.com/ros-gbp/simple_grasping-release.git
       version: 0.2.2-0
     status: developed
   slam_constructor:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8755,7 +8755,7 @@ repositories:
       - robot_calibration_msgs
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/fetchrobotics-gbp/robot_calibration-release.git
+      url: https://github.com/ros-gbp/robot_calibration-release.git
       version: 0.5.5-0
     source:
       type: git


### PR DESCRIPTION
Not sure why I originally created these in fetchrobotics-gbp, since the source repos are personal repos.