### PR TITLE
mvsim: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1660,6 +1660,22 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
       version: master
     status: maintained
+  mvsim:
+    doc:
+      type: git
+      url: https://github.com/ual-arm-ros-pkg/mvsim.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
+      version: 0.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ual-arm-ros-pkg/mvsim.git
+      version: master
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.2.0-0`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## mvsim

```
* fix build against mrpt1
* update to package XML format 2
* fix build in mrpt 2.0
* use docker in travis
* Allow mvsim to be built w/o ROS again
* Merge pull request #10 <https://github.com/ual-arm-ros-pkg/mvsim/issues/10> from spsancti/master
  GSoC contribution to mvsim
  See discussion thread: https://github.com/MRPT/GSoC2017-discussions/issues/2
* Added description of world files
* Added description of loggers and Ward-Iagnemma friction model
* Added refernce to Torsen-defferntial
* Added desctiption of Ackermann-drivetrain dynamics
* Added Doxyfile
* Added user manual with basic friction model described
* Added text logger for CSV format
* Add mvsim slam demo.
* fix catkin deps: it now requires mrpt_bridge
* LaserScanner: new option to make all fixtures invisible
* Contributors: Borys Tymchenko, Jose Luis Blanco Claraco, Logrus
```
