### PR TITLE
hector_models: 0.5.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1202,6 +1202,22 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: master
     status: unmaintained
+  hector_models:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
+      version: kinetic-devel
+    release:
+      packages:
+      - hector_components_description
+      - hector_models
+      - hector_sensors_description
+      - hector_xacro_tools
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
+      version: 0.5.0-0
+    status: maintained
   hokuyo3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.5.0-0`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## hector_components_description

```
* Update raycast self filter config for head
* Increase realsense self filter collision size
* Add cylinder geoms for raycast self filtering
* Add macro for being able to set realsense params in more detail
* Update vlp16 mount macro
* Merge branch 'update_transmissions' into kinetic-devel
  Fix xmlns for all xacro files
* Update to transmissions, prepending "hardware_interface/"
* Make tracker sensor head macro independent of vision box properties
* Add plugin for using spinning sensors with gazebo
* Add additional macros of components
* Fix xacro tag
* Merge commit '57d7a25756af77265cfd73298fa5d32' into indigo-devel
* added makro that allows you to define a calibration transformation
* Contributors: Martin Oehler, Stefan Kohlbrecher
```

## hector_models

- No changes

## hector_sensors_description

```
* added calibration parameter
* added macro for generic 360 cameras
* add the realsense D435
* Add macro for being able to set realsense params in more detail
* Update VLP16 macro to provide normal and advanced versions
* Properly use cameraName tag and topics relative to camera namespace
* Fix ricoh_theta camera name and topic setup
* Add ricoh_theta model usable with gazebo8+
* Merge branch 'kinetic-devel' of https://github.com/tu-darmstadt-ros-pkg/hector_models into kinetic-devel
* Merge branch 'update_transmissions' into kinetic-devel
  Fix xmlns for all xacro files
* Merge pull request #5 <https://github.com/tu-darmstadt-ros-pkg/hector_models/issues/5> from cschindlbeck/fix_include_in_kinect
  Fix missing include in kinect_camera
* Reduce vlp16 min range
* Fix missing include in kinect
* Optimize simulated vlp16 for performance
* fixed warning
* Add optional macro for setting realsense topics
* Reduce min range for Realsense as we're mostly interested in rgb data for now
* Fix R200 FOV to be in line with real camera
* Switch to using velodyne_simulator
* VLP-16 basics
* changed minimal laser scanner distance
* Fix coloring for simulated depth cameras (RGB vs BGR)
  See https://bitbucket.org/osrf/gazebo/issues/1865/rendering-depthcamera-does-not-output
* Adjust realsense FOV to be in line with real rgb sensor FOV
* Modify realsense r200 macro to also make version without geometry available
* Merge commit '57d7a25756af77265cfd73298fa5d32' into indigo-devel
* Change thermal cam default topic name to image_raw instead of image
* Move cam link to where real realsense driver expects it (rgb cam frame)
* Remove frames as part of model as they are published based on internal intrinsics on real sensor
* Corrected realsense frames and measures
* Image topic corrected
* Changed resolution to match real cam
* Contributors: Alexander Stumpf, Chris Schindlbeck, Christian Rose, Marius Schnaubelt, Martin Oehler, Philipp Schillinger, Stefan Kohlbrecher
```

## hector_xacro_tools

```
* Merge branch 'update_transmissions' into kinetic-devel
  Fix xmlns for all xacro files
* Update to transmissions, prepending "hardware_interface/"
* fixed warning
* Add macro for default setting joint properties
* Contributors: Alexander Stumpf, Stefan Kohlbrecher
```
