### PR TITLE
dataspeed_pds: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2498,7 +2498,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/dataspeed_pds


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.2-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `1.0.1-0`

## dataspeed_pds

- No changes

## dataspeed_pds_can

- No changes

## dataspeed_pds_msgs

- No changes

## dataspeed_pds_rqt

```
* Removed unnecessary dependency
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_scripts

- No changes
