### PR TITLE
hector_gazebo: 0.5.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -961,6 +961,23 @@ repositories:
       url: https://github.com/CogRob/catkin_grpc.git
       version: master
     status: developed
+  hector_gazebo:
+    doc:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
+      version: kinetic-devel
+    release:
+      packages:
+      - hector_gazebo
+      - hector_gazebo_plugins
+      - hector_gazebo_thermal_camera
+      - hector_gazebo_worlds
+      - hector_sensors_gazebo
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
+      version: 0.5.1-0
+    status: maintained
   hector_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.5.1-0`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## hector_gazebo

- No changes

## hector_gazebo_plugins

```
* Merge pull request #44 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/44> from esteve/gazebo8
  Use Gazebo 8 APIs to avoid deprecation warnings.
* Fix indent
* Depend on gazebo_dev instead
* Use sdf::Time to read time periods from SDF files.
* Only include math headers when building for Gazebo < 8
* Use Gazebo 8 APIs to avoid deprecation warnings.
* Merge pull request #36 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/36> from vincentrou/get_fix_status
  [gazebo_plugins] Ensure to get gps fix status as an int in urdf
* hector_gazebo_plugins: numeric conversion of NavSatFix status and service from SDF without std::stoi
* [gazebo_plugins] Ensure to get gps fix status as an int
* hector_gazebo_plugins/hector_gazebo_thermal_camera: removed catkin_package(DEPENDS gazebo) declaration which was a no-op anyway
  See https://github.com/ros-simulation/gazebo_ros_pkgs/pull/537.
* Contributors: Esteve Fernandez, Johannes Meyer, Vincent Rousseau
```

## hector_gazebo_thermal_camera

```
* Merge pull request #44 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/44> from esteve/gazebo8
  Use Gazebo 8 APIs to avoid deprecation warnings.
* hector_gazebo_plugins/hector_gazebo_thermal_camera: removed catkin_package(DEPENDS gazebo) declaration which was a no-op anyway
  See https://github.com/ros-simulation/gazebo_ros_pkgs/pull/537.
* Contributors: Esteve Fernandez, Johannes Meyer
```

## hector_gazebo_worlds

- No changes

## hector_sensors_gazebo

- No changes
