### PR TITLE
Adding modros to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5444,6 +5444,15 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/mobility_base_simulator
       version: default
     status: developed
+  modros:
+    doc:
+      type: git
+      url: https://github.com/ModROS/modros.git
+      version: kinetic
+    source:
+      type: git
+      url: https://github.com/ModROS/modros.git
+      version: kinetic
   mongodb_store:
     release:
       packages:


### PR DESCRIPTION
I'd like my package modros to be indexed and documented on ros.org. Its purpose is as an interface between ROS and the modeling language Modelica.