### PR TITLE
bagger: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -625,6 +625,12 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pal-gbp/backward_ros-release.git
       version: 0.1.6-0
+  bagger:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/squarerobot/bagger-release.git
+      version: 0.1.1-0
   baldor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.1-0`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.5`
- previous version for package: `null`

## bagger

```
* Initial Commit
* Contributors: Brenden Gibbons
```
