### PR TITLE
modros: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5444,6 +5444,20 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/mobility_base_simulator
       version: default
     status: developed
+  modros:
+    doc:
+      type: git
+      url: https://github.com/ModROS/modros.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ModROS/modros-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ModROS/modros.git
+      version: master
   mongodb_store:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `modros` to `0.1.0-0`:

- upstream repository: https://github.com/ModROS/modros.git
- release repository: https://github.com/ModROS/modros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## modros

```
* Added Changelog for releasing via bloom
```
