### PR TITLE
ifopt: 2.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3692,6 +3692,16 @@ repositories:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ethz-adrl/ifopt-release.git
+      version: 2.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
     status: developed
   image_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.0.1-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ifopt

```
* make IPOPT the default ON solver option
* Add documentation and update package.xml to use ubuntu ipopt install coinor-libipopt-dev
* Use FindIpopt.cmake (from robotology/idyntree)
* Set default solver to mumps, as this is free one installed in ubuntu
* Define SNOPT/IPOPT location also through environmental variable
* Contributors: Alexander Winkler
```
