### PR TITLE
towr: 1.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12086,6 +12086,19 @@ repositories:
       type: git
       url: https://github.com/ethz-adrl/towr.git
       version: master
+    release:
+      packages:
+      - towr
+      - towr_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ethz-adrl/towr-release.git
+      version: 1.2.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ethz-adrl/towr.git
+      version: master
     status: developed
   trac_ik:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.2.1-0`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## towr

```
* set parameters for hyq and terrains examples
* rename constraints and variables for more consistency
* renamed main library (towr_core -> towr) and removed ros meta package
* Contributors: Alexander Winkler
```

## towr_ros

```
* adapt to revised ifopt version and build structure
* preparation for ANYmal experiments
* Contributors: Alexander Winkler
```
