### PR TITLE
modelica_bridge: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5460,6 +5460,20 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/mobility_base_simulator
       version: default
     status: developed
+  modelica_bridge:
+    doc:
+      type: git
+      url: https://github.com/ModROS/modelica_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ModROS/modelica_bridge-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ModROS/modelica_bridge.git
+      version: master
   mongodb_store:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `modelica_bridge` to `0.1.0-0`:

- upstream repository: https://github.com/ModROS/modelica_bridge.git
- release repository: https://github.com/ModROS/modelica_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## modelica_bridge

```
* Added link to online documentation of modelica_bridge
* Fixed CHANGELOG.rst
* Added Doxygen documentation generated by rosdoc_lite
```
