### PR TITLE
web_video_server: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13282,7 +13282,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/web_video_server-release.git
-      version: 0.0.7-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/web_video_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.1.0-0`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.7-0`

## web_video_server

```
* Avoid queuing of images on slow ethernet connection (#64 <https://github.com/RobotWebTools/web_video_server/issues/64>)
* use SteadyTimer (if available) for cleaning up inactive streams (#63 <https://github.com/RobotWebTools/web_video_server/issues/63>)
  * use SteadyTimer for cleaning up inactive streams
  so that cleanup works correctly even if system time changes
  SteadyTimer is available since roscpp 1.13.1
  * possibility to use SteadyTimer on older ROS versions
  when SteadyTimer has been backported to those...
* Fix segfault in libav_streamer destructor (resolves #59 <https://github.com/RobotWebTools/web_video_server/issues/59>) (#60 <https://github.com/RobotWebTools/web_video_server/issues/60>)
* Fix vp8 in kinetic add vp9 and h264 support (#52 <https://github.com/RobotWebTools/web_video_server/issues/52>)
  * fix vp8 in kinetic
  * add h264 and vp9 support
* Add Indigo test matrix in travis configuration (#50 <https://github.com/RobotWebTools/web_video_server/issues/50>)
* Set image streamer as inactive if topic is not available (#53 <https://github.com/RobotWebTools/web_video_server/issues/53>)
  * Resolves #38 <https://github.com/RobotWebTools/web_video_server/issues/38>
* Fix Build for ubuntu 14.04 (#48 <https://github.com/RobotWebTools/web_video_server/issues/48>)
  * fix issue #47 <https://github.com/RobotWebTools/web_video_server/issues/47>
  * fix double free
* Revert "use SteadyTimer for cleaning up inactive streams (#45 <https://github.com/RobotWebTools/web_video_server/issues/45>)" (#51 <https://github.com/RobotWebTools/web_video_server/issues/51>)
  This reverts commit ae74f19ada22f288a7c7a99ada7a1b9b6037c7ce.
* use SteadyTimer for cleaning up inactive streams (#45 <https://github.com/RobotWebTools/web_video_server/issues/45>)
  so that cleanup works correctly even if system time changes
* Use trusty instead of xenial.  See travis-ci/travis-ci#7260 <https://github.com/travis-ci/travis-ci/issues/7260> (#49 <https://github.com/RobotWebTools/web_video_server/issues/49>)
  * Also see RobotWebTools/rosbridge_suite#311 <https://github.com/RobotWebTools/rosbridge_suite/issues/311>
* Contributors: Felix Ruess, James Bailey, Jihoon Lee, randoms, schallerr
```
