### PR TITLE
scratch4robots: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11182,11 +11182,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/Scratch4Robots-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/JdeRobot/Scratch4Robots.git
       version: master
+    status: developed
   segway_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scratch4robots` to `0.0.2-0`:

- upstream repository: https://github.com/JdeRobot/Scratch4Robots.git
- release repository: https://github.com/JdeRobot/Scratch4Robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.1-0`
