### PR TITLE
rc_dynamics_api: 0.7.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2957,7 +2957,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/roboception-gbp/rc_dynamics_api-release.git
-      version: 0.6.0-0
+      version: 0.7.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_dynamics_api` to `0.7.0-0`:

- upstream repository: https://github.com/roboception/rc_dynamics_api.git
- release repository: https://github.com/roboception-gbp/rc_dynamics_api-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.0-0`

## rc_dynamics_api

```
* add saveSlamMap, loadSlamMap and removeSlamMap methods
* getSlamTrajectory doesn't time out by default anymore
```
