### PR TITLE
rc_genicam_api: 1.3.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11025,7 +11025,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 1.3.10-0
+      version: 1.3.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `1.3.11-0`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.3.10-0`

## rc_genicam_api

```
* don't install bash completion by default (doesn't work on ROS buildfarm)
* make sure installed net_perf_check.sh script is executable
```
