### PR TITLE
dataspeed_pds: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1783,6 +1783,27 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dataspeed_can
       version: default
     status: developed
+  dataspeed_pds:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dataspeed_pds
+      version: default
+    release:
+      packages:
+      - dataspeed_pds
+      - dataspeed_pds_can
+      - dataspeed_pds_msgs
+      - dataspeed_pds_rqt
+      - dataspeed_pds_scripts
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
+      version: 1.0.2-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dataspeed_pds
+      version: default
+    status: developed
   dbw_mkz_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.2-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## dataspeed_pds

- No changes

## dataspeed_pds_can

- No changes

## dataspeed_pds_msgs

- No changes

## dataspeed_pds_rqt

```
* Removed unnecessary dependency
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_scripts

- No changes
