### PR TITLE
modelica_bridge: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5469,11 +5469,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ModROS/modelica_bridge-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ModROS/modelica_bridge.git
       version: master
+    status: developed
   mongodb_store:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `modelica_bridge` to `0.1.1-0`:

- upstream repository: https://github.com/ModROS/modelica_bridge.git
- release repository: https://github.com/ModROS/modelica_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.0-0`

## modelica_bridge

```
* Edited package description
* Updated documentation
* Edited README.md
* Edited documentation for modelica_bridge
* Edited <depend> tags in package.xml
* Added install target for modbridge node
* Edited documentation for modelica_bridge
```
