### PR TITLE
Bloom fluent logger ros 0

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2633,7 +2633,7 @@ repositories:
     source:
       type: git
       url: https://github.com/akio/fluent_logger_ros.git
-      version: 0.1.0
+      version: kinetic-devel 
     status: developed
   follow_waypoints:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2624,6 +2624,17 @@ repositories:
       url: https://github.com/ros-drivers/flir_ptu.git
       version: master
     status: maintained
+  fluent_logger_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/akio/ros_fluent_logger-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/akio/fluent_logger_ros.git
+      version: 0.1.0
+    status: developed
   follow_waypoints:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2633,7 +2633,7 @@ repositories:
     source:
       type: git
       url: https://github.com/akio/fluent_logger_ros.git
-      version: kinetic-devel 
+      version: kinetic-devel
     status: developed
   follow_waypoints:
     doc:


### PR DESCRIPTION
Second attempt to release `fluent_logger_ros`.
----

Increasing version of package(s) in repository `fluent_logger_ros` to `0.1.0-0`:

- upstream repository: https://github.com/akio/fluent_logger_ros.git
- release repository: https://github.com/akio/ros_fluent_logger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## fluent_logger_ros

```
* Initial release
```
