### PR TITLE
towr: 1.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12146,7 +12146,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-adrl/towr-release.git
-      version: 1.2.1-0
+      version: 1.2.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.2.2-0`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.2.1-0`

## towr

```
* remove controller specifc code from towr_ros
* moved height map from towr_ros to towr
* moved robots models and gait generator from towr_ros to towr
* move dynamic and kinematic models from towr_ros -> towr
* remove all catkin macros from towr::CMakeLists.txt
* Contributors: Alexander Winkler
```

## towr_ros

```
* remove controller specifc code from towr_ros
* removed exe subfolder
* moved height map from towr_ros to towr
* moved robots models and gait generator from towr_ros to towr
* move dynamic and kinematic models from towr_ros -> towr
* add ncurses and xterm dependencies to package.xml
* Contributors: Alexander Winkler
```
