### PR TITLE
rc_visard: 2.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11045,7 +11045,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.1.0-0
+      version: 2.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.2.0-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.1.0-0`

## rc_visard

- No changes

## rc_visard_description

```
* Gazebo model added
* bugfixing in launch file
* inertia added to URDF models
* Contributors: florek
```

## rc_visard_driver

```
* fix out1_mode/out2_mode description and default
* change/add service calls for onboard SLAM module:
  - rename dynamics_reset_slam to slam_reset
  - rename get_trajectory to slam_get_trajectory
  - add slam_save_map, slam_load_map and slam_remove_map
* install Rviz example config file
```
