### PR TITLE
xpp: 1.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13557,7 +13557,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.7-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.6-0`

## xpp

- No changes

## xpp_examples

```
* only show urdfs from current examples in rviz
* Contributors: Alexander Winkler
```

## xpp_hyq

```
* add rviz launch specifically for hyq
* Contributors: Alexander Winkler
```

## xpp_msgs

- No changes

## xpp_quadrotor

```
* modified default rviz launch scripts
* Merge branch 'master' of github.com:leggedrobotics/xpp
* 1.0.6
* update changelogs
* Contributors: Alexander Winkler
```

## xpp_states

```
* add names to biped and quadruped ids
* Contributors: Alexander Winkler
```

## xpp_vis

```
* modified default rviz launch scripts
* Contributors: Alexander Winkler
```
