### PR TITLE
velodyne_simulator: 1.0.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12949,7 +12949,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.7-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.6-0`

## velodyne_description

```
* Added GPU support
* Updated inertia tensors for VLP-16 and HDL-32E to realistic values
* Removed unnecessary file extraction code in cmake
* Contributors: Kevin Hallenbeck, Max Schwarz
```

## velodyne_gazebo_plugins

```
* Added GPU support
* Added support for Gazebo 9
* Improved behavior of max range calculation
* Removed trailing slashes in robot namespace
* Fixed resolution of 1 not supported
* Fixed issue with only 1 vert or horiz ray
* Fixed cmake exports and warning
* Contributors: Kevin Hallenbeck, Jacob Seibert, Naoki Mizuno
```

## velodyne_simulator

- No changes
