### PR TITLE
velodyne_simulator: 1.0.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4695,6 +4695,25 @@ repositories:
       url: https://github.com/beltransen/velo2cam_gazebo.git
       version: master
     status: maintained
+  velodyne_simulator:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: master
+    release:
+      packages:
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
+      version: 1.0.7-0
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: master
+    status: maintained
   video_stream_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.7-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## velodyne_description

```
* Added GPU support
* Updated inertia tensors for VLP-16 and HDL-32E to realistic values
* Removed unnecessary file extraction code in cmake
* Contributors: Kevin Hallenbeck, Max Schwarz
```

## velodyne_gazebo_plugins

```
* Added GPU support
* Added support for Gazebo 9
* Improved behavior of max range calculation
* Removed trailing slashes in robot namespace
* Fixed resolution of 1 not supported
* Fixed issue with only 1 vert or horiz ray
* Fixed cmake exports and warning
* Contributors: Kevin Hallenbeck, Jacob Seibert, Naoki Mizuno
```

## velodyne_simulator

- No changes
