### PR TITLE
remove pybind11 from indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10301,7 +10301,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
-      version: 2.2.3-1
   pyros:
     doc:
       type: git


### PR DESCRIPTION
Removing the version will effectively remove it

Reverts #18282 due to not building https://github.com/ipab-slmc/pybind11_catkin/issues/1

@wxmerkt FYI