### PR TITLE
cog_publisher: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1474,6 +1474,22 @@ repositories:
       url: https://github.com/ipa320/cob_supported_robots.git
       version: indigo_dev
     status: developed
+  cog_publisher:
+    doc:
+      type: git
+      url: git@github.com:OUXT-Polaris/cog_publisher-release.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/cog_publisher-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: git@github.com:OUXT-Polaris/cog_publisher-release.git
+      version: master
+    status: developed
+    status_description: release center of gravity publisher.
   collada_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cog_publisher` to `1.0.1-0`:

- upstream repository: https://github.com/OUXT-Polaris/cog_publisher.git
- release repository: https://github.com/OUXT-Polaris/cog_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## cog_publisher

```
* update dependencies
* update package.xml
* add build status in README.md
* add LICENCE and .travis.yml
* initial commit
* Contributors: Masaya Kataoka
```
