### PR TITLE
rc_cloud_accumulator: 1.0.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2290,7 +2290,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_cloud_accumulator-release.git
-      version: 1.0.0-0
+      version: 1.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_cloud_accumulator` to `1.0.4-0`:

- upstream repository: https://github.com/roboception/rc_cloud_accumulator.git
- release repository: https://github.com/roboception-gbp/rc_cloud_accumulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`

## rc_cloud_accumulator

```
* Merged pull request by Mikael Arguedas to fix debian stretch builds
```
