### PR TITLE
.: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6,6 +6,15 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  .:
+    release:
+      packages:
+      - cog_publisher
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@github.com:OUXT-Polaris/cog_publisher-release.git
+      version: 1.0.1-1
+    status: developed
   abb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `.` to `1.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/cog_publisher.git
- release repository: git@github.com:OUXT-Polaris/cog_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## cog_publisher

```
* update dependencies
* update package.xml
* add build status in README.md
* add LICENCE and .travis.yml
* initial commit
* Contributors: Masaya Kataoka
```
