### PR TITLE
teb_local_planner: 0.6.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11812,7 +11812,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.6.10-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.9-0`

## teb_local_planner

```
* Parameter switching_blocking_period added to homotopy class planner parameter group.
  Values greater than zero enforce the homotopy class planner to only switch to new equivalence classes as soon
  as the given period is expired (this might reduce oscillations in some scenarios). The value is set to zero seconds
  by default in order to not change the behavior of existing configurations.
* Fixed unconsistent naming of parameter global_plan_viapoint_sep.
  The parameter retrieved at startup was global_plan_via_point_sep and via dynamic_reconfigure it was global_plan_viapoint_sep.
  global_plan_via_point_sep has now been replaced by global_plan_viapoint_sep since this is more consistent with the variable name
  in the code as well as weight_viapoint and the ros wiki description.
  In order to not break things, the old parameter name can still be used. However, a deprecated warning is printed.
* transformGlobalPlan searches now for the closest point within the complete subset of the global plan in the local costmap:
  In every sampling interval, the global plan is processed in order to find the closest pose to the robot (as reference start)
  and the current end pose (either local at costmap boundary or max_global_plan_lookahead_dist).
  Previously, the search algorithm stopped as soon as the distance to the robot increased once.
  This caused troubles with more complex global plans, hence the new strategy checks the complete subset
  of the global plan in the local costmap for the closest distance to the robot.
* via-points that are very close to the current robot pose or behind the robot are now skipped (in non-ordered mode)
* Edge creation: minor performance improvement for dynamic obstacle edges
* dynamic_reconfigure: parameter visualize_with_time_as_z_axis_scale moved to group trajectory
* Contributors: Christoph Rösmann
```
