### PR TITLE
ibeo_core: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4896,6 +4896,17 @@ repositories:
       url: https://github.com/iav-student/iav_depthimage_to_laserscan.git
       version: master
     status: maintained
+  ibeo_core:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/astuff/ibeo_core-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ibeo_core.git
+      version: release
+    status: developed
   icart_mini:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_core` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/ibeo_core.git
- release repository: https://github.com/astuff/ibeo_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
