### PR TITLE
ibeo_core: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3699,6 +3699,17 @@ repositories:
       url: https://github.com/husky/husky.git
       version: kinetic-devel
     status: maintained
+  ibeo_core:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/astuff/ibeo_core-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ibeo_core.git
+      version: release
+    status: developed
   ifm_o3mxxx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_core` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/ibeo_core.git
- release repository: https://github.com/astuff/ibeo_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
