### PR TITLE
ibeo_core: 2.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1250,6 +1250,17 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: master
     status: developed
+  ibeo_core:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/astuff/ibeo_core-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ibeo_core.git
+      version: release
+    status: developed
   ifopt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_core` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/ibeo_core.git
- release repository: https://github.com/astuff/ibeo_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
