### PR TITLE
ibeo_core: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -994,6 +994,17 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
       version: 0.5.0-0
     status: maintained
+  ibeo_core:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/astuff/ibeo_core-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ibeo_core.git
+      version: release
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_core` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/ibeo_core.git
- release repository: https://github.com/astuff/ibeo_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
