### PR TITLE
[rosdep] add python3-numpy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4350,7 +4350,7 @@ python3-nose:
   ubuntu: [python3-nose]
 python3-numpy:
   debian: [python3-numpy]
-  gentoo: [dev-python/nose]
+  gentoo: [dev-python/numpy]
   ubuntu: [python3-numpy]
 python3-pep8:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4348,6 +4348,10 @@ python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]
   ubuntu: [python3-nose]
+python3-numpy:
+  debian: [python3-numpy]
+  gentoo: [dev-python/nose]
+  ubuntu: [python3-numpy]
 python3-pep8:
   debian:
     buster: [python3-pep8]


### PR DESCRIPTION
Ubuntu: https://packages.ubuntu.com/bionic/python3-numpy
Debian: https://packages.debian.org/stretch/python3-numpy
Gentoo: https://packages.gentoo.org/packages/dev-python/numpy