### PR TITLE
gazebo_ros_pkgs: 2.8.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -679,7 +679,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.8.3-0
+      version: 2.8.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.8.4-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.8.3-0`

## gazebo_dev

- No changes

## gazebo_msgs

```
* Correct documentation on SetModelConfiguration.srv
* Contributors: Kevin Allen
```

## gazebo_plugins

```
* Fix various xacro/xml issues with tests
* Fix handling of boolean values since Gazebo API returns
  'true'/'false' as '1'/'0' strings
* Add auto_distortion parameter to camera utils
* Corrected depth camera plugin initialization (#748)
  * Initialize depth_image_connect_count_ to 0
  * Removed duplicate line in CMakeLists.txt
* Fix melodic compiler warnings (#744)
  * Fix model_state_test. -v means --version not --verbose
  * fix gazebo9 warnings by removing Set.*Accel calls
  * gazebo_plugins: don't use -r in tests
* add missing distortion test worlds
* fix 16bit test name
* test for triggered_camera
* update copyright dates and remove copied comments
* remove compiler directives for old gazebo versions
* use correct timestamp for images
* adds triggered cameras and multicameras
* Contributors: Jose Luis Rivero, Kevin Allen, Martin Ganeff, Morgan Quigley, Steven Peters, Timo Korthals, iche033
```

## gazebo_ros

```
* Refactor spawn_model script
  * more robust -package_to_model implementation (issue #449)
  * add stdin as source option
  * parse arguments with argparse
  * remove deprecated/unused -gazebo and -trimesh options
* Fix physics reconfigure within namespace (issue #507)
* Contributors: Kevin Allen, Steven Peters
```

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
