### PR TITLE
xpp: 1.0.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13584,7 +13584,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.8-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.7-0`

## xpp

- No changes

## xpp_examples

- No changes

## xpp_hyq

```
* avoid IK segfault for biped/hyq when not enough ee positions sent
* removed limits on hyqleg joint angles
* Contributors: Alexander Winkler
```

## xpp_msgs

- No changes

## xpp_quadrotor

- No changes

## xpp_states

```
* avoid IK segfault for biped/hyq when not enough ee positions sent
* Contributors: Alexander Winkler
```

## xpp_vis

```
* update catkin syntax for unit tests
* Fix unit test through visualizer improvement.
* fix wrongly displaying old markers when switching robots.
* make printouts in DEVEL only
* Contributors: Alexander Winkler
```
