### PR TITLE
towr: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12173,7 +12173,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-adrl/towr-release.git
-      version: 1.2.2-0
+      version: 1.3.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.3.0-0`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.2.2-0`

## towr

```
* add sample gaits for mono-, bi- and quadruped
* Contributors: Alexander Winkler
```

## towr_ros

```
* visualize goal state on terrain
* Remove redundant rviz terrain visualizer and instead generate
  surface patches directly from height map information
* correctly visualize rviz range-of-motion boxes
* visualize first state
* make GUI static
* Contributors: Alexander Winkler
```
