### PR TITLE
Add libopensplice67 key for Gentoo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2385,6 +2385,7 @@ libopenscenegraph:
   gentoo: [dev-games/openscenegraph]
   ubuntu: [openscenegraph, libopenscenegraph-dev]
 libopensplice67:
+  gentoo: [=sci-libs/opensplice-6.7.*]
   ubuntu:
     bionic: [libopensplice67]
     xenial: [libopensplice67]


### PR DESCRIPTION
This resolves a dependency blocking the following ROS 2 Bouncy Ebuilds from being generated by superflore.

```
>>>> rmw_opensplice_cpp:
>>>>   ['libopensplice67']
>>>> opensplice_cmake_module:
>>>>   ['libopensplice67']
>>>> rosidl_typesupport_opensplice_c:
>>>>   ['libopensplice67']
>>>> rosidl_typesupport_opensplice_cpp:
>>>>   ['libopensplice67']
```