### PR TITLE
Increasing version of rqt_image_view in kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10378,7 +10378,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_image_view-release.git
-      version: 0.4.11-0
+      version: 0.4.13-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of rqt_image_view in ROS kinetic from 0.4.11-0 to 0.4.13-0

- 0.4.13 (2018-05-02)
  - add build dependency on Qt5 dev package
- 0.4.12 (2018-05-02)
  - save and restore the smooth image check box state
  - allow image rotation in 90° steps
  - use Python distutils to install the global rqt_image_view executable