### PR TITLE
ibeo_lux: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4907,6 +4907,17 @@ repositories:
       url: https://github.com/astuff/ibeo_core.git
       version: release
     status: developed
+  ibeo_lux:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/astuff/ibeo_lux-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ibeo_lux.git
+      version: release
+    status: developed
   icart_mini:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_lux` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/ibeo_lux
- release repository: https://github.com/astuff/ibeo_lux-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
