### PR TITLE
ibeo_lux: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3726,6 +3726,17 @@ repositories:
       url: https://github.com/astuff/ibeo_core.git
       version: release
     status: developed
+  ibeo_lux:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/astuff/ibeo_lux-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ibeo_lux.git
+      version: release
+    status: developed
   ifm_o3mxxx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_lux` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/ibeo_lux
- release repository: https://github.com/astuff/ibeo_lux-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
