### PR TITLE
ibeo_lux: 2.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1261,6 +1261,17 @@ repositories:
       url: https://github.com/astuff/ibeo_core.git
       version: release
     status: developed
+  ibeo_lux:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/astuff/ibeo_lux-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ibeo_lux.git
+      version: release
+    status: developed
   ifopt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_lux` to `2.0.0-0`:

- upstream repository: https://github.com/astuff/ibeo_lux
- release repository: https://github.com/astuff/ibeo_lux-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
