### PR TITLE
add python3-mock rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4344,6 +4344,11 @@ python3-gitlab:
     xenial:
       pip:
         packages: [python-gitlab]
+python3-mock:
+  debian: [python3-mock]
+  fedora: [python3-mock]
+  gentoo: [dev-python/mock]
+  ubuntu: [python3-mock]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]


### PR DESCRIPTION
Debian: https://packages.debian.org/stretch/python3-mock
Gentoo: https://packages.gentoo.org/packages/dev-python/mock
Fedora: https://koji.fedoraproject.org/koji/buildinfo?buildID=1091756
Ubuntu: https://packages.ubuntu.com/bionic/python3-mock