### PR TITLE
rr_swiftnav_piksi: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10844,6 +10844,11 @@ repositories:
       type: git
       url: https://github.com/roverrobotics/rr_swiftnav_piksi.git
       version: devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RoverRobotics/rr_swiftnav_piksi-release.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/roverrobotics/rr_swiftnav_piksi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_swiftnav_piksi` to `0.0.1-0`:

- upstream repository: https://github.com/RoverRobotics/rr_swiftnav_piksi.git
- release repository: https://github.com/RoverRobotics/rr_swiftnav_piksi-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rr_swiftnav_piksi

```
* first public release for Kinetic
```
