### PR TITLE
ros_fmu: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2704,6 +2704,20 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: melodic
     status: maintained
+  ros_fmu:
+    release:
+      packages:
+      - ros_fmu
+      - ros_fmu_examples
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/boschresearch/ros_fmu-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/boschresearch/ros_fmu.git
+      version: master
+    status: maintained
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_fmu` to `1.0.0-0`:

- upstream repository: https://github.com/boschresearch/ros_fmu.git
- release repository: https://github.com/boschresearch/ros_fmu-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ros_fmu

```
* Initial version.
```

## ros_fmu_examples

```
* Initial version.
```
