### PR TITLE
geometry2: 0.6.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -855,7 +855,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.6.3-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.2-0`

## geometry2

- No changes

## tf2

```
* preserve constness of const argument to avoid warnings (#307 <https://github.com/ros/geometry2/issues/307>)
* Change comment style for unused doxygen (#297 <https://github.com/ros/geometry2/issues/297>)
* Contributors: Jacob Perron, Tully Foote
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* Changed access to Vector to prevent memory leak (#305 <https://github.com/ros/geometry2/issues/305>)
* Added WrenchStamped transformation (#302 <https://github.com/ros/geometry2/issues/302>)
* Contributors: Denis Štogl, Markus Grimm
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
