### PR TITLE
pid: 0.0.26-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2691,7 +2691,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/AndyZe/pid-release.git
-      version: 0.0.25-0
+      version: 0.0.26-0
     source:
       type: git
       url: https://bitbucket.org/AndyZe/pid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.26-0`:

- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZe/pid-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.25-0`
