### PR TITLE
rosauth: 0.1.7-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2725,6 +2725,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: melodic-devel
     status: maintained
+  rosauth:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gt-rail-release/rosauth-release.git
+      version: 0.1.7-2
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: develop
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `0.1.7-2`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/gt-rail-release/rosauth-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rosauth

```
* Merge pull request #8 from ckrooss/develop
  Added gencpp-dependency for test target
* Added gencpp-dependency for test target
* Contributors: Russell Toris, ckrooss
```
