### PR TITLE
ifopt: 2.0.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1277,6 +1277,16 @@ repositories:
       type: git
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ethz-adrl/ifopt-release.git
+      version: 2.0.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
     status: developed
   image_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.0.3-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ifopt

```
* Add codefactor integration and contributing guidelines
* display indices more precisely in printout
* remove rsl jekins, use ros build farm
* remove warning from version number
* Contributors: Alexander Winkler
```
