### PR TITLE
ifopt: 2.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1016,6 +1016,22 @@ repositories:
       url: https://github.com/astuff/ibeo_lux.git
       version: release
     status: developed
+  ifopt:
+    doc:
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ethz-adrl/ifopt-release.git
+      version: 2.0.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ethz-adrl/ifopt.git
+      version: master
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.0.3-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ifopt

```
* Add codefactor integration and contributing guidelines
* display indices more precisely in printout
* remove rsl jekins, use ros build farm
* remove warning from version number
* Contributors: Alexander Winkler
```
