### PR TITLE
xpp: 1.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -17277,7 +17277,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.6-0
+      version: 1.0.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.9-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.6-0`

## xpp

- No changes

## xpp_examples

- No changes

## xpp_hyq

```
* Merge pull request #7 from zlingkang/xacropi2xacro
  change deprecated xacro.py to xacro
* Contributors: zlingkang
```

## xpp_msgs

- No changes

## xpp_quadrotor

```
* Merge pull request #7 from zlingkang/xacropi2xacro
  change deprecated xacro.py to xacro
* Contributors: zlingkang
```

## xpp_states

- No changes

## xpp_vis

- No changes
