### PR TITLE
xpp: 1.0.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3878,6 +3878,30 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: melodic-devel
     status: maintained
+  xpp:
+    doc:
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    release:
+      packages:
+      - xpp
+      - xpp_examples
+      - xpp_hyq
+      - xpp_msgs
+      - xpp_quadrotor
+      - xpp_states
+      - xpp_vis
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/leggedrobotics/xpp-release.git
+      version: 1.0.9-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    status: maintained
   xv_11_laser_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.9-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## xpp

- No changes

## xpp_examples

- No changes

## xpp_hyq

```
* Merge pull request #7 from zlingkang/xacropi2xacro
  change deprecated xacro.py to xacro
* Contributors: zlingkang
```

## xpp_msgs

- No changes

## xpp_quadrotor

```
* Merge pull request #7 from zlingkang/xacropi2xacro
  change deprecated xacro.py to xacro
* Contributors: zlingkang
```

## xpp_states

- No changes

## xpp_vis

- No changes
