### PR TITLE
power_msgs: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9737,7 +9737,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/power_msgs.git
+      version: indigo-devel
     status: developed
   pr2_apps:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9732,7 +9732,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fetchrobotics/power_msgs.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.2.1-0`:

- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.0-0`

## power_msgs

```
* updates ownership
* Merge pull request #8 <https://github.com/fetchrobotics/power_msgs/issues/8> from cjds/errors
  Added error messages to the battery state for more information
* added error messages to the battery state for more information in FC
* Merge pull request #6 <https://github.com/fetchrobotics/power_msgs/issues/6> from macmason/master
  Add LICENSE file.
* Add LICENSE file.
* Contributors: Carl Saldanha, Mac Mason, Michael Ferguson, Russell Toris, cjds
```
