### PR TITLE
power_msgs: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2129,6 +2129,13 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  power_msgs:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
+      version: 0.3.0-0
+    status: maintained
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## power_msgs

```
* updates ownership
* Merge pull request #8 <https://github.com/fetchrobotics/power_msgs/issues/8> from cjds/errors
  Added error messages to the battery state for more information
* added error messages to the battery state for more information in FC
* Merge pull request #6 <https://github.com/fetchrobotics/power_msgs/issues/6> from macmason/master
  Add LICENSE file.
* Add LICENSE file.
* Contributors: Carl Saldanha, Mac Mason, Michael Ferguson, Russell Toris, cjds
```
