### PR TITLE
fetch_ros: 0.7.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3438,11 +3438,10 @@ repositories:
       - fetch_moveit_config
       - fetch_navigation
       - fetch_teleop
-      - freight_calibration
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.7.13-0
+      version: 0.7.14-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.7.14-0`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.7.13-0`

## fetch_calibration

```
* updates ownership
* Contributors: Russell Toris
```

## fetch_depth_layer

```
* updates ownership
* Contributors: Russell Toris
```

## fetch_description

```
* updates ownership
* Contributors: Russell Toris
```

## fetch_ikfast_plugin

```
* updates ownership
* Contributors: Russell Toris
```

## fetch_maps

```
* updates ownership
* Contributors: Russell Toris
```

## fetch_moveit_config

```
* updates ownership
* Contributors: Russell Toris
```

## fetch_navigation

```
* updates ownership
* Merge pull request #76 <https://github.com/fetchrobotics/fetch_ros/issues/76> from 708yamaguchi/change-amcl-param
  Localized position of fetch often jumps
* change odom model type and params for amcl
* Contributors: Derek, Naoya Yamaguchi, Russell Toris
```

## fetch_teleop

```
* updates ownership
* Merge pull request #68 <https://github.com/fetchrobotics/fetch_ros/issues/68> from BillWSY/indigo-devel
  Fixes an issue that tuck_arm.py spawns new roscore.
* Fixes an issue that tuck_arm.py spawns new roscore.
  tuck_arm.py calls roslaunch without --wait flag, which may spawn new ROS
  master in a racing condition.
* Contributors: Michael Ferguson, Russell Toris, Shengye Wang
```
