### PR TITLE
fetch_msgs: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3402,7 +3402,7 @@ repositories:
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git
-      version: master
+      version: indigo-devel
     status: developed
   fetch_pbd:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3398,7 +3398,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3390,7 +3390,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git
-      version: master
+      version: indigo-devel
     release:
       packages:
       - fetch_auto_dock_msgs


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `1.0.1-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`

## fetch_auto_dock_msgs

- No changes

## fetch_driver_msgs

```
* updates ownership
* Merge pull request #11 <https://github.com/fetchrobotics/fetch_msgs/issues/11> from chadrockey/revert-10-safety_laser
  Revert "Add header and remove unused information from SafetyLaserState"
* Revert "Add header and remove unused information from SafetyLaserState"
* Merge pull request #10 <https://github.com/fetchrobotics/fetch_msgs/issues/10> from chadrockey/safety_laser
  Add header and remove unused information from SafetyLaserState
* Add header and remove unused information from SafetyLaserState
* Contributors: Chad Rockey, Russell Toris
```
