### PR TITLE
Re-add pybind11_catkin to indigo (Revert #18356)

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10326,6 +10326,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
+      version: 2.2.3-1
   pyros:
     doc:
       type: git


### PR DESCRIPTION
The build issues documented in https://github.com/ipab-slmc/pybind11_catkin/issues/1 should now be fixed.

This reverts commit 71d6005f8d46ba0b71919b79614b727e592d705c.