### PR TITLE
pybind11_catkin: 2.2.3-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10326,6 +10326,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
+      version: 2.2.3-2
   pyros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.2.3-2`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
