### PR TITLE
video_stream_opencv: 1.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13023,7 +13023,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers/video_stream_opencv-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/ros-drivers/video_stream_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_stream_opencv` to `1.1.3-0`:

- upstream repository: https://github.com/ros-drivers/video_stream_opencv.git
- release repository: https://github.com/ros-drivers/video_stream_opencv-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.2-0`

## video_stream_opencv

```
* Fixing ever growing memory when using boost::sync_queue (Issue #20) by reimplementing thread safety of frames queue using std classes. boost::sync_queue is buggy (keeps on allocating memory over time).
* Contributors: Axel13fr
```
