### PR TITLE
jsk_roseus: 1.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4408,12 +4408,13 @@ repositories:
       packages:
       - jsk_roseus
       - roseus
+      - roseus_mongo
       - roseus_smach
       - roseus_tutorials
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.6.3-0
+      version: 1.7.0-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.7.0-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.6.3-0`

## jsk_roseus

- No changes

## roseus

```
* (ros::tf-transform->coords) failed with with geometry_msgs::Transform (#563 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/563>)
  * fix when tf-transform->coords receives geometry_msgs::Transform
  * [test/eustf.l] Add test to check (ros::tf-transform->coords) with geometry_msgs::Transform
* [roseus-utils.l]fix eusobj->marker-msg (#555 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/555>)
  * load dependent packages if msg/srv is not found in ros::load-ros-manifest
  * add ros::rospack-depends
  * roseus is always have roseus/ros/roseus
  * add debug message when loading manifest/msg/srv files, also more message when we need to avoid using load-ros-manifest
  * INDIGO: https://github.com/jsk-ros-pkg/jsk_roseus/issues/554if pkg without msg, need to return no-msg-package
  JADE/KINETIC: https://github.com/jsk-ros-pkg/jsk_robot/issues/823
  package without msg does not have manifest.l
  
    * fix find-load-msg-path, use dirs ~/share instaed of ~/share/roseus, it does not change logic
  
* do not load manifest.l when we have source tree, but does not have manifest.l because of missing msg/srv (#554 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/554>)
* add test to check :connection-header (#540 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/540>)
  * roseusp.cpp : add :connection-header method
  * add test to check :connection-header
* fix dead locking on accessing rosparam in timer callback (#557 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/557>)
  * test-mark-lock.l: add function using mark_lock
  * roseus: remove mutex_lock / unlock
  * roseus: add test code for dead locking of mark_lock
* add test code for [unexpected behavior if message has property name] #508 (#509 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/509>)
  * add test code for #508
* add ros::duration-sleep (#549 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/549>)
  * test/test-roseus.l : add test for ros::duration-sleep
  * roseus.cpp/roseus.l : add ros::duration-sleep
* Support both AcitonGoal and Goal in :send-goal (#546 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/546>)
  * test/simple-client-test.l: fix typo returns -> return
  * actionlib.l:send-goal : send-goal accepts both ActionGoal and Goal, where Python and C only takes Goal, but original roseus takes ActoinGoal, here we make ActionGoal when Goal is passed as python/c client
  * send SimpleGoal, not SimpleActionGoal
* roseus.cpp: use boost::shared_ptr for ros::Rate (#553 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/553>)
* add test to check numbers in node name (#536) (#552 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/552>)
  * Allow numbers on ros::roseus node name
  * add test to check numbers in node name (#536)
* Fix roseus test error, see https://github.com/jsk-ros-pkg/jsk_roseus/pull/545#issuecomment-349224047 (#551 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/551>)
  * add more messages, fix for roslaunch 1.12.8, due to //github.com/ros/ros_comm/issues/1097,
  * print error message when test-rosmaster failed
  * relax hzerror in test-anonymous.test,  ex, https://travis-ci.org/jsk-ros-pkg/jsk_roseus/jobs/313841319
  * test-roseus.l: test-master, add comment on tests
  * test-roseus.l: fix test error on test-masterros::get-uri returns http://localhost:11311, not http://localhost:11311/, also accept arbitrary order in ros::get-nodes, ros::get-topics tests
* Contributors: Yuki Furuta, Guilherme Affonso, Kei Okada, Naoki Hiraoka, Iori Yanokura
```

## roseus_mongo

```
* roseus_mongo: support non blocking insertion & update docstring (#541 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/541>)
  * roseus_mongo: skip non wait insertion test on hydro
  * roseus_mongo: minor fix in CMakeLists.txt
  * roseus_mongo: support update method
  * roseus_mongo: bugfix: assert on decoding string without blacket
  * roseus_mongo: add docs; minor fix
  * roseus_mongo: support non blocking insertion
* Contributors: Yuki Furuta
```

## roseus_smach

```
* Bugfixes and test codes for roseus_smach (#566 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/566>)
  * roseus_smach: add log messages on state transition
  * roseus_smach: fix: pass :cancel state to action-client-state
  * roseus_smach: fix test
  * roseus_smach: add test code for smach-actionlib
  * - Fix: indentationsFix: [bug] userdata is not kept if not given as arguments
  
  Add: Test code for action-client-state class
  
  Add: action-client-state sets action result/feedback to userdata for key :result/:feedback
* [roseus_smach] func: make-state-machine accepts various edges (#548 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/548>)
  * correct doc of :add-transition:add-transition do not accept list as exec-result
  
    * update make-state-machine docstring
    * set testfunc for transition in make-state-machine
    * func: make-state-machine accepts various edges
  
* [roseus_smach] pass userdata keys to state-machine in execution (#549 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/549>)
  * add exec-state-machine test
  * pass userdata keys to state-machine in execution
* Contributors: Shingo Kitagawa, Yuki Furuta
```

## roseus_tutorials

- No changes
