### PR TITLE
Simplify python-docopt rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -970,14 +970,10 @@ python-dlib:
   ubuntu:
     pip: [dlib]
 python-docopt:
-  debian:
-    buster: [python-docopt]
-    jessie: [python-docopt]
-    stretch: [python-docopt]
+  debian: [python-docopt]
   fedora: [python-docopt]
   gentoo: [dev-python/docopt]
-  ubuntu:
-    pip: [docopt]
+  ubuntu: [python-docopt]
 python-docutils:
   arch: [python2-docutils]
   debian: [python-docutils]


### PR DESCRIPTION
It's available on all supported ubuntu platforms: https://packages.ubuntu.com/trusty/python-docopt
And on all debian too: https://packages.debian.org/jessie/python-docopt