### PR TITLE
visualstates: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13219,7 +13219,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/JdeRobot/VisualStates.git
-      version: 0.1.1
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -13229,7 +13229,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/JdeRobot/VisualStates.git
-      version: 0.1.1
+      version: master
     status: developed
   volksbot_driver:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13215,6 +13215,22 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: kinetic-devel
     status: maintained
+  visualstates:
+    doc:
+      type: git
+      url: https://github.com/JdeRobot/VisualStates.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/JdeRobot/VisualStates-release.git
+      version: 0.1.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/VisualStates.git
+      version: 0.1.1
+    status: developed
   volksbot_driver:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13226,7 +13226,6 @@ repositories:
       url: https://github.com/JdeRobot/VisualStates-release.git
       version: 0.1.1-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/JdeRobot/VisualStates.git
       version: master

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2812,6 +2812,9 @@ python-qt5-bindings-gl:
     xenial: [python-pyqt5.qtopengl]
     yakkety: [python-pyqt5.qtopengl]
     zesty: [python-pyqt5.qtopengl]
+python-qt5-bindings-qsci:
+  ubuntu:
+    xenial: [python-pyqt5.qsci]
 python-qt5-bindings-webkit:
   arch: [python2-pyqt5]
   debian:
@@ -3574,6 +3577,9 @@ python-sympy:
     wily_python3: [python3-sympy]
     xenial: [python-sympy]
     xenial_python3: [python3-sympy]
+python-sysv-ipc:
+  ubuntu:
+    xenial: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]
   fedora: [python-tablib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3580,7 +3580,7 @@ python-sympy:
     xenial_python3: [python3-sympy]
 python-sysv-ipc:
   debian: [python-sysv-ipc]
-  fedora: [python-sysv-ipc]
+  fedora: [python2-sysv-ipc]
   ubuntu: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2813,8 +2813,9 @@ python-qt5-bindings-gl:
     yakkety: [python-pyqt5.qtopengl]
     zesty: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
-  ubuntu:
-    xenial: [python-pyqt5.qsci]
+  debian: [python-pyqt5.qsci]
+  fedora: [python2-qscintilla-qt5]
+  ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-webkit:
   arch: [python2-pyqt5]
   debian:
@@ -3578,8 +3579,9 @@ python-sympy:
     xenial: [python-sympy]
     xenial_python3: [python3-sympy]
 python-sysv-ipc:
-  ubuntu:
-    xenial: [python-sysv-ipc]
+  debian: [python-sysv-ipc]
+  fedora: [python-sysv-ipc]
+  ubuntu: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]
   fedora: [python-tablib]


### PR DESCRIPTION
Increasing version of package(s) in repository `visualstates` to `0.1.1-0`:

- upstream repository: https://github.com/JdeRobot/VisualStates.git
- release repository: https://github.com/JdeRobot/VisualStates-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## visualstates

```
* set the version of the ros package as 0.1.0
* Merge pull request #55 <https://github.com/JdeRobot/VisualStates/issues/55> from JdeRobot/ros-package
  Generated ROS package dependencies are fixed. fixes #37 <https://github.com/JdeRobot/VisualStates/issues/37>
* cpp ros package can use python run time
* The generated code does not have runtime but depends on the visualstates package itself
* config dialog supports only ROS communication interface
* Merge pull request #40 <https://github.com/JdeRobot/VisualStates/issues/40> from JdeRobot/none-config-fix
  if config is none create it as jderobotconfig and fixes #39 <https://github.com/JdeRobot/VisualStates/issues/39>
* if config is none create it as jderobotconfig
* Merge pull request #36 <https://github.com/JdeRobot/VisualStates/issues/36> from JdeRobot/ros-package
  VisualState tool is redesigned as a ROS package
* ros package of visualstates merging with the final code structure and improvements from master
* fixed remaining empty  merge characters in the source code
* merge from codegen-bug pull request of pushkal
* merge from pushkal's external ros package pull request
* restructure the project for ros
* format commands as source code
* change project directory to have everything under src directory
* Merge pull request #21 <https://github.com/JdeRobot/VisualStates/issues/21> from pushkalkatara/patch-1
  have quotation around path to handle path with with space
* Permissions to script in folders with space
  https://github.com/TheRoboticsClub/colab-gsoc2018-PushkalKatara/issues/8
  Solves #8 <https://github.com/JdeRobot/VisualStates/issues/8>
* Merge pull request #19 <https://github.com/JdeRobot/VisualStates/issues/19> from JdeRobot/subautomata-remove-fix
  Fixing subautomata removal bug
* get the parent node from treemodel
* ignore precompiled python files pyc
* Merge pull request #13 <https://github.com/JdeRobot/VisualStates/issues/13> from JdeRobot/generated_code_dependencies
  Correcting installation path for standalone installation
* add installation directives to README file
* check ROS message directory
* fix the cmake installation path
* Merge pull request #9 <https://github.com/JdeRobot/VisualStates/issues/9> from JdeRobot/standalone_visualstates
  Fixing cmake paths
* fixing cmake paths
* Merge pull request #8 <https://github.com/JdeRobot/VisualStates/issues/8> from JdeRobot/standalone_visualstates
  Migration of VisualStates tool to its own repository
* added examples and updated installation cmake to copy examples under share folder
* ignore .idea directory
* apply small changes for having standalone visualstates
* Merge branch 'master' of github.com:JdeRobot/VisualStates
* first commit
* Solved minor bug in visualStates installation
* remove the sample folder inside visualStates, old examples will reside in src/examples/visualStates
* visualStates_py renamed to visualStates
* remove old visualstates
* #993 <https://github.com/JdeRobot/VisualStates/issues/993> refactored JderobotConfig.cmake included cmake wrappers
* Merge branch 'global/build/792-fix-warnings' of https://github.com/lr-morales/JdeRobot into lr-morales-global/build/792-fix-warnings
* class name change is fixed
* merge from master
* to be able to access cmakevar.hpp add build directory to include directories
* remove the generated file to prevent misunderstanding
* install glade file to general glade path, get cmake variables through a c++ class, fix broken library path after moving install prefix to /opt/jderobot
* merge from jderobot_comm
* [Issue #792 <https://github.com/JdeRobot/VisualStates/issues/792>] Removes compilation warnings from tool visualStates
* [issue #890 <https://github.com/JdeRobot/VisualStates/issues/890>] Solved installation bug in visualStates
* [issue #879 <https://github.com/JdeRobot/VisualStates/issues/879>] solved bug in a visualStates file install
* [issue #879 <https://github.com/JdeRobot/VisualStates/issues/879>] Solved bug in some libraries installation
* [issue #879 <https://github.com/JdeRobot/VisualStates/issues/879>] Updated visualStates.cpp bug with getinterfaces.sh location
* [issue #879 <https://github.com/JdeRobot/VisualStates/issues/879>] updated visualStates.cpp for installation in /opt/jderobot
* [issue #879 <https://github.com/JdeRobot/VisualStates/issues/879>] moved all installation of libs to /opt/jderobot/libs instead of /opt/jderobot/libs/jderobot/
* [issue #879 <https://github.com/JdeRobot/VisualStates/issues/879>] moved all installations to /opt/jderobot
* change name visualHFSM in variable and class names to visualStates
* visualHFSM name is changed to visualStates name in the source code
* Contributors: AAAAAAAAA, Aitor Martinez, Aitor Martínez Fernández, Francisco Pérez, Francisco Rivas, Jose Maria Canas Plaza, Luis Roberto Morales Iglesias, Okan Aşık, Pushkal Katara
```
