### PR TITLE
ros_pytest: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9727,6 +9727,21 @@ repositories:
       url: https://github.com/easymov/ros_peerjs-release.git
       version: 0.1.8-0
     status: developed
+  ros_pytest:
+    doc:
+      type: git
+      url: https://github.com/machinekoder/ros_pytest.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/machinekoder/ros_pytest-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/machinekoder/ros_pytest.git
+      version: kinetic-devel
+    status: developed
   ros_realtime:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_pytest` to `0.1.0-0`:

- upstream repository: https://github.com/machinekoder/ros_pytest.git
- release repository: https://github.com/machinekoder/ros_pytest-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
