### PR TITLE
ros_canopen: 0.8.0-0 in 'melodic/distribution.yaml' [bloom] #wrid18

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2542,6 +2542,30 @@ repositories:
       url: https://github.com/ros/ros.git
       version: kinetic-devel
     status: maintained
+  ros_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: melodic
+    release:
+      packages:
+      - can_msgs
+      - canopen_402
+      - canopen_chain_node
+      - canopen_master
+      - canopen_motor_node
+      - ros_canopen
+      - socketcan_bridge
+      - socketcan_interface
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: melodic-devel
+    status: maintained
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.8.0-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## can_msgs

- No changes

## canopen_402

```
* handle invalid supported drive modes object
* made Mode402::registerMode a variadic template
* use std::isnan
* migrated to std::atomic
* migrated to std::unordered_map and std::unordered_set
* migrated to std pointers
* fix initialization bug in ProfiledPositionMode
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

```
* migrated to std::function and std::bind
* make sync_node return proper error codes
* refactored PublishFunc
* migrated to std::atomic
* migrated to std pointers
* removed deprecated types
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* migrated to std::function and std::bind
* migrated to std::atomic
* got rid of boost::noncopyable
* replaced BOOST_FOREACH
* migrated to std::unordered_map and std::unordered_set
* migrated to std pointers
* provided KeyHash
  for use with unordered containers
* added c_array access functons to can::Frame
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

```
* migrated to std::function and std::bind
* use std::isnan
* migrated to std::atomic
* migrated to std::unordered_map and std::unordered_set
* migrated to std pointers
* removed deprecated types
* introduced HandleLayerSharedPtr
* Contributors: Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

```
* keep NodeHandle alive in socketcan_bridge tests
* migrated to std::function and std::bind
* migrated to std pointers
* compare can_msgs::Frame and can::Frame properly
* Contributors: Mathias Lüdtke
```

## socketcan_interface

```
* migrated to std::function and std::bind
* got rid of boost::noncopyable
* replaced BOOST_FOREACH
* migrated to std::unordered_map and std::unordered_set
* migrated to std:array
* migrated to std pointers
* removed deprecated types
* introduced ROSCANOPEN_MAKE_SHARED
* added c_array access functons to can::Frame
* Contributors: Mathias Lüdtke
```
