### PR TITLE
pr2_gripper_sensor: 1.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7807,6 +7807,26 @@ repositories:
       url: https://github.com/PR2-prime/pr2_ethercat_drivers.git
       version: kinetic-devel
     status: unmaintained
+  pr2_gripper_sensor:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_gripper_sensor.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_gripper_sensor
+      - pr2_gripper_sensor_action
+      - pr2_gripper_sensor_controller
+      - pr2_gripper_sensor_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
+      version: 1.0.10-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_gripper_sensor.git
+      version: hydro-devel
+    status: unmaintained
   pr2_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.10-0`:

- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## pr2_gripper_sensor

```
* Merge pull request #14 <https://github.com/pr2/pr2_gripper_sensor/issues/14> from PR2/fix_maintainer
  change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* set license of pr2_gripper_sensor to BSD
* change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* Contributors: Kei Okada
```

## pr2_gripper_sensor_action

```
* Merge pull request #14 <https://github.com/pr2/pr2_gripper_sensor/issues/14> from PR2/fix_maintainer
  change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* Merge pull request #10 <https://github.com/pr2/pr2_gripper_sensor/issues/10> from furushchev/use-env
  [pr2_gripper_sensor_action] use optenv instead of direct use pr2.machine in launch
* use optenv instead of direct use pr2.machine
* Contributors: Devon Ash, Kei Okada, Yuki Furuta
```

## pr2_gripper_sensor_controller

```
* Merge pull request #14 <https://github.com/pr2/pr2_gripper_sensor/issues/14> from PR2/fix_maintainer
  change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* Merge pull request #11 <https://github.com/pr2/pr2_gripper_sensor/issues/11> from archielee/hydro-devel
  Removed lines in each yaml file relating to a controller for the othe…
* Removed lines in each yaml file relating to a controller for the other side
* Forgot word
* Added include destinatoin
* removed unnec
* revert
* Fixed lib path
* Contributors: Archie Lee, Kei Okada, TheDash, archielee
```

## pr2_gripper_sensor_msgs

```
* Merge pull request #14 <https://github.com/pr2/pr2_gripper_sensor/issues/14> from PR2/fix_maintainer
  change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* change maintainer to mailto:ros-orphaned-packages@googlegroups.com
* Contributors: Kei Okada
```
