### PR TITLE
async_web_server_cpp: 0.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -100,6 +100,13 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: release
     status: developed
+  async_web_server_cpp:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gt-rail-release/async_web_server_cpp-release.git
+      version: 0.0.3-0
+    status: unmaintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `0.0.3-0`:

- upstream repository: https://github.com/GT-RAIL/async_web_server_cpp.git
- release repository: https://github.com/gt-rail-release/async_web_server_cpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## async_web_server_cpp

```
* Merge pull request #6 from mitchellwills/develop
  Added some tests
* Added filesystem tests
* Added some more tests (including websocket tests)
* Added some more http tests
* Added an echo test and enabled tests on travis
* Began working on some tests
* Fixed missing boost dep
* Merge pull request #5 from mitchellwills/develop
  Some more improvements
* Added filesystem request handler
  This serves both files from a given root and directory listings (if requested)
* Modified request handler signature so that it can reject requests (causing them to be pushed to the next handler in a handler group)
* Now load a file to be served each time it is requested
* Fix HTTP Server stop to allow it to be safe to call multiple times
* Merge pull request #4 from mitchellwills/develop
  A few small improvements
* Allow for a server to be created even if the system has no non-local IP
  See http://stackoverflow.com/questions/5971242/how-does-boost-asios-hostname-resolution-work-on-linux-is-it-possible-to-use-n
* Changed write resource to be a const shared ptr
* Contributors: Mitchell Wills, Russell Toris
```
