### PR TITLE
geometry2: 0.5.18-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3071,7 +3071,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.5.17-0
+      version: 0.5.18-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.5.18-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.5.17-0`

## geometry2

- No changes

## tf2

```
* preserve constness of const argument to avoid warnings (#307 <https://github.com/ros/geometry2/issues/307>)
* Change comment style for unused doxygen (#297 <https://github.com/ros/geometry2/issues/297>)
* Contributors: Jacob Perron, Tully Foote
```

## tf2_bullet

- No changes

## tf2_eigen

```
* Adds toMsg & fromMsg for Eigen Vector3 (#294 <https://github.com/ros/geometry2/issues/294>)
* Adds additional conversions for tf2, KDL, Eigen (#292 <https://github.com/ros/geometry2/issues/292>)
* Contributors: Ian McMahon
```

## tf2_geometry_msgs

```
* Changed access to Vector to prevent memory leak (#305 <https://github.com/ros/geometry2/issues/305>)
* Boilerplate for Sphinx (#284 <https://github.com/ros/geometry2/issues/284>)
* tf2_geometry_msgs added doTransform implementations for not stamped P… (#262 <https://github.com/ros/geometry2/issues/262>)
* New functionality to transform PoseWithCovarianceStamped messages. (#282 <https://github.com/ros/geometry2/issues/282>)
* Contributors: Blake Anderson, Markus Grimm, Tully Foote, cwecht
```

## tf2_kdl

```
* Adds additional conversions for tf2, KDL, Eigen (#292 <https://github.com/ros/geometry2/issues/292>)
* Contributors: Ian McMahon
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* tf2_ros::Buffer: canTransform can now deal with timeouts smaller than… (#286 <https://github.com/ros/geometry2/issues/286>)
* More spinning to make sure the message gets through for #129 <https://github.com/ros/geometry2/issues/129>
* Contributors: Tully Foote, cwecht
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
