### PR TITLE
mrpt_bridge: 0.1.25-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5805,7 +5805,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
-      version: 0.1.24-0
+      version: 0.1.25-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_bridge` to `0.1.25-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_bridge.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.24-0`

## mrpt_bridge

```
* Merge pull request #3 <https://github.com/mrpt-ros-pkg/mrpt_bridge/issues/3> from tuw-robotics/master
  TPose2D to geometry_msgs::Pose
* Update pose.h
* TPose2D Conversion to geometry_msgs::Pose added
* Merge pull request #2 <https://github.com/mrpt-ros-pkg/mrpt_bridge/issues/2> from clalancette/fix-deb-stretch
  Fix deb stretch
* Fix build warnings for signed/unsigned comparison.
  The width and height of the OccupancyGrid metadata are both
  uint32, so make the loop iterator type match.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Workaround Debian stretch not properly setting up Qt dependencies.
  libpcl-dev really has a dependency on Qt5Widgets, but that
  is not expressed by the Debian Stretch packages.  We workaround
  it here by forcing the dependency in both the package.xml and
  the CMakeLists.txt
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette, Jose Luis Blanco-Claraco, Markus Bader
```
