### PR TITLE
add libneon27-gnutls-dev rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2239,6 +2239,10 @@ libncurses-dev:
   gentoo: [sys-libs/ncurses]
   macports: [ncurses]
   ubuntu: [libncurses5-dev]
+libneon27-gnutls-dev:
+  debian: [libneon27-gnutls-dev]
+  gentoo: [gnutls]
+  ubuntu: [libneon27-gnutls-dev]
 libnl-3:
   arch: [libnl]
   debian: [libnl-3-200, libnl-genl-3-200]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2241,7 +2241,7 @@ libncurses-dev:
   ubuntu: [libncurses5-dev]
 libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
-  gentoo: [gnutls]
+  gentoo: [neon]
   ubuntu: [libneon27-gnutls-dev]
 libnl-3:
   arch: [libnl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2241,7 +2241,7 @@ libncurses-dev:
   ubuntu: [libncurses5-dev]
 libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
-  gentoo: [neon]
+  gentoo: [net-libs/neon]
   ubuntu: [libneon27-gnutls-dev]
 libnl-3:
   arch: [libnl]


### PR DESCRIPTION
Ubuntu: https://packages.ubuntu.com/bionic/libneon27-gnutls-dev
Debian: https://packages.debian.org/stretch/libneon27-gnutls-dev
Gentoo: https://packages.gentoo.org/packages/net-libs/gnutls
