### PR TITLE
fetch_tools: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3456,7 +3456,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_tools.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3451,7 +3451,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fetchrobotics/fetch_tools.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -3460,7 +3460,7 @@ repositories:
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_tools.git
-      version: master
+      version: indigo-devel
     status: developed
   fiducials:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.1.5-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.4-0`

## fetch_tools

```
* updates ownership
* Merge pull request #11 <https://github.com/fetchrobotics/fetch_tools/issues/11> from fetchrobotics/rctoris-patch-1
  Adds audio group to new users
* Update create_account.py
* Merge pull request #10 <https://github.com/fetchrobotics/fetch_tools/issues/10> from alexhenning/better-default-build
  No longer defaults to debug builds
* No longer defaults to debug builds
  Defaulting to debug was a mistake, instead, this provides an option that
  makes it easy to change the build type to debug (or anything else) with
  tab completion.
* Merge pull request #9 <https://github.com/fetchrobotics/fetch_tools/issues/9> from mehwang/more_hardware_info
  Expand hardware info retrieval and add read_board to debug_snapshot
* Expand hardware info retrieval and add read_board
* Contributors: Alex Henning, Michael Ferguson, Michael Hwang, Russell Toris
```
