### PR TITLE
fetch_tools: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -617,6 +617,21 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/fanuc_post_processor.git
       version: melodic
     status: developed
+  fetch_tools:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_tools.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_tools.git
+      version: melodic-devel
+    status: maintained
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.2.0-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## fetch_tools

```
* updates ownership
* Update create_account.py
* Expand hardware info retrieval and add read_board
* Contributors: Alex Henning, Michael Ferguson, Michael Hwang, Russell Toris
```
