### PR TITLE
interactive_markers: 1.11.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4071,7 +4071,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.11.3-0
+      version: 1.11.4-0
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.11.4-0`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.11.3-0`

## interactive_markers

```
* Fixed a crash when updates arrive, or are being processed, while shutdown is called (#36 <https://github.com/ros-visualization/interactive_markers/issues/36>)
* Contributors: Simon Schmeisser
```
