### PR TITLE
interactive_markers: 1.11.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5362,7 +5362,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.11.3-0
+      version: 1.11.4-0
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.11.4-0`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.11.3-0`

## interactive_markers

```
* Fixed a crash when updates arrive, or are being processed, while shutdown is called (#36 <https://github.com/ros-visualization/interactive_markers/issues/36>)
* Contributors: Simon Schmeisser
```
