### PR TITLE
rr_swiftnav_piksi: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10880,7 +10880,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics/rr_swiftnav_piksi-release.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/roverrobotics/rr_swiftnav_piksi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_swiftnav_piksi` to `0.0.1-1`:

- upstream repository: https://github.com/RoverRobotics/rr_swiftnav_piksi.git
- release repository: https://github.com/RoverRobotics/rr_swiftnav_piksi-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.1-0`

## rr_swiftnav_piksi

```
* first public release for Kinetic
```
