### PR TITLE
robot_controllers: 0.6.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2466,6 +2466,25 @@ repositories:
       url: https://github.com/mikeferguson/robot_calibration.git
       version: master
     status: maintained
+  robot_controllers:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: melodic-devel
+    release:
+      packages:
+      - robot_controllers
+      - robot_controllers_interface
+      - robot_controllers_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: melodic-devel
+    status: maintained
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.6.0-0`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## robot_controllers

```
* updates ownership
* Contributors: Russell Toris
```

## robot_controllers_interface

```
* updates ownership
* Contributors: Russell Toris
```

## robot_controllers_msgs

```
* updates ownership
* Contributors: Russell Toris
```
