### PR TITLE
neonavigation: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8222,6 +8222,33 @@ repositories:
       url: https://github.com/neobotix/neo_driver.git
       version: indigo_dev
     status: developed
+  neonavigation:
+    doc:
+      type: git
+      url: https://github.com/at-wat/neonavigation.git
+      version: master
+    release:
+      packages:
+      - costmap_cspace
+      - joystick_interrupt
+      - map_organizer
+      - neonavigation
+      - neonavigation_common
+      - neonavigation_launch
+      - obj_to_pointcloud
+      - planner_cspace
+      - safety_limiter
+      - track_odometry
+      - trajectory_tracker
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/at-wat/neonavigation-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/at-wat/neonavigation.git
+      version: master
+    status: developed
   neonavigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.2.0-0`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## costmap_cspace

```
* Fix build on Indigo (#180 <https://github.com/at-wat/neonavigation/issues/180>)
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Fix package dependencies (#167 <https://github.com/at-wat/neonavigation/issues/167>)
* Fix naming styles (#166 <https://github.com/at-wat/neonavigation/issues/166>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* costmap_cspace: add StopPropagation layer (#153 <https://github.com/at-wat/neonavigation/issues/153>)
* costmap_cspace: install header files (#155 <https://github.com/at-wat/neonavigation/issues/155>)
* costmap_cspace: fix layer order handling from the parameter (#154 <https://github.com/at-wat/neonavigation/issues/154>)
* costmap_cspace: clear update region on output layer (#139 <https://github.com/at-wat/neonavigation/issues/139>)
* costmap_cspace: clear previous position on overlay map (#135 <https://github.com/at-wat/neonavigation/issues/135>)
* Add integration demo (#133 <https://github.com/at-wat/neonavigation/issues/133>)
* costmap_cspace: add unknown handler layer (#132 <https://github.com/at-wat/neonavigation/issues/132>)
* costmap_cspace: memory access optimizations (#131 <https://github.com/at-wat/neonavigation/issues/131>)
* costmap_cspace: keep overlay maps which arrived before base map (#124 <https://github.com/at-wat/neonavigation/issues/124>)
* costmap_cspace: always store received overlay map (#109 <https://github.com/at-wat/neonavigation/issues/109>)
* costmap_cspace: make static layers configurable (#108 <https://github.com/at-wat/neonavigation/issues/108>)
* costmap_cspace: make costmap layer structure configurable (#106 <https://github.com/at-wat/neonavigation/issues/106>)
* costmap_cspace: refactor CSpace3Cache class (#105 <https://github.com/at-wat/neonavigation/issues/105>)
* costmap_cspace: add stacked costmap class (#104 <https://github.com/at-wat/neonavigation/issues/104>)
* costmap_cspace: remove retval of setFootprint (#103 <https://github.com/at-wat/neonavigation/issues/103>)
* costmap_cspace: move XML-polygon conversion into Polygon class (#102 <https://github.com/at-wat/neonavigation/issues/102>)
* costmap cspace: add layer type check (#101 <https://github.com/at-wat/neonavigation/issues/101>)
* costmap_cspace: refactor costmap layer classes (#100 <https://github.com/at-wat/neonavigation/issues/100>)
* costmap_cspace: make costmap layers stackable (#99 <https://github.com/at-wat/neonavigation/issues/99>)
* costmap_cspace: make cspace template customizable (#96 <https://github.com/at-wat/neonavigation/issues/96>)
* costmap_cspace: hold CSpace3D object as shared_ptr (#95 <https://github.com/at-wat/neonavigation/issues/95>)
* Suppress compile warnings and test with -Werror. (#82 <https://github.com/at-wat/neonavigation/issues/82>)
* costmap_cspace: fix frame of z-filter in pointcloud2_to_map. (#80 <https://github.com/at-wat/neonavigation/issues/80>)
* costmap_cspace: fix angular grid accessor before receiving the first map.
* Add missing dep to xmlrpcpp. (#52 <https://github.com/at-wat/neonavigation/issues/52>)
* Remove dummy dep to system_lib. (#51 <https://github.com/at-wat/neonavigation/issues/51>)
* costmap_cspace: adds unit tests. (#48 <https://github.com/at-wat/neonavigation/issues/48>)
* costmap_cspace: fixes memory access error on global map boundary. (#49 <https://github.com/at-wat/neonavigation/issues/49>)
* costmap_cspace: refactors costmap_cspace package. (#47 <https://github.com/at-wat/neonavigation/issues/47>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* costmap_cspace: pointcloud2_to_map: adds singleshot data input (#41 <https://github.com/at-wat/neonavigation/issues/41>)
* Fix coding styles. (#39 <https://github.com/at-wat/neonavigation/issues/39>)
* costmap_cspace: add pointcloud2_to_map node. (#35 <https://github.com/at-wat/neonavigation/issues/35>)
* costmap_cspace: laserscan_to_map: accumerate scans. (#34 <https://github.com/at-wat/neonavigation/issues/34>)
* costmap_cspace: adds laserscan_to_map node. (#33 <https://github.com/at-wat/neonavigation/issues/33>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* costmap_cspace, planner_cspace: fixes pkg dependencies
* changes planner and costmap package names with a postfix _cspace
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

```
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* joystick_interrupt: fix topic ns and meta-package dep (#173 <https://github.com/at-wat/neonavigation/issues/173>)
* Subtree-merge joystick_interrupt (#172 <https://github.com/at-wat/neonavigation/issues/172>)
* Contributors: Atsushi Watanabe
```

## map_organizer

```
* Fix build on Indigo (#180 <https://github.com/at-wat/neonavigation/issues/180>)
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Fix package dependencies (#167 <https://github.com/at-wat/neonavigation/issues/167>)
* Fix naming styles (#166 <https://github.com/at-wat/neonavigation/issues/166>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* map_organizer: fix naming style. (#84 <https://github.com/at-wat/neonavigation/issues/84>)
* Fix find_package(Eigen3). (#83 <https://github.com/at-wat/neonavigation/issues/83>)
* Suppress compile warnings and test with -Werror. (#82 <https://github.com/at-wat/neonavigation/issues/82>)
* map_organizer: extract maps by rate based thresholds. (#65 <https://github.com/at-wat/neonavigation/issues/65>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* map_organizer: pointcloud_to_maps: makes parameters configurable. (#40 <https://github.com/at-wat/neonavigation/issues/40>)
* Fix coding styles. (#39 <https://github.com/at-wat/neonavigation/issues/39>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* Subtree-merge 'map_organizer' package
* Contributors: Atsushi Watanabe
```

## neonavigation

```
* joystick_interrupt: fix topic ns and meta-package dep (#173 <https://github.com/at-wat/neonavigation/issues/173>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* changes planner and costmap package names with a postfix _cspace
* 3D (x, y, yaw) costmap and path planner
* Contributors: Atsushi Watanabe
```

## neonavigation_common

```
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Contributors: Atsushi Watanabe
```

## neonavigation_launch

```
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* costmap_cspace: fix layer order handling from the parameter (#154 <https://github.com/at-wat/neonavigation/issues/154>)
* Add integration demo (#133 <https://github.com/at-wat/neonavigation/issues/133>)
* costmap_cspace: add unknown handler layer (#132 <https://github.com/at-wat/neonavigation/issues/132>)
* safety_limiter: add watchdog timer (#123 <https://github.com/at-wat/neonavigation/issues/123>)
* safety_limiter: use timer instead of spinOnce (#121 <https://github.com/at-wat/neonavigation/issues/121>)
* planner_cspace: support parallel aster search (#118 <https://github.com/at-wat/neonavigation/issues/118>)
* costmap_cspace: make static layers configurable (#108 <https://github.com/at-wat/neonavigation/issues/108>)
* costmap_cspace: make costmap layer structure configurable (#106 <https://github.com/at-wat/neonavigation/issues/106>)
* planner_cspace: add simple action client for robot patrol. (#61 <https://github.com/at-wat/neonavigation/issues/61>)
* neonavigation_launch, planner_cspace: add simple simulator. (#59 <https://github.com/at-wat/neonavigation/issues/59>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* changes planner and costmap package names with a postfix _cspace
* neonavigation_launch: updates trajectory_tracker parameters
* neonavigation_launch: specifies parameter to control yaw at the goal
* neonavigation_launch: changes in-place rotation threshold
* neonavigation_launch: adds arg to specify path looking ahead range
* neonavigation_launch: removes tolerance parameters to use default value
* neonavigation_launch: adds parameter to specify goal topic
* neonavigation_launch: removes unused parameters
* neonavigation_launch: adds args to set planner and costmap parameters
* neonavigation_launch: add args for simulation
* neonavigation_launch: add launch file to use costmap_3d and planner_3d
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

```
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Fix package dependencies (#167 <https://github.com/at-wat/neonavigation/issues/167>)
* Fix naming styles (#166 <https://github.com/at-wat/neonavigation/issues/166>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* obj_to_pointcloud: fix naming style. (#85 <https://github.com/at-wat/neonavigation/issues/85>)
* Fix find_package(Eigen3). (#83 <https://github.com/at-wat/neonavigation/issues/83>)
* Suppress compile warnings and test with -Werror. (#82 <https://github.com/at-wat/neonavigation/issues/82>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* Fix coding styles. (#39 <https://github.com/at-wat/neonavigation/issues/39>)
* obj_to_pointcloud: support pcd file (#29 <https://github.com/at-wat/neonavigation/issues/29>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* Subtree-merge 'obj_to_pointcloud' package
* Contributors: Atsushi Watanabe
```

## planner_cspace

```
* planner_cspace: fix restriction of path segment connection (#191 <https://github.com/at-wat/neonavigation/issues/191>)
* planner_cspace: fix boundary check (#190 <https://github.com/at-wat/neonavigation/issues/190>)
* planner_cspace: fix unconverged switching back vibration (#183 <https://github.com/at-wat/neonavigation/issues/183>)
* Reduce random test failure (#181 <https://github.com/at-wat/neonavigation/issues/181>)
* Update CI (#179 <https://github.com/at-wat/neonavigation/issues/179>)
* Fix cost in heuristic function for make_plan service (#178 <https://github.com/at-wat/neonavigation/issues/178>)
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* planner_cspace: add make plan service (#169 <https://github.com/at-wat/neonavigation/issues/169>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Fix package dependencies (#167 <https://github.com/at-wat/neonavigation/issues/167>)
* Fix naming styles (#166 <https://github.com/at-wat/neonavigation/issues/166>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* planner_cspace: fix clearing remembered costmap (#158 <https://github.com/at-wat/neonavigation/issues/158>)
* planner_cspace: fix partial costmap update with unknown cells (#156 <https://github.com/at-wat/neonavigation/issues/156>)
* planner_cspace: remember costmap using binary bayes filter (#149 <https://github.com/at-wat/neonavigation/issues/149>)
* planner_cspace: fix position jump detection (#150 <https://github.com/at-wat/neonavigation/issues/150>)
* planner_cspace: fix remembering costmap (#147 <https://github.com/at-wat/neonavigation/issues/147>)
* planner_cspace: use frame_id of incoming message to set dummy robot pose (#145 <https://github.com/at-wat/neonavigation/issues/145>)
* planner_cspace: add odom publisher to dummy robot (#143 <https://github.com/at-wat/neonavigation/issues/143>)
* planner_cspace: add preempt (#137 <https://github.com/at-wat/neonavigation/issues/137>)
* planner_cspace: minor optimizations (#129 <https://github.com/at-wat/neonavigation/issues/129>)
* planner_cspace: disable performance test by default (#127 <https://github.com/at-wat/neonavigation/issues/127>)
* planner_cspace: support parallel distance map search (#125 <https://github.com/at-wat/neonavigation/issues/125>)
* planner_cspace: support parallel aster search (#118 <https://github.com/at-wat/neonavigation/issues/118>)
* Add abort (#116 <https://github.com/at-wat/neonavigation/issues/116>)
* planner_cspace: increase navigation test time limit (#98 <https://github.com/at-wat/neonavigation/issues/98>)
* planner_cspace: validate goal position. (#90 <https://github.com/at-wat/neonavigation/issues/90>)
* Suppress compile warnings and test with -Werror. (#82 <https://github.com/at-wat/neonavigation/issues/82>)
* Fix header of empty path. (#79 <https://github.com/at-wat/neonavigation/issues/79>)
* planner_cspace: cache motion interpolation. (#75 <https://github.com/at-wat/neonavigation/issues/75>)
* planner_cspace: add planning performance test. (#74 <https://github.com/at-wat/neonavigation/issues/74>)
* planner_cspace: add navigation integration test. (#73 <https://github.com/at-wat/neonavigation/issues/73>)
* planner_cspace: add test for cyclic_vec. (#72 <https://github.com/at-wat/neonavigation/issues/72>)
* planner_cspace: fix naming styles in blockmem_gridmap. (#69 <https://github.com/at-wat/neonavigation/issues/69>)
* planner_cspace: add test for blockmem_gridmap. (#70 <https://github.com/at-wat/neonavigation/issues/70>)
* planner_cspace: install patrol actionlib client. (#64 <https://github.com/at-wat/neonavigation/issues/64>)
* planner_cspace: initialize dummy robot status. (#62 <https://github.com/at-wat/neonavigation/issues/62>)
* planner_cspace: add simple action client for robot patrol. (#61 <https://github.com/at-wat/neonavigation/issues/61>)
* planner_cspace: add missing dependency to boost::chrono. (#60 <https://github.com/at-wat/neonavigation/issues/60>)
* planner_cspace: add actionlib support. (#58 <https://github.com/at-wat/neonavigation/issues/58>)
* neonavigation_launch, planner_cspace: add simple simulator. (#59 <https://github.com/at-wat/neonavigation/issues/59>)
* planner_space: fix naming styles. (#57 <https://github.com/at-wat/neonavigation/issues/57>)
* planner_cspace: refactor separating classes. (#55 <https://github.com/at-wat/neonavigation/issues/55>)
* planner_cspace: fix distance map init timing. (#53 <https://github.com/at-wat/neonavigation/issues/53>)
* Remove dummy dep to system_lib. (#51 <https://github.com/at-wat/neonavigation/issues/51>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* Fix coding styles. (#39 <https://github.com/at-wat/neonavigation/issues/39>)
* planner_cspace: fixes ignore range handling (#28 <https://github.com/at-wat/neonavigation/issues/28>)
* planner_cspace: fixes memory leak on remembered costmap (#27 <https://github.com/at-wat/neonavigation/issues/27>)
* planner_cspace: adds service to forget remembered costmap (#26 <https://github.com/at-wat/neonavigation/issues/26>)
* planner_cspace: fixes logic of remember_update parameter (#25 <https://github.com/at-wat/neonavigation/issues/25>)
* planner_cspace: fixes wrong direction of path end (#24 <https://github.com/at-wat/neonavigation/issues/24>)
* planner_cspace: fixes straight motion discriminant (#23 <https://github.com/at-wat/neonavigation/issues/23>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* costmap_cspace, planner_cspace: fixes pkg dependencies
* planner_cspace: adds planner for 2dof serial joints (#6 <https://github.com/at-wat/neonavigation/issues/6>)
* planner_cspace: uses template to specify dimension
* changes planner and costmap package names with a postfix _cspace
* Contributors: Atsushi Watanabe, Yuta Koga, Yutaka Takaoka
```

## safety_limiter

```
* safety_limiter: update document (#192 <https://github.com/at-wat/neonavigation/issues/192>)
* safety_limiter: fix safety limit logic (#187 <https://github.com/at-wat/neonavigation/issues/187>)
* safety_limiter: fix input cloud buffering (#184 <https://github.com/at-wat/neonavigation/issues/184>)
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Fix package dependencies (#167 <https://github.com/at-wat/neonavigation/issues/167>)
* Fix naming styles (#166 <https://github.com/at-wat/neonavigation/issues/166>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* safety_limiter: add watchdog timer (#123 <https://github.com/at-wat/neonavigation/issues/123>)
* safety_limiter: use timer instead of spinOnce (#121 <https://github.com/at-wat/neonavigation/issues/121>)
* safety_limiter: fix naming style. (#86 <https://github.com/at-wat/neonavigation/issues/86>)
* Suppress compile warnings and test with -Werror. (#82 <https://github.com/at-wat/neonavigation/issues/82>)
* safety_limiter: avoid kdtree build for empty cloud. (#67 <https://github.com/at-wat/neonavigation/issues/67>)
* Add missing dep to xmlrpcpp. (#52 <https://github.com/at-wat/neonavigation/issues/52>)
* safety_limiter: support fragmented pointcloud input. (#43 <https://github.com/at-wat/neonavigation/issues/43>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* Fix coding styles. (#39 <https://github.com/at-wat/neonavigation/issues/39>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* safety_limiter: increases subscribe buffer length for safety disable input
* safety_limiter: adds time margin in collision test
* safety_limiter: uses pcl's erase-remove_if
* safety_limiter: fixes safety disable mode to ignore cloud timeout
* safety_limiter: adds safety disable input
* safety_limiter: fixes pointcloud height handling
* safety_limiter: reduces pointcloud timeout warning
* safety_limiter: publishes stop command if no pointcloud received
* safety_limiter: Motion limiter for collision prevention
* Contributors: Atsushi Watanabe
```

## track_odometry

```
* Fix build on Indigo (#180 <https://github.com/at-wat/neonavigation/issues/180>)
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Fix package dependencies (#167 <https://github.com/at-wat/neonavigation/issues/167>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* track_odometry: use timer instead of spinOnce (#122 <https://github.com/at-wat/neonavigation/issues/122>)
* track_odometry: fix eigen include dir (#115 <https://github.com/at-wat/neonavigation/issues/115>)
* track_odometry: use position diff instead of twist.linear (#113 <https://github.com/at-wat/neonavigation/issues/113>)
* track_odometry: overwrite odometry child_frame_id (#112 <https://github.com/at-wat/neonavigation/issues/112>)
* track_odometry: fix naming style. (#91 <https://github.com/at-wat/neonavigation/issues/91>)
* track_odometry: add publish_tf option. (#78 <https://github.com/at-wat/neonavigation/issues/78>)
* Remove dummy dep to system_lib. (#51 <https://github.com/at-wat/neonavigation/issues/51>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* Fix coding styles. (#39 <https://github.com/at-wat/neonavigation/issues/39>)
* track_odometry: adds an option to use without odometry input (#30 <https://github.com/at-wat/neonavigation/issues/30>)
* track_odometry: tf_projection: adds parameter to add tf timestamp offset (#21 <https://github.com/at-wat/neonavigation/issues/21>)
* track_odometry: tf_projection: adds option to eliminate roll/pitch (#20 <https://github.com/at-wat/neonavigation/issues/20>)
* track_odometry: refactors tf_projection test code (#19 <https://github.com/at-wat/neonavigation/issues/19>)
* track_odometry: removes projected tf output and add tf_projection node (#17 <https://github.com/at-wat/neonavigation/issues/17>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* track_odometry: suppresses warnings until receiving first message
* track_odometry: implements kalman filter (#9 <https://github.com/at-wat/neonavigation/issues/9>)
* track_odometry: fixes delta time and buffering
* track_odometry: uses latest transform between imu and base_link
* Subtree-merge 'track_odometry' package
* Contributors: Atsushi Watanabe
```

## trajectory_tracker

```
* Fix namespace migration messages (#174 <https://github.com/at-wat/neonavigation/issues/174>)
* Fix topic/service namespace model (#168 <https://github.com/at-wat/neonavigation/issues/168>)
* Fix package dependencies (#167 <https://github.com/at-wat/neonavigation/issues/167>)
* Update package descriptions and unify license and version (#165 <https://github.com/at-wat/neonavigation/issues/165>)
* Use neonavigation_msgs package (#164 <https://github.com/at-wat/neonavigation/issues/164>)
* trajectory_tracker: reduce angular oscillation (#120 <https://github.com/at-wat/neonavigation/issues/120>)
* trajectory_tracker: use timer instead of spinOnce polling (#119 <https://github.com/at-wat/neonavigation/issues/119>)
* trajectory_tracker: fix naming style. (#92 <https://github.com/at-wat/neonavigation/issues/92>)
* Support package install. (#45 <https://github.com/at-wat/neonavigation/issues/45>)
* Fix coding styles. (#39 <https://github.com/at-wat/neonavigation/issues/39>)
* trajectory_tracker: removes unnecessary launch files (#18 <https://github.com/at-wat/neonavigation/issues/18>)
* trajectory_tracker: adds option to store timestamp in recorded path (#13 <https://github.com/at-wat/neonavigation/issues/13>)
* adds READMEs (#11 <https://github.com/at-wat/neonavigation/issues/11>)
* trajectory_tracker: subtree merge changes on trajectory_tracker repository
* Subtree-merge 'trajectory_tracker' package
* Contributors: Atsushi Watanabe
```
