### PR TITLE
mir_robot: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5498,6 +5498,29 @@ repositories:
       url: https://github.com/tork-a/minas.git
       version: master
     status: developed
+  mir_robot:
+    doc:
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: kinetic
+    release:
+      packages:
+      - mir_actions
+      - mir_description
+      - mir_driver
+      - mir_gazebo
+      - mir_msgs
+      - mir_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uos-gbp/mir_robot-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: kinetic
+    status: developed
   mobility_base_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.0-0`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## mir_actions

```
* Initial release
* Contributors: Martin Günther
```

## mir_description

```
* Initial release
* Contributors: Martin Günther
```

## mir_driver

```
* Initial release
* Contributors: Martin Günther
```

## mir_gazebo

```
* Initial release
* Contributors: Martin Günther
```

## mir_msgs

```
* Initial release
* Contributors: Martin Günther
```

## mir_navigation

```
* Initial release
* Contributors: Martin Günther
```
