### PR TITLE
dataspeed_can: 1.0.10-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -374,6 +374,26 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
     status: maintained
+  dataspeed_can:
+    doc:
+      type: hg
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can
+      version: default
+    release:
+      packages:
+      - dataspeed_can
+      - dataspeed_can_msg_filters
+      - dataspeed_can_tools
+      - dataspeed_can_usb
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
+      version: 1.0.10-0
+    source:
+      type: hg
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can
+      version: default
+    status: developed
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.10-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

```
* Removed unnecessary rostest dependency
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_tools

- No changes

## dataspeed_can_usb

- No changes
