### PR TITLE
towr: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3662,6 +3662,25 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
       version: melodic
     status: maintained
+  towr:
+    doc:
+      type: git
+      url: https://github.com/ethz-adrl/towr.git
+      version: master
+    release:
+      packages:
+      - towr
+      - towr_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ethz-adrl/towr-release.git
+      version: 1.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ethz-adrl/towr.git
+      version: master
+    status: developed
   tracetools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.3.1-1`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## towr

```
* Improve API (#23 <https://github.com/ethz-adrl/towr/issues/23>)
* Remove redundant total time (duration set by endeffectors)
* Contributors: Alexander Winkler
```

## towr_ros

```
* Improve API (#23 <https://github.com/ethz-adrl/towr/issues/23>)
* add gait optimization and replay speed to UI
* Add ROS and codefactor badges to readme (#22 <https://github.com/ethz-adrl/towr/issues/22>)
* Contributors: Alexander Winkler
```
