### PR TITLE
dataspeed_pds: 1.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -394,6 +394,27 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dataspeed_can
       version: default
     status: developed
+  dataspeed_pds:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dataspeed_pds
+      version: default
+    release:
+      packages:
+      - dataspeed_pds
+      - dataspeed_pds_can
+      - dataspeed_pds_msgs
+      - dataspeed_pds_rqt
+      - dataspeed_pds_scripts
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
+      version: 1.0.2-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dataspeed_pds
+      version: default
+    status: developed
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.2-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## dataspeed_pds

- No changes

## dataspeed_pds_can

- No changes

## dataspeed_pds_msgs

- No changes

## dataspeed_pds_rqt

```
* Removed unnecessary dependency
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_scripts

- No changes
