### PR TITLE
dbw_mkz_ros: 1.0.13-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -415,6 +415,28 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/dataspeed_pds
       version: default
     status: developed
+  dbw_mkz_ros:
+    doc:
+      type: hg
+      url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
+      version: default
+    release:
+      packages:
+      - dbw_mkz
+      - dbw_mkz_can
+      - dbw_mkz_description
+      - dbw_mkz_joystick_demo
+      - dbw_mkz_msgs
+      - dbw_mkz_twist_controller
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
+      version: 1.0.13-0
+    source:
+      type: hg
+      url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
+      version: default
+    status: developed
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_mkz_ros` to `1.0.13-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
- release repository: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## dbw_mkz

- No changes

## dbw_mkz_can

```
* Updated firmware versions
* Added option to enable/disable warnings on received command messages
* Added support for the RES+ and RES- buttons
* Added explicit casts to float
* Added firmware version of separate shifting module
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_description

- No changes

## dbw_mkz_joystick_demo

```
* Warn and suggest fix for incorrect Logitech gamepad X/D switch configuration
* Removed joystick_demo namespace
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_msgs

```
* Added support for the RES+ and RES- buttons
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_twist_controller

```
* Fixed compile error on ROS Melodic and Ubuntu Bionic
* Contributors: Kevin Hallenbeck
```
