### PR TITLE
pybind11_catkin: 2.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8097,6 +8097,12 @@ repositories:
       url: https://github.com/stonier/py_trees_ros.git
       version: devel
     status: developed
+  pybind11_catkin:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wxmerkt/pybind11_catkin-release.git
+      version: 2.2.3-0
   pyros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.2.3-0`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
