### PR TITLE
pybind11_catkin: 2.2.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2285,6 +2285,12 @@ repositories:
       url: https://github.com/stonier/py_trees.git
       version: devel
     status: maintained
+  pybind11_catkin:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wxmerkt/pybind11_catkin-release.git
+      version: 2.2.3-0
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.2.3-0`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
