### PR TITLE
bagger: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -626,11 +626,16 @@ repositories:
       url: https://github.com/pal-gbp/backward_ros-release.git
       version: 0.1.6-0
   bagger:
+    doc:
+      type: git
+      url: https://github.com/squarerobot/bagger.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
+    status: maintained
   baldor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.2-0`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.1-0`

## bagger

```
* Fix some urls and Fix #1 <https://github.com/squarerobot/bagger/issues/1>
* Contributors: Brenden Gibbons
```
