### PR TITLE
Revert "pybind11_catkin: 2.2.3-0 in 'melodic/distribution.yaml' [bloom]"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2285,12 +2285,6 @@ repositories:
       url: https://github.com/stonier/py_trees.git
       version: devel
     status: maintained
-  pybind11_catkin:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/wxmerkt/pybind11_catkin-release.git
-      version: 2.2.3-0
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#18471

Reverting pybind11_catkin from melodic due to installing a conflicting version of pybind11 which is upstream as of artful 

@wxmerkt

We talked about in https://github.com/ros/rosdistro/pull/18282#issuecomment-400583057 we can do the extra cmake-modules only but this appears to have the full implementation installed.