### PR TITLE
Add minimal alpine rosdeps for ros_core

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2992,7 +2992,7 @@ libssh2-dev:
   gentoo: [net-libs/libssh2]
   ubuntu: [libssh2-1-dev]
 libssl-dev:
-  alpine: [openssl1.0-dev]
+  alpine: [libressl-dev]
   arch: [openssl]
   debian: [libssl-dev]
   fedora: [openssl-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -992,7 +992,7 @@ golang-go:
 google-mock:
   alpine:
     source:
-      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/googletest/googletest.rdmanifest'
+      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/googlemock/googlemock.rdmanifest'
   arch: [gmock]
   debian: [google-mock]
   fedora: [gmock-devel]
@@ -1138,9 +1138,7 @@ gstreamer1.0-x:
   gentoo: ['media-libs/gst-plugins-base:1.0[X,pango]']
   ubuntu: [gstreamer1.0-x]
 gtest:
-  alpine:
-    source:
-      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/googletest/googletest.rdmanifest'
+  alpine: [gtest-dev, gtest]
   arch: [gtest]
   debian: [libgtest-dev]
   fedora: [gtest-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -54,6 +54,7 @@ apache2-mpm-prefork:
   gentoo: ['www-servers/apache[apache2_mpms_prefork]']
   ubuntu: [apache2-mpm-prefork]
 apr:
+  alpine: [apr, apr-util]
   arch: [apr, apr-util]
   cygwin: [libapr1, libaprutil1]
   debian: [libapr1-dev, libaprutil1-dev]
@@ -266,6 +267,7 @@ bluez-hcidump:
     wily: [bluez-hcidump]
     xenial: [bluez-hcidump]
 boost:
+  alpine: [boost-dev]
   arch: [boost]
   cygwin: [libboost-devel, libboost1.40]
   debian:
@@ -330,6 +332,7 @@ bullet:
     yakkety: [libbullet-dev]
     zesty: [libbullet-dev]
 bzip2:
+  alpine: [bzip2-dev]
   arch: [bzip2]
   cygwin: [bzip2]
   debian: [libbz2-dev]
@@ -391,6 +394,7 @@ clang-format:
   gentoo: [sys-devel/clang]
   ubuntu: [clang-format]
 cmake:
+  alpine: [cmake]
   arch: [cmake]
   debian: [cmake]
   fedora: [cmake]
@@ -986,6 +990,9 @@ golang-go:
   gentoo: [dev-lang/go]
   ubuntu: [golang-go]
 google-mock:
+  alpine:
+    source:
+      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/googletest/googletest.rdmanifest'
   arch: [gmock]
   debian: [google-mock]
   fedora: [gmock-devel]
@@ -1131,6 +1138,9 @@ gstreamer1.0-x:
   gentoo: ['media-libs/gst-plugins-base:1.0[X,pango]']
   ubuntu: [gstreamer1.0-x]
 gtest:
+  alpine:
+    source:
+      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/googletest/googletest.rdmanifest'
   arch: [gtest]
   debian: [libgtest-dev]
   fedora: [gtest-devel]
@@ -1531,6 +1541,9 @@ libconfig-dev:
   gentoo: ['dev-libs/libconfig[cxx]']
   ubuntu: [libconfig-dev]
 libconsole-bridge-dev:
+  alpine:
+    source:
+      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/console-bridge/console-bridge.rdmanifest'
   arch: [console-bridge]
   debian: [libconsole-bridge-dev]
   fedora: [console-bridge-devel]
@@ -1883,6 +1896,7 @@ libgoogle-glog-dev:
   gentoo: [dev-cpp/glog]
   ubuntu: [libgoogle-glog-dev]
 libgpgme-dev:
+  alpine: [gpgme-dev]
   arch: [gpgme]
   debian:
     buster: [libgpgme-dev]
@@ -2532,6 +2546,7 @@ libpng12-dev:
   slackware: [libpng]
   ubuntu: [libpng12-dev]
 libpoco-dev:
+  alpine: [poco-dev]
   arch: [poco]
   debian: [libpoco-dev]
   fedora: [poco-devel]
@@ -2979,6 +2994,7 @@ libssh2-dev:
   gentoo: [net-libs/libssh2]
   ubuntu: [libssh2-1-dev]
 libssl-dev:
+  alpine: [openssl1.0-dev]
   arch: [openssl]
   debian: [libssl-dev]
   fedora: [openssl-devel]
@@ -3543,6 +3559,9 @@ lm-sensors:
   gentoo: [sys-apps/lm_sensors]
   ubuntu: [lm-sensors]
 log4cxx:
+  alpine:
+    source:
+      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/log4cxx/log4cxx.rdmanifest'
   arch: [log4cxx]
   cygwin: [liblog4cxx-devel]
   debian:
@@ -3608,6 +3627,7 @@ lua5.2-dev:
   gentoo: ['dev-lang/lua:5.2']
   ubuntu: [liblua5.2-dev]
 lz4:
+  alpine: [lz4-dev]
   arch: [lz4]
   debian: [liblz4-dev]
   fedora: [lz4-devel]
@@ -4040,6 +4060,7 @@ php:
     yakkety: [php7.0]
     zesty: [php7.0]
 pkg-config:
+  alpine: [pkgconf]
   arch: [pkg-config]
   cygwin: [pkg-config]
   debian: [pkg-config]
@@ -4314,6 +4335,7 @@ rtmidi:
   fedora: [rtmidi-devel]
   ubuntu: [librtmidi-dev]
 sbcl:
+  alpine: [sbcl]
   arch: [sbcl]
   debian: [sbcl]
   fedora: [sbcl]
@@ -4721,6 +4743,7 @@ time:
   gentoo: [sys-process/time]
   ubuntu: [time]
 tinyxml:
+  alpine: [tinyxml-dev]
   arch: [tinyxml]
   debian: [libtinyxml-dev]
   fedora: [tinyxml-devel]
@@ -4732,6 +4755,7 @@ tinyxml:
   slackware: [tinyxml]
   ubuntu: [libtinyxml-dev]
 tinyxml2:
+  alpine: [tinyxml2-dev]
   arch: [tinyxml2]
   debian: [libtinyxml2-dev]
   fedora: [tinyxml2-devel]
@@ -5053,6 +5077,7 @@ yaml:
   macports: [libyaml]
   ubuntu: [libyaml-dev]
 yaml-cpp:
+  alpine: [yaml-cpp-dev]
   arch: [yaml-cpp]
   debian:
     buster: [libyaml-cpp-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -210,7 +210,7 @@ pyside-tools:
   gentoo: [dev-python/pyside-tools]
   ubuntu: [pyside-tools]
 python:
-  alpine: [python2]
+  alpine: [python2-dev]
   arch: [python2]
   cygwin: [python]
   debian: [python-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -125,6 +125,7 @@ mercurial:
     pip:
       packages: [mercurial]
 paramiko:
+  alpine: [py-paramiko]
   arch: [python2-paramiko]
   debian: [python-paramiko]
   fedora: [python-paramiko]
@@ -209,6 +210,7 @@ pyside-tools:
   gentoo: [dev-python/pyside-tools]
   ubuntu: [pyside-tools]
 python:
+  alpine: [python2]
   arch: [python2]
   cygwin: [python]
   debian: [python-dev]
@@ -315,6 +317,7 @@ python-argh:
   gentoo: [dev-python/argh]
   ubuntu: [python-argh]
 python-argparse:
+  alpine: [py-argparse]
   arch: [python2]
   debian:
     buster: [libpython2.7-stdlib]
@@ -587,6 +590,9 @@ python-catkin-lint:
   fedora: [python-catkin_lint]
   ubuntu: [python-catkin-lint]
 python-catkin-pkg:
+  alpine:
+    pip:
+      packages: [catkin-pkg]
   arch: [python2-catkin_pkg]
   debian: [python-catkin-pkg]
   fedora: [python-catkin_pkg]
@@ -791,6 +797,7 @@ python-couchdb:
   gentoo: [dev-python/couchdb-python]
   ubuntu: [python-couchdb]
 python-coverage:
+  alpine: [py-coverage]
   arch: [python2-coverage]
   debian: [python-coverage]
   fedora: [python-coverage]
@@ -847,6 +854,7 @@ python-crccheck-pip:
     pip:
       packages: [crccheck]
 python-crypto:
+  alpine: [py-crypto]
   arch: [python2-crypto]
   debian: [python-crypto]
   fedora: [python-crypto]
@@ -940,6 +948,7 @@ python-defer-pip:
     pip:
       packages: [defer]
 python-defusedxml:
+  alpine: [py-defusedxml]
   arch: [python2-defusedxml]
   debian: [python-defusedxml]
   fedora: [python-defusedxml]
@@ -1012,6 +1021,9 @@ python-easygui:
   fedora: [python-easygui]
   ubuntu: [python-easygui]
 python-empy:
+  alpine:
+    pip:
+      packages: [empy]
   arch: [python2-empy]
   debian: [python-empy]
   fedora: [python-empy]
@@ -1347,6 +1359,9 @@ python-gitpython-pip:
     pip:
       packages: [gitpython]
 python-gnupg:
+  alpine:
+    pip:
+      packages: [python-gnupg]
   arch: [python2-gnupg]
   debian: [python-gnupg]
   fedora: [python-gnupg]
@@ -1550,6 +1565,7 @@ python-hypothesis:
     zesty: [python-hypothesis]
     zesty_python3: [python3-hypothesis]
 python-imaging:
+  alpine: [py-imaging]
   arch: [python2-pillow]
   debian: [python-imaging]
   fedora:
@@ -1833,6 +1849,7 @@ python-mechanize:
   gentoo: [dev-python/mechanize]
   ubuntu: [python-mechanize]
 python-mock:
+  alpine: [py-mock]
   arch: [python2-mock]
   debian: [python-mock]
   fedora: [python-mock]
@@ -1935,6 +1952,7 @@ python-netaddr:
     yakkety: [python-netaddr]
     zesty: [python-netaddr]
 python-netifaces:
+  alpine: [py-netifaces]
   arch: [python2-netifaces]
   debian: [python-netifaces]
   fedora: [python-netifaces]
@@ -2000,6 +2018,7 @@ python-networkx:
     zesty: [python-networkx]
     zesty_python3: [python3-networkx]
 python-nose:
+  alpine: [py-nose]
   arch: [python2-nose]
   debian: [python-nose]
   fedora: [python-nose]
@@ -2033,6 +2052,7 @@ python-nose:
     yakkety: [python-nose]
     zesty: [python-nose]
 python-numpy:
+  alpine: [py-numpy]
   arch: [python2-numpy]
   debian: [python-numpy]
   fedora: [numpy]
@@ -2176,6 +2196,7 @@ python-pandas:
   gentoo: [dev-python/pandas]
   ubuntu: [python-pandas]
 python-paramiko:
+  alpine: [py-paramiko]
   arch: [python2-paramiko]
   debian: [python-paramiko]
   fedora: [python-paramiko]
@@ -3003,6 +3024,9 @@ python-responses-pip:
     pip:
       packages: [responses]
 python-rosdep:
+  alpine:
+    pip:
+      packages: [rosdep]
   arch: [python2-rosdep]
   debian: [python-rosdep]
   fedora: [python-rosdep]
@@ -3114,6 +3138,9 @@ python-rosinstall-generator:
     trusty: [python-rosinstall-generator]
     trusty_python3: [python3-rosinstall-generator]
 python-rospkg:
+  alpine:
+    pip:
+      packages: [rospkg]
   arch: [python2-rospkg]
   debian: [python-rospkg]
   fedora: [python-rospkg]
@@ -4237,6 +4264,7 @@ python-xmltodict:
     yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
 python-yaml:
+  alpine: [py-yaml]
   arch: [python2-yaml]
   centos: [PyYAML]
   debian: [python-yaml]


### PR DESCRIPTION
With https://github.com/ros-infrastructure/rospkg/pull/148 and https://github.com/ros-infrastructure/rosdep/pull/616,
all packages required by ros_core can be installed by rosdep on Alpine Linux (edge version)

Tested with https://github.com/at-wat/alpine-ros/tree/master/melodic-ros-core-alpine