### PR TITLE
fmi_adapter: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -733,6 +733,20 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: melodic-devel
     status: maintained
+  fmi_adapter:
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/boschresearch/fmi_adapter-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: master
+    status: maintained
   four_wheel_steering_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `1.0.0-0`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/boschresearch/fmi_adapter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## fmi_adapter

```
* Initial version.
```

## fmi_adapter_examples

```
* Initial version.
```
