### PR TITLE
Added adafruit pip packages and scipy for Ubuntu Bionic

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1,3 +1,10 @@
+adafruit-ads1x15-pip:
+  debian:
+    pip:
+      packages: [Adafruit-ADS1x15]
+  ubuntu:
+    pip:
+      packages: [Adafruit-ADS1x15]
 adafruit-gpio-pip:
   debian:
     pip:
@@ -137,6 +144,13 @@ paramiko:
       packages: [paramiko]
   rhel: [python-paramiko]
   ubuntu: [python-paramiko]
+pi-ina219-pip:
+  debian:
+    pip:
+      packages: [pi-ina219]
+  ubuntu:
+    pip:
+      packages: [pi-ina219]
 pika:
   debian: [python-pika]
   gentoo: [dev-python/pika]
@@ -3673,6 +3687,7 @@ python-sympy:
   fedora: [sympy]
   gentoo: [dev-python/sympy]
   ubuntu:
+    bionic: [python-sympy]
     lucid: [python-sympy]
     maverick: [python-sympy]
     natty: [python-sympy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3687,7 +3687,9 @@ python-sympy:
   fedora: [sympy]
   gentoo: [dev-python/sympy]
   ubuntu:
+    artful: [python-sympy]
     bionic: [python-sympy]
+    cosmic: [python-sympy]
     lucid: [python-sympy]
     maverick: [python-sympy]
     natty: [python-sympy]


### PR DESCRIPTION
Replaces issue #18328 where it now contains only adafruit related python packages.

The INA219 is an i2c current sensor, that can be used to monitor current in robots:
https://pypi.org/project/pi-ina219/

The ADS1015 is an i2c analog to digital converter, Adafruit sells a board with this sensor along with the python driver:
https://pypi.org/project/Adafruit-ADS1x15/

Sympy is a package for symbolic mathematics with Python:
https://pypi.org/project/sympy/
python-sympy Ubuntu: https://packages.ubuntu.com/bionic/python-sympy