### PR TITLE
p2os: 2.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2557,6 +2557,9 @@ repositories:
       - p2os_urdf
       tags:
         release: release/lunar/{package}/{version}
+        ? !!binary |
+          cmVsZWFzZQ==
+        : b'release/lunar/{package}/{version}'
       url: https://github.com/allenh1/p2os-release.git
       version: 2.1.0-0
     source:


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.1.0-0`:- upstream repository: https://github.com/allenh1/p2os- release repository: https://github.com/allenh1/p2os-release.git- distro file: `lunar/distribution.yaml`- bloom version: `0.6.6`- previous version for package: `2.1.0-0`