### PR TITLE
fetch_msgs: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -691,7 +691,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git
-      version: indigo-devel
+      version: melodic-devel
     release:
       packages:
       - fetch_auto_dock_msgs

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -687,6 +687,24 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/fanuc_post_processor.git
       version: melodic
     status: developed
+  fetch_msgs:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_msgs.git
+      version: indigo-devel
+    release:
+      packages:
+      - fetch_auto_dock_msgs
+      - fetch_driver_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_msgs.git
+      version: melodic-devel
+    status: maintained
   fetch_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `1.1.0-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
