### PR TITLE
neonavigation: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8243,7 +8243,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.2.1-0`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.0-0`

## costmap_cspace

```
* Fix missing package dependencies (#194 <https://github.com/at-wat/neonavigation/issues/194>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

- No changes

## map_organizer

```
* Compile with PCL_NO_PRECOMPILE (#195 <https://github.com/at-wat/neonavigation/issues/195>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

```
* Compile with PCL_NO_PRECOMPILE (#195 <https://github.com/at-wat/neonavigation/issues/195>)
* Fix missing package dependencies (#194 <https://github.com/at-wat/neonavigation/issues/194>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

```
* Fix missing package dependencies (#194 <https://github.com/at-wat/neonavigation/issues/194>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* Compile with PCL_NO_PRECOMPILE (#195 <https://github.com/at-wat/neonavigation/issues/195>)
* Contributors: Atsushi Watanabe
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
