### PR TITLE
added libmongoclient-dev 

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2188,8 +2188,12 @@ libmodbus-dev:
   fedora: [libmodbus-devel]
   ubuntu: [libmodbus-dev]
 libmongoclient-dev:
+  debian: [libmongoclient-dev]
+  fedora: [mongo-cxx-driver]
   ubuntu:
+    artful: [libmongoclient-dev]
     bionic: [libmongoclient-dev]
+    cosmid: [libmongoclient-dev]
 libmotif-dev:
   arch: [lesstif]
   debian: [libmotif-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2190,10 +2190,7 @@ libmodbus-dev:
 libmongoclient-dev:
   debian: [libmongoclient-dev]
   fedora: [mongo-cxx-driver]
-  ubuntu:
-    artful: [libmongoclient-dev]
-    bionic: [libmongoclient-dev]
-    cosmid: [libmongoclient-dev]
+  ubuntu: [libmongoclient-dev]
 libmotif-dev:
   arch: [lesstif]
   debian: [libmotif-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2188,8 +2188,8 @@ libmodbus-dev:
   fedora: [libmodbus-devel]
   ubuntu: [libmodbus-dev]
 libmongoclient-dev:
-  ubuntu: 
-    bionic: [libmongoclient-dev]      
+  ubuntu:
+    bionic: [libmongoclient-dev]
 libmotif-dev:
   arch: [lesstif]
   debian: [libmotif-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2187,6 +2187,9 @@ libmodbus-dev:
   debian: [libmodbus-dev]
   fedora: [libmodbus-devel]
   ubuntu: [libmodbus-dev]
+libmongoclient-dev:
+  ubuntu: 
+    bionic: [libmongoclient-dev]      
 libmotif-dev:
   arch: [lesstif]
   debian: [libmotif-dev]


### PR DESCRIPTION
C++ mongo client  legacy version added to base.yaml for Ubuntu bionic; As far as I am aware this is new  package in bionic, not available in earlier distros. This package is not to be conuised with libmongo-client-dev which is an unofficial C driver;

https://packages.ubuntu.com/bionic/libmongoclient-dev

Currently this is wrapped and released as libmongocxx_ros for kinetic and indigo through the [mongodb_store](https://github.com/strands-project/mongodb_store.git) stack. This can now be replaced by a system dependency. 

We are also planning on releasing our [perception framework](https://github.com/RoboSherlock/robosherlock) later this year through bloom which will depend on this. 

