### PR TITLE
pid: 0.0.27-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7562,7 +7562,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AndyZe/pid-release.git
-      version: 0.0.26-0
+      version: 0.0.27-0
     source:
       type: git
       url: https://bitbucket.org/AndyZe/pid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pid` to `0.0.27-0`:

- upstream repository: https://bitbucket.org/AndyZe/pid
- release repository: https://github.com/AndyZe/pid-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.26-0`
