### PR TITLE
fmi_adapter: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -759,7 +759,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `1.0.1-0`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/boschresearch/fmi_adapter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`

## fmi_adapter

```
* Throwing runtime_error in case of failed fmi2 function call.
```

## fmi_adapter_examples

```
* Throwing runtime_error in case of failed fmi2 function call in FMIAdapter.
```
