### PR TITLE
arduino_daq: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -267,6 +267,21 @@ repositories:
       url: https://github.com/AutonomyLab/ardrone_autonomy.git
       version: indigo-devel
     status: developed
+  arduino_daq:
+    doc:
+      type: git
+      url: https://github.com/ual-arm-ros-pkg/arduino_daq.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ual-arm-ros-pkg-release/arduino_daq-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ual-arm-ros-pkg/arduino_daq.git
+      version: master
+    status: maintained
   aruco_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `arduino_daq` to `1.0.1-0`:

- upstream repository: https://github.com/ual-arm-ros-pkg/arduino_daq.git
- release repository: https://github.com/ual-arm-ros-pkg-release/arduino_daq-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## arduino_daq

```
* Initial public release
* Contributors: Francisco José Mañas Álvarez, FranciscoJManasAlvarez, Jose Luis Blanco, Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco, Jose-Luis Blanco, Jose-Luis Blanco-Claraco
```
