### PR TITLE
Remove ira_photonfocus_driver indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5412,12 +5412,6 @@ repositories:
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
     status: end-of-life
-  ira_photonfocus_driver:
-    source:
-      type: git
-      url: https://github.com/iralabdisco/ira_photonfocus_driver.git
-      version: master
-    status: maintained
   iss_taskboard_gazebo:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4077,16 +4077,6 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
-  ira_laser_tools:
-    doc:
-      type: git
-      url: https://github.com/iralabdisco/ira_laser_tools.git
-      version: kinetic
-    source:
-      type: git
-      url: https://github.com/iralabdisco/ira_laser_tools.git
-      version: kinetic
-    status: maintained
   iot_bridge:
     doc:
       type: git
@@ -4102,6 +4092,16 @@ repositories:
       url: https://github.com/corb555/iot_bridge.git
       version: kinetic-devel
     status: developed
+  ira_laser_tools:
+    doc:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    source:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    status: maintained
   ivcon:
     release:
       tags:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4077,6 +4077,16 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  ira_laser_tools:
+    doc:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    source:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    status: maintained
   iot_bridge:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4097,11 +4097,15 @@ repositories:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
       version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/iralabdisco/ira_laser_tools-release.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
       version: kinetic
-    status: maintained
   ivcon:
     release:
       tags:


### PR DESCRIPTION
We want to remove ira_photonfocus_driver because we have compiling error