### PR TITLE
neonavigation: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6364,6 +6364,33 @@ repositories:
       url: https://github.com/ros-planning/navigation_tutorials.git
       version: indigo-devel
     status: maintained
+  neonavigation:
+    doc:
+      type: git
+      url: https://github.com/at-wat/neonavigation.git
+      version: master
+    release:
+      packages:
+      - costmap_cspace
+      - joystick_interrupt
+      - map_organizer
+      - neonavigation
+      - neonavigation_common
+      - neonavigation_launch
+      - obj_to_pointcloud
+      - planner_cspace
+      - safety_limiter
+      - track_odometry
+      - trajectory_tracker
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/at-wat/neonavigation-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/at-wat/neonavigation.git
+      version: master
+    status: developed
   neonavigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.2.1-0`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## costmap_cspace

```
* Fix missing package dependencies (#194 <https://github.com/at-wat/neonavigation/issues/194>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

- No changes

## map_organizer

```
* Compile with PCL_NO_PRECOMPILE (#195 <https://github.com/at-wat/neonavigation/issues/195>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

```
* Compile with PCL_NO_PRECOMPILE (#195 <https://github.com/at-wat/neonavigation/issues/195>)
* Fix missing package dependencies (#194 <https://github.com/at-wat/neonavigation/issues/194>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

```
* Fix missing package dependencies (#194 <https://github.com/at-wat/neonavigation/issues/194>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* Compile with PCL_NO_PRECOMPILE (#195 <https://github.com/at-wat/neonavigation/issues/195>)
* Contributors: Atsushi Watanabe
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
