### PR TITLE
remove ira_photonfocus_driver Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5413,12 +5413,6 @@ repositories:
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
     status: end-of-life
-  ira_photonfocus_driver:
-    source:
-      type: git
-      url: https://github.com/iralabdisco/ira_photonfocus_driver.git
-      version: master
-    status: maintained
   iss_taskboard_gazebo:
     doc:
       type: git

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2239,6 +2239,10 @@ libncurses-dev:
   gentoo: [sys-libs/ncurses]
   macports: [ncurses]
   ubuntu: [libncurses5-dev]
+libneon27-gnutls-dev:
+  debian: [libneon27-gnutls-dev]
+  gentoo: [gnutls]
+  ubuntu: [libneon27-gnutls-dev]
 libnl-3:
   arch: [libnl]
   debian: [libnl-3-200, libnl-genl-3-200]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2241,7 +2241,7 @@ libncurses-dev:
   ubuntu: [libncurses5-dev]
 libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
-  gentoo: [gnutls]
+  gentoo: [neon]
   ubuntu: [libneon27-gnutls-dev]
 libnl-3:
   arch: [libnl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2241,7 +2241,7 @@ libncurses-dev:
   ubuntu: [libncurses5-dev]
 libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
-  gentoo: [neon]
+  gentoo: [net-libs/neon]
   ubuntu: [libneon27-gnutls-dev]
 libnl-3:
   arch: [libnl]


### PR DESCRIPTION
remove ira_photonfocus_driver from indigo
Because we have compiling error