### PR TITLE
remove ira_photonfocus_driver Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5412,12 +5412,6 @@ repositories:
       url: https://github.com/ipa320/ipa_canopen.git
       version: indigo_dev
     status: end-of-life
-  ira_photonfocus_driver:
-    source:
-      type: git
-      url: https://github.com/iralabdisco/ira_photonfocus_driver.git
-      version: master
-    status: maintained
   iss_taskboard_gazebo:
     doc:
       type: git


### PR DESCRIPTION
remove ira_photonfocus_driver for compiling error