### PR TITLE
robotnik_msgs: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9275,7 +9275,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_msgs` to `0.2.4-0`:

- upstream repository: https://github.com/RobotnikAutomation/robotnik_msgs.git
- release repository: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.2.3-0`

## robotnik_msgs

```
* LaserStatus: added free_warning flag
* SafetyModuleStatus msg: added manual_realeas and bumper_override
* Added SafetyModuleStatus and LaserStatus msg. Added SetLaserMode service
* added time_charging to BatteryStatus.msg
* added is_charging flag to BatteryStatus.msg
* added averagecurrent and analog inputs to MotorStatus msg
* Contributors: David, rguzman1, Álex
```
