### PR TITLE
multimaster_fkie: 0.8.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5968,7 +5968,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.7.8-0
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.8.0-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.7.8-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

- No changes

## master_sync_fkie

- No changes

## multimaster_fkie

```
* node_manager_fkie: added warning if while remote start no executable was found
  rosrun throws no error if no executable was found it is only an output.
* node_manager_fkie: fixed activation of minimized launch editor
* node_manager_fkie: added settings parameter 'movable dock widgets' to prevent dock widgets from moving
* node_manager_fkie: fixed error in select_dialog on close node_manager
* node_manager_fkie: added group icon with count of nodes inside
* node_manager_fkie: added info icons for groups
* node_manager_fkie: added timer to close exit dialog on close node_manager
* node_manager_fkie: fixed delay open io screen
* node_manager_fkie: use priority queue for sreen io only if normal queue has more than 5 elements
* node_manager_fkie: reduced update count
* node_manager_fkie: changed color of question box
* node_manager_fkie: added link for nodelet manager in description of nodelets
* node_manager_fkie: add an option to disable the question dialog while restart nodelets
* node_manager_fkie: changed background of question dialog to non transparent
* node_manager_fkie: changed question dialog for launch and transfer files
* changed visualization for available configurations, added visualisation for nodelets
  changed qestion dialog on changes of launch files and restart of
  nodelets
* node_manager_fkie: fixed trasfer of wrong files on change to remote hosts
* node_manager_fkie: editor: fix recursive search
* node_manager_fkie: fixed crash on call of an unknown service
* node_manager_fkie: fix administratively prohibited error while delete logs
  This error occurs while delete more than 10 logs on remote host
* node_manager_fkie: resolve pkg:// in all arguments
* node_manager_fkie: fix crash while assigne color
* Added configuration for Travis CI
* Contributors: Timo Röhling, Alexander Tiderko
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: added warning if while remote start no executable was found
  rosrun throws no error if no executable was found it is only an output.
* node_manager_fkie: fixed activation of minimized launch editor
* node_manager_fkie: added settings parameter 'movable dock widgets' to prevent dock widgets from moving
* node_manager_fkie: fixed error in select_dialog on close node_manager
* node_manager_fkie: added group icon with count of nodes inside
* node_manager_fkie: added info icons for groups
* node_manager_fkie: added timer to close exit dialog on close node_manager
* node_manager_fkie: fixed delay open io screen
* node_manager_fkie: use priority queue for sreen io only if normal queue has more than 5 elements
* node_manager_fkie: reduced update count
* node_manager_fkie: changed color of question box
* node_manager_fkie: added link for nodelet manager in description of nodelets
* node_manager_fkie: add an option to disable the question dialog while restart nodelets
* node_manager_fkie: changed background of question dialog to non transparent
* node_manager_fkie: changed question dialog for launch and transfer files
* changed visualization for available configurations, added visualisation for nodelets
  changed qestion dialog on changes of launch files and restart of
  nodelets
* node_manager_fkie: fixed trasfer of wrong files on change to remote hosts
* node_manager_fkie: editor: fix recursive search
* node_manager_fkie: fixed crash on call of an unknown service
* node_manager_fkie: fix administratively prohibited error while delete logs
  This error occurs while delete more than 10 logs on remote host
* node_manager_fkie: resolve pkg:// in all arguments
* node_manager_fkie: fix crash while assigne color
* Contributors: Alexander Tiderko
```
