### PR TITLE
ifopt: 2.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3766,7 +3766,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 2.0.3-0
+      version: 2.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.0.4-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.0.3-0`

## ifopt

```
* generalize ipopt solver interface, so source never has to be touched.
* Fix/simplify image path in doxygen.
* Simplify and generalize testing procedure (#25 <https://github.com/ethz-adrl/ifopt/issues/25>)
* have cmake fail if IPOPT version <3.11.9
* Install binaries to /lib/ifopt, just as catkin does.
* Update README.md to always use make test for testing.
* Improve doxygen (#22 <https://github.com/ethz-adrl/ifopt/issues/22>)
* Contributors: Alexander Winkler
```
