### PR TITLE
neonavigation: 0.2.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2225,7 +2225,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.2.2-0`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.1-0`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

```
* Workaround for debian stretch build problem (#199 <https://github.com/at-wat/neonavigation/issues/199>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

```
* Workaround for debian stretch build problem (#199 <https://github.com/at-wat/neonavigation/issues/199>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

- No changes

## safety_limiter

```
* Workaround for debian stretch build problem (#199 <https://github.com/at-wat/neonavigation/issues/199>)
* Contributors: Atsushi Watanabe
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
