### PR TITLE
dynamixel_sdk: 3.6.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2142,7 +2142,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.5.4-0
+      version: 3.6.2-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.6.2-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `3.5.4-0`

## dynamixel_sdk

```
* added python modules for ROS to ros folder
* moved cpp library files for ROS to ros folder
* created an ROS package separately #187 <https://github.com/ROBOTIS-GIT/DynamixelSDK/issues/187>
* modified the e-Manual address to emanual.robotis.com
* Contributors: Pyo
```
