### PR TITLE
novatel_gps_driver: 3.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2006,7 +2006,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 3.4.0-0
+      version: 3.5.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.5.0-0`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.4.0-0`

## novatel_gps_driver

```
* Update documentation
* Fix parsing of gprmc messages for OEM4 models (#22)
* Finish serial commands with [CR][LF] (Carriage-Return Line-Feed) (#21)
* Adds configuration parameter span_frame_to_ros_frame. (#20)
* Adds additional IMUs defined in the OEM7 firmware. (#17)
* Enable the driver to determine IMU sample rate from the IMU type (#9)
* Contributors: Ellon Paiva Mendes, Joshua Whitley, Matthew, P. J. Reed
```

## novatel_gps_msgs

```
* Update documentation
* Contributors: P. J. Reed
```
