### PR TITLE
rr_openrover_basic: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10966,7 +10966,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics/rr_openrover_basic-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/RoverRobotics/rr_openrover_basic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_basic` to `0.0.2-0`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_basic.git
- release repository: https://github.com/RoverRobotics/rr_openrover_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.1-0`

## rr_openrover_basic

```
* Fixed low-speed mode turning so it has a continuous turning speed range.
* Added dependency to generate messages cpp to CMakeLists
* updated package.xml to new format
```
