### PR TITLE
mir_robot: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5519,7 +5519,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.1-0`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`

## mir_actions

- No changes

## mir_description

```
* gazebo: Remove leading slashes in TF frames
  TF2 doesn't like it (e.g., robot_localization).
* Contributors: Martin Günther
```

## mir_driver

```
* mir_driver: Remove leading slashes in TF frames
* mir_driver: Install launch directory
* Contributors: Martin Günther
```

## mir_gazebo

```
* gazebo: Replace robot_pose_ekf with robot_localization
  robot_pose_ekf is deprecated, and has been removed from the navigation
  stack starting in melodic.
* gazebo: Adjust ekf.yaml
* gazebo: Copy robot_localization/ekf_template.yaml
  ... for modification.
* Contributors: Martin Günther
```

## mir_msgs

- No changes

## mir_navigation

- No changes
