### PR TITLE
mir_robot: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7274,6 +7274,29 @@ repositories:
       url: https://github.com/tork-a/minas.git
       version: master
     status: developed
+  mir_robot:
+    doc:
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: indigo
+    release:
+      packages:
+      - mir_actions
+      - mir_description
+      - mir_driver
+      - mir_gazebo
+      - mir_msgs
+      - mir_navigation
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/uos-gbp/mir_robot-release.git
+      version: 1.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: indigo
+    status: developed
   mjpeg_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.1-0`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## mir_actions

- No changes

## mir_description

```
* gazebo: Remove leading slashes in TF frames
  TF2 doesn't like it (e.g., robot_localization).
* Contributors: Martin Günther
```

## mir_driver

```
* mir_driver: Remove leading slashes in TF frames
* mir_driver: Install launch directory
* Contributors: Martin Günther
```

## mir_gazebo

```
* gazebo: Replace robot_pose_ekf with robot_localization
  robot_pose_ekf is deprecated, and has been removed from the navigation
  stack starting in melodic.
* gazebo: Adjust ekf.yaml
* gazebo: Copy robot_localization/ekf_template.yaml
  ... for modification.
* Contributors: Martin Günther
```

## mir_msgs

- No changes

## mir_navigation

- No changes
