### PR TITLE
towr: 1.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12323,7 +12323,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-adrl/towr-release.git
-      version: 1.3.0-0
+      version: 1.3.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.3.2-0`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.3.0-0`

## towr

```
* adapt to more generic ifopt solver interface.
* Improve doxygen  (#26 <https://github.com/ethz-adrl/towr/issues/26>)
  * add overview on main doxygen landing
  * add doxygen groups to variables/constraints/costs
  * add parameter explanation
* Contributors: Alexander Winkler
```

## towr_ros

```
* adapt to more generic ifopt solver interface.
* Contributors: Alexander Winkler
```
