### PR TITLE
towr: 1.3.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3789,7 +3789,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ethz-adrl/towr-release.git
-      version: 1.3.1-1
+      version: 1.3.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.3.2-0`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.3.1-1`

## towr

```
* adapt to more generic ifopt solver interface.
* Improve doxygen  (#26 <https://github.com/ethz-adrl/towr/issues/26>)
  * add overview on main doxygen landing
  * add doxygen groups to variables/constraints/costs
  * add parameter explanation
* Contributors: Alexander Winkler
```

## towr_ros

```
* adapt to more generic ifopt solver interface.
* Contributors: Alexander Winkler
```
