### PR TITLE
sbpl: 1.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4370,6 +4370,12 @@ repositories:
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
       version: master
     status: developed
+  sbpl:
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/sbpl-release.git
+      version: 1.2.0-0
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbpl` to `1.2.0-0`:

- upstream repository: https://github.com/sbpl/sbpl
- release repository: https://github.com/ros-gbp/sbpl-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
