### PR TITLE
sbpl: 1.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3646,6 +3646,12 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: melodic-devel
     status: developed
+  sbpl:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/sbpl-release.git
+      version: 1.2.0-0
   sick_tim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbpl` to `1.2.0-0`:

- upstream repository: https://github.com/sbpl/sbpl
- release repository: https://github.com/ros-gbp/sbpl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
