### PR TITLE
openni2_camera: 0.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2516,9 +2516,8 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.3.0-0
+      version: 0.4.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.4.0-0`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.0-0`

## openni2_camera

- No changes

## openni2_launch

```
* Add a simple roswtf plugin. #80 <https://github.com/ros-drivers/openni2_camera/issues/80>
* Contributors: Isaac I.Y. Saito, PlusOne Robotics Inc.
```
