### PR TITLE
Adding python-imaging-imagetk

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1600,7 +1600,8 @@ python-imaging:
     zesty: [python-imaging]
     zesty_python3: [python3-imaging]
 python-imaging-imagetk:
-    ubuntu: [python-pil.imagetk]
+  debian: [python-pil.imagetk]
+  ubuntu: [python-pil.imagetk]
 python-impacket:
   debian: [python-impacket]
   fedora: [python-impacket]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1599,6 +1599,13 @@ python-imaging:
     yakkety_python3: [python3-imaging]
     zesty: [python-imaging]
     zesty_python3: [python3-imaging]
+python-imaging-imagetk:
+  ubuntu:
+      artful: [python-pil.imagetk]
+      bionic: [python-pil.imagetk]
+      cosmic: [python-pil.imagetk]
+      trusty: [python-pil.imagetk]
+      xenial: [python-pil.imagetk]
 python-impacket:
   debian: [python-impacket]
   fedora: [python-impacket]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1600,12 +1600,7 @@ python-imaging:
     zesty: [python-imaging]
     zesty_python3: [python3-imaging]
 python-imaging-imagetk:
-  ubuntu:
-      artful: [python-pil.imagetk]
-      bionic: [python-pil.imagetk]
-      cosmic: [python-pil.imagetk]
-      trusty: [python-pil.imagetk]
-      xenial: [python-pil.imagetk]
+    ubuntu: [python-pil.imagetk]
 python-impacket:
   debian: [python-impacket]
   fedora: [python-impacket]


### PR DESCRIPTION
Here is a link to ubuntu: packages:
https://packages.ubuntu.com/trusty/python-pil.imagetk

The Imagetk module provides functions to convert PIL images to the format that is need to display the images in a GUI with tkinter. We use it to display dynamic images in a simple GUI that we use to control our robot.