### PR TITLE
Added Adafruit ADS1x15 and pi-ina219-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1,3 +1,10 @@
+adafruit-ads1x15-pip:
+  debian:
+    pip:
+      packages: [adafruit-ads1x15]
+  ubuntu:
+    pip:
+      packages: [adafruit-ads1x15]
 adafruit-gpio-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -144,6 +144,13 @@ paramiko:
       packages: [paramiko]
   rhel: [python-paramiko]
   ubuntu: [python-paramiko]
+pi-ina219-pip:
+  debian:
+    pip:
+      packages: [pi-ina219]
+  ubuntu:
+    pip:
+      packages: [pi-ina219]
 pika:
   debian: [python-pika]
   gentoo: [dev-python/pika]


### PR DESCRIPTION
Added two modules available via pip:
- **adafruit-ads1x15-pip**: Python code to use the ADS1015 and ADS1115 analog to digital converters
- **pi-ina219-pip**: This Python library supports the INA219 voltage, current and power monitor from Texas Instruments using the I2C bus