### PR TITLE
jskeus: 1.2.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5914,7 +5914,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.1.0-0
+      version: 1.2.0-1
     status: developed
   katana_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.2.0-1`:

- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.0-0`
