### PR TITLE
jskeus: 1.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1306,6 +1306,17 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: master
     status: developed
+  jskeus:
+    doc:
+      type: git
+      url: https://github.com/euslisp/jskeus.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jskeus-release.git
+      version: 1.2.0-0
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.2.0-0`:

- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
