### PR TITLE
euslisp: 9.25.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -757,6 +757,17 @@ repositories:
       url: https://github.com/ensenso/ros_driver.git
       version: master
     status: developed
+  euslisp:
+    doc:
+      type: git
+      url: https://github.com/tork-a/euslisp-release.git
+      version: release/lunar/euslisp
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/euslisp-release.git
+      version: 9.25.0-0
+    status: developed
   executive_smach:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.25.0-0`:

- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
