### PR TITLE
neonavigation: 0.2.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2242,7 +2242,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.2.3-0`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.2-0`

## costmap_cspace

```
* Fix test names (#202 <https://github.com/at-wat/neonavigation/issues/202>)
* Install sample files and nodes for demo (#201 <https://github.com/at-wat/neonavigation/issues/201>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

```
* Install sample files and nodes for demo (#201 <https://github.com/at-wat/neonavigation/issues/201>)
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

- No changes

## planner_cspace

```
* Fix test names (#202 <https://github.com/at-wat/neonavigation/issues/202>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

- No changes

## track_odometry

```
* Fix test names (#202 <https://github.com/at-wat/neonavigation/issues/202>)
* Contributors: Atsushi Watanabe
```

## trajectory_tracker

- No changes
