### PR TITLE
jskeus: 1.2.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1332,7 +1332,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.2.0-0
+      version: 1.2.0-3
     status: developed
   kdl_parser:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.2.0-3`:

- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.2.0-0`
