### PR TITLE
jskeus: 1.2.0-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1549,7 +1549,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/tork-a/jskeus-release.git
-      version: 1.2.0-0
+      version: 1.2.0-1
     status: developed
   json_transport:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jskeus` to `1.2.0-1`:

- upstream repository: https://github.com/euslisp/jskeus
- release repository: https://github.com/tork-a/jskeus-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.2.0-0`
