### PR TITLE
sbg_driver: 1.1.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11299,7 +11299,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
-      version: 1.1.6-0
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `1.1.7-0`:

- upstream repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
- release repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.6-0`
