### PR TITLE
sbg_driver: 1.1.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4391,7 +4391,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
-      version: 1.1.6-0
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `1.1.7-0`:

- upstream repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver.git
- release repository: https://github.com/ENSTABretagneRobotics/sbg_ros_driver-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.6-0`
