### PR TITLE
pilz_robots: 0.2.1-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7624,7 +7624,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
new patch version; Changelog:
* Add `<url>` tag to all package.xml files
* test launch files and add missing dependencies


Increasing version of package in repository `pilz_robots` to 0.2.1-0:

*    upstream repository: https://github.com/PilzDE/pilz_robots.git
*    release repository: https://github.com/PilzDE/pilz_robots-release.git
*    distro file: kinetic/distribution.yaml
*    bloom version: 0.6.4
*    previous version for package: 0.2.0-0
