### PR TITLE
ros_type_introspection: 1.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3002,6 +3002,20 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: melodic-devel
     status: maintained
+  ros_type_introspection:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/facontidavide/ros_type_introspection-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: master
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `1.1.1-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ros_type_introspection

```
* split the project into two packages to reduce dependencies
* Contributors: Davide Faconti
```
