### PR TITLE
mavros: 0.26.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1886,7 +1886,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.26.0-0
+      version: 0.26.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.26.1-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.26.0-0`

## libmavconn

- No changes

## mavros

```
* setpoint_velocity: fix yaw rate setpoint rotation
* lib fix #1051 <https://github.com/mavlink/mavros/issues/1051>: Add APM BOAT modes support.
  Currently SURFACE_BOAT uses same code as Rover2,
  just different vehicle type.
* Contributors: TSC21, Vladimir Ermakov
```

## mavros_extras

```
* trajectory: update plugin to match mavlink change from trajectory msg to
  trajectory_representation_waypoints
* Contributors: Martina
```

## mavros_msgs

- No changes

## test_mavros

- No changes
