### PR TITLE
libuvc: 0.0.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1464,6 +1464,21 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
     status: maintained
+  libuvc:
+    doc:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ktossell/libuvc-release.git
+      version: 0.0.6-0
+    source:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: master
+    status: unmaintained
   lusb:
     doc:
       type: hg

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1472,7 +1472,7 @@ repositories:
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/ktossell/libuvc-release.git
+      url: https://github.com/ros-drivers-gbp/libuvc-release.git
       version: 0.0.6-0
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.6-0`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: ~~https://github.com/ktossell/libuvc-release.git~~ https://github.com/ros-drivers-gbp/libuvc-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
