### PR TITLE
libuvc_ros: 0.0.10-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1496,6 +1496,24 @@ repositories:
       url: https://github.com/ktossell/libuvc.git
       version: master
     status: unmaintained
+  libuvc_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/libuvc_ros.git
+      version: master
+    release:
+      packages:
+      - libuvc_camera
+      - libuvc_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/libuvc_ros-release.git
+      version: 0.0.10-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/libuvc_ros.git
+      version: master
+    status: unmaintained
   lusb:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc_ros` to `0.0.10-0`:

- upstream repository: https://github.com/ros-drivers/libuvc_ros.git
- release repository: https://github.com/ros-drivers-gbp/libuvc_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## libuvc_camera

```
* Merge pull request #46 <https://github.com/ros-drivers/libuvc_ros/issues/46> from k-okada/master
  set timestamp
* set only when frame->capture_time is 0
* set ros::Time::now() because libuvc does not set capture_time (https://github.com/ktossell/libuvc/blob/master/src/stream.c#L1100)
* Merge pull request #45 <https://github.com/ros-drivers/libuvc_ros/issues/45> from mikaelarguedas/patch-2
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Merge pull request #42 <https://github.com/ros-drivers/libuvc_ros/issues/42> from mikaelarguedas/patch-1
  fix compiler warning
* fix compiler warning
  http://build.ros.org/view/Ldev/job/Ldev__libuvc_ros__ubuntu_xenial_amd64/3/warnings21Result/
* Contributors: Kei Okada, Mikael Arguedas
```

## libuvc_ros

- No changes
