### PR TITLE
dynamixel-workbench: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2104,7 +2104,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 0.3.1-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.3.1-0`

## dynamixel_workbench

```
* upgraded read time #162
* added Dynamixel PRO information #162
* added proext function and amended readRegister
* added mutex for log thread
* added timer for data log
* added PROext header
* added readRegister function
* updated dxl ext function
* update dxl pro info
* update proInfo func
* modified max radian position
* Contributors: Darby Lim, Pyo
```

## dynamixel_workbench_controllers

```
* upgraded read time #162
* added Dynamixel PRO information #162
* added PROext header
* Contributors: Darby Lim, Pyo
```

## dynamixel_workbench_operators

```
* None
```

## dynamixel_workbench_single_manager

```
* upgraded read time #162
* added Dynamixel PRO information #162
* added proext function and amended readRegister
* added PROext header
* Contributors: Darby Lim, Pyo
```

## dynamixel_workbench_single_manager_gui

```
* upgraded read time #162
* added Dynamixel PRO information #162
* added mutex for log thread
* added timer for data log
* added PROext header
* updated dxl ext function
* Contributors: Darby Lim, Pyo
```

## dynamixel_workbench_toolbox

```
* upgraded read time #162
* added Dynamixel PRO information #162
* added readRegister function
* update dxl pro info
* update proInfo func
* modified max radian position
* Contributors: Darby Lim, Pyo, Taehun Lim
```
