### PR TITLE
turtlebot3_msgs: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3940,6 +3940,21 @@ repositories:
       url: https://github.com/bosch-robotics-cr/tracetools.git
       version: devel
     status: developed
+  turtlebot3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: melodic-devel
+    status: developed
   tuw_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## turtlebot3_msgs

```
* added sensors
* deleted unused msg and srv
* separated turtlebot3_msgs and applications related messages
* merged pull request #10 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/10> #9 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/9> #8 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/8> #7 <https://github.com/ROBOTIS-GIT/turtlebot3_msgs/issues/7>
* Contributors: Darby Lim, Gilbert, Pyo
```
