### PR TITLE
hls-lfcd-lds-driver: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1142,6 +1142,23 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
       version: 0.5.0-0
     status: maintained
+  hls-lfcd-lds-driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: melodic-devel
+    release:
+      packages:
+      - hls_lfcd_lds_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: melodic-devel
+    status: developed
   ibeo_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hls-lfcd-lds-driver` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## hls_lfcd_lds_driver

```
* modified max-range to avoid fencepost error.
* merged pull request #27 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/27> from skasperski/master
  Corrected max-range to avoid fencepost error.
* merged pull request #29 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/29> #28 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/28> #24 <https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver/issues/24>
* Contributors: Gilbert, Sebastian Kasperski, Pyo
```
