### PR TITLE
turtlebot3_simulations: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12512,7 +12512,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 1.0.2-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.2-0`

## turtlebot3_fake

```
* added TurtleBot3 Waffle Pi
* Contributors: Darby Lim, Pyo
```

## turtlebot3_gazebo

```
* modified uri path
* modified autorace
* delete remap
* Contributors: Darby Lim, Gilbert, Pyo
```

## turtlebot3_simulations

```
* added TurtleBot3 Waffle Pi
* modified uri path
* modified autorace
* delete remap
* Contributors: Darby Lim, Gilbert, Pyo
```
