### PR TITLE
turtlebot3_applications_msgs: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3940,6 +3940,21 @@ repositories:
       url: https://github.com/bosch-robotics-cr/tracetools.git
       version: devel
     status: developed
+  turtlebot3_applications_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications_msgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
+      version: melodic-devel
+    status: developed
   tuw_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## turtlebot3_applications_msgs

```
* separated turtlebot3_msgs and applications related messages
* Contributors: Darby Lim
```
