### PR TITLE
Added libdxflib-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1592,6 +1592,8 @@ libdw-dev:
   gentoo: [dev-libs/elfutils]
   ubuntu: [libdw-dev]
 libdxflib-dev:
+  debian: [libdxflib-dev]
+  fedora: [libdxflib-devel]
   ubuntu: [libdxflib-dev]
 libesd0-dev:
   debian: [libesd0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1591,6 +1591,8 @@ libdw-dev:
   fedora: [elfutils-devel]
   gentoo: [dev-libs/elfutils]
   ubuntu: [libdw-dev]
+libdxflib-dev:
+  ubuntu: [libdxflib-dev]
 libesd0-dev:
   debian: [libesd0-dev]
   fedora: [esound-devel]


### PR DESCRIPTION
dxflib is a C++ library for reading DXF files used by CAD software, e.g. LibreCAD. We use DXF files to import manually drawn graphs for robot route planning.

Here are links to the packages provided by the included distributions:

* [debian](https://packages.debian.org/stretch/libdxflib-dev)
* [fedora](https://apps.fedoraproject.org/packages/libdxflib-devel)
* [ubuntu](https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=libdxflib-dev&searchon=names)