### PR TITLE
cob_calibration_data: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1732,7 +1732,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.9-0`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.8-0`

## cob_calibration_data

```
* Merge pull request #148 <https://github.com/ipa320/cob_calibration_data/issues/148> from HannesBachter/add_cob4-13_cardiff
  calibrate head cam for cob4-13
* calibrate head cam
* Merge pull request #147 <https://github.com/ipa320/cob_calibration_data/issues/147> from ipa-fxm/add_cob4-13_cardiff
  add cob4-13 cardiff
* Merge pull request #146 <https://github.com/ipa320/cob_calibration_data/issues/146> from ipa-fxm/add_cob4-18_323
  add cob4-18 323
* add cob4-13 cardiff
* add cob4-18 323
* Contributors: Felix Messmer, Florian Weisshardt, cob4-13, ipa-fxm
```
