### PR TITLE
add ntpdate for fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3488,11 +3488,13 @@ npm:
   gentoo: ['net-libs/nodejs[npm]']
   ubuntu: [npm]
 ntp:
+  arch: [ntp]
   debian: [ntp]
   fedora: [ntp]
   gentoo: [net-misc/ntp]
   ubuntu: [ntp]
 ntpdate:
+  arch: [ntp]
   debian: [ntpdate]
   fedora: [ntpdate]
   gentoo: [net-misc/ntp]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3494,6 +3494,7 @@ ntp:
   ubuntu: [ntp]
 ntpdate:
   debian: [ntpdate]
+  fedora: [ntpdate]
   gentoo: [net-misc/ntp]
   ubuntu: [ntpdate]
 nvidia-cg:


### PR DESCRIPTION
seems available for fedora, too: https://apps.fedoraproject.org/packages/ntpdate