### PR TITLE
cob_common: 0.6.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1205,7 +1205,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.9-0`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.8-0`

## cob_common

```
* update maintainer
* Contributors: fmessmer
```

## cob_description

```
* update maintainer
* Merge pull request #254 <https://github.com/ipa320/cob_common/issues/254> from fmessmer/add_realsense_d435
  add urdf for realsense_d435
* add urdf for realsense_d435
* Merge pull request #253 <https://github.com/ipa320/cob_common/issues/253> from fmessmer/fix_fisheye
  properly simulate fisheye camera
* properly simulate fisheye camera
* Merge pull request #245 <https://github.com/ipa320/cob_common/issues/245> from floweisshardt/rotate_base_link
  rotate base link
* add base_charger_link
* cleanup and rename links
* Merge pull request #252 <https://github.com/ipa320/cob_common/issues/252> from ipa-bnm/fix/wheel_radius
  fixed wheel radius
* fixed wheel radius
* Merge pull request #249 <https://github.com/ipa320/cob_common/issues/249> from ipa-fxm/position_interface_base_rotation_joints
  add PositionJointInterface for fdm rotation joints
* add PositionJointInterface for fdm rotation joints
* added parameter for drive direction
* rotate base link (close to working), docking missing
* Contributors: Benjamin Maidel, Felix Messmer, cob4-13, eva-bonn, fmessmer, ipa-bnm, ipa-fxm
```

## cob_msgs

```
* update maintainer
* Contributors: fmessmer
```

## cob_srvs

```
* update maintainer
* Contributors: fmessmer
```

## raw_description

```
* fix syntax
* fix torso urdf for raw3-1 (#241 <https://github.com/ipa320/cob_common/issues/241>)
  * updated raw3-1 configuration
  * Changed back to collision box
  * Using inertia macro
  * Use geometry macro
* Contributors: Felix Messmer, Richard Bormann
```
