### PR TITLE
cob_supported_robots: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2083,7 +2083,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.9-0`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.8-0`

## cob_supported_robots

```
* update maintainer
* Merge pull request #16 <https://github.com/ipa320/cob_supported_robots/issues/16> from ipa-fxm/add_cob4-13_cardiff
  add cob4-13 cardiff
* Merge pull request #15 <https://github.com/ipa320/cob_supported_robots/issues/15> from ipa-fxm/add_cob4-18_323
  add cob4-18 323
* add cob4-13 cardiff
* add cob4-18 323
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer, ipa-fxm
```
