### PR TITLE
cob_driver: 0.6.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1844,7 +1844,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.12-0`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.11-0`

## cob_base_drive_chain

- No changes

## cob_bms_driver

```
* update maintainer
* Merge pull request #374 <https://github.com/ipa320/cob_driver/issues/374> from floweisshardt/feature/round_remaining_capacity
  round remaining_capacity
* adjust to real driver precision
* round remaining_capacity
* Contributors: Felix Messmer, fmessmer, ipa-fmw, ipa-fxm
```

## cob_camera_sensors

- No changes

## cob_canopen_motor

- No changes

## cob_driver

```
* update maintainer
* Contributors: fmessmer
```

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

```
* update maintainer
* Contributors: fmessmer
```

## cob_mimic

```
* update maintainer
* Merge pull request #375 <https://github.com/ipa320/cob_driver/issues/375> from fmessmer/bulletproof_mimic
  bulletproof mimic
* bulletproof mimic
* Merge pull request #371 <https://github.com/ipa320/cob_driver/issues/371> from fmessmer/mimic_play_nondefault_mimics
  allow to play non-default mimics by specifying full filepath
* allow to play non-default mimics by specifying full filepath
* Contributors: Felix Messmer, fmessmer, ipa-fxm
```

## cob_phidget_em_state

```
* update maintainer
* Contributors: fmessmer
```

## cob_phidget_power_state

```
* update maintainer
* Contributors: fmessmer
```

## cob_phidgets

```
* update maintainer
* Contributors: fmessmer
```

## cob_relayboard

- No changes

## cob_scan_unifier

```
* update maintainer
* Merge pull request #366 <https://github.com/ipa320/cob_driver/issues/366> from ipa-bnm/feature/scan_unifier
  merge up to 4 laserscans
* merge up to 4 laserscans
* Contributors: Benjamin Maidel, Richard Bormann, fmessmer
```

## cob_sick_lms1xx

- No changes

## cob_sick_s300

```
* update maintainer
* Merge pull request #377 <https://github.com/ipa320/cob_driver/issues/377> from fmessmer/fix_sicks300_rate
  remove faulty publish_rate mechanism
* remove faulty publish_rate mechanism
* Contributors: Felix Messmer, fmessmer, ipa-fxm
```

## cob_sound

```
* update maintainer
* Merge pull request #376 <https://github.com/ipa320/cob_driver/issues/376> from fmessmer/bulletproof_sound
  bulletproof sound
* bulletproof sound
* Merge pull request #362 <https://github.com/ipa320/cob_driver/issues/362> from ipa-fmw/fix/sound_play
  [cob_sound] catch if filename is empty or invalid
* catch if filename is empty
* Contributors: Felix Messmer, fmessmer, ipa-fxm, msh
```

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes
