### PR TITLE
cob_hand: 0.6.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1348,7 +1348,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_hand-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ipa320/cob_hand.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_hand` to `0.6.4-0`:

- upstream repository: https://github.com/ipa320/cob_hand.git
- release repository: https://github.com/ipa320/cob_hand-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.3-0`

## cob_hand

```
* update maintainer
* Contributors: fmessmer
```

## cob_hand_bridge

```
* update maintainer
* Merge pull request #22 <https://github.com/ipa320/cob_hand/issues/22> from ipa-bnm/fix/cob_hand_init
  Reset error in init
* reset error on init
* readded local launch file
* Merge pull request #21 <https://github.com/ipa320/cob_hand/issues/21> from ipa-bnm/feature/direct_sdh_connection
  added ros node for direct sdax communication
* mojin robotics copyright
* remove launch file
* added ros node for direct sdax communication
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, fmessmer, ipa-fmw
```
