### PR TITLE
cob_navigation: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1396,7 +1396,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.6-0`

## cob_linear_nav

```
* Merge pull request #100 <https://github.com/ipa320/cob_navigation/issues/100> from ipa-bnm/fix/simple_goal
  fixed goal Validation
* Merge pull request #101 <https://github.com/ipa320/cob_navigation/issues/101> from ipa-bnm/fix/angular_dist_calculation
  fixed shortest angular distance calculation
* fixed calculation of shortest angluar distance between current and desired yaw
* replaced canTransform with waitForTransform to give move_base some chance receiving the transformation needed for move base goal
* Contributors: Benjamin Maidel, Felix Messmer, Richard Bormann
```

## cob_map_accessibility_analysis

- No changes

## cob_mapping_slam

- No changes

## cob_navigation

- No changes

## cob_navigation_config

```
* Merge pull request #105 <https://github.com/ipa320/cob_navigation/issues/105> from floweisshardt/feature/add_cob4-13_and_cob4-16
  add cob4-13 and cob4-16
* add cob4-13 and cob4-16
* Contributors: Florian Weisshardt, ipa-fmw
```

## cob_navigation_global

- No changes

## cob_navigation_local

- No changes

## cob_navigation_slam

- No changes
