### PR TITLE
cob_perception_common: 0.6.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1420,7 +1420,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.6.12-0`:

- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.11-0`

## cob_3d_mapping_msgs

- No changes

## cob_cam3d_throttle

- No changes

## cob_image_flip

```
* fixed opencv include names (#90 <https://github.com/ipa320/cob_perception_common/issues/90>)
  fixed opencv include names
* Contributors: Richard Bormann
```

## cob_object_detection_msgs

- No changes

## cob_object_detection_visualizer

- No changes

## cob_perception_common

- No changes

## cob_perception_msgs

- No changes

## cob_vision_utils

- No changes
