### PR TITLE
cob_robots: 0.6.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1442,7 +1442,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.8-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.9-0`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.8-0`

## cob_bringup

```
* update maintainer
* Merge pull request #764 <https://github.com/ipa320/cob_robots/issues/764> from fmessmer/dualdistro_compatible_env_sh
  select rosdistro in env.sh
* select rosdistro in env.sh
* Merge pull request #760 <https://github.com/ipa320/cob_robots/issues/760> from ipa-fxm/cob4-10_hw_upgrade
  cob4-10 hw upgrade
* cob4-10 hw upgrade
* Merge pull request #759 <https://github.com/ipa320/cob_robots/issues/759> from ipa-fxm/fix_grippers_onboard_driver
  re-add joint_names param + consistent launch structure for sdhx with remote driver
* add fake_diagnostics for grippers in sim
* prepare launch file for sdhx with remote driver
* fix joint_names params for robots with onboard gripper driver
* Merge pull request #713 <https://github.com/ipa320/cob_robots/issues/713> from bbrito/ur_launch_pkg_config
  adding pkg_hardware_config arg
* Merge pull request #757 <https://github.com/ipa320/cob_robots/issues/757> from ipa-fxm/migrate_unity_structure
  simplify config structure
* simplify config structure
* Merge pull request #756 <https://github.com/ipa320/cob_robots/issues/756> from HannesBachter/add_cob4-13_cardiff
  changes for cob4-13
* enable grippers in simulation
* undo post shipping changes
* add cob4-cardiff
* Merge pull request #747 <https://github.com/ipa320/cob_robots/issues/747> from ipa-fxm/add_cob4-13_cardiff
  add cob4-13 cardiff
* Merge pull request #753 <https://github.com/ipa320/cob_robots/issues/753> from ipa-bnm/feature/sdhx_local
  launch local sdhx driver on cob4-16 gripper computer
* added launch to start sdhx localy on raspbarry and removed launch from bringup
  fixed typo
* Merge pull request #741 <https://github.com/ipa320/cob_robots/issues/741> from ipa-fxm/cob-uh_final
  [WIP] cob-uh final
* Merge pull request #750 <https://github.com/ipa320/cob_robots/issues/750> from ipa-fxm/add_missing_components_cob4-18
  add light and em monitor
* add light and em monitor
* cob4-13 config fixes
* Merge pull request #746 <https://github.com/ipa320/cob_robots/issues/746> from ipa-fxm/add_cob4-18_323
  add cob4-18 323
* add grippers cob-uh
* add arms cob-uh
* add cob4-18 323
* add cob4-13 cardiff
* adding pkg_hardware_config arg
* Contributors: Benjamin Maidel, Bruno Brito, Felix Messmer, Florian Weisshardt, Richard Bormann, cob4-13, fmessmer, ipa-fmw, ipa-fxm
```

## cob_default_robot_behavior

```
* update maintainer
* Merge pull request #763 <https://github.com/ipa320/cob_robots/issues/763> from HannesBachter/fix/mojin
  say mojin
* Merge pull request #762 <https://github.com/ipa320/cob_robots/issues/762> from ipa-fxm/behaviors_for_all_mimics
  provide behaviors for all available mimics
* provide behaviors for all available mimics
* say mojin
* Merge pull request #757 <https://github.com/ipa320/cob_robots/issues/757> from ipa-fxm/migrate_unity_structure
  simplify config structure
* simplify config structure
* Merge pull request #747 <https://github.com/ipa320/cob_robots/issues/747> from ipa-fxm/add_cob4-13_cardiff
  add cob4-13 cardiff
* add cob4-13 cardiff
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer, ipa-fxm, mailto:robot@cob4-16
```

## cob_default_robot_config

```
* update maintainer
* Merge pull request #760 <https://github.com/ipa320/cob_robots/issues/760> from ipa-fxm/cob4-10_hw_upgrade
  cob4-10 hw upgrade
* cob4-10 hw upgrade
* Merge pull request #759 <https://github.com/ipa320/cob_robots/issues/759> from ipa-fxm/fix_grippers_onboard_driver
  re-add joint_names param + consistent launch structure for sdhx with remote driver
* revert: remove obsolete joint_names param
* Merge pull request #757 <https://github.com/ipa320/cob_robots/issues/757> from ipa-fxm/migrate_unity_structure
  simplify config structure
* simplify config structure
* Merge pull request #756 <https://github.com/ipa320/cob_robots/issues/756> from HannesBachter/add_cob4-13_cardiff
  changes for cob4-13
* add cob4-cardiff
* Merge pull request #755 <https://github.com/ipa320/cob_robots/issues/755> from ipa-bnm/removed_unsave_buttons
  removed unsafe buttons
* removed unsafe buttons
* no head for cob4-13
* Merge pull request #747 <https://github.com/ipa320/cob_robots/issues/747> from ipa-fxm/add_cob4-13_cardiff
  add cob4-13 cardiff
* Merge pull request #750 <https://github.com/ipa320/cob_robots/issues/750> from ipa-fxm/add_missing_components_cob4-18
  add light and em monitor
* add light and em monitor
* cob4-13 config fixes
* Merge pull request #746 <https://github.com/ipa320/cob_robots/issues/746> from ipa-fxm/add_cob4-18_323
  add cob4-18 323
* add cob4-18 323
* add cob4-13 cardiff
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, cob4-13, fmessmer, ipa-fmw, ipa-fxm, mailto:robot@cob4-16
```

## cob_hardware_config

```
* update maintainer
* Merge pull request #761 <https://github.com/ipa320/cob_robots/issues/761> from ipa-fxm/cob4-7_mods
  cob4-7 without arms
* cob4-7 without arms
* Merge pull request #760 <https://github.com/ipa320/cob_robots/issues/760> from ipa-fxm/cob4-10_hw_upgrade
  cob4-10 hw upgrade
* cob4-10 hw upgrade
* Merge pull request #757 <https://github.com/ipa320/cob_robots/issues/757> from ipa-fxm/migrate_unity_structure
  simplify config structure
* simplify config structure
* Merge pull request #756 <https://github.com/ipa320/cob_robots/issues/756> from HannesBachter/add_cob4-13_cardiff
  changes for cob4-13
* remove obsolete include
* remove obsolete files
* add cob4-cardiff
* Merge pull request #747 <https://github.com/ipa320/cob_robots/issues/747> from ipa-fxm/add_cob4-13_cardiff
  add cob4-13 cardiff
* Merge pull request #741 <https://github.com/ipa320/cob_robots/issues/741> from ipa-fxm/cob-uh_final
  [WIP] cob-uh final
* Merge pull request #750 <https://github.com/ipa320/cob_robots/issues/750> from ipa-fxm/add_missing_components_cob4-18
  add light and em monitor
* add light and em monitor
* cob4-13 config fixes
* Merge pull request #746 <https://github.com/ipa320/cob_robots/issues/746> from ipa-fxm/add_cob4-18_323
  add cob4-18 323
* calibrate base cob4-18
* tune pc_monitor thresholds
* tune docking parameter
* add grippers cob-uh
* add arms cob-uh
* calibrate base uh
* add cob4-18 323
* add cob4-13 cardiff
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, cob4-13, fmessmer, ipa-fmw, ipa-fxm, mailto:robot@cob4-16
```

## cob_moveit_config

```
* update maintainer
* Merge pull request #747 <https://github.com/ipa320/cob_robots/issues/747> from ipa-fxm/add_cob4-13_cardiff
  add cob4-13 cardiff
* add cob4-13 cardiff
* Contributors: Florian Weisshardt, fmessmer, ipa-fxm
```

## cob_robots

```
* update maintainer
* Contributors: fmessmer
```
