### PR TITLE
cob_simulation: 0.6.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2048,7 +2048,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.6.10-0`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.9-0`

## cob_bringup_sim

```
* update maintainer
* Contributors: fmessmer
```

## cob_gazebo

```
* update maintainer
* Contributors: fmessmer
```

## cob_gazebo_objects

- No changes

## cob_gazebo_worlds

```
* Merge pull request #162 <https://github.com/ipa320/cob_simulation/issues/162> from ipa320/pass_missing_arg
  pass missing robot_env argument
* pass missing robot_env argument
* Contributors: Felix Messmer, ipa-fxm
```

## cob_simulation

- No changes
