### PR TITLE
schunk_modular_robotics: 0.6.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11366,7 +11366,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.11-0`:

- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.10-0`

## schunk_description

- No changes

## schunk_libm5api

- No changes

## schunk_modular_robotics

- No changes

## schunk_powercube_chain

- No changes

## schunk_sdh

```
* Merge pull request #204 <https://github.com/ipa320/schunk_modular_robotics/issues/204> from christian-rauch/pressure
  Publish tactile data as pressure
* report pressure in Pascal (Pa)
* publish tactile matrix in pressure units
* configure DSA debug level and tactile sensitivity through ROS parameters
* Merge pull request #202 <https://github.com/ipa320/schunk_modular_robotics/issues/202> from christian-rauch/fix_exceptions
  Revert "catch exceptions by const reference"
* Revert "catch exceptions by const reference"
  This reverts commit 0da887264e5ccfbbf5b552f5c50e45d80fe0a01a.
* Contributors: Christian Rauch, Felix Messmer
```

## schunk_simulated_tactile_sensors

- No changes
