### PR TITLE
jsk_roseus: 1.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5872,7 +5872,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.6.3-0
+      version: 1.7.1-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.7.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.6.3-0`

## jsk_roseus

- No changes

## roseus

```
* add melodic test (#567 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/567>)
  * use rosrun roseus roseus test/test-namespace.l, instead of /usr/bin/env roseus
* update function using new defun function (#569 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/569>)
  * CHNAGED EusLisp defun() arguments, see https://github.com/euslisp/EusLisp/pull/300
  * force generate defun.h header file
  * use euslisp(9.24)'s new defun api roseus.cpp taht takes doc as argument, remove _defun
  * add documentation string to defun functions
  * add documentation string to defun functions, (roseus_c_util.c uses NULL because this is not exported functions
* [roseus.l] add length check for argument when searching __log:=t (#568 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/568>)
* Contributors: Kei Okada, Yohei Kakiuchi
```

## roseus_mongo

```
* add melodic test (#567 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/567>)
  * rosues_mongo/CMakeLists.txt: check mongodb_store package and deciede to run tests
* Contributors: Kei Okada
```

## roseus_smach

```
* add melodic test (#567 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/567>)
  * split test_samples.test into test_samples_action_client_state.test, since it is always failling on only installed test https://api.travis-ci.org/v3/job/406576370/log.txt, not sure why...
  * roseus_smach/test/test_samples.test: extend time-limit to 300
  * add retry for testtest_roseus_smach_samples
  the test failing https://api.travis-ci.org/v3/job/406540328/log.txt
  is this related to memory leak? https://github.com/jsk-ros-pkg/jsk_roseus/pull/563
  ```
  mstart testing [test-smach-sample-userdata]
  mfoo-count is not set. Setting 0
  start testing [test-smach-action-client-state]
  m;p=pointer?(0x6690338)
  ;; Segmentation Fault.
  terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
  [Testcase: testtest_roseus_smach_samples] ... FAILURE!
  FAILURE: test [test_roseus_smach_samples] did not generate test results
  File \"/usr/lib/python2.7/unittest/case.py\", line 329, in run
  testMethod()
  File \"/opt/ros/kinetic/lib/python2.7/dist-packages/rostest/runner.py\", line 164, in fn
  self.assert\_(os.path.isfile(test_file), \"test [%s] did not generate test results\"%test_name)
  File \"/usr/lib/python2.7/unittest/case.py\", line 422, in assertTrue
  raise self.failureException(msg)
  ```
* Contributors: Kei Okada
```

## roseus_tutorials

```
* run depends on pr2eus has circular dependencies, so removed from package.xml (#569 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/569>)
* Contributors: Kei Okada
```
