### PR TITLE
opencv_apps: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2227,6 +2227,21 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  opencv_apps:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-perception/opencv_apps-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/opencv_apps.git
+      version: indigo
+    status: developed
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_apps` to `2.0.0-0`:

- upstream repository: https://github.com/ros-perception/opencv_apps.git
- release repository: https://github.com/ros-perception/opencv_apps-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## opencv_apps

```
* Fix namespace and pkg name of nodelets (Closes (#21 <https://github.com/ros-perception/opencv_apps/issues/21>)) (#74 <https://github.com/ros-perception/opencv_apps/issues/74>)
  Fix namespace and pkg name of nodelets
* Add pyramids_nodelet (#37 <https://github.com/ros-perception/opencv_apps/issues/37>)
  * use toCvCopy instead of CvShare in adding_images
* adding_images_nodelt :support different size of images (#57 <https://github.com/ros-perception/opencv_apps/issues/57>)
* fix contour moment program (#66 <https://github.com/ros-perception/opencv_apps/issues/66>)
  * contour_moments_nodelet.cpp: remove redundant codes, use input encoding
  * contour_moments_nodelet.cpp: sort contours by the area
  * contour_moments_nodelet.cpp: remove tailing NR from NODELET_INFO
* fix for opencv 3.3.1 (#71 <https://github.com/ros-perception/opencv_apps/issues/71>)
  * fix launch/test fiels for opencv3.3
  * goodFeaturesTrack takes useHarriesDetector == false
  * opencv 3.3.1 has newer FaceRecognizer
* Contributors: Kei Okada, Iori Yanokura
```
