### PR TITLE
jsk_roseus: 1.7.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1354,6 +1354,24 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: master
     status: developed
+  jsk_roseus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    release:
+      packages:
+      - jsk_roseus
+      - roseus
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jsk_roseus-release.git
+      version: 1.7.1-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+      version: master
+    status: developed
   jskeus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.7.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## jsk_roseus

- No changes

## roseus

```
* add melodic test (#567 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/567>)
  * use rosrun roseus roseus test/test-namespace.l, instead of /usr/bin/env roseus
* update function using new defun function (#569 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/569>)
  * CHNAGED EusLisp defun() arguments, see https://github.com/euslisp/EusLisp/pull/300
  * force generate defun.h header file
  * use euslisp(9.24)'s new defun api roseus.cpp taht takes doc as argument, remove _defun
  * add documentation string to defun functions
  * add documentation string to defun functions, (roseus_c_util.c uses NULL because this is not exported functions
* [roseus.l] add length check for argument when searching __log:=t (#568 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/568>)
* Contributors: Kei Okada, Yohei Kakiuchi
```
