### PR TITLE
handle_detector: 1.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3361,6 +3361,21 @@ repositories:
       url: https://github.com/crigroup/handeye.git
       version: master
     status: developed
+  handle_detector:
+    doc:
+      type: git
+      url: https://github.com/atenpas/handle_detector.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/atenpas/handle_detector-release.git
+      version: 1.3.1-0
+    source:
+      type: git
+      url: https://github.com/atenpas/handle_detector.git
+      version: kinetic
+    status: maintained
   hebiros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handle_detector` to `1.3.1-0`:

- upstream repository: https://github.com/atenpas/handle_detector
- release repository: https://github.com/atenpas/handle_detector-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## handle_detector

```
* removed pcl ros includes from importance sampling
* update CHANGELOG
* update CHANGELOG
* Contributors: atenpas
```
