### PR TITLE
turtlebot3_simulations: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4005,6 +4005,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
       version: melodic-devel
     status: developed
+  turtlebot3_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: melodic-devel
+    release:
+      packages:
+      - turtlebot3_fake
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: melodic-devel
+    status: developed
   tuw_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## turtlebot3_fake

```
* added TurtleBot3 Waffle Pi
* Contributors: Darby Lim, Pyo
```

## turtlebot3_gazebo

```
* modified uri path
* modified autorace
* delete remap
* Contributors: Darby Lim, Gilbert, Pyo
```

## turtlebot3_simulations

```
* added TurtleBot3 Waffle Pi
* modified uri path
* modified autorace
* delete remap
* Contributors: Darby Lim, Gilbert, Pyo
```
