### PR TITLE
Adding teleop_twist_keyboard_cpp

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12077,6 +12077,16 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  teleop_twist_keyboard_cpp:
+    doc:
+      type: git
+      url: https://github.com/methylDragon/teleop_twist_keyboard_cpp.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/methylDragon/teleop_twist_keyboard_cpp.git
+      version: master
+    status: maintained
   tensorflow_ros_cpp:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3939,6 +3939,16 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  teleop_twist_keyboard_cpp:
+    doc:
+      type: git
+      url: https://github.com/methylDragon/teleop_twist_keyboard_cpp.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/methylDragon/teleop_twist_keyboard_cpp.git
+      version: master
+    status: maintained
   tensorflow_ros_cpp:
     doc:
       type: git


### PR DESCRIPTION
Wrote a C++ implementation of the teleop_twist_keyboard_node.

It's very useful for integrating with other protocols and frameworks that use C++.