### PR TITLE
turtlebot3: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12420,7 +12420,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`

## turtlebot3

```
* added bringup to load multiple robot simply #251
* added arguments for multiple robot
* added odometrySource
* modified camera topic name
* modified base_scan update_rate and add param on diff_drive #258
* modified the laser scanner update_rate in the gazebo xacro files #258
* modified origin of collision in Waffle URDF
* updated turtlebot3_diagnostic node
* updated firmware version from 1.2.0 to 1.2.2
* updated get firmware version
* updated version check function
* updated warn msg for version check
* deleted unused get_scan function #227
* Contributors: Darby Lim, Gilbert, Eduardo Avelar, shtseng, Pyo
```

## turtlebot3_bringup

```
* added bringup to load multiple robot simply #251
* added argument about namespace
* updated turtlebot3_diagnostic node
* updated firmware version from 1.2.0 to 1.2.2
* updated get firmware version
* updated version check function
* updated warn msg for version check
* Contributors: Darby Lim, Gilbert, Pyo
```

## turtlebot3_description

```
* added bringup to load multiple robot simply #251
* added odometrySource
* modified camera topic name
* modified base_scan update_rate and add param on diff_drive #258
* modified the laser scanner update_rate in the gazebo xacro files #258
* modified origin of collision in Waffle URDF
* Contributors: Darby Lim, Gilbert, shtseng, Pyo
```

## turtlebot3_example

```
* added bringup to load multiple robot simply #251
* modified topic name
* deleted unused get_scan function #227
* Contributors: Darby Lim, Eduardo Avelar, Gilbert, Pyo
```

## turtlebot3_navigation

```
* added bringup to load multiple robot simply #251
* added arguments for multiple robot
* Contributors: Darby Lim, Gilbert, Pyo
```

## turtlebot3_slam

```
* added bringup to load multiple robot simply #251
* added arguments for multiple robot
* Contributors: Darby Lim, Gilbert, Pyo
```

## turtlebot3_teleop

```
* none
```
