### PR TITLE
Revert "cob_hand: 0.6.4-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1348,7 +1348,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_hand-release.git
-      version: 0.6.4-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_hand.git


### PR DESCRIPTION
Reverts ros/rosdistro#18599

@fmessmer FYI

The builds for cob_hand_bridge are failing on all platforms after this release: http://build.ros.org/job/Ksrc_uX__cob_hand_bridge__ubuntu_xenial__source/