### PR TITLE
Revert "cob_hand: 0.6.4-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1922,7 +1922,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_hand-release.git
-      version: 0.6.4-0
+      version: 0.6.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_hand.git


### PR DESCRIPTION
Reverts ros/rosdistro#18598

@fmessmer FYI

The builds for cob_hand_bridge are failing on all platforms after this release: http://build.ros.org/job/Isrc_uT__cob_hand_bridge__ubuntu_trusty__source/