### PR TITLE
rr_openrover_basic: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10996,7 +10996,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics/rr_openrover_basic-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/RoverRobotics/rr_openrover_basic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_basic` to `0.0.4-0`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_basic.git
- release repository: https://github.com/RoverRobotics/rr_openrover_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.3-0`

## rr_openrover_basic

```
* Added drive_type ROS param to switch odometry between 4wd, 2wd, and flipper robots
```
