### PR TITLE
kdl_parser: 1.13.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1395,7 +1395,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/kdl_parser-release.git
-      version: 1.13.0-0
+      version: 1.13.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `1.13.1-0`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros-gbp/kdl_parser-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.13.0-0`

## kdl_parser

```
* Fix up missing link tags in some XML files. (#15 <https://github.com/ros/kdl_parser/issues/15>)
* Contributors: Chris Lalancette
```

## kdl_parser_py

```
* Remove the declaration of a library from kdl_parser_py. (#14 <https://github.com/ros/kdl_parser/issues/14>)
* Remove unused kdl_parser_py.urdf. (#17 <https://github.com/ros/kdl_parser/issues/17>)
* Contributors: Chris Lalancette
```
