### PR TITLE
kdl_parser: 1.11.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5955,7 +5955,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/kdl_parser-release.git
-      version: 1.11.14-0
+      version: 1.11.15-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `1.11.15-0`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros-gbp/kdl_parser-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.11.14-0`

## kdl_parser

```
* update links now that this is in its own repo
* Contributors: Mikael Arguedas
```

## kdl_parser_py

```
* Remove unused test file. (#19 <https://github.com/ros/kdl_parser/issues/19>)
* update links now that this is in its own repo
* Contributors: Chris Lalancette, Mikael Arguedas
```
