### PR TITLE
kdl_parser: 1.12.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1627,7 +1627,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/kdl_parser-release.git
-      version: 1.12.10-0
+      version: 1.12.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `1.12.11-0`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros-gbp/kdl_parser-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.12.10-0`

## kdl_parser

```
* Style fixes from ros2 (#11 <https://github.com/ros/kdl_parser/issues/11>)
* Make rostest a test_depend (#3 <https://github.com/ros/kdl_parser/issues/3>)
* update links now that this is in its own repo
* Contributors: Chris Lalancette, Mikael Arguedas
```

## kdl_parser_py

```
* Remove unused kdl_parser_py.urdf. (#18 <https://github.com/ros/kdl_parser/issues/18>)
* Make rostest a test_depend (#3 <https://github.com/ros/kdl_parser/issues/3>)
* update links now that this is in its own repo
* Contributors: Chris Lalancette, Mikael Arguedas
```
