### PR TITLE
cob_command_tools: 0.6.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1758,7 +1758,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.7-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.9-0`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.7-0`

## cob_command_gui

```
* update maintainer
* Contributors: ipa-fxm
```

## cob_command_tools

```
* update maintainer
* Contributors: ipa-fxm
```

## cob_dashboard

```
* update maintainer
* Contributors: ipa-fxm
```

## cob_helper_tools

```
* update maintainer
* Contributors: ipa-fxm
```

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* update maintainer
* Contributors: ipa-fxm
```

## cob_script_server

```
* update maintainer
* Contributors: ipa-fxm
```

## cob_teleop

```
* update maintainer
* Contributors: ipa-fxm
```

## generic_throttle

```
* update maintainer
* Contributors: ipa-fxm
```

## service_tools

```
* update maintainer
* Contributors: ipa-fxm
```
