### PR TITLE
rc_genicam_api: 1.3.12-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3104,7 +3104,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 1.3.11-0
+      version: 1.3.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `1.3.12-0`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.3.11-0`

## rc_genicam_api

```
* Getting chunk data in gc_stream and storing disparity image with all parameters for reconstruction if possible
* Error handling in gc_stream changed by first checking for incomplete buffer and then for image present
```
