### PR TITLE
Added intelhex pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -104,6 +104,16 @@ gunicorn:
   fedora: [python-gunicorn]
   gentoo: [www-servers/gunicorn]
   ubuntu: [gunicorn]
+intelhex-pip:
+  debian:
+    pip:
+      packages: [intelhex]
+  fedora:
+    pip:
+      packages: [intelhex]
+  ubuntu:
+    pip:
+      packages: [intelhex]
 ipython:
   debian: [ipython]
   fedora: [python-ipython]


### PR DESCRIPTION
IntelHex:
[https://pypi.org/project/IntelHex/](https://pypi.org/project/IntelHex/)

Used to enable microcontroller updates with hex files from a ros package.