### PR TITLE
jsk_model_tools: 0.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4390,6 +4390,10 @@ repositories:
       version: master
     status: developed
   jsk_model_tools:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
+      version: master
     release:
       packages:
       - eus_assimp
@@ -4399,7 +4403,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.3.5-0
+      version: 0.4.0-0
     status: developed
   jsk_planning:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.4.0-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.5-0`

## eus_assimp

```
* since euslisp 9.25.0, we need to add 5 arguments including doc string with defun() (#217 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/217>)
* [eus_assimp] add use-coordinate option to append-vertices in order to express all the vertices respect to world frame (#210 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/210>)
* [eus_assimp] need to set faces before calling gl::make-glvertices-fro (#208 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/208>)
* Fix for arm processor (#209 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/209>)
  * fix for arm64/v8 aarch64 is 64bit
* [eus_assimp] mesh2wrl.sh: add utility scripts  (#206 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/206>)
* Contributors: Eisoku Kuroiwa, Kei Okada, Yohei Kakiuchi
```

## euscollada

```
* Replace euscollada for using ROS collada/urdf parser. It can convert both collada and urdf to eusmodel (#216 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/216>)
  * [euscollada] previous collada2eus can be used by collada2eus.orig
  * [euscollada, collada2eus_urdfmodel] switch default model format (:collada->:urdf)
  * [euscollada] use collada2eus_urdfmodel as collada2eus
  * [euscollada,collada2eus_urdfmodel] fix parsing arguments
  * [euscollada,collada2eus_urdfmodel] fix reset-pose
  * [euscollada,collada2eus,collada2eus_urdfmodel] fix centroid
  * [euscollada, euscollada-robot.l] fix inertia conversion when weight is zero
  * [euscollada] fix message when robot.yaml has shorter length of angle-vector
  * [euscollada] do not make small cube for link without geometry
  * [euscollada] fix using _fixed_jt as slot name for fixed joint
  * [euscollada] add add_normal argument
* [euscollada] fix travis testtest (#215 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/215>)
  * fix timeout for reading stream
  * set origin of robot before comparing centroid
* Update collada2eus_urdfmodel (#212 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/212>)
  * [euscollada/collada2eus_urdfmodel] update for using non mesh geometry(BOX, CYLINDER, SPHERE)
  * [euscollada/collada2eus_urdfmodel] fix, the same as #174 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/174>
  * [euscollada/collada2eus_urdfmodel] fix warning message for reading urdf file
  * [euscollada/collada2eus_urdfmodel] fix min-max range for a continuous joint
  * [euscollada/collada2eus_urdfmodel] fix for writing non mesh geometry
* fix to run installed euscollada (#213 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/213>)
  * enable to run within write-protected directory
  * euscollada: install sh fails as PROGRAMS
* src/collada2eus.cpp: fix wrong python style string #174 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/174> (#204 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/204>)
* Contributors: Kei Okada, Yohei Kakiuchi
```

## eusurdf

```
* [eusurdf] add cmake target for generating Semantic map from eusmodel (#194 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/194>)
  * [eusurdf] add cmake target for generating ontology if generator exists
  * [eusurdf][package.xml] add python-lxml as run_depend
* Fix for arm processor (#209 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/209>)
  * use LinuxARM ARCHDIR for CMKAE_SYSTEM_PROCESSOR armv/aarch64
* Contributors: Yohei Kakiuchi, Yuki Furuta
```

## jsk_model_tools

- No changes
