### PR TITLE
teraranger_array: 1.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12142,7 +12142,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git
-      version: 1.3.1-1
+      version: 1.3.2-0
     status: maintained
   teraranger_array_converter:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `1.3.2-0`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.3.1-1`

## teraranger_array

```
* Update Readme for Tower Evo
* Set default rate to ASAP
* Add 500 et 600 Hz mode
* Add specific firing mode for TeraRanger Tower Evo
* Contributors: Baptiste Potier, Pierre-Louis Kabaradjian
```
