### PR TITLE
navigation: 1.16.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2021,6 +2021,28 @@ repositories:
       type: git
       url: https://github.com/ros-planning/navigation.git
       version: melodic-devel
+    release:
+      packages:
+      - amcl
+      - base_local_planner
+      - carrot_planner
+      - clear_costmap_recovery
+      - costmap_2d
+      - dwa_local_planner
+      - fake_localization
+      - global_planner
+      - map_server
+      - move_base
+      - move_slow_and_clear
+      - nav_core
+      - navfn
+      - navigation
+      - rotate_recovery
+      - voxel_grid
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation-release.git
+      version: 1.16.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.16.0-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## amcl

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Merge pull request #734 <https://github.com/ros-planning/navigation/issues/734> from ros-planning/melodic_731
  AMCL dynamic reconfigure: Extend parameter range (Forward port #731 <https://github.com/ros-planning/navigation/issues/731>)
* Merge pull request #728 <https://github.com/ros-planning/navigation/issues/728> from ros-planning/melodic_tf2_conversion
  switch AMCL to use TF2
* fix swapped odom1/4 in omni model, fixes #499 <https://github.com/ros-planning/navigation/issues/499>
* Merge pull request #730 <https://github.com/ros-planning/navigation/issues/730> from Glowcloud/melodic-devel
  Fix for Potential Memory Leak  in AmclNode::reconfigureCB #729 <https://github.com/ros-planning/navigation/issues/729>
* Fix for Potential Memory Leak  in AmclNode::reconfigureCB
* switch AMCL to use TF2
* Merge pull request #727 <https://github.com/ros-planning/navigation/issues/727> from ros-planning/melodic_668
  Update laser_model_type enum on AMCL.cfg (Melodic port of #668 <https://github.com/ros-planning/navigation/issues/668>)
* Update laser_model_type enum on AMCL.cfg
  Adding likelihood_field_prob laser model option on AMCL.cfg to be able to control dynamic parameters with this laser sensor model.
* Merge pull request #723 <https://github.com/ros-planning/navigation/issues/723> from moriarty/melodic-buildfarm-errors
  Melodic buildfarm errors
* include <memory> for std::shared_ptr
* Merge pull request #718 <https://github.com/ros-planning/navigation/issues/718> from moriarty/tf2-buffer-ptr
  [melodic] tf2_buffer_ -> tf2_buffer_ptr_
* [melodic] tf2_buffer_ -> tf2_buffer_ptr_
  Change required due to changes in upstream dependencies:
  ros/geometry#163 <https://github.com/ros/geometry/issues/163>: "Maintain & expose tf2 Buffer in shared_ptr for tf"
  fixes ros-planning/navigation#717 <https://github.com/ros-planning/navigation/issues/717> (for compile errors at least.)
* Contributors: Alexander Moriarty, Glowcloud, Martin Ganeff, Michael Ferguson, Miguel Cordero, Vincent Rabaud, maracuya-robotics
```

## base_local_planner

```
* Remove PCL #765 <https://github.com/ros-planning/navigation/issues/765>
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Fix trajectory obstacle scoring in dwa_local_planner.
* Make trajectory scoring scales consistent.
* unify parameter names between base_local_planner and dwa_local_planner
  addresses parts of #90 <https://github.com/ros-planning/navigation/issues/90>
* fix param to min_in_place_vel_theta, closes #487 <https://github.com/ros-planning/navigation/issues/487>
* add const to getLocalPlane, fixes #709 <https://github.com/ros-planning/navigation/issues/709>
* Merge pull request #732 <https://github.com/ros-planning/navigation/issues/732> from marting87/small_typo_fixes
  Small typo fixes in ftrajectory_planner_ros and robot_pose_ekf
* Fixed typos for base_local_planner
* Contributors: Alexander Moriarty, David V. Lu, Martin Ganeff, Michael Ferguson, Pavlo Kolomiiets, Rein Appeldoorn, Vincent Rabaud, moriarty
```

## carrot_planner

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Contributors: Michael Ferguson, Rein Appeldoorn, Vincent Rabaud
```

## clear_costmap_recovery

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Contributors: Michael Ferguson, Vincent Rabaud
```

## costmap_2d

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* unify combination_method dynamic reconfig, closes #402 <https://github.com/ros-planning/navigation/issues/402>
* Merge pull request #723 <https://github.com/ros-planning/navigation/issues/723> from moriarty/melodic-buildfarm-errors
  Melodic buildfarm errors
* [costmap_2d/test] set empty transform to Identity
* fix test: abs(unsigned int) is ambiguous
  Instead, compare values and subtract smaller from larger to find
  the dx and dy.
* fixes pluginlib deprecated header warnings
* Merge pull request #694 <https://github.com/ros-planning/navigation/issues/694> from ros-planning/lunar_691
  costmap variable init & cleanup (forward port of #691 <https://github.com/ros-planning/navigation/issues/691>)
* remove unused got_footprint_
* initialize all costmap variables
* Merge pull request #686 <https://github.com/ros-planning/navigation/issues/686> from ros-planning/lunar_675
  Fixed race condition with costmaps in LayeredCostmap::resizeMap()
* Fixed race condition with costmaps in LayeredCostmap::resizeMap()
  LayeredCostmap::updateMap() and LayeredCostmap::resizeMap() write to the master grid costmap.
  And these two functions can be called by different threads at the same time.
  One example of these cases is a race condition between subscriber callback thread
  dealing with dynamically-size-changing static_layer and periodical updateMap() calls from Costmap2DROS thread.
  Under the situation the master grid costmap is not thread-safe.
  LayeredCostmap::updateMap() already used the master grid costmap's lock.
* Contributors: Alexander Moriarty, David V. Lu, Jaeyoung Lee, Michael Ferguson, Vincent Rabaud
```

## dwa_local_planner

```
* Merge pull request #765 <https://github.com/ros-planning/navigation/issues/765> from ros-planning/remove_pcl
  remove left over PCL depends in dwa_local_planner
* Remove PCL from local planners
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Make trajectory scoring scales consistent.
* unify parameter names between base_local_planner and dwa_local_planner
  addresses parts of #90 <https://github.com/ros-planning/navigation/issues/90>
* Contributors: David V. Lu, Michael Ferguson, Pavlo Kolomiiets, Vincent Rabaud, moriarty
```

## fake_localization

```
* Merge pull request #690 <https://github.com/ros-planning/navigation/issues/690> from ros-planning/lunar_609
  switch fake_localization to tf2.
* Contributors: Michael Ferguson, Vincent Rabaud
```

## global_planner

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* feat(orientation_filter): Added additional orientation filter options (#739 <https://github.com/ros-planning/navigation/issues/739>)
  * feat(orientation_filter): Added additional orientation filter options
  Enables plan references with different orientations for omni-base
  controllers. The following options are added:
  - Backward (backward path traversal, pose points to previous point)
  - Leftward (lateral path traversal in the positive y direction)
  - Rightward (lateral path traversal in the negative y direction)
  * Updated orientation filter option description
  * Added window size parameter to orientation filter
  Previously, the orientation was calculated using the current and the
  next point. However, when the path is somewhat jumpy, this results in
  poor orientations. By adding this parameter and altering the orientation
  calculation, the calculated orientation can be smoothened along the path
  by taking into account a larger window. The orientation of index point i
  will be calculated using the positions of i - window_size and i +
  window_size.
* Contributors: Michael Ferguson, Rein Appeldoorn, Vincent Rabaud
```

## map_server

```
* Merge pull request #735 <https://github.com/ros-planning/navigation/issues/735> from ros-planning/melodic_708
  Allow specification of free/occupied thresholds for map_saver (#708 <https://github.com/ros-planning/navigation/issues/708>)
* Allow specification of free/occupied thresholds for map_saver (#708 <https://github.com/ros-planning/navigation/issues/708>)
  * add occupied threshold command line parameter to map_saver (--occ)
  * add free threshold command line parameter to map_saver (--free)
* Merge pull request #704 <https://github.com/ros-planning/navigation/issues/704> from DLu/fix573_lunar
  Map server wait for a valid time fix [lunar]
* Map server wait for a valid time, fix #573 <https://github.com/ros-planning/navigation/issues/573> (#700 <https://github.com/ros-planning/navigation/issues/700>)
  When launching the map_server with Gazebo, the current time is picked
  before the simulation is started and then has a value of 0.
  Later when querying the stamp of the map, a value of has a special
  signification on tf transform for example.
* Contributors: Michael Ferguson, Romain Reignier, ipa-fez
```

## move_base

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Merge pull request #723 <https://github.com/ros-planning/navigation/issues/723> from moriarty/melodic-buildfarm-errors
  Melodic buildfarm errors
* Merge pull request #719 <https://github.com/ros-planning/navigation/issues/719> from ros-planning/lunar_711
  adding mutex locks to costmap clearing service
* Contributors: Alexander Moriarty, Michael Ferguson, Vincent Rabaud, stevemacenski
```

## move_slow_and_clear

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Contributors: Michael Ferguson, Vincent Rabaud
```

## nav_core

```
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* unify parameter names between base_local_planner and dwa_local_planner
  addresses parts of #90 <https://github.com/ros-planning/navigation/issues/90>
* fix param names of RotateRecovery, closes #706 <https://github.com/ros-planning/navigation/issues/706>
* Contributors: David V. Lu, Michael Ferguson, Vincent Rabaud
```

## navfn

```
* Remove dependency on PCL
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* Merge pull request #737 <https://github.com/ros-planning/navigation/issues/737> from marting87/minor_comment_fixes
  Minor comment corrections
* Contributors: David V. Lu, Martin Ganeff, Michael Ferguson, Vincent Rabaud
```

## navigation

```
* remove robot_pose_ekf, see #701 <https://github.com/ros-planning/navigation/issues/701>
* Contributors: Michael Ferguson
```

## rotate_recovery

```
* Remove dependency on PCL
* Switch to TF2 #755 <https://github.com/ros-planning/navigation/issues/755>
* fix param names of RotateRecovery, closes #706 <https://github.com/ros-planning/navigation/issues/706>
* Contributors: David V. Lu, Michael Ferguson, Vincent Rabaud
```

## voxel_grid

- No changes
