### PR TITLE
Added the xmlrpc-c-c++ library

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3468,6 +3468,12 @@ libxml2:
 libxml2-utils:
   debian: [libxml2-utils]
   ubuntu: [libxml2-utils]
+libxmlrpc-c++:
+  arch: [xmlrpc-c]
+  debian: [libxmlrpc-c++8-dev]
+  fedora: [xmlrpc-c-devel]
+  gentoo: ['dev-libs/xmlrpc-c']
+  ubuntu: [libxmlrpc-c++8-dev]
 libxmu-dev:
   arch: [libxmu]
   debian: [libxmu-dev]


### PR DESCRIPTION
This library is needed by the ifm3d library which is
the core library for the ifm3d-ros ROS node which
I do plan to integrate.

- Arch package [xmlrpc-c](https://www.archlinux.org/packages/community/x86_64/xmlrpc-c/)
- Debian [libxmlrpc-c++8-dev](https://packages.debian.org/jessie/libxmlrpc-c++8-dev)
- Fedora [xmlrpc-c-devel](https://fedora.pkgs.org/26/fedora-x86_64/xmlrpc-c-devel-1.48.0-4.fc26.x86_64.rpm.html)
- Gentoo [xmlrpc-c](https://packages.gentoo.org/packages/dev-libs/xmlrpc-c)
- Ubuntu  [libxmlrpc-c++8-dev](https://packages.ubuntu.com/xenial/libxmlrpc-c++8-dev)

Signed-off-by: Christian Ege <christian.ege@ifm.com>