### PR TITLE
Remove ar_sys

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -344,21 +344,6 @@ repositories:
       url: https://github.com/RIVeR-Lab/apriltags_ros.git
       version: indigo-devel
     status: maintained
-  ar_sys:
-    doc:
-      type: git
-      url: https://github.com/Sahloul/ar_sys.git
-      version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/Sahloul/arsys_release.git
-      version: 1.0.4-0
-    source:
-      type: git
-      url: https://github.com/Sahloul/ar_sys.git
-      version: indigo-devel
-    status: developed
   ar_tools:
     doc:
       type: git


### PR DESCRIPTION
That users's account appears to have been deactivated. None of the repositories are reachable and the user's account homepage is also a 404