### PR TITLE
navigation: 1.16.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2054,7 +2054,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.16.0-0
+      version: 1.16.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.16.1-0`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.16.0-0`

## amcl

```
* Merge pull request #770 <https://github.com/ros-planning/navigation/issues/770> from ros-planning/fix_debians
  Fix debian builds (closes #769 <https://github.com/ros-planning/navigation/issues/769>)
* make AMCL depend on sensor_msgs
  previously, amcl depended on TF, which depended on
  sensor_msgs.
* Contributors: Michael Ferguson
```

## base_local_planner

- No changes

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

```
* Merge pull request #770 <https://github.com/ros-planning/navigation/issues/770> from ros-planning/fix_debians
  Fix debian builds (closes #769 <https://github.com/ros-planning/navigation/issues/769>)
* add tf2_geometry_msgs depend to costmap_2d
* Contributors: Michael Ferguson
```

## dwa_local_planner

- No changes

## fake_localization

- No changes

## global_planner

- No changes

## map_server

- No changes

## move_base

- No changes

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
