### PR TITLE
rplidar_ros: 1.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13214,7 +13214,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/kintzhao/rplidar_ros-release.git
-      version: 1.5.7-0
+      version: 1.7.0-0
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.7.0-0`:

- upstream repository: https://github.com/Slamtec/rplidar_ros.git
- release repository: https://github.com/kintzhao/rplidar_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.5.7-0`

## rplidar_ros

```
* Update RPLIDAR SDK to 1.7.0
* support scan points farther than 16.38m
* upport display and set scan mode
* Contributors: kint
```
