### PR TITLE
rplidar_ros: 1.7.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13208,7 +13208,7 @@ repositories:
   rplidar_ros:
     doc:
       type: git
-      url: https://github.com/robopeak/rplidar_ros.git
+      url: https://github.com/Slamtec/rplidar_ros.git
       version: master
     release:
       tags:
@@ -13217,7 +13217,7 @@ repositories:
       version: 1.7.0-0
     source:
       type: git
-      url: https://github.com/robopeak/rplidar_ros.git
+      url: https://github.com/Slamtec/rplidar_ros.git
       version: master
     status: maintained
   rqt:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13213,8 +13213,8 @@ repositories:
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/kintzhao/rplidar_ros-release.git
-      version: 1.5.7-0
+      url: https://github.com/Slamtec/rplidar_ros-release.git
+      version: 1.7.0-0
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.7.0-0`:

- upstream repository: https://github.com/Slamtec/rplidar_ros.git
- release repository: https://github.com/Slamtec/rplidar_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.5.7-0`

## rplidar_ros

```
* Update RPLIDAR SDK to 1.7.0
* support scan points farther than 16.38m
* upport display and set scan mode
* Contributors: kint
```
