### PR TITLE
rplidar_ros: 1.7.0-1 in 'jade/distribution.yaml' [bloom]

### DIFF
--- a/jade/distribution.yaml
+++ b/jade/distribution.yaml
@@ -6101,8 +6101,8 @@ repositories:
     release:
       tags:
         release: release/jade/{package}/{version}
-      url: https://github.com/kintzhao/rplidar_ros-release.git
-      version: 1.5.7-0
+      url: https://github.com/Slamtec/rplidar_ros-release.git
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/robopeak/rplidar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.7.0-1`:

- upstream repository: https://github.com/Slamtec/rplidar_ros.git
- release repository: https://github.com/Slamtec/rplidar_ros-release.git
- distro file: `jade/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.5.7-0`

## rplidar_ros

```
* Update RPLIDAR SDK to 1.7.0
* support scan points farther than 16.38m
* upport display and set scan mode
* Contributors: kint
```
