### PR TITLE
rplidar_ros: 1.7.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3790,6 +3790,22 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: jade-devel
     status: maintained
+  rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/Slamtec/rplidar_ros-release.git
+      version: 1.7.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: master
+    status: maintained
   rqt:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3801,7 +3801,6 @@ repositories:
       url: https://github.com/Slamtec/rplidar_ros-release.git
       version: 1.7.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/Slamtec/rplidar_ros.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.7.0-0`:

- upstream repository: https://github.com/Slamtec/rplidar_ros.git
- release repository: https://github.com/Slamtec/rplidar_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rplidar_ros

```
* Update RPLIDAR SDK to 1.7.0
* support scan points farther than 16.38m
* upport display and set scan mode
* Contributors: kint
```
