### PR TITLE
rplidar_ros: 1.7.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3338,6 +3338,22 @@ repositories:
       url: https://github.com/PickNikRobotics/rosparam_shortcuts.git
       version: melodic-devel
     status: developed
+  rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Slamtec/rplidar_ros-release.git
+      version: 1.7.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: master
+    status: maintained
   rqt:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3349,7 +3349,6 @@ repositories:
       url: https://github.com/Slamtec/rplidar_ros-release.git
       version: 1.7.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/Slamtec/rplidar_ros.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `1.7.0-0`:

- upstream repository: https://github.com/Slamtec/rplidar_ros.git
- release repository: https://github.com/Slamtec/rplidar_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rplidar_ros

```
* Update RPLIDAR SDK to 1.7.0
* support scan points farther than 16.38m
* upport display and set scan mode
* Contributors: kint
```
