### PR TITLE
ifopt: 2.0.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1190,7 +1190,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 2.0.4-0
+      version: 2.0.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.0.5-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.0.4-0`

## ifopt

```
* set default print level to 4 to show derivative test errors.
* Improve print-out of cost terms (specifically print cost)
* Improve docs (#27 <https://github.com/ethz-adrl/ifopt/issues/27>)
* Implemented more efficient method for building constraint jacobian (#26 <https://github.com/ethz-adrl/ifopt/issues/26>)
* Contributors: Alexander Winkler, fbiemueller
```
