### PR TITLE
towr: 1.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4045,7 +4045,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ethz-adrl/towr-release.git
-      version: 1.3.2-0
+      version: 1.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.4.0-0`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.3.2-0`

## towr

```
* Simplify extension / adding own formulation (#38 <https://github.com/ethz-adrl/towr/issues/38>)
* Facilitate towr_ros user extension (#34 <https://github.com/ethz-adrl/towr/issues/34>)
* Greatly simplify phase node formulations (#33 <https://github.com/ethz-adrl/towr/issues/33>)
* keep overview in github readme, not separated into doxygen & github
* rename CD to SRBD and improve documentation
* rename nodes to node variables
* Contributors: Alexander Winkler
```

## towr_ros

```
* Facilitate towr_ros user extension (#34 <https://github.com/ethz-adrl/towr/issues/34>)
* Add easy plotting of trajectories with rqt_bag
* add option to visualize variable initialization
* Allow shorthand to launch with gdb
* Contributors: Alexander Winkler
```
