### PR TITLE
mir_robot: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7272,10 +7272,11 @@ repositories:
       - mir_gazebo
       - mir_msgs
       - mir_navigation
+      - mir_robot
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.2-0`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.1-0`

## mir_actions

- No changes

## mir_description

- No changes

## mir_driver

- No changes

## mir_gazebo

```
* mir_gazebo: Install config directory
* Contributors: Martin Günther
```

## mir_msgs

- No changes

## mir_navigation

- No changes

## mir_robot

```
* Add metapackage
* Contributors: Martin Günther
```
