### PR TITLE
Add python3 opencv dependency for ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4441,10 +4441,8 @@ python3-numpy:
 python3-opencv:
   debian:
     buster: [python3-opencv]
-    stretch: null
   ubuntu:
     bionic: [python3-opencv]
-    xenial: null
 python3-pep8:
   debian:
     buster: [python3-pep8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4443,9 +4443,7 @@ python3-opencv:
     buster: [python3-opencv]
   ubuntu:
     bionic: [python3-opencv]
-    xenial:
-      pip:
-        packages: [opencv-python]
+    xenial: null
 python3-pep8:
   debian:
     buster: [python3-pep8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4439,7 +4439,13 @@ python3-numpy:
   gentoo: [dev-python/numpy]
   ubuntu: [python3-numpy]
 python3-opencv:
-  ubuntu: [python3-opencv]
+  debian:
+    buster: [python3-opencv]
+  ubuntu:
+    bionic: [python3-opencv]
+    xenial:
+      pip:
+        packages: [opencv-python]
 python3-pep8:
   debian:
     buster: [python3-pep8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4441,6 +4441,7 @@ python3-numpy:
 python3-opencv:
   debian:
     buster: [python3-opencv]
+    stretch: null
   ubuntu:
     bionic: [python3-opencv]
     xenial: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4438,6 +4438,8 @@ python3-numpy:
   debian: [python3-numpy]
   gentoo: [dev-python/numpy]
   ubuntu: [python3-numpy]
+python3-opencv:
+  ubuntu: [python3-opencv]
 python3-pep8:
   debian:
     buster: [python3-pep8]


### PR DESCRIPTION
Ubuntu: https://packages.ubuntu.com/bionic/python3-opencv

Now only add for ubuntu firstly to use, because it's already on the way for the other Linux flavors while they're finally ready and stable, e.g Debian: https://packages.debian.org/search?keywords=python3-opencv