### PR TITLE
mapviz: 0.2.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1813,7 +1813,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.2.6-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.5-0`

## mapviz

- No changes

## mapviz_plugins

```
* Fix timestamp interval (#588 <https://github.com/swri-robotics/mapviz/issues/588>)
* Update path_plugin.cpp (#586 <https://github.com/swri-robotics/mapviz/issues/586>)
* Replace depcreated plugin macro with newer version
* Contributors: Matthew, P. J. Reed, camjaws
```

## multires_image

- No changes

## tile_map

- No changes
