### PR TITLE
moveit_python: 0.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2090,6 +2090,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: kinetic-devel
     status: maintained
+  moveit_python:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/moveit_python.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/mikeferguson/moveit_python-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/moveit_python.git
+      version: master
+    status: maintained
   moveit_resources:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.3.0-0`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## moveit_python

```
* add namespace functionality on planning_scene_interface.py
* additional cleanup/documentation
  * use apply_service for colors
  * rename sentUpdate to sendUpdate, add docs
  * rename wait param to use_service (the meaning has changed)
  * remove some spammy logging
  * don't waitForSync when using service
* Merge pull request #10 <https://github.com/mikeferguson/moveit_python/issues/10> from alemme/master
  adapt the code for the apply service
* added services to add objects to environment and attach them. Following http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/pr2_tutorials/planning/src/doc/planning_scene_ros_api_tutorial.html#interlude-synchronous-vs-asynchronous-updates
* Contributors: Benjamin-Tan, Lemme, Michael Ferguson
```
