### PR TITLE
moveit_python: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5785,7 +5785,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.2.17-1
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/moveit_python.git
+      version: master
     status: developed
   moveit_resources:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.3.0-0`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.17-1`

## moveit_python

```
* add namespace functionality on planning_scene_interface.py
* additional cleanup/documentation
  * use apply_service for colors
  * rename sentUpdate to sendUpdate, add docs
  * rename wait param to use_service (the meaning has changed)
  * remove some spammy logging
  * don't waitForSync when using service
* Merge pull request #10 <https://github.com/mikeferguson/moveit_python/issues/10> from alemme/master
  adapt the code for the apply service
* added services to add objects to environment and attach them. Following http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/pr2_tutorials/planning/src/doc/planning_scene_ros_api_tutorial.html#interlude-synchronous-vs-asynchronous-updates
* Contributors: Benjamin-Tan, Lemme, Michael Ferguson
```
