### PR TITLE
arbotix: 0.10.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -90,6 +90,28 @@ repositories:
       url: https://github.com/ros-perception/ar_track_alvar.git
       version: kinetic-devel
     status: maintained
+  arbotix:
+    doc:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: indigo-devel
+    release:
+      packages:
+      - arbotix
+      - arbotix_controllers
+      - arbotix_firmware
+      - arbotix_msgs
+      - arbotix_python
+      - arbotix_sensors
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/vanadiumlabs/arbotix_ros-release.git
+      version: 0.10.0-0
+    source:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: indigo-devel
+    status: maintained
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix` to `0.10.0-0`:

- upstream repository: https://github.com/vanadiumlabs/arbotix_ros.git
- release repository: https://github.com/vanadiumlabs/arbotix_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## arbotix

- No changes

## arbotix_controllers

```
* Set queue_size=5 on all publishers
* Check if command exceeds opening limits
* Contributors: Jorge Santos
```

## arbotix_firmware

- No changes

## arbotix_msgs

- No changes

## arbotix_python

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```

## arbotix_sensors

```
* Set queue_size=5 on all publishers
* Contributors: Jorge Santos
```
