### PR TITLE
Adding graph_rviz_plugin to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1079,6 +1079,12 @@ repositories:
       url: https://github.com/davetcoleman/graph_msgs.git
       version: jade-devel
     status: maintained
+  graph_rviz_plugin:
+    doc:
+      type: git
+      url: https://gitlab.com/InstitutMaupertuis/graph_rviz_plugin.git
+      version: melodic
+    status: maintained
   grasping_msgs:
     doc:
       type: git


### PR DESCRIPTION
This is a RViz plugin that allows to draw graphs from topic values.