### PR TITLE
jsk_model_tools: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5738,7 +5738,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.4.1-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.4.0-0`

## eus_assimp

- No changes

## euscollada

```
* [euscollada] fix collision model for version 0.4.0f( #218 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/218>)
* Contributors: Yohei Kakiuchi
```

## eusurdf

- No changes

## jsk_model_tools

- No changes
