### PR TITLE
xsens_driver: 2.2.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4557,7 +4557,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
-      version: 2.2.0-0
+      version: 2.2.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/ethzasl_xsens_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_driver` to `2.2.1-0`:

- upstream repository: https://github.com/ethz-asl/ethzasl_xsens_driver.git
- release repository: https://github.com/ethz-asl/ethzasl_xsens_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.2.0-0`

## xsens_driver

```
* fix frame reorientation (only for orientation and linear velocity)
* fix skip-factor command line (#80 <https://github.com/ethz-asl/ethzasl_xsens_driver/issues/80>)
* Contributors: Francis Colas
```
