### PR TITLE
rosdep: Add python-ntplib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1825,6 +1825,11 @@ python-nose:
     xenial_python3: [python3-nose]
     yakkety: [python-nose]
     zesty: [python-nose]
+python-ntplib:
+  debian: [python-ntplib]
+  fedora: [python-ntplib]
+  gentoo: [dev-python/ntplib]
+  ubuntu: [python-ntplib]
 python-numpy:
   arch: [python2-numpy]
   debian: [python-numpy]


### PR DESCRIPTION
Add python package **ntplib** to rosdep.

"This module offers a simple interface to query NTP servers from Python." [[1](https://pypi.org/project/ntplib/)]

We use it to synchronise the time between machines in a distributed system, mostly to avoid TF timing issues.

I tested on Ubuntu, package names for other systems are based on Google research.

- Ubuntu: https://packages.ubuntu.com/search?keywords=python-ntplib&searchon=names&suite=all&section=all
- Debian: https://packages.debian.org/stable/python/python-ntplib
- Fedora: https://apps.fedoraproject.org/packages/python-ntplib
- Gentoo: https://packages.gentoo.org/packages/dev-python/ntplib