### PR TITLE
qt_gui_core: 0.3.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3056,7 +3056,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.8-0
+      version: 0.3.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.9-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.8-0`

## qt_dotgraph

- No changes

## qt_gui

```
* load and save perspective file path and name adjustments (#118 <https://github.com/ros-visualization/qt_gui_core/issues/118>)
* add hint to run with --force-discover, when no plugin found (#119 <https://github.com/ros-visualization/qt_gui_core/issues/119>)
* remove --multi-process command line argument (#116 <https://github.com/ros-visualization/qt_gui_core/issues/116>)
* avoid crash when a plugin in .perspective is not available (#110 <https://github.com/ros-visualization/qt_gui_core/issues/110>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

```
* change included pluginlib header to avoid deprecation warning (#114 <https://github.com/ros-visualization/qt_gui_core/issues/114>)
```

## qt_gui_py_common

- No changes
