### PR TITLE
rosconsole_bridge: 0.5.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3275,7 +3275,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole_bridge-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole_bridge` to `0.5.2-0`:

- upstream repository: https://github.com/ros/rosconsole_bridge.git
- release repository: https://github.com/ros-gbp/rosconsole_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.5.1-0`

## rosconsole_bridge

```
* fix static destruction ordering issue on macOS (#16 <https://github.com/ros/rosconsole_bridge/issues/16>)
```
