### PR TITLE
code_coverage: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1504,6 +1504,21 @@ repositories:
       url: https://github.com/ipa320/cob_supported_robots.git
       version: indigo_dev
     status: developed
+  code_coverage:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/code_coverage.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/mikeferguson/code_coverage-gbp.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/code_coverage.git
+      version: master
+    status: developed
   cog_publisher:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.2.0-0`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## code_coverage

```
* First release
* Contributors: Michael Ferguson
```
