### PR TITLE
add tensorflow-gpu to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3820,6 +3820,19 @@ python-tensorflow-pip:
   ubuntu:
     pip:
       packages: [tensorflow]
+python-tensorflow-gpu-pip:
+  debian:
+    pip:
+      packages: [tensorflow-gpu]
+  fedora:
+    pip:
+      packages: [tensorflow-gpu]
+  osx:
+    pip:
+      packages: [tensorflow-gpu]
+  ubuntu:
+    pip:
+      packages: [tensorflow-gpu]
 python-termcolor:
   debian:
     buster: [python-termcolor]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3807,19 +3807,6 @@ python-telegram-bot:
   ubuntu:
     pip:
       packages: [python-telegram-bot]
-python-tensorflow-pip:
-  debian:
-    pip:
-      packages: [tensorflow]
-  fedora:
-    pip:
-      packages: [tensorflow]
-  osx:
-    pip:
-      packages: [tensorflow]
-  ubuntu:
-    pip:
-      packages: [tensorflow]
 python-tensorflow-gpu-pip:
   debian:
     pip:
@@ -3833,6 +3820,19 @@ python-tensorflow-gpu-pip:
   ubuntu:
     pip:
       packages: [tensorflow-gpu]
+python-tensorflow-pip:
+  debian:
+    pip:
+      packages: [tensorflow]
+  fedora:
+    pip:
+      packages: [tensorflow]
+  osx:
+    pip:
+      packages: [tensorflow]
+  ubuntu:
+    pip:
+      packages: [tensorflow]
 python-termcolor:
   debian:
     buster: [python-termcolor]


### PR DESCRIPTION
I want to add tensorflow-gpu package to rosdep.

package url:[tensorflow-gpu](https://pypi.org/project/tensorflow-gpu/)
I want to use tensorflow with GPU in rospy.