### PR TITLE
added chrony to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -387,6 +387,13 @@ chromium-browser:
   fedora: [chromium]
   gentoo: [www-client/chromium]
   ubuntu: [chromium-browser]
+chrony:
+  arch: [chrony]
+  debian: [chrony]
+  fedora: [chrony]
+  gentoo: [net-misc/chrony]
+  opensuse: [chrony]
+  ubuntu: [chrony]
 clang-format:
   debian:
     buster: [clang-format]


### PR DESCRIPTION
We use [chrony](https://chrony.tuxfamily.org/index.html) in one of our projects. Would be great to have it via rosdep.
Links to the added distributions:

[arch](https://www.archlinux.org/packages/?name=chrony)
[debian](https://packages.debian.org/sid/chrony)
[fedora](https://apps.fedoraproject.org/packages/chrony)
[gentoo](http://packages.gentoo.org/package/net-misc/chrony)
[opensuse](https://build.opensuse.org/package/show/network:time/chrony)
[ubuntu](https://launchpad.net/ubuntu/+source/chrony)


Thanks!
