### PR TITLE
rospilot: 1.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3396,6 +3396,17 @@ repositories:
       url: https://github.com/PickNikRobotics/rosparam_shortcuts.git
       version: melodic-devel
     status: developed
+  rospilot:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rospilot/rospilot-release.git
+      version: 1.5.0-0
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot.git
+      version: melodic
+    status: developed
   rplidar_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.5.0-0`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rospilot

```
* Upgrade to Angular 5.2.11
* Upgrade Highcharts
* Set both pts and dts in video recorder
* Properly set time_base on video recorder codec
* Remove usage of deprecated encoding/decoding functions
* Remove usage of deprecated AVPicture
* Fix AVStream::codec deprecation warnings
* Add error handling for call to avformat_write_header()
* Cleanup VideoRecorder::stop()
* Switch Travis to build melodic
* Update ffmpeg usage to compile against newest version
* Update environment variable to PGPASSWORD
* Switch to Melodic-friendly dependencies
* Hack: monkey patch Mapnik to fix Tilestache dependency
* Contributors: Christopher Berner
```
