### PR TITLE
qt_gui_core: 0.3.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8456,7 +8456,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.9-0
+      version: 0.3.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.10-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.9-0`

## qt_dotgraph

- No changes

## qt_gui

```
* keep multi_process variable in standalone mode (#120 <https://github.com/ros-visualization/qt_gui_core/issues/120>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
