### PR TITLE
costmap_converter: 0.0.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -431,6 +431,22 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
     status: maintained
+  costmap_converter:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
+      version: 0.0.9-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: master
+    status: developed
   dataspeed_can:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.9-0`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## costmap_converter

```
* Moved plugin loader for static costmap conversion to BaseCostmapToDynamicObstacles.
  The corresponding ROS parameter static_converter_plugin is now defined in the CostmapToDynamicObstacles namespace.
* Contributors: Christoph Rösmann
```
