### PR TITLE
ipcamera_driver: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4168,7 +4168,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/alireza-hosseini/ipcamera_driver-release
+      url: https://github.com/alireza-hosseini/ipcamera_driver-release.git
       version: 0.1.1-1
     source:
       test_pull_requests: true

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4160,6 +4160,22 @@ repositories:
       url: https://github.com/corb555/iot_bridge.git
       version: kinetic-devel
     status: developed
+  ipcamera_driver:
+    doc:
+      type: git
+      url: https://github.com/alireza-hosseini/ipcamera_driver.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/alireza-hosseini/ipcamera_driver-release
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/alireza-hosseini/ipcamera_driver.git
+      version: master
+    status: developed
   ivcon:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ipcamera_driver` to `0.1.1-1`:

- upstream repository: https://github.com/alireza-hosseini/ipcamera_driver.git
- release repository: https://github.com/alireza-hosseini/ipcamera_driver-release
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## ipcamera_driver

- No changes
