### PR TITLE
sbpl: 1.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11384,7 +11384,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/sbpl-release.git
-      version: 1.2.0-2
+      version: 1.3.1-0
   scan_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbpl` to `1.3.1-0`:

- upstream repository: https://github.com/sbpl/sbpl
- release repository: https://github.com/ros-gbp/sbpl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.2.0-2`
