### PR TITLE
Adding vulkan loader library and dev files to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3409,9 +3409,7 @@ libvtk-qt:
     yakkety: [libvtk6-qt-dev]
     zesty: [libvtk6-qt-dev]
 libvulkan-dev:
-  debian:
-    buster: [libvulkan-dev]
-    stretch: [libvulkan-dev]
+  debian: [libvulkan-dev]
   fedora: [vulkan-devel]
   gentoo: [media-libs/vulkan-loader]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3408,6 +3408,17 @@ libvtk-qt:
     xenial: [libvtk6-qt-dev]
     yakkety: [libvtk6-qt-dev]
     zesty: [libvtk6-qt-dev]
+libvulkan-dev:
+  debian:
+    buster: [libvulkan-dev]
+    stretch: [libvulkan-dev]
+  fedora: [vulkan-devel]
+  gentoo: [media-libs/vulkan-loader]
+  ubuntu:
+    artful: [libvulkan-dev]
+    bionic: [libvulkan-dev]
+    cosmic: [libvulkan-dev]
+    xenial: [libvulkan-dev]
 libwebp-dev:
   debian: [libwebp-dev]
   fedora: [libwebp-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3413,10 +3413,8 @@ libvulkan-dev:
   fedora: [vulkan-devel]
   gentoo: [media-libs/vulkan-loader]
   ubuntu:
-    artful: [libvulkan-dev]
-    bionic: [libvulkan-dev]
-    cosmic: [libvulkan-dev]
-    xenial: [libvulkan-dev]
+    '*': [libvulkan-dev]
+    trusty: null
 libwebp-dev:
   debian: [libwebp-dev]
   fedora: [libwebp-devel]


### PR DESCRIPTION
We use the [vulkan loader library](https://github.com/KhronosGroup/Vulkan-Loader) and associated dev files in a VR application. It would make our CI happy if it were in rosdep.

Links to the distro-specific packages added:
[debian](https://packages.debian.org/sid/libvulkan-dev)
[fedora](https://apps.fedoraproject.org/packages/vulkan-devel#)
[gentoo](https://packages.gentoo.org/packages/media-libs/vulkan-loader)
[ubuntu](https://packages.ubuntu.com/xenial/libvulkan-dev)

Many thanks,
Ethan