### PR TITLE
rosmon: 1.0.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3748,7 +3748,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.8-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.7-0`

## rosmon

```
* main: Add option for flushing the logfile
  Add --flush option that will flush the logfile after each entry.
* Merge pull request #35 <https://github.com/xqms/rosmon/issues/35>
  More complete support for rosparam features
* Merge pull request #34 <https://github.com/xqms/rosmon/issues/34>
  YAML quoted strings
* launch: rosparam: support binary data
* launch: rosparam: correctly handle explicit YAML type tags
* launch: support rosparam angle computations
* launch: always map YAML quoted values to string params
  These always get mapped to str by python's yaml.load, which is used by
  roslaunch, so we do the same here.
* Contributors: Max Schwarz, Nikos Skalkotos
```
