### PR TITLE
urg_c: 1.0.405-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4857,7 +4857,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/urg_c-release.git
-      version: 1.0.404-0
+      version: 1.0.405-0
     source:
       type: git
       url: https://github.com/ros-drivers/urg_c.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.405-0`:

- upstream repository: git://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros-gbp/urg_c-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.404-0`

## urg_c

```
* pass *pointer to* system timestamp, sync issue on quit
* Adding new maintainer.
* Contributors: Tony Baltovski, knickels
```
