### PR TITLE
urg_c: 1.0.405-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4401,6 +4401,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: melodic-devel
     status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/urg_c-release.git
+      version: 1.0.405-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: master
+    status: maintained
   usb_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.405-0`:

- upstream repository: git://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros-gbp/urg_c-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## urg_c

```
* pass *pointer to* system timestamp, sync issue on quit
* Adding new maintainer.
* Contributors: Tony Baltovski, knickels
```
