### PR TITLE
astuff_sensor_msgs: 2.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -525,16 +525,19 @@ repositories:
       packages:
       - astuff_sensor_msgs
       - delphi_esr_msgs
+      - delphi_mrr_msgs
       - delphi_srr_msgs
       - ibeo_msgs
       - kartech_linear_actuator_msgs
       - mobileye_560_660_msgs
       - neobotix_usboard_msgs
       - pacmod_msgs
+      - perception_msgs
+      - radar_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 2.0.1-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `2.2.0-0`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.0.1-0`

## astuff_sensor_msgs

```
* Moved radar_msgs and perception_msgs from platform_automation_msgs to astuff_sensor_msgs.
```

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

```
* Merge pull request #20 <https://github.com/astuff/astuff_sensor_msgs/issues/20> from ASDeveloper00/master
  MRR clean up : ESR, styling, bug fixes
* MRR - Initial commit
  * all newly created messages for MRR repo
  * all newly added message definitions
  * committed by Brad
* Contributors: ASDeveloper00, Daniel-Stanek, sepidj
```

## delphi_srr_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

- No changes

## perception_msgs

```
* Moving perception_msgs from platform_automation_msgs.
* Contributors: Joe Buckner, Joshua Whitley
```

## radar_msgs

```
* Moving radar_msgs from platform_automation_msgs.
* Contributors: Joe Buckner, Joshua Whitley, Sam Rustan
```
