### PR TITLE
mavros: 0.26.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5420,7 +5420,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.26.1-0
+      version: 0.26.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.26.2-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.26.1-0`

## libmavconn

- No changes

## mavros

```
* Moving gps_rtk to mavros_extras
* Update copyright name
* Updating the gps_rtk plugin to fit mavros guidelines:
  - Updating max_frag_len to allow changes in size in MAVLink seamlessly
  - Using std::copy instead of memset
  - Zero fill with std::fill
  - Preapply the sequence flags
  - Use of std iterators
  - Add the maximal data size in the mavros_msgs
* uncrustify
* Update comments for the renaming
* Renaming the GPS RTK module, Adding fragmentation, Changing the RTCM message
* RTK Plugin; to forward RTCM messages
  Signed-off-by: Alexis Paques <mailto:alexis.paques@gmail.com>
* Contributors: Alexis Paques
```

## mavros_extras

```
* Fix namespace (std->extras)
* Changing the callback name to rtcm_cb
  Adding doxygen documentation
* Sort the plugins by alphabetical order
* Put back the casting
* Using size_t instead of int
  Using the same rtcm_data message
  Remove int casting
* Moving gps_rtk to mavros_extras
* Contributors: Alexis Paques
```

## mavros_msgs

```
* Updating the gps_rtk plugin to fit mavros guidelines:
  - Updating max_frag_len to allow changes in size in MAVLink seamlessly
  - Using std::copy instead of memset
  - Zero fill with std::fill
  - Preapply the sequence flags
  - Use of std iterators
  - Add the maximal data size in the mavros_msgs
* Renaming the GPS RTK module, Adding fragmentation, Changing the RTCM message
* RTK Plugin; to forward RTCM messages
  Signed-off-by: Alexis Paques <mailto:alexis.paques@gmail.com>
* Contributors: Alexis Paques
```

## test_mavros

- No changes
