### PR TITLE
teb_local_planner_tutorials: 0.2.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4123,6 +4123,22 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: melodic-devel
     status: developed
+  teb_local_planner_tutorials:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
+      version: 0.2.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
+      version: melodic-devel
+    status: developed
   teleop_twist_keyboard:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner_tutorials` to `0.2.3-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## teb_local_planner_tutorials

```
* tf prefixes removed to comply with tf2
* Contributors: Christoph Rösmann
```
