### PR TITLE
Add rosdep keys for libssh

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3012,6 +3012,11 @@ libsrtp0-dev:
   fedora: [libsrtp-devel]
   gentoo: ['net-libs/libsrtp:0']
   ubuntu: [libsrtp0-dev]
+libssh-dev:
+  debian: [libssh-dev]
+  fedora: [libssh-devel]
+  gentoo: [net-libs/libssh]
+  ubuntu: [libssh-dev]
 libssh2:
   debian: [libssh2-1]
   fedora: [libssh2]


### PR DESCRIPTION
I have a project where I use libssh instead of libssh2 which is already present in the rosdep keys. Different than the name might imply libssh2 is not the second version of libssh. libssh is actually more advanced than libssh2, see here for a comparison of libssh and libssh2: https://www.libssh2.org/libssh2-vs-libssh.html

Package links for different distributions:
Ubuntu: https://packages.ubuntu.com/bionic/libssh-dev
Debian: https://packages.debian.org/sid/libssh-dev
Fedora: http://rpmfind.net/linux/rpm2html/search.php?query=libssh-devel
