### PR TITLE
automotive_autonomy_msgs: 2.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -180,6 +180,21 @@ repositories:
       url: https://github.com/ros-drivers/audio_common.git
       version: master
     status: maintained
+  automotive_autonomy_msgs:
+    release:
+      packages:
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/astuff/automotive_autonomy_msgs-release.git
+      version: 2.0.2-0
+    source:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    status: developed
   auv_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `automotive_autonomy_msgs` to `2.0.2-0`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## automotive_autonomy_msgs

```
* Changed metapackage name to automotive_autonomy_msgs.
* Moving perception_msgs to astuff_sensor_msgs.
* Moving radar_msgs to astuff_sensor_msgs.
* Fixing license in package.xml.
* Updating package.xml to format 2.
* Standardizing package.xml files.
* Version bump and minor formatting clean-up.
* Major package reorganization. See README for new package definitions.
* Adding HMI Messages.
* Updating metapackage.
* Name changes for consistency. Updating all other packages to match.
* Contributors: Daniel Stanek, Joe Buckner, Joshua Whitley, Sam Rustan
```

## automotive_navigation_msgs

```
* Reorganized messages into renamed packages.
* Changed package name from module_comm_msgs to automotive_navigation_msgs.
* add RouteArray message to handle roads with more than one lane
* Fixing license in package.xml.
* Add ACC max distance in meters so that it can be displayed on shuttle GUI instead of just the 0 to 100% value on the existing highway autopilot GUI
* Add more lane styles to lane boundary message to support double lines
* Add lane boundary messages
* Add new message for velocity and acceleration that includes a calculated covariance
* Add Direction message from marti_localization_msgs
* Add ROS service to request map images
* Updating package.xml to format 2.
* Standardizing package.xml files.
* Version bump and minor formatting clean-up.
* Adding headers to some files that were missing them.
* Moving VelocityAccel to module_comm_msgs.
* Major package reorganization. See README for new package definitions.
* Contributors: Daniel Stanek, Joshua Whitley
```

## automotive_platform_msgs

```
* Reorganized messages under new package names.
* Changed package name from platform_comm_msgs to automotive_platform_msgs.
* Fixing license in package.xml.
* Updating package.xml to format 2.
* Standardizing package.xml files.
* Version bump and minor formatting clean-up.
* Moving VelocityAccel to module_comm_msgs.
* Major package reorganization. See README for new package definitions.
* Contributors: Daniel Stanek, Joshua Whitley
```
