### PR TITLE
phidgets_drivers: 0.7.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2829,7 +2829,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.5-0
+      version: 0.7.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.6-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.7.5-0`

## libphidget21

```
* libphidget21: Disable warning in CFLAGS
* Contributors: Martin Günther
```

## phidgets_api

- No changes

## phidgets_drivers

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_imu

```
* phidgets_imu: Ensure strictly ordered timestamps (#26 <https://github.com/ros-drivers/phidgets_drivers/issues/26>)
  Fixes #17 <https://github.com/ros-drivers/phidgets_drivers/issues/17>.
* Contributors: Michael Grupp, Martin Günther
```
