### PR TITLE
laser_proc: 0.1.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1569,6 +1569,12 @@ repositories:
       type: git
       url: https://github.com/ros-perception/laser_pipeline.git
       version: hydro-devel
+  laser_proc:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/laser_proc-release.git
+      version: 0.1.4-0
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `0.1.4-0`:

- upstream repository: git://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros-gbp/laser_proc-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## laser_proc

```
* Install fix for Android.
* Contributors: Chad Rockey
```
