### PR TITLE
plotjuggler: 1.7.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2542,15 +2542,20 @@ repositories:
       version: master
     status: maintained
   plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 1.7.0-0
+      version: 1.7.2-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
       version: master
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `1.7.2-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.7.0-0`

## plotjuggler

```
* Update .travis.yml
* fixed potential thread safety problem
* trying to apply changes discussed in issue #96
* add transport hint
* make hyperlinks clickable by allowing to open external links (#95)
* Contributors: Davide Faconti, Romain Reignier
* Update .travis.yml
* fixed potential thread safety problem
* trying to apply changes discussed in issue #96
* add transport hint
* make hyperlinks clickable by allowing to open external links (#95)
* Contributors: Davide Faconti, Romain Reignier
```
