### PR TITLE
[python-pep8] [ubuntu] wildcard for python2 where possible and added python3 for >trusty

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2299,6 +2299,8 @@ python-pep8:
     pip:
       packages: [pep8]
   ubuntu:
+    bionic: [python-pep8]
+    bionic_python3: [python3-pep8]
     precise: [pep8]
     quantal: [pep8]
     raring: [pep8]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2299,21 +2299,21 @@ python-pep8:
     pip:
       packages: [pep8]
   ubuntu:
-    bionic: [python-pep8]
+    '*': [python-pep8]
+    artful_python3: [python3-pep8]
     bionic_python3: [python3-pep8]
+    cosmic_python3: [python3-pep8]
     precise: [pep8]
     quantal: [pep8]
     raring: [pep8]
     saucy: [pep8]
     trusty: [pep8]
+    trusty_python3: [python3-pep8]
     utopic: [pep8]
     vivid: [pep8]
     wily: [pep8]
-    xenial: [python-pep8]
     xenial_python3: [python3-pep8]
-    yakkety: [python-pep8]
     yakkety_python3: [python3-pep8]
-    zesty: [python-pep8]
     zesty_python3: [python3-pep8]
 python-percol:
   debian:


### PR DESCRIPTION
- https://packages.ubuntu.com/bionic/python-pep8
- https://packages.ubuntu.com/bionic/python3-pep8

- [x] rosdistro_reformat
- [x] nosetests 