### PR TITLE
code_coverage: 0.2.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -350,7 +350,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/code_coverage-gbp.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/mikeferguson/code_coverage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.2.1-0`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.0-0`

## code_coverage

```
* Merge pull request #3 <https://github.com/mikeferguson/code_coverage/issues/3> from mikeferguson/catkin_build_fix
  Add support for catkin_tools (fixes #2 <https://github.com/mikeferguson/code_coverage/issues/2>)
* add information on how to run with catkin_tools
* minor escaping patch to work with catkin_tools
* Contributors: Michael Ferguson
```
