### PR TITLE
moveit_python: 0.3.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2156,7 +2156,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.3.1-0`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.0-0`

## moveit_python

```
* add missing namespace to apply service
* Contributors: Michael Ferguson
```
