### PR TITLE
moveit_python: 0.3.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1964,7 +1964,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.3.1-0`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.0-0`

## moveit_python

```
* add missing namespace to apply service
* Contributors: Michael Ferguson
```
