### PR TITLE
code_coverage: 0.2.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -502,6 +502,21 @@ repositories:
       type: git
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
+  code_coverage:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/code_coverage.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/mikeferguson/code_coverage-gbp.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/code_coverage.git
+      version: master
+    status: developed
   collada_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.2.1-0`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## code_coverage

```
* Merge pull request #3 <https://github.com/mikeferguson/code_coverage/issues/3> from mikeferguson/catkin_build_fix
  Add support for catkin_tools (fixes #2 <https://github.com/mikeferguson/code_coverage/issues/2>)
* add information on how to run with catkin_tools
* minor escaping patch to work with catkin_tools
* Contributors: Michael Ferguson
```
