### PR TITLE
simple_grasping: 0.2.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4565,6 +4565,21 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: lunar
     status: developed
+  simple_grasping:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/simple_grasping-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: master
+    status: maintained
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.2.2-0`:

- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/ros-gbp/simple_grasping-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## simple_grasping

```
* parameterize gripper opening tolerance
* Contributors: Michael Ferguson
```
