### PR TITLE
simple_grasping: 0.2.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4081,6 +4081,21 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: melodic
     status: developed
+  simple_grasping:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/simple_grasping-release.git
+      version: 0.2.2-0
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: master
+    status: maintained
   sophus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.2.2-0`:

- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/ros-gbp/simple_grasping-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## simple_grasping

```
* parameterize gripper opening tolerance
* Contributors: Michael Ferguson
```
