### PR TITLE
open_karto: 1.1.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2616,7 +2616,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/open_karto.git
-      version: melodic-devel
+      version: indigo-devel
     release:
       tags:
         release: release/lunar/{package}/{version}

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2612,6 +2612,21 @@ repositories:
       url: https://github.com/ose-support-ros/omronsentech_camera.git
       version: master
     status: developed
+  open_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/open_karto.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/open_karto-release.git
+      version: 1.1.4-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/open_karto.git
+      version: indigo-devel
+    status: maintained
   open_street_map:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.1.4-0`:

- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## open_karto

```
* update build status badges
* Adds LocalizedRangeScanWithPoints range scan
* Contributors: Michael Ferguson, Russell Toris
```
