### PR TITLE
sparse_bundle_adjustment: 0.3.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4630,6 +4630,21 @@ repositories:
       url: https://github.com/smits/soem.git
       version: master
     status: maintained
+  sparse_bundle_adjustment:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/sparse_bundle_adjustment.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/sparse_bundle_adjustment.git
+      version: indigo-devel
+    status: maintained
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.3.2-0`:

- upstream repository: https://github.com/ros-perception/sparse_bundle_adjustment.git
- release repository: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## sparse_bundle_adjustment

```
* major build/install fixes for the farm
* Contributors: Michael Ferguson
```
