### PR TITLE
teb_local_planner: 0.7.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4757,7 +4757,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.7.4-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.7.3-0`

## teb_local_planner

```
* bugfix in calculateHSignature. Fixes #90 <https://github.com/rst-tu-dortmund/teb_local_planner/issues/90>.
* fixed centroid computation in a special case of polygon-obstacles
* Contributors: Christoph Rösmann
```
