### PR TITLE
teb_local_planner: 0.8.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4203,7 +4203,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.8.1-0`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.8.0-0`

## teb_local_planner

```
* bugfix in calculateHSignature. Fixes #90 <https://github.com/rst-tu-dortmund/teb_local_planner/issues/90>.
* fixed centroid computation in a special case of polygon-obstacles
* Contributors: Christoph Rösmann
```
