### PR TITLE
Removing kvaser_interface due to missing prereqs.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6192,16 +6192,6 @@ repositories:
       type: git
       url: https://github.com/uos/kurt_navigation.git
       version: indigo
-  kvaser_interface:
-    doc:
-      type: git
-      url: https://github.com/astuff/kvaser_interface.git
-      version: release
-    source:
-      type: git
-      url: https://github.com/astuff/kvaser_interface.git
-      version: release
-    status: maintained
   lama:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4782,16 +4782,6 @@ repositories:
       url: https://github.com/ros-industrial/kuka_experimental.git
       version: indigo-devel
     status: developed
-  kvaser_interface:
-    doc:
-      type: git
-      url: https://github.com/astuff/kvaser_interface.git
-      version: release
-    source:
-      type: git
-      url: https://github.com/astuff/kvaser_interface.git
-      version: release
-    status: maintained
   kvh_drivers:
     doc:
       type: git


### PR DESCRIPTION
Building this package requires that a Kvaser-specific library be built on the target system. Since that library is not available in the standard Ubuntu repos (though I do have a PPA for it), the build farm build continues to fail. Removing for now.