### PR TITLE
nonpersistent_voxel_layer: 1.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6680,6 +6680,11 @@ repositories:
       type: git
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nonpersistent_voxel_layer` to `1.1.2-0`:

- upstream repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
- release repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
