### PR TITLE
simple_grasping: 0.3.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4619,7 +4619,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/simple_grasping-release.git
-      version: 0.2.2-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/mikeferguson/simple_grasping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.3.1-0`:

- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/ros-gbp/simple_grasping-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.2-0`

## simple_grasping

```
* insert proper key name
* Contributors: Michael Ferguson
```
