### PR TITLE
pilz_robots: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7735,7 +7735,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.2.2-0
+      version: 0.3.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.3.0-0`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.2-0`

## pilz_robots

```
* separate gripper from the package (update readme, next release to melodic as well)
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* remove dependency on gripper
```

## prbt_support

```
* remove dependency on gripper
```
