### PR TITLE
pilz_robots: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2575,6 +2575,26 @@ repositories:
       url: https://bitbucket.org/AndyZe/pid.git
       version: master
     status: maintained
+  pilz_robots:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/pilz_robots.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pilz_robots
+      - prbt_ikfast_manipulator_plugin
+      - prbt_moveit_config
+      - prbt_support
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PilzDE/pilz_robots-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/PilzDE/pilz_robots.git
+      version: kinetic-devel
+    status: developed
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.3.0-0`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pilz_robots

```
* separate gripper from the package (update readme, next release to melodic as well)
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* remove dependency on gripper
```

## prbt_support

```
* remove dependency on gripper
```
