### PR TITLE
Added python-pika-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2363,6 +2363,13 @@ python-pexpect:
     wily_python3: [python3-pexpect]
     xenial: [python-pexpect]
     xenial_python3: [python3-pexpect]
+python-pika-pip:
+  debian:
+    pip:
+      packages: [pika]
+  ubuntu:
+    pip:
+      packages: [pika]
 python-pip:
   arch: [python2-pip]
   debian: [python-pip]


### PR DESCRIPTION
pika is already available as rosdep but installed via `dpkg`, we required the newer version available via `pip`. I just added the entry since I do not want to break anything. What's the best practice here?