### PR TITLE
dbw_fca_ros: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1873,6 +1873,27 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/dataspeed_pds
       version: default
     status: developed
+  dbw_fca_ros:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dbw_fca_ros
+      version: default
+    release:
+      packages:
+      - dbw_fca
+      - dbw_fca_can
+      - dbw_fca_description
+      - dbw_fca_joystick_demo
+      - dbw_fca_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
+      version: 0.0.1-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/dbw_fca_ros
+      version: default
+    status: maintained
   dbw_mkz_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `0.0.1-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## dbw_fca

```
* Initial release
* Contributors: Kevin Hallenbeck
```

## dbw_fca_can

```
* Initial release
* Contributors: Kevin Hallenbeck
```

## dbw_fca_description

```
* Initial release
* Contributors: Kevin Hallenbeck
```

## dbw_fca_joystick_demo

```
* Initial release
* Contributors: Kevin Hallenbeck
```

## dbw_fca_msgs

```
* Initial release
* Contributors: Kevin Hallenbeck
```
