### PR TITLE
jasper is not available on recent ubuntu/debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1285,7 +1285,9 @@ jack:
   ubuntu: [libjack-jackd2-dev]
 jasper:
   arch: [jasper]
-  debian: [libjasper-dev]
+  debian:
+    jessie: [libjasper-dev]
+    wheezy: [libjasper-dev]
   fedora: [jasper-devel]
   freebsd: [jasper]
   gentoo: [media-libs/jasper]
@@ -1294,7 +1296,21 @@ jasper:
   slackware:
     slackpkg:
       packages: [jasper]
-  ubuntu: [libjasper-dev]
+  ubuntu:
+    lucid: [libjasper-dev]
+    maverick: [libjasper-dev]
+    natty: [libjasper-dev]
+    oneiric: [libjasper-dev]
+    precise: [libjasper-dev]
+    quantal: [libjasper-dev]
+    raring: [libjasper-dev]
+    saucy: [libjasper-dev]
+    trusty: [libjasper-dev]
+    utopic: [libjasper-dev]
+    vivid: [libjasper-dev]
+    wily: [libjasper-dev]
+    xenial: [libjasper-dev]
+    yakkety: [libjasper-dev]
 java:
   arch: [jdk7-openjdk]
   debian:


### PR DESCRIPTION
`libjasper-dev` was removed from debian https://web.archive.org/web/20160402170040/https://release.debian.org/transitions/html/jasper-rm.html
It is not available on Debian Stretch and later, also not available on Ubuntu Zesty and later.

Closes #18173
