### PR TITLE
Adding ros_anomaly_detector to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9778,6 +9778,12 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/ros_additive_manufacturing.git
       version: kinetic
     status: developed
+  ros_anomaly_detector:
+    doc:
+      type: git
+      url: https://github.com/narayave/ros_anomaly_detector.git
+      version: master
+    status: maintained
   ros_canopen:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5588,6 +5588,12 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: kinetic-devel
     status: maintained
+  mh5_anomaly_detector:
+    doc:
+      type: git
+      url: https://github.com/narayave/mh5_anomaly_detector.git
+      version: master
+    status: maintained
   micros_swarm_framework:
     doc:
       type: git
@@ -9778,12 +9784,6 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/ros_additive_manufacturing.git
       version: kinetic
     status: developed
-  ros_anomaly_detector:
-    doc:
-      type: git
-      url: https://github.com/narayave/ros_anomaly_detector.git
-      version: master
-    status: maintained
   ros_canopen:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repo, ros_anomaly_detector, to be indexed and documented on ros.org