### PR TITLE
schunk_modular_robotics: 0.6.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4106,6 +4106,23 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.3.1-0
+  schunk_modular_robotics:
+    doc:
+      type: git
+      url: https://github.com/ipa320/schunk_modular_robotics.git
+      version: melodic_release_candidate
+    release:
+      packages:
+      - schunk_description
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/schunk_modular_robotics-release.git
+      version: 0.6.12-0
+    source:
+      type: git
+      url: https://github.com/ipa320/schunk_modular_robotics.git
+      version: indigo_dev
+    status: maintained
   sick_tim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.12-0`:

- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## schunk_description

```
* Merge pull request #200 <https://github.com/ipa320/schunk_modular_robotics/issues/200> from PilzDE/fix-pg70-urdf-limits
  fix PG+70 limits and simplify collision model
* fix limits and simplify collision model
  The gripper fingers both can move 30mm according to the datasheet
  to give a distance of 60mm between the fingers.
  The _finger_palm_link can be easily simplified as a box geometry
  for faster collision checking.
* Contributors: Joachim Schleicher, Nadia Hammoudeh García
```
