### PR TITLE
schunk_modular_robotics: 0.6.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11531,7 +11531,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.12-0`:

- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.11-0`

## schunk_description

```
* Merge pull request #200 <https://github.com/ipa320/schunk_modular_robotics/issues/200> from PilzDE/fix-pg70-urdf-limits
  fix PG+70 limits and simplify collision model
* fix limits and simplify collision model
  The gripper fingers both can move 30mm according to the datasheet
  to give a distance of 60mm between the fingers.
  The _finger_palm_link can be easily simplified as a box geometry
  for faster collision checking.
* Contributors: Joachim Schleicher, Nadia Hammoudeh García
```

## schunk_libm5api

- No changes

## schunk_modular_robotics

- No changes

## schunk_powercube_chain

- No changes

## schunk_sdh

- No changes

## schunk_simulated_tactile_sensors

- No changes
