### PR TITLE
fake_joint: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2570,6 +2570,25 @@ repositories:
       type: git
       url: https://github.com/neka-nat/ez_interactive_marker.git
       version: kinetic-devel
+  fake_joint:
+    doc:
+      type: git
+      url: https://github.com/tork-a/fake_joint.git
+      version: master
+    release:
+      packages:
+      - fake_joint
+      - fake_joint_driver
+      - fake_joint_launch
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/fake_joint-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/tork-a/fake_joint.git
+      version: master
+    status: developed
   fanuc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fake_joint` to `0.0.2-1`:

- upstream repository: https://github.com/tork-a/fake_joint.git
- release repository: https://github.com/tork-a/fake_joint-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## fake_joint

```
* Add fake_joint meta-package
* Contributors: Ryosuke Tajima
```
