### PR TITLE
adi_driver: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -129,7 +129,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/adi_driver-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/tork-a/adi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_driver` to `1.0.2-0`:

- upstream repository: https://github.com/tork-a/adi_driver.git
- release repository: https://github.com/tork-a/adi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.1-0`

## adi_driver

```
* Add bias estimation service(#13 <https://github.com/tork-a/adi_driver/issues/13>)
  - Add function for bias estimation
  - Add bias estimation time function
  - Remove unnecessary depens on imu_tools
* Add temperature topic(#17 <https://github.com/tork-a/adi_driver/issues/17>)
  - Add topic description to README.md
  - Add mutex lock for data queues in the test script
  - Add test for temperature publishing
* Add circleci badge(#18 <https://github.com/tork-a/adi_driver/issues/18>)
* Adaptation for Circleci 2.0(#16 <https://github.com/tork-a/adi_driver/issues/16>)
  - Add circleci v2.0 config file
* Contributors: Kazuki Takao, Ryosuke Tajima
```
