### PR TITLE
ros_comm: 1.13.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3495,7 +3495,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.13.6-0
+      version: 1.13.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.13.7-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.13.6-0`

## message_filters

```
* rename Python message_filters.Cache.getLastestTime to getLatestTime (#1450 <https://github.com/ros/ros_comm/issues/1450>)
```

## ros_comm

- No changes

## rosbag

```
* add TransportHint options --tcpnodelay and --udp (#1295 <https://github.com/ros/ros_comm/issues/1295>)
* fix check for header first in rosbag play for rate control topic (#1352 <https://github.com/ros/ros_comm/issues/1352>)
```

## rosbag_storage

- No changes

## rosconsole

- No changes

## roscpp

```
* add hasStarted() to Timer API (#1464 <https://github.com/ros/ros_comm/issues/1464>)
* force a rebuild of the pollset on flag changes (#1393 <https://github.com/ros/ros_comm/issues/1393>)
* fix integer overflow for oneshot timers (#1382 <https://github.com/ros/ros_comm/issues/1382>)
* convert the period standard deviation in StatisticsLogger to Duration at the end (#1361 <https://github.com/ros/ros_comm/issues/1361>)
* replace DCL pattern with static variable (#1365 <https://github.com/ros/ros_comm/issues/1365>)
```

## rosgraph

- No changes

## roslaunch

```
* fix "pass_all_args" for roslaunch-check, add nosetest (#1368 <https://github.com/ros/ros_comm/issues/1368>)
* add substitution when loading yaml files (#1354 <https://github.com/ros/ros_comm/issues/1354>)
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* fix some errors in some probably not frequented code paths (#1415 <https://github.com/ros/ros_comm/issues/1415>)
* fix thread problem with get_topics() (#1416 <https://github.com/ros/ros_comm/issues/1416>)
* add rosconsole echo (#1324 <https://github.com/ros/ros_comm/issues/1324>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

```
* add public get_topic_list() function for use in other scripts (#1154 <https://github.com/ros/ros_comm/issues/1154>, #1407 <https://github.com/ros/ros_comm/issues/1407>)
```

## roswtf

- No changes

## topic_tools

```
* check that output topic is valid in demux (#1367 <https://github.com/ros/ros_comm/issues/1367>)
```

## xmlrpcpp

```
* fixes for OSX (#1402 <https://github.com/ros/ros_comm/issues/1402>)
* take XmlRpcValue by *const* ref. in operator<< (#1350 <https://github.com/ros/ros_comm/issues/1350>)
* fix various compiler warnings on bionic (#1325 <https://github.com/ros/ros_comm/issues/1325>)
```
