### PR TITLE
rospack: 2.5.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3877,7 +3877,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.5.0-0
+      version: 2.5.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.5.1-0`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.5.0-0`

## rospack

```
* add run_depend on ros_environment (#88 <https://github.com/ros/rospack/issues/88>)
```
