### PR TITLE
genmsg: 0.5.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1018,7 +1018,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.10-0
+      version: 0.5.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.11-0`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.5.10-0`

## genmsg

```
* use ast.literal_eval instead of eval (#73 <https://github.com/ros/genmsg/issues/73>)
* fix undefined name in case of exception (#75 <https://github.com/ros/genmsg/issues/75>)
```
