### PR TITLE
bond_core: 1.8.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -282,7 +282,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.8.1-0
+      version: 1.8.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.3-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.8.1-0`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Argument to Boost Milliseconds must be integral in Boost >= 1.67 (#37 <https://github.com/ros/bond_core/issues/37>)
  * Argument to Boost milliseconds  must be integral
  * Fix style
  * More consistent type
* Contributors: Paul-Edouard Sarlin
```

## bondpy

- No changes

## smclib

- No changes
