### PR TITLE
simplify python-flake8 and python-flask rules with wildcard

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1152,16 +1152,8 @@ python-fixtures:
   gentoo: [dev-python/fixtures]
   ubuntu: [python-fixtures]
 python-flake8:
-  debian:
-    buster: [python-flake8]
-    jessie: [python-flake8]
-    stretch: [python-flake8]
-  fedora:
-    '21': [python-flake8]
-    '22': [python-flake8]
-    '23': [python-flake8]
-    '24': [python-flake8]
-    heisenbug: [python-flake8]
+  debian: [python-flake8]
+  fedora: [python-flake8]
   gentoo: [dev-python/flake8]
   ubuntu:
     '*': [python-flake8]
@@ -1171,21 +1163,8 @@ python-flask:
   fedora: [python-flask]
   gentoo: [dev-python/flask]
   ubuntu:
-    lucid: [python-flask]
-    maverick: [python-flask]
-    natty: [python-flask]
-    oneiric: [python-flask]
-    precise: [python-flask]
-    quantal: [python-flask]
-    raring: [python-flask]
-    saucy: [python-flask]
-    trusty: [python-flask]
+    '*': [python-flask]
     trusty_python3: [python3-flask]
-    utopic: [python-flask]
-    vivid: [python-flask]
-    wily: [python-flask]
-    xenial: [python-flask]
-    yakkety: [python-flask]
 python-flask-appbuilder-pip:
   debian:
     pip:


### PR DESCRIPTION
Follow-up of #18869 

After this change, the only platform getting a rule while not having a package for it is wheezy.
As it's been EOL for a while I think it's acceptable to not have to maintain individual OS names