### PR TITLE
fetch_open_auto_dock: 0.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -833,11 +833,19 @@ repositories:
       version: melodic-devel
     status: maintained
   fetch_open_auto_dock:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_open_auto_dock.git
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp.git
       version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_open_auto_dock.git
+      version: melodic-devel
     status: maintained
   fetch_tools:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -832,6 +832,13 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_msgs.git
       version: melodic-devel
     status: maintained
+  fetch_open_auto_dock:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp.git
+      version: 0.1.1-0
+    status: maintained
   fetch_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_open_auto_dock` to `0.1.1-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_open_auto_dock.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## fetch_open_auto_dock

```
* First release of auto dock
* Contributors: Russell Toris
```
