### PR TITLE
sparse_bundle_adjustment: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4204,7 +4204,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 0.3.2-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/ros-perception/sparse_bundle_adjustment.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.4.0-0`:

- upstream repository: https://github.com/ros-perception/sparse_bundle_adjustment.git
- release repository: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.2-0`

## sparse_bundle_adjustment

```
* Merge pull request #3 <https://github.com/ros-perception/sparse_bundle_adjustment/issues/3> from moriarty/melodic-devel
  [melodic-devel][18.04] fix compile errors
* [melodic-devel][18.04] fix compile errors
  fix compile errors for newer gcc
* Merge pull request #2 <https://github.com/ros-perception/sparse_bundle_adjustment/issues/2> from ros-perception/maintainer-add
  Adding myself as a maintainer for sparse_bundle_adjustment
* Adding myself as a maintainer for sparse_bundle_adjustment
* Contributors: Alexander Moriarty, Luc Bettaieb, Michael Ferguson
```
