### PR TITLE
pr2_simulator: 2.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8228,7 +8228,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_simulator-release.git
-      version: 2.0.10-0
+      version: 2.0.11-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.11-0`:

- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.0.10-0`

## pr2_controller_configuration_gazebo

- No changes

## pr2_gazebo

```
* Merge pull request #142 <https://github.com/PR2/pr2_simulator/issues/142> from pushkalkatara/kinetic-devel
  Issue #141 <https://github.com/PR2/pr2_simulator/issues/141>
* Issue #141 <https://github.com/PR2/pr2_simulator/issues/141>
* Contributors: Kei Okada, Pushkal Katara
```

## pr2_gazebo_plugins

```
* Merge pull request #140 <https://github.com/PR2/pr2_simulator/issues/140> from furushchev/fix-power-monitor
  fix gazebo_ros_power_monitor plugin
* cleanup pr2_power_monitor plugin codes
* fix to work gazebo_ros_power_monitor plugin
* Contributors: Furushchev, Kei Okada
```

## pr2_simulator

- No changes
