### PR TITLE
mav_comm: 3.3.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6954,10 +6954,11 @@ repositories:
       packages:
       - mav_comm
       - mav_msgs
+      - mav_planning_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.2.0-1
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/ethz-asl/mav_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.0-1`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.2.0-1`

## mav_comm

```
* More utilities and lower level UAV kinematics, see mav_msgs changelog for details.
* 2D polygon planning msgs, see planings_msgs changelog for details.
```

## mav_msgs

```
* Add time conversion utilities.
* Add motor position and force default topics.
* Add conversion from pose message to Eigen trajectory point.
* Add angular accelerations as member of EigenMavState to calculate motor speeds.
* Contributors: Helen Oleynikova, Karen Bodie, Rik Bähnemann
```

## mav_planning_msgs

```
* Add 2D polygon messages and services.
* Add ROS and Eigen conversions.
* Add standard services and trajectory messages.
* Add mav_planning_msgs
* Contributors: Helen Oleynikova, Rik Bähnemann
```
