### PR TITLE
mav_comm: 3.2.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5448,6 +5448,10 @@ repositories:
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
       version: 1.0.8-0
   mav_comm:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
     release:
       packages:
       - mav_comm
@@ -5455,7 +5459,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.2.0-1
+      version: 3.2.0-2
+    source:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: 3.3.3
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.2.0-2`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.2.0-1`

## mav_comm

```
* See mav_msgs changelog for details.
```

## mav_msgs

```
* Access covariance in eigen odometry
* External force default topic
* External wind speed default topic
```
