### PR TITLE
mav_comm: 3.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1965,6 +1965,24 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: master
     status: developed
+  mav_comm:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: 3.3.0
+    release:
+      packages:
+      - mav_comm
+      - mav_msgs
+      - mav_planning_msgs
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ethz-asl/mav_comm-release.git
+      version: 3.3.0-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: 3.3.0
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.0-0`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## mav_comm

```
* More utilities and lower level UAV kinematics, see mav_msgs changelog for details.
* 2D polygon planning msgs, see planings_msgs changelog for details.
```

## mav_msgs

```
* Add time conversion utilities.
* Add motor position and force default topics.
* Add conversion from pose message to Eigen trajectory point.
* Add angular accelerations as member of EigenMavState to calculate motor speeds.
* Contributors: Helen Oleynikova, Karen Bodie, Rik Bähnemann
```

## mav_planning_msgs

```
* Add 2D polygon messages and services.
* Add ROS and Eigen conversions.
* Add standard services and trajectory messages.
* Add mav_planning_msgs
* Contributors: Helen Oleynikova, Rik Bähnemann
```
