### PR TITLE
mav_comm: 3.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5448,14 +5448,23 @@ repositories:
       url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
       version: 1.0.8-0
   mav_comm:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
     release:
       packages:
       - mav_comm
       - mav_msgs
+      - mav_planning_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.2.0-1
+      version: 3.3.0-1
+    source:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.0-1`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.2.0-1`

## mav_comm

```
* More utilities and lower level UAV kinematics, see mav_msgs changelog for details.
* 2D polygon planning msgs, see planings_msgs changelog for details.
```

## mav_msgs

```
* Add time conversion utilities.
* Add motor position and force default topics.
* Add conversion from pose message to Eigen trajectory point.
* Add angular accelerations as member of EigenMavState to calculate motor speeds.
* Contributors: Helen Oleynikova, Karen Bodie, Rik Bähnemann
```

## mav_planning_msgs

```
* Add 2D polygon messages and services.
* Add ROS and Eigen conversions.
* Add standard services and trajectory messages.
* Add mav_planning_msgs
* Contributors: Helen Oleynikova, Rik Bähnemann
```
