### PR TITLE
EOL Artful

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,7 +8,6 @@ release_platforms:
   fedora:
   - '28'
   ubuntu:
-  - artful
   - bionic
 repositories:
   abseil_cpp:


### PR DESCRIPTION
Last sync for artful [is out](https://discourse.ros.org/t/new-packages-for-melodic-2018-08-20/5798). Removing it from the distro file so that bloom doesn't generate metadata for it anymore.