### PR TITLE
py_trees: 0.6.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2727,7 +2727,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.6.1-0`:

- upstream repository: https://github.com/stonier/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.0-0`

## py_trees

```
* Oneshot bugfix - no longer permanently modifies the original class
```
