### PR TITLE
py_trees_msgs: 0.3.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2734,6 +2734,17 @@ repositories:
       url: https://github.com/stonier/py_trees.git
       version: devel
     status: maintained
+  py_trees_msgs:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees_msgs.git
+      version: release/0.3-melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stonier/py_trees_msgs-release.git
+      version: 0.3.5-0
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.3.5-0`:

- upstream repository: https://github.com/stonier/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`
