### PR TITLE
rc_visard: 2.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3294,7 +3294,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.2.0-0
+      version: 2.3.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.3.0-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.2.0-0`

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

```
* read params from parameter server before falling back to current device params
* New image topics ...out1_low and ...out1_high are offered if iocontrol module is available
```
