### PR TITLE
mav_comm: 3.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5460,11 +5460,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.3.0-1
+      version: 3.3.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/mav_comm.git
       version: master
+    status: developed
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.1-0`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.3.0-1`

## mav_comm

```
* Change maintainer.
* Add dependencies, see planning_msgs changelog for details.
```

## mav_msgs

```
* Fix Eigen3 warning. Migration from Jade.
* Change maintainer.
```

## mav_planning_msgs

```
* Fix Eigen3 warning. Migration from Jade.
* Add std_msgs, eigen and cmake_modules dependencies.
```
