### PR TITLE
mav_comm: 3.3.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1978,7 +1978,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.3.0-1
+      version: 3.3.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/mav_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.1-0`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.3.0-1`

## mav_comm

```
* Change maintainer.
* Add dependencies, see planning_msgs changelog for details.
```

## mav_msgs

```
* Fix Eigen3 warning. Migration from Jade.
* Change maintainer.
```

## mav_planning_msgs

```
* Fix Eigen3 warning. Migration from Jade.
* Add std_msgs, eigen and cmake_modules dependencies.
```
