### PR TITLE
mav_comm: 3.3.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1785,6 +1785,25 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: master
     status: developed
+  mav_comm:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
+    release:
+      packages:
+      - mav_comm
+      - mav_msgs
+      - mav_planning_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ethz-asl/mav_comm-release.git
+      version: 3.3.1-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/mav_comm.git
+      version: master
+    status: developed
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.1-0`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## mav_comm

```
* Change maintainer.
* Add dependencies, see planning_msgs changelog for details.
```

## mav_msgs

```
* Fix Eigen3 warning. Migration from Jade.
* Change maintainer.
```

## mav_planning_msgs

```
* Fix Eigen3 warning. Migration from Jade.
* Add std_msgs, eigen and cmake_modules dependencies.
```
