### PR TITLE
sparse_bundle_adjustment: 0.4.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4222,7 +4222,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros-perception/sparse_bundle_adjustment.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.4.1-0`:

- upstream repository: https://github.com/ros-perception/sparse_bundle_adjustment.git
- release repository: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.4.0-0`

## sparse_bundle_adjustment

```
* Merge pull request #4 <https://github.com/ros-perception/sparse_bundle_adjustment/issues/4> from moriarty/eigen-and-pkg-fmt-2
  Fixes Eigen3 warnings and bumps to package.xml format 2
* Update email address so I see build failures
* [REP-140] Package.xml format 2
* fix deprecated eigen3 cmake warning
* Contributors: Alexnader Moriarty, Michael Ferguson, Steffen Fuchs
```
