### PR TITLE
slam_karto: 0.8.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4206,6 +4206,21 @@ repositories:
       url: https://github.com/mikeferguson/simple_grasping.git
       version: master
     status: maintained
+  slam_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/slam_karto-release.git
+      version: 0.8.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: melodic-devel
+    status: maintained
   sophus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.8.0-0`:

- upstream repository: https://github.com/ros-perception/slam_karto.git
- release repository: https://github.com/ros-gbp/slam_karto-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## slam_karto

```
* update maintainer email
* Merge pull request #19 <https://github.com/ros-perception/slam_karto/issues/19> from ros-perception/maintainer-add
  Adding myself as a maintainer for slam_karto
* Adding myself as a maintainer for slam_karto
* Merge pull request #15 <https://github.com/ros-perception/slam_karto/issues/15> from jasonimercer/lock-fix
  Fixed locks so they stay in scope until the end of the method.
* Fixed locks so they stay in scope until the end of the method.
* Merge pull request #14 <https://github.com/ros-perception/slam_karto/issues/14> from xpharry/indigo-devel
  modify for stage simulation
* modify for stage simulation
* Merge pull request #9 <https://github.com/ros-perception/slam_karto/issues/9> from hvpandya/patch-1
  Update karto_slam.launch
* Update karto_slam.launch
  package name must be slam_karto
* Contributors: Harsh Pandya, Jason Mercer, Luc Bettaieb, Michael Ferguson, xpharry
```
