### PR TITLE
slam_karto: 0.7.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4697,6 +4697,21 @@ repositories:
       url: https://github.com/ros-perception/slam_gmapping.git
       version: hydro-devel
     status: unmaintained
+  slam_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/slam_karto-release.git
+      version: 0.7.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: indigo-devel
+    status: maintained
   soem:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.7.3-0`:

- upstream repository: https://github.com/ros-perception/slam_karto.git
- release repository: https://github.com/ros-gbp/slam_karto-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## slam_karto

```
* fixed the upside-down detection
* update maintainer email
* Contributors: Michael Ferguson, mgerdzhev
```
