### PR TITLE
tf2_web_republisher: 0.3.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4898,6 +4898,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  tf2_web_republisher:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
+      version: 0.3.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: master
+    status: maintained
   towr:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `0.3.2-0`:

- upstream repository: https://github.com/RobotWebTools/tf2_web_republisher.git
- release repository: https://github.com/RobotWebTools-release/tf2_web_republisher-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## tf2_web_republisher

```
* Merge pull request #25 <https://github.com/RobotWebTools/tf2_web_republisher/issues/25> from VictorLamoine/develop
  Fix compilation with c++11
* add rostest
* Update travis configuration to test against kinetic (#24 <https://github.com/RobotWebTools/tf2_web_republisher/issues/24>)
* Merge pull request #22 <https://github.com/RobotWebTools/tf2_web_republisher/issues/22> from daniel86/develop
  Added dependency to message_generation and message_runtime
* Contributors: Daniel Bessler, Jihoon Lee, Nils Berg, Victor Lamoine
```
