### PR TITLE
Adding komodo_2.0 to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4541,7 +4541,7 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_soft.git
       version: kinetic
     status: maintained
-  komodo_2.0:
+  komodo2:
     doc:
       type: git
       url: https://github.com/robotican/komodo_2.0.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4544,11 +4544,11 @@ repositories:
   komodo_2.0:
     doc:
       type: git
-      url: http://wiki.ros.org/komodo2
+      url: https://github.com/robotican/komodo_2.0.git
       version: kinetic
     source:
       type: git
-      url: https://github.com/robotican/komodo_2.0
+      url: https://github.com/robotican/komodo_2.0.git
       version: kinetic
     status: maintained
   korg_nanokontrol:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4541,6 +4541,16 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_soft.git
       version: kinetic
     status: maintained
+  komodo_2.0:
+    doc:
+      type: git
+      url: http://wiki.ros.org/komodo2
+      version: kinetic
+    source:
+      type: git
+      url: https://github.com/robotican/komodo_2.0
+      version: kinetic
+    status: maintained
   korg_nanokontrol:
     doc:
       type: git


### PR DESCRIPTION
i'd like komodo_2.0 to be indexed and documented on ros.org