### PR TITLE
Add python-pixel-ring-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2350,6 +2350,16 @@ python-pip:
   fedora: [python-pip]
   gentoo: [dev-python/pip]
   ubuntu: [python-pip]
+python-pixel-ring-pip:
+  debian:
+    pip:
+      packages: [pixel-ring]
+  fedora:
+    pip:
+      packages: [pixel-ring]
+  ubuntu:
+    pip:
+      packages: [pixel-ring]
 python-pkg-resources:
   debian: [python-pkg-resources]
   ubuntu: [python-pkg-resources]


### PR DESCRIPTION
Add `pixel-ring` PYPI module.
This module is an interface for controlling RGB LED for ReSpeaker USB 6+1 Microphone Array.
https://pypi.org/project/pixel-ring/

Link to the product:
https://www.seeedstudio.com/ReSpeaker-Mic-Array-v2.0-p-3053.html