### PR TITLE
trac_ik: 1.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4427,6 +4427,27 @@ repositories:
       url: https://github.com/ethz-adrl/towr.git
       version: master
     status: developed
+  trac_ik:
+    doc:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    release:
+      packages:
+      - trac_ik
+      - trac_ik_examples
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
+      - trac_ik_python
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/traclabs/trac_ik-release.git
+      version: 1.5.0-0
+    source:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: master
+    status: maintained
   tracetools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.5.0-0`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## trac_ik

```
* Switch to C++-11 threads and pointers instead of Boost
```
