### PR TITLE
trac_ik: 1.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4453,7 +4453,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.5.0-0
+      version: 1.5.0-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.5.0-1`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.5.0-0`

## trac_ik

```
* Switch to C++-11 threads and pointers instead of Boost
```
