### PR TITLE
sparse_bundle_adjustment: 0.4.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4737,7 +4737,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 0.3.2-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros-perception/sparse_bundle_adjustment.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.4.2-0`:

- upstream repository: https://github.com/ros-perception/sparse_bundle_adjustment.git
- release repository: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.2-0`

## sparse_bundle_adjustment

```
* rework how we set the C++ standard
* Merge pull request #6 <https://github.com/ros-perception/sparse_bundle_adjustment/issues/6> from moriarty/set-cpp-11
  Set C++ 11
* [Maintainers] Add myself as a maintainer
  Mostly so that I can see build failures.
* [CMake][C++11] compile with -std=c++11
* Contributors: Alexander Moriarty, Michael Ferguson
```
