### PR TITLE
roscpp_core: 0.6.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10258,7 +10258,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.9-0
+      version: 0.6.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.11-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.9-0`

## cpp_common

- No changes

## roscpp_serialization

```
* replace reinterpret_cast with memcpy to avoid undefined behaviour/alignment issues (#83 <https://github.com/ros/roscpp_core/issues/83>)
```

## roscpp_traits

- No changes

## rostime

```
* argument to boost microseconds must be integral for Boost 1.67 and newer compatibility (#79 <https://github.com/ros/roscpp_core/issues/79>)
* remove empty destructor of TimeBase (which makes TimeBase, Time and WallTime trivially copyable) (#82 <https://github.com/ros/roscpp_core/issues/82>)
```
