### PR TITLE
ros_comm: 1.12.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9887,7 +9887,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.13-0
+      version: 1.12.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.14-0`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.12.13-0`

## message_filters

```
* rename Python message_filters.Cache.getLastestTime to getLatestTime (#1450 <https://github.com/ros/ros_comm/issues/1450>)
```

## ros_comm

- No changes

## rosbag

```
* add TransportHint options --tcpnodelay and --udp (#1295 <https://github.com/ros/ros_comm/issues/1295>)
* fix check for header first in rosbag play for rate control topic (#1352 <https://github.com/ros/ros_comm/issues/1352>)
```

## rosbag_storage

- No changes

## rosconsole

- No changes

## roscpp

```
* add hasStarted() to Timer API (#1464 <https://github.com/ros/ros_comm/issues/1464>)
* force a rebuild of the pollset on flag changes (#1393 <https://github.com/ros/ros_comm/issues/1393>)
* fix integer overflow for oneshot timers (#1382 <https://github.com/ros/ros_comm/issues/1382>)
* convert the period standard deviation in StatisticsLogger to Duration at the end (#1361 <https://github.com/ros/ros_comm/issues/1361>)
* replace DCL pattern with static variable (#1365 <https://github.com/ros/ros_comm/issues/1365>)
```

## rosgraph

- No changes

## roslaunch

```
* fix "pass_all_args" for roslaunch-check, add nosetest (#1368 <https://github.com/ros/ros_comm/issues/1368>)
* add substitution when loading yaml files (#1354 <https://github.com/ros/ros_comm/issues/1354>)
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* fix some errors in some probably not frequented code paths (#1415 <https://github.com/ros/ros_comm/issues/1415>)
* fix thread problem with get_topics() (#1416 <https://github.com/ros/ros_comm/issues/1416>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* check that output topic is valid in demux (#1367 <https://github.com/ros/ros_comm/issues/1367>)
```

## xmlrpcpp

```
* take XmlRpcValue by *const* ref. in operator<< (#1350 <https://github.com/ros/ros_comm/issues/1350>)
```
