### PR TITLE
mav_comm: 3.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5460,7 +5460,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.3.1-0
+      version: 3.3.2-0
     source:
       type: git
       url: https://github.com/ethz-asl/mav_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.2-0`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.3.1-0`

## mav_comm

```
* Fix indigo eigen3 compatibility.
```

## mav_msgs

```
* Fix indigo eigen3 compatibility.
```

## mav_planning_msgs

```
* Fix indigo eigen3 compatibility.
```
