### PR TITLE
mav_comm: 3.3.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1978,7 +1978,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ethz-asl/mav_comm-release.git
-      version: 3.3.1-0
+      version: 3.3.2-0
     source:
       type: git
       url: https://github.com/ethz-asl/mav_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mav_comm` to `3.3.2-0`:

- upstream repository: https://github.com/ethz-asl/mav_comm.git
- release repository: https://github.com/ethz-asl/mav_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.3.1-0`

## mav_comm

```
* Fix indigo eigen3 compatibility.
```

## mav_msgs

```
* Fix indigo eigen3 compatibility.
```

## mav_planning_msgs

```
* Fix indigo eigen3 compatibility.
```
