### PR TITLE
code_coverage: 0.2.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -353,7 +353,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/code_coverage-gbp.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/mikeferguson/code_coverage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.2.3-0`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.2-0`

## code_coverage

```
* Merge pull request #7 <https://github.com/mikeferguson/code_coverage/issues/7> from jschleicher/fix/installed_package
  fix search path for installed package
* fix search path for installed package
  Closes #6 <https://github.com/mikeferguson/code_coverage/issues/6>
* Contributors: Joachim Schleicher, Michael Ferguson
```
