### PR TITLE
py_trees_ros: 0.5.14-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2779,6 +2779,21 @@ repositories:
       url: https://github.com/stonier/py_trees_msgs-release.git
       version: 0.3.5-0
     status: maintained
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees_ros.git
+      version: release/0.5-melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros-release.git
+      version: 0.5.14-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees_ros.git
+      version: release/0.5-melodic
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.14-0`:

- upstream repository: https://github.com/stonier/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
