### PR TITLE
rqt_py_trees: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3903,6 +3903,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: master
     status: maintained
+  rqt_py_trees:
+    doc:
+      type: git
+      url: https://github.com/stonier/rqt_py_trees.git
+      version: release/0.3-melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stonier/rqt_py_trees-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/rqt_py_trees.git
+      version: release/0.3-melodic
+    status: maintained
   rqt_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_trees` to `0.3.0-0`:

- upstream repository: https://github.com/stonier/rqt_py_trees.git
- release repository: https://github.com/stonier/rqt_py_trees-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rqt_py_trees

```
* getting ready for first kinetic release
```
