### PR TITLE
fiducials: 0.8.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2668,7 +2668,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.8.3-0
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.8.3-1`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.8.3-0`

## aruco_detect

```
* Merge pull request #100 <https://github.com/UbiquityRobotics/fiducials/issues/100> from alex-gee/kinetic-devel
* Add dictionary parameter to launch file
* Contributors: Alexander Gutenkunst, Rohan Agrawal
```

## fiducial_msgs

- No changes

## fiducial_slam

```
* Keep publishing map -> odom tf even if not fiducials are visible (#103 <https://github.com/UbiquityRobotics/fiducials/issues/103>)
* Contributors: Jim Vaughan
```

## fiducials

- No changes
