### PR TITLE
urg_stamped: 0.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5070,6 +5070,21 @@ repositories:
       url: https://github.com/ros-drivers/urg_node.git
       version: indigo-devel
     status: maintained
+  urg_stamped:
+    doc:
+      type: git
+      url: https://github.com/seqsense/urg_stamped.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/seqsense/urg_stamped-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/seqsense/urg_stamped.git
+      version: master
+    status: developed
   usb_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.2-0`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## urg_stamped

```
* Fix license in manifest (#39 <https://github.com/seqsense/urg_stamped/issues/39>)
* Update README (#36 <https://github.com/seqsense/urg_stamped/issues/36>)
* Estimate sub-millisecond timestamp (#35 <https://github.com/seqsense/urg_stamped/issues/35>)
  
    * Estimate sub-millisecond timestamp by complementary filter fusing timestamp and packet arrival time
    * Add packet arrival time outlier removal
    * Add zero-delay moving average
    * Add unit tests for filters
  
* Add build matrix for ROS indigo/kinetic/melodic (#38 <https://github.com/seqsense/urg_stamped/issues/38>)
  
    * Add build matrix
    * Fix workspace init
    * Fix rosdep argument
    * Fold test details
    * Fix test for latest g++
  
* Merge pull request #34 <https://github.com/seqsense/urg_stamped/issues/34> from seqsense/update-manifest-format
* Update manifest format
* Receive both MD and ME response by one callback (#33 <https://github.com/seqsense/urg_stamped/issues/33>)
* Make some info messages debug level (#30 <https://github.com/seqsense/urg_stamped/issues/30>)
* Fix step chage of estimated time origin (#28 <https://github.com/seqsense/urg_stamped/issues/28>)
* Update CI settings (#26 <https://github.com/seqsense/urg_stamped/issues/26>)
* Apply Apache License 2.0 (#25 <https://github.com/seqsense/urg_stamped/issues/25>)
* Add periodic communication delay estimation (#23 <https://github.com/seqsense/urg_stamped/issues/23>)
  
    * Add periodic communication delay estimation
    * Make timeSync and delayEstimation exclusive
    * Retry TM command if not responded
    * Reduce duration for delay estimation
  
* Fix time origin calculation (#21 <https://github.com/seqsense/urg_stamped/issues/21>)
  
    * Fix delay check
    * Estimate time using received time and estimated delay
    * Fix time origin calculation
  
* Randomize time sync timing (#20 <https://github.com/seqsense/urg_stamped/issues/20>)
* Tweak UTM behavior with intensity (#18 <https://github.com/seqsense/urg_stamped/issues/18>)
* Fix II response parsing on UTM (#17 <https://github.com/seqsense/urg_stamped/issues/17>)
* Add TCP connection watchdog (#15 <https://github.com/seqsense/urg_stamped/issues/15>)
* Handle device timestamp overflow (#12 <https://github.com/seqsense/urg_stamped/issues/12>)
  
    * Handle device timestamp overflow
    * Add test for Walltime
  
* Add test for Decoder (#14 <https://github.com/seqsense/urg_stamped/issues/14>)
* Validate checksum (#11 <https://github.com/seqsense/urg_stamped/issues/11>)
* Add publish_intensity parameter (#9 <https://github.com/seqsense/urg_stamped/issues/9>)
* Fix clock gain estimation (#7 <https://github.com/seqsense/urg_stamped/issues/7>)
  
    * Rely on sinle clock gain estimation
  
* Make debug outputs detailed (#6 <https://github.com/seqsense/urg_stamped/issues/6>)
* Add CI (#4 <https://github.com/seqsense/urg_stamped/issues/4>)
  
    * Add CI
    * Fix lint errors
  
* Estimate device clock gain (#3 <https://github.com/seqsense/urg_stamped/issues/3>)
* Increase outlier removal thresholds
* Fix message header
* Fix boost placeholder namespace
* Calculate timestamp in system time
* Use urg_node compatible parameter names
* Change path and namespace to scip2
* Add communication delay estimation
* Output LaserScan messages
* Add stream data processors
* Add parameter response processors
* Add base protocol layer
* Add TCP connection layer
* Contributors: Atsushi Watanabe, So Jomura, jojo43
```
