### PR TITLE
fiducials: 0.8.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2668,7 +2668,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.8.3-0
+      version: 0.8.4-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.8.4-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.8.3-0`

## aruco_detect

```
* Use publish_images param as intended (#106 <https://github.com/UbiquityRobotics/fiducials/issues/106>)
* Update README.md
* Contributors: Jim Vaughan
```

## fiducial_msgs

- No changes

## fiducial_slam

```
* Don't publish pose if camera position is not known
* Update README.md
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducials

- No changes
