### PR TITLE
Add clang-tidy rosdep keys for debian and ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -400,6 +400,13 @@ clang-format:
     stretch: [clang-format]
   gentoo: [sys-devel/clang]
   ubuntu: [clang-format]
+clang-tidy:
+  debian:
+    buster: [clang-tidy]
+    stretch: [clang-tidy]
+  ubuntu:
+    '*': [clang-tidy]
+    trusty: null
 cmake:
   alpine: [cmake]
   arch: [cmake]


### PR DESCRIPTION
Adding the following keys for `clang-tidy`:

- Ubuntu: https://packages.ubuntu.com/search?keywords=clang-tidy
- Debian Stretch: https://packages.debian.org/stretch/clang-tidy
- Debian Buster: https://packages.debian.org/buster/clang-tidy

There's a gentoo package named `clang`, but i'm very unfamiliar with gentoo and was unable to determine if it has `clang-tidy` contained within, so I left it out. If I need to add it back in let me know. Didn't see anything for Fedora.