### PR TITLE
change lunar branch for open_karto

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2654,7 +2654,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/open_karto.git
-      version: indigo-devel
+      version: melodic-devel
     release:
       tags:
         release: release/lunar/{package}/{version}
@@ -2663,7 +2663,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/open_karto.git
-      version: indigo-devel
+      version: melodic-devel
     status: maintained
   open_street_map:
     doc:


### PR DESCRIPTION
We ended up releasing the melodic-devel version of sparse_bundle_adjustment, migrating open/slam_karto one at a time to match