### PR TITLE
add dpkg-dev and debhelper to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -561,6 +561,10 @@ daemontools:
   debian: [daemontools]
   gentoo: [virtual/daemontools]
   ubuntu: [daemontools]
+debhelper:
+  debian: [debhelper]
+  fedora: [debhelper]
+  ubuntu: [debhelper]
 debtree:
   debian: [debtree]
   ubuntu: [debtree]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -609,6 +609,10 @@ dpkg:
   fedora: [dpkg]
   gentoo: [app-arch/dpkg]
   ubuntu: [dpkg]
+dpkg-dev:
+  debian: [dpkg-dev]
+  fedora: [dpkg-dev]
+  ubuntu: [dpkg-dev]
 dvipng:
   arch: [texlive-bin]
   debian: [dvipng]


### PR DESCRIPTION
I want to add debhelper and dpkg-dev package to rosdep in order to build our ros packeage as a single dpkg file.

This is the debhelper and dpkg-dev package description URL

1.debhelper
[Debian](https://packages.debian.org/sid/debhelper)
[Fedora](https://apps.fedoraproject.org/packages/debhelper)
[Ubuntu](https://packages.ubuntu.com/xenial/debhelper)

2.dpkg-dev
[Debian](https://packages.debian.org/stretch/dpkg-dev)
[Fedora](https://apps.fedoraproject.org/packages/dpkg-dev)
[Ubuntu](https://packages.ubuntu.com/xenial/dpkg-dev)