### PR TITLE
ira_laser_tools: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4257,11 +4257,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
-      version: 1.0.0-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
       version: kinetic
+    status: developed
   ivcon:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ira_laser_tools` to `1.0.2-0`:

- upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
- release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`

## ira_laser_tools

```
* add libvtk-qt dependency to fix debian stretch builds
  and link to paper in README.md
* Contributors: Pietro Colombo
```
