### PR TITLE
static_tf: 0.0.2-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15337,7 +15337,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wu-robotics/static_tf_release.git
-      version: 0.0.1-1
+      version: 0.0.2-2
     source:
       type: git
       url: https://github.com/DLu/static_tf.git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_tf` to `0.0.2-2`:

- upstream repository: https://github.com/DLu/static_tf.git
- release repository: https://github.com/wu-robotics/static_tf_release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.1-1`
