### PR TITLE
static_tf: 0.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4786,6 +4786,21 @@ repositories:
       url: https://github.com/ros-simulation/stage_ros.git
       version: lunar-devel
     status: maintained
+  static_tf:
+    doc:
+      type: git
+      url: https://github.com/DLu/static_tf.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/wu-robotics/static_tf_release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/DLu/static_tf.git
+      version: master
+    status: maintained
   std_capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_tf` to `0.0.2-0`:

- upstream repository: https://github.com/DLu/static_tf.git
- release repository: https://github.com/wu-robotics/static_tf_release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
