### PR TITLE
laser_filtering: 0.0.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1723,6 +1723,24 @@ repositories:
       url: https://github.com/ros-perception/laser_assembler.git
       version: hydro-devel
     status: maintained
+  laser_filtering:
+    doc:
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: hydro_devel
+    release:
+      packages:
+      - laser_filtering
+      - map_laser
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/wu-robotics/laser_filtering_release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: hydro_devel
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filtering` to `0.0.4-0`:

- upstream repository: https://github.com/DLu/laser_filtering.git
- release repository: https://github.com/wu-robotics/laser_filtering_release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
