### PR TITLE
pr2_mechanism_msgs: 1.8.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3072,6 +3072,17 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pr2_mechanism_msgs:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_mechanism_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
+      version: 1.8.2-0
+    status: unmaintained
   pyros_config:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism_msgs` to `1.8.2-0`:

- upstream repository: https://github.com/PR2/pr2_mechanism_msgs.git
- release repository: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pr2_mechanism_msgs

```
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
