### PR TITLE
pr2_mechanism_msgs: 1.8.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2770,6 +2770,17 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
       version: 0.3.0-0
     status: maintained
+  pr2_mechanism_msgs:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_mechanism_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
+      version: 1.8.2-0
+    status: unmaintained
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism_msgs` to `1.8.2-0`:

- upstream repository: https://github.com/PR2/pr2_mechanism_msgs.git
- release repository: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pr2_mechanism_msgs

```
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
