### PR TITLE
rosdep : add qtdeclarative5-dev (QtQml and QtQuick)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2925,13 +2925,6 @@ libqt5x11extras5-dev:
   freebsd: [qt5-x11extras]
   gentoo: ['dev-qt/qtx11extras:5']
   ubuntu: [libqt5x11extras5-dev]
-qtdeclarative5-dev:
-  arch: [qt5-declarative]
-  debian: [qtdeclarative5-dev]
-  fedora: [qt5-qtdeclarative-devel]
-  freebsd: [qt5-qml, qt5-quick]
-  gentoo: ['dev-qt/qtdeclarative:5']
-  ubuntu: [qtdeclarative5-dev]
 libqtgui4:
   arch: [qt4]
   debian: [libqtgui4]
@@ -4364,6 +4357,13 @@ qtbase5-dev:
   opensuse: [libqt5-qtbase-common-devel, libqt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qtbase5-dev]
+qtdeclarative5-dev:
+  arch: [qt5-declarative]
+  debian: [qtdeclarative5-dev]
+  fedora: [qt5-qtdeclarative-devel]
+  freebsd: [qt5-qml, qt5-quick]
+  gentoo: ['dev-qt/qtdeclarative:5']
+  ubuntu: [qtdeclarative5-dev]
 qtmobility-dev:
   arch: [qtmobility]
   debian: [qtmobility-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2925,6 +2925,13 @@ libqt5x11extras5-dev:
   freebsd: [qt5-x11extras]
   gentoo: ['dev-qt/qtx11extras:5']
   ubuntu: [libqt5x11extras5-dev]
+qtdeclarative5-dev:
+  arch: [qt5-declarative]
+  debian: [qtdeclarative5-dev]
+  fedora: [qt5-qtdeclarative-devel]
+  freebsd: [qt5-qml, qt5-quick]
+  gentoo: ['dev-qt/qtdeclarative:5']
+  ubuntu: [qtdeclarative5-dev]
 libqtgui4:
   arch: [qt4]
   debian: [libqtgui4]


### PR DESCRIPTION
Add an entry for the qtdeclarative5 package.

ubuntu : https://packages.ubuntu.com/bionic/qtdeclarative5-dev
debian : https://packages.debian.org/stretch/qtdeclarative5-dev
freebsd : https://www.freshports.org/lang/qt5-qml/ , https://www.freshports.org/x11-toolkits/qt5-quick/
gentoo : https://packages.gentoo.org/packages/dev-qt/qtdeclarative
fedora : https://fedora.pkgs.org/27/fedora-i386/qt5-qtdeclarative-devel-5.9.1-1.fc27.i686.rpm.html
arch : https://www.archlinux.org/packages/extra/x86_64/qt5-declarative/