### PR TITLE
rtctree: 3.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4520,6 +4520,21 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: lunar-devel
     status: maintained
+  rtctree:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rtctree-release.git
+      version: release/hydro/rtctree
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/rtctree-release.git
+      version: 3.0.1-0
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtctree.git
+      version: master
+    status: developed
   rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtctree` to `3.0.1-0`:

- upstream repository: https://github.com/gbiggs/rtctree.git
- release repository: https://github.com/tork-a/rtctree-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
