### PR TITLE
rtsprofile: 2.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4520,6 +4520,21 @@ repositories:
       url: https://github.com/introlab/rtabmap_ros.git
       version: lunar-devel
     status: maintained
+  rtsprofile:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: release/hydro/rtsprofile
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtsprofile.git
+      version: master
+    status: developed
   rtt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsprofile` to `2.0.0-0`:

- upstream repository: https://github.com/gbiggs/rtsprofile.git
- release repository: https://github.com/tork-a/rtsprofile-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
