### PR TITLE
app_manager: 1.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -90,6 +90,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  app_manager:
+    doc:
+      type: git
+      url: https://github.com/pr2/app_manager.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/app_manager-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/pr2/app_manager.git
+      version: kinetic-devel
+    status: unmaintained
   ar_track_alvar:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `app_manager` to `1.1.0-0`:

- upstream repository: https://github.com/pr2/app_manager.git
- release repository: https://github.com/ros-gbp/app_manager-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## app_manager

```
* Support loading installed apps from export tags (#7 <https://github.com/PR2/app_manager//issues/7>)
  * app_manager: add reload_app_list service to dynamically reload apps
  * filter apps by robot platform
  * add support for loading app directories from plugins
* Cleanup unused files (#6 <https://github.com/PR2/app_manager//issues/6>)
* Contributors: Yuki Furuta
```
