### PR TITLE
pr2_kinematics: 1.0.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2770,6 +2770,24 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
       version: 0.3.0-0
     status: maintained
+  pr2_kinematics:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_kinematics.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_arm_kinematics
+      - pr2_kinematics
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_kinematics-release.git
+      version: 1.0.9-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_kinematics.git
+      version: kinetic-devel
+    status: unmaintained
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.9-0`:

- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/pr2-gbp/pr2_kinematics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pr2_arm_kinematics

```
* Merge pull request #10 <https://github.com/pr2/pr2_kinematics/issues/10> from k-okada/use_pose
  PoseMsgToKDL is deperecated use poseMsgToKDL
* Merge pull request #9 <https://github.com/pr2/pr2_kinematics/issues/9> from k-okada/remove_get_solver_info2
  remove GetKinematicsSolverInfo, whcih is deprecated in kinetic
* Merge pull request #8 <https://github.com/pr2/pr2_kinematics/issues/8> from k-okada/add_c11
  add c++11 option for error: ‘shared_ptr’ in namespace ‘std’ does not …
* Merge pull request #7 <https://github.com/pr2/pr2_kinematics/issues/7> from k-okada/orp
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* PoseMsgToKDL is deperecated use poseMsgToKDL
* remove GetKinematicsSolverInfo, whcih is deprecated in kinetic https://github.com/ros-planning/moveit_msgs/issues/3
* add c++11 option for error: ‘shared_ptr’ in namespace ‘std’ does not name a template type typedef std::shared_ptr<Type> Name##Ptr; error
* Contributors: Kei Okada
```

## pr2_kinematics

```
* Merge pull request #11 <https://github.com/pr2/pr2_kinematics/issues/11> from k-okada/orp2
  change maintainer to ROS orphaned package maintainer
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
