### PR TITLE
willow_maps: 1.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4951,6 +4951,21 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  willow_maps:
+    doc:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/willow_maps-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: kinetic-devel
+    status: unmaintained
   wu_ros_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `willow_maps` to `1.0.3-0`:

- upstream repository: https://github.com/pr2/willow_maps.git
- release repository: https://github.com/ros-gbp/willow_maps-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## willow_maps

```
* Merge pull request #2 <https://github.com/pr2/willow_maps/issues/2> from k-okada/fix_cmake
  Fix cmake
* Merge pull request #1 <https://github.com/pr2/willow_maps/issues/1> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* update CMake files
  use download.ros.org instead of code.ros.org/svn
  remove willow-2010-02-18-0.025.pgm and willow-sans-whitelab-2010-02-18-0.025.pgm, whcih are not found in download.ros.org
  add code to install .xml and .pgm files
* change maintainer to ROS orphaned package maintainer
* Changed willow maps names
* Contributors: Kei Okada, TheDash
```
