### PR TITLE
people: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7600,13 +7600,15 @@ repositories:
     release:
       packages:
       - face_detector
+      - leg_detector
       - people
       - people_msgs
       - people_tracking_filter
+      - people_velocity_tracker
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.0.10-1
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.1.0-0`:

- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.10-1`
