### PR TITLE
roscompile: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12740,7 +12740,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/DLu/roscompile.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.0.1-0`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`
