### PR TITLE
roscompile: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10221,7 +10221,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.0.1-0`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`
