### PR TITLE
roscompile: 1.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3758,6 +3758,24 @@ repositories:
       url: https://github.com/RobotWebTools/rosbridge_suite.git
       version: develop
     status: maintained
+  roscompile:
+    doc:
+      type: git
+      url: https://github.com/DLu/roscompile.git
+      version: master
+    release:
+      packages:
+      - ros_introspection
+      - roscompile
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/wu-robotics/roscompile-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/DLu/roscompile.git
+      version: master
+    status: developed
   rosconsole_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.0.1-0`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
