### PR TITLE
roscompile: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3491,6 +3491,24 @@ repositories:
       url: https://github.com/RobotWebTools/rosbridge_suite.git
       version: develop
     status: maintained
+  roscompile:
+    doc:
+      type: git
+      url: https://github.com/DLu/roscompile.git
+      version: master
+    release:
+      packages:
+      - ros_introspection
+      - roscompile
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wu-robotics/roscompile-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/DLu/roscompile.git
+      version: master
+    status: developed
   rosconsole:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.0.1-0`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
