### PR TITLE
Add libspatialite rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3030,6 +3030,16 @@ libsoqt4-dev:
   fedora: [SoQt-devel]
   gentoo: [media-libs/SoQt]
   ubuntu: [libsoqt4-dev]
+libspatialite:
+  arch: [libspatialite]
+  debian:
+    '*': [libsqlite3-mod-spatialite]
+    jessie: [libspatialite5]
+  fedora: [libspatialite]
+  gentoo: ['dev-db/spatialite:0']
+  ubuntu:
+    '*': [libsqlite3-mod-spatialite]
+    trusty: [libspatialite5]
 libspnav-dev:
   arch: [libspnav]
   debian: [libspnav-dev]


### PR DESCRIPTION
This adds a rosdep key for SpatiaLite, a library for loading Spatial SQL
capabilities into a SQLite database:

Documentation: https://www.gaia-gis.it/fossil/libspatialite/index

- Arch: https://www.archlinux.org/packages/community/x86_64/libspatialite/
- Fedora: https://src.fedoraproject.org/rpms/libspatialite
- Debian:
   - Buster: https://packages.debian.org/buster/libsqlite3-mod-spatialite
   - Jessie: https://packages.debian.org/jessie/libspatialite5
   - Sid: https://packages.debian.org/sid/libsqlite3-mod-spatialite
   - Stretch: https://packages.debian.org/stretch/libsqlite3-mod-spatialite
- Gentoo: https://gentoobrowse.randomdan.homeip.net/packages/dev-db/spatialite
- Ubuntu:
   - Artful: https://packages.ubuntu.com/artful/libsqlite3-mod-spatialite
   - Bionic: https://packages.ubuntu.com/bionic/libsqlite3-mod-spatialite
   - Cosmic: https://packages.ubuntu.com/cosmic/libsqlite3-mod-spatialite
   - Trusty: https://packages.ubuntu.com/trusty/libspatialite5
   - Xenial: https://packages.ubuntu.com/xenial/libsqlite3-mod-spatialite