### PR TITLE
pr2_kinematics: 1.0.10-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2870,7 +2870,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_kinematics-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/pr2/pr2_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_kinematics` to `1.0.10-0`:

- upstream repository: https://github.com/PR2/pr2_kinematics.git
- release repository: https://github.com/pr2-gbp/pr2_kinematics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.9-0`

## pr2_arm_kinematics

```
* Merge pull request #12 from PR2/add_travis
  add travis.yml and fix for melodic
* fix for kdl v1.4.0 (melodic), c.f. https://github.com/ros-planning/moveit/pull/906
* Contributors: Kei Okada
```

## pr2_kinematics

- No changes
