### PR TITLE
camera_umd: 0.2.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -252,7 +252,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/camera_umd-release.git
-      version: 0.2.5-0
+      version: 0.2.6-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/camera_umd.git
+      version: master
     status: unmaintained
   cartesian_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_umd` to `0.2.6-0`:

- upstream repository: https://github.com/ros-drivers/camera_umd.git
- release repository: https://github.com/ros-drivers-gbp/camera_umd-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.5-0`

## camera_umd

- No changes

## jpeg_streamer

- No changes

## uvc_camera

```
* Merge pull request #21 <https://github.com/ros-drivers/camera_umd/issues/21> from ros-drivers/add_travis
  add .travis.yml including melodic
* Merge remote-tracking branch 'mikaelarguedas/patch-1' into add_travis
* update to use non deprecated pluginlib macro
* Contributors: Kei Okada, Mikael Arguedas
```
