### PR TITLE
people: 1.1.2-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2958,7 +2958,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.1.0-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.1.2-1`:

- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.0-1`
