### PR TITLE
astuff_sensor_msgs: 2.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -751,7 +751,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 2.2.1-1
+      version: 2.2.2-0
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `2.2.2-0`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.2.1-1`

## astuff_sensor_msgs

- No changes

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

```
* Merge pull request #23 <https://github.com/astuff/astuff_sensor_msgs/issues/23> from ASDeveloper00/bugfix
* MRR detection msg - datatype correction
* Contributors: Joshua Whitley, sepidj
```

## delphi_srr_msgs

- No changes

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

```
* Merge pull request #24 <https://github.com/astuff/astuff_sensor_msgs/issues/24> from astuff/maint/add_none_shift_cmd
* PACMod: Removing unused report values.
* MKZ: Adding NONE value to shift states.
* Contributors: Joshua Whitley, driscoll85
```

## radar_msgs

- No changes
