### PR TITLE
astuff_sensor_msgs: 2.2.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -171,7 +171,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 2.2.1-0
+      version: 2.2.2-0
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `2.2.2-0`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.2.1-0`

## astuff_sensor_msgs

- No changes

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

```
* Merge pull request #23 <https://github.com/astuff/astuff_sensor_msgs/issues/23> from ASDeveloper00/bugfix
* MRR detection msg - datatype correction
* Contributors: Joshua Whitley, sepidj
```

## delphi_srr_msgs

- No changes

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

```
* Merge pull request #24 <https://github.com/astuff/astuff_sensor_msgs/issues/24> from astuff/maint/add_none_shift_cmd
* PACMod: Removing unused report values.
* MKZ: Adding NONE value to shift states.
* Contributors: Joshua Whitley, driscoll85
```

## radar_msgs

- No changes
