### PR TITLE
Added libdlib-dev To The rosdep base.yaml File

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1375,7 +1375,6 @@ libdevil-dev:
   ubuntu: [libdevil-dev]
 libdlib-dev: 
   debian: [libdlib-dev]
-  fedora: [dlib-devel]
   gentoo:
     portage:
       packages: [sci-libs/dlib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1378,7 +1378,9 @@ libdlib-dev:
   gentoo:
     portage:
       packages: [sci-libs/dlib]
-  ubuntu: [libdlib-dev]
+  ubuntu: 
+    '*': [libdlib-dev]
+    trusty: null
 libdmtx-dev:
   arch: [libdmtx]
   debian: [libdmtx-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1373,6 +1373,13 @@ libdevil-dev:
     portage:
       packages: [media-libs/devil]
   ubuntu: [libdevil-dev]
+libdlib-dev: 
+  debian: [libdlib-dev]
+  fedora: [dlib-devel]
+  gentoo:
+    portage:
+      packages: [sci-libs/dlib]
+  ubuntu: [libdlib-dev]
 libdmtx-dev:
   arch: [libdmtx]
   debian: [libdmtx-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1373,12 +1373,12 @@ libdevil-dev:
     portage:
       packages: [media-libs/devil]
   ubuntu: [libdevil-dev]
-libdlib-dev: 
+libdlib-dev:
   debian: [libdlib-dev]
   gentoo:
     portage:
       packages: [sci-libs/dlib]
-  ubuntu: 
+  ubuntu:
     '*': [libdlib-dev]
     trusty: null
 libdmtx-dev:


### PR DESCRIPTION
Rational For Adding Package:
Needed for it's global optimization functions, ie. `find_max_global` and `find_min_global`

Package web listings:
- Debian: https://packages.debian.org/search?keywords=libdlib-dev
- Ubuntu: https://packages.ubuntu.com/xenial/libdlib-dev
- Gentoo: https://packages.gentoo.org/packages/sci-libs/dlib
