### PR TITLE
jog_control: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4359,6 +4359,26 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/jog_arm.git
       version: kinetic
     status: developed
+  jog_control:
+    doc:
+      type: git
+      url: https://github.com/tork-a/jog_control.git
+      version: master
+    release:
+      packages:
+      - jog_control
+      - jog_controller
+      - jog_launch
+      - jog_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/jog_control-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/tork-a/jog_control.git
+      version: master
+    status: developed
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jog_control` to `0.0.1-0`:

- upstream repository: https://github.com/tork-a/jog_control.git
- release repository: https://github.com/tork-a/jog_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## jog_control

```
* Prepare for releasing
  * Add jog_control meta-package
* Contributors: Ryosuke Tajima
```

## jog_controller

```
* Prepare for releasing (#28)
  - Add further dpendency
* Migrating rostests from jog_controller to jog_launch (#27)
  - Add waitForTransform for test code
  - make it optional to specify controller_name (should be remove later)
  - Remove unused variable
  - add UR3 and UR3 rostest
  - Adjust joypad scale for more safer control
* Add jog_launch package (#26)
  - Remove running tests(transfer to jog_launch afterwards)
  - Add settings for UR and tra1
* Add joypad descriptions (#24)
* Fix readme (#21)
  - Add how-to description to jog_controller/README.md
  - Add description into tra1_jog.yaml
* Add ur5 tests (#14)
  - Expand queue size for solve test failure
  - Add frame jog test for UR5
  - Add test_jog_frame.py to test jog frame
  - Add UR5 rostest for CMakeLists.txt
  - Add UR5 gazebo test for joint_jog
  - Change to test joint jog around a home position
  - Change to handle the jog command with partial joint names
  - Add initial test file for UR5
* Add config and launch files for hironx (#10)
  - Set default use_joy argument false
* Support precise jog control (#13)
  - Modify vs060 test
  - Modify for precise jog_frame control
  - Add test_jog_joint.py to test precise jog
  - Checking with VS060
* Change to avoid loop in jog control
  - Update reference joint state only if the jog command is not continuous
  - Change jog panel not to publish command when the command is all zero
* Add param exclude joints (#9)
* add config and launch files for hironx.
* Add motoman_sda10f and update README
* Add baxter_fake.launch which use fake_joint_driver
* Add exclude_joint_names param to exclude joint
* Add support for multiple joint_states (#8)
* Add tests and travis (#7)
* Add test for baxter (hztest only)
  - baxter_moveit_config is not released, so it remain disabled
  - Give up TRA1 test until minas is fixed
* Add support for multiple joint_states
  - ex. Baxter produces separated JointStates for grippers
* Add dependency on nextage_moveit_config
* Add exec dependency for nextage_ros_bridge
* Remove launch check templary for travis
* Add Nextage tests (hztest only)
* Fix build dependency
* Add hztest for TRA1
* Fix to obtain correct cinfo for jog_frame_node
* Fix to get first joint state message
* Fix the joy_to_jog_frame node to work
* Fix bug of invalid action name for use_action
  - Baxter will get error because this bug
* Add orientation jog (#5)
  - Improve display panel
  - Add rotation jog
* Change the naming of JogJoint and JogFrame messages (#1)
  - Change jog_msgs member name
* Add baxter settings, improve joint jog (#3)
* Improve joint jog node
  - Support multiple controllers
  - We just specify the list of joint to jog
  - Fix Baxter settings
* Remove controller_name from joint jog setting
* Add baxter settings
* Add action option (#2)
* Add motoman_sia20d jog settings
* Change abb_irb2400 jog settings
* Add time_from_start parameter
* Add use_action option for jog joint node
* Change panel timer to 10Hz
  - To avoid oscilation
  - It may change the response
* Add abb_irb2400 settings
* Add use_action option
* Changes for jog(frame and joint) controllers
  - Organize parameters
  - Check to invalid IK solution
* Add settings for NEXTAGE Open
* Add settings for DENSO VS060
* Modify settings for MOTOMAN sia5d
* Modify setting for UR5 gazebo
* Modify setting for MELFA rv7fl
* Modify setting for TRA1 manipulator
* jog_frame_panel: move_group from list in parameter groups
* Add motoman_sia5d example
* Add jog_joint_panel rviz plugin
* Add documents, quickstart launch files
* Add jog_frame rviz panel plugin
* Add prototype of jog_joint_node
* Add jog_controller/jog_frame_node proto
* Contributors: Ryosuke Tajima, aislab
```

## jog_launch

```
* Prepare for releasing (#28)
* Migrating rostests from jog_controller to jog_launch (#27)
  - Add missing dependency
* Modify nextage's test
  - It expects start_position feature in fake_joint_driver
* Add tra1 tests
  - Purge tra1_bringup from dependency
* Add UR3 rostest
* Change use_rviz default false for test
* add UR3 and UR3 rostest
* Fix wrong link_name for joypad control
* Add jog_launch package (#26)
* Modify document, check it work as it saids
* Reduce launch check for the files not ready
* Move setting files to jog_launch package
* Add settings for UR and tra1
* Contributors: Ryosuke Tajima
```

## jog_msgs

```
* Prepare for releasing
* Change the naming of JogJoint and JogFrame messages (#1)
  * Add documents, quickstart launch files
  * Change joints to joint_names
  * Change the naming of JogJoint and JogFrame messages
  * Add avoid_collisions to JogFrame
* Add jog_msgs package
* Contributors: Ryosuke Tajima
```
