### PR TITLE
jsk_3rdparty: 2.1.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1607,6 +1607,41 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: indigo-devel
     status: maintained
+  jsk_3rdparty:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+      version: master
+    release:
+      packages:
+      - assimp_devel
+      - bayesian_belief_networks
+      - collada_urdf_jsk_patch
+      - downward
+      - ff
+      - ffha
+      - jsk_3rdparty
+      - julius
+      - julius_ros
+      - libcmt
+      - libsiftfast
+      - lpg_planner
+      - mini_maxwell
+      - nlopt
+      - opt_camera
+      - pgm_learner
+      - respeaker_ros
+      - ros_speech_recognition
+      - rospatlite
+      - rosping
+      - rostwitter
+      - slic
+      - voice_text
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/jsk_3rdparty-release.git
+      version: 2.1.11-0
+    status: developed
   jsk_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.11-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## downward

```
* downward: compile with -Wno-maybe-uninitialized to avoid error for 18.04 (#154 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/154>)
* Contributors: Kei Okada
```

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

- No changes

## julius_ros

- No changes

## libcmt

```
* libcmt: opencv2/xfeatures2d.hpp only required between 3.1.0 <= OPENCV_VERSION_CODE < 3.2.0 (#154 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/154>)
* Contributors: Kei Okada
```

## libsiftfast

```
* fix for melodic (#154 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/154>)
  * libsiftfast : add 02.cmake_warn_narrowing.patch 03.skip_python_bindings.patch.bak 04.boost_65_numpy_1_10.patch for 18.04
  * libsiftfast: patch all fiels within pathes directory
* Contributors: Kei Okada
```

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

```
* add nlopt-extras.cmake to set nlopt_INCLUDE_DIR for https://github.com/jsk-ros-pkg/jsk_control/issues/696 (#153 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/153>)
* Contributors: Kei Okada
```

## opt_camera

- No changes

## pgm_learner

- No changes

## respeaker_ros

```
* Add respeaker_ros package (#152 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/152>)
* Contributors: Yuki Furuta
```

## ros_speech_recognition

- No changes

## rospatlite

- No changes

## rosping

```
* run sudo -E and set LD_LIBRARY_PATH, because LD_LIBRARY_PATH is not passwed after sudo -E or suid, see set ld_library_path within (#154 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/154>)
* Contributors: Kei Okada
```

## slic

- No changes

## voice_text

- No changes
