### PR TITLE
Python boto3

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1390,6 +1390,12 @@ libavahi-core-dev:
   fedora: [avahi-devel]
   gentoo: [net-dns/avahi]
   ubuntu: [libavahi-core-dev]
+libb64-dev:
+  arch: [libb64]
+  debian: [libb64-dev]
+  fedora: [libb64-devel]
+  gentoo: [libb64]
+  ubuntu: [libb64-dev]
 libbison-dev:
   debian: [libbison-dev]
   fedora: [bison-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -576,7 +576,9 @@ python-boto3:
   fedora: [python2-boto3]
   gentoo: [dev-python/boto3]
   opensuse: [python-boto3]
-  ubuntu: [python-boto3]
+  ubuntu:
+    '*': [python-boto3]
+    trusty: null
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -570,6 +570,13 @@ python-boltons:
     zesty:
       pip:
         packages: [boltons]
+python-boto3:
+  arch: [python-boto3]
+  debian: [python-boto3]
+  fedora: [python2-boto3]
+  gentoo: [dev-python/boto3]
+  opensuse: [python-boto3]
+  ubuntu: [python-boto3]
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]


### PR DESCRIPTION
We use [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) (that's the Amazon Web Services API) in one of our projects. Source code [here](https://github.com/boto/boto3) Would be nice to have it via rosdep.

[arch](https://www.archlinux.org/packages/community/any/python-boto3/)
[debian](https://packages.debian.org/search?searchon=names&keywords=boto3)
[fedora](https://apps.fedoraproject.org/packages/python2-boto3)
[gentoo](https://packages.gentoo.org/packages/dev-python/boto3)
[opensuse](https://software.opensuse.org/package/python-boto3)
[ubuntu](https://launchpad.net/ubuntu/+source/python-boto3)

Thank You!