### PR TITLE
people: 1.1.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2688,7 +2688,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.1.2-0`:

- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.1-0`
