### PR TITLE
navigation_layers: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2330,6 +2330,25 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: melodic-devel
     status: maintained
+  navigation_layers:
+    doc:
+      type: git
+      url: https://github.com/DLu/navigation_layers.git
+      version: indigo
+    release:
+      packages:
+      - navigation_layers
+      - range_sensor_layer
+      - social_navigation_layers
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wu-robotics/navigation_layers_release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/DLu/navigation_layers.git
+      version: indigo
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_layers` to `0.4.0-0`:

- upstream repository: https://github.com/DLu/navigation_layers.git
- release repository: https://github.com/wu-robotics/navigation_layers_release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## navigation_layers

```
* Clean up with roscompile
* Contributors: David V. Lu
```

## range_sensor_layer

```
* Clean up with roscompile
* range sensor layer: Remove parameter max_angle (#38 <https://github.com/DLu/navigation_layers/issues/38>)
  Any value set for max_angle gets overwritten in updateCostmap() so the
  parameter can safely be removed.
* Issue #22 <https://github.com/DLu/navigation_layers/issues/22>: on updateCostmap, only touch cells within the triangular projection of the sensor cone. I also add a parameter to regulate (and deactivate) this feature (#30 <https://github.com/DLu/navigation_layers/issues/30>)
* Add buffer clearing when calling deactivate() or activate(). (#33 <https://github.com/DLu/navigation_layers/issues/33>)
* Contributors: David V. Lu, Jorge Santos Simón, Krit Chaiso, nxdefiant
```

## social_navigation_layers

```
* Clean up with roscompile
* Contributors: David V. Lu
```
