### PR TITLE
pacmod3: 1.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2624,7 +2624,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/pacmod3-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/astuff/pacmod3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod3` to `1.1.1-0`:

- upstream repository: https://github.com/astuff/pacmod3.git
- release repository: https://github.com/astuff/pacmod3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.0-0`

## pacmod3

```
* Merge pull request #34 <https://github.com/astuff/pacmod3/issues/34> from astuff/maint/add_none_shift_cmd
* Removing unused COMMANDED_VALUE values on SHIFT_RPT.
* Adding NONE shift value.
* Merge pull request #33 <https://github.com/astuff/pacmod3/issues/33> from astuff/fix/percent-signs
* Removed erroneous percent sign from signal units
  Before: Percentages were being reported as a decimal value between 0 and 1
  with a percentage sign.  E.g. 0.5 would be reported, but the intent
  was to convey 50%.  i.e. the report or command would read 0.5%
  when it should've read 50% or just simply 0.5.
  After: Values will be reported without the '%' sign.  They report as decimal
  values.
* Forgot to bump DBC after last minor change.
* Merge pull request #32 <https://github.com/astuff/pacmod3/issues/32> from astuff/fix/steering-rpt-units
* Corrected Steering report units JIRA: LEXUS-131
  Before: steering_rpt reported commanded position in rad/s.
  After: steering_rpt reports commanded position in rad.
* Contributors: Daniel-Stanek, Joshua Whitley, Sam Rustan, Zach Oakes, driscoll85
```
