### PR TITLE
pacmod_game_control: 2.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7536,7 +7536,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/pacmod_game_control-release.git
-      version: 2.1.0-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod_game_control` to `2.2.0-0`:

- upstream repository: https://github.com/astuff/pacmod_game_control.git
- release repository: https://github.com/astuff/pacmod_game_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.1.0-0`

## pacmod_game_control

```
* Merge pull request #44 <https://github.com/astuff/pacmod_game_control/issues/44> from astuff/feat/lexus_braking_curve
* 0.625 and 6.25 are not the same value
* Added cubic braking curve
* Merge pull request #43 <https://github.com/astuff/pacmod_game_control/issues/43> from astuff/feat/multiple_button_enable
* Press start AND select to enable
* Merge pull request #42 <https://github.com/astuff/pacmod_game_control/issues/42> from astuff/fix/resume_control_after_estop
* Changing pacmod_enable flag after return form e-stop
* Contributors: Joshua Whitley, Kyle Rector, Sam Rustan, Zach Oakes
```
