### PR TITLE
pacmod_game_control: 2.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2639,7 +2639,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/pacmod_game_control-release.git
-      version: 2.1.0-1
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod_game_control` to `2.2.0-0`:

- upstream repository: https://github.com/astuff/pacmod_game_control.git
- release repository: https://github.com/astuff/pacmod_game_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.1.0-1`

## pacmod_game_control

```
* Merge pull request #44 <https://github.com/astuff/pacmod_game_control/issues/44> from astuff/feat/lexus_braking_curve
* 0.625 and 6.25 are not the same value
* Added cubic braking curve
* Merge pull request #43 <https://github.com/astuff/pacmod_game_control/issues/43> from astuff/feat/multiple_button_enable
* Press start AND select to enable
* Merge pull request #42 <https://github.com/astuff/pacmod_game_control/issues/42> from astuff/fix/resume_control_after_estop
* Changing pacmod_enable flag after return form e-stop
* Contributors: Joshua Whitley, Kyle Rector, Sam Rustan, Zach Oakes
```
