### PR TITLE
async_comm: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -543,6 +543,22 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: release
     status: developed
+  async_comm:
+    doc:
+      type: git
+      url: https://github.com/dpkoch/async_comm.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/dpkoch/async_comm-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dpkoch/async_comm.git
+      version: master
+    status: developed
   async_web_server_cpp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `async_comm` to `0.1.0-0`:

- upstream repository: https://github.com/dpkoch/async_comm.git
- release repository: https://github.com/dpkoch/async_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## async_comm

```
* Initial release
* Contributors: Daniel Koch, James Jackson
```
