### PR TITLE
rosparam_handler: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13038,7 +13038,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/cbandera/rosparam_handler-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/cbandera/rosparam_handler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_handler` to `0.1.4-0`:

- upstream repository: https://github.com/cbandera/rosparam_handler.git
- release repository: https://github.com/cbandera/rosparam_handler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.3-0`

## rosparam_handler

```
* update doc
* fix #57 <https://github.com/cbandera/rosparam_handler/issues/57>
  replace map/vec custom stream op by func
* update readme
* add toConfig
* Fix #47 <https://github.com/cbandera/rosparam_handler/issues/47>
  Do not print error message while retrieving param with default value.
* Contributors: Jeremie Deray, artivis
```
