### PR TITLE
jsk_model_tools: 0.4.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5776,7 +5776,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     status: developed
   jsk_planning:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.4.2-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.4.1-0`

## eus_assimp

- No changes

## euscollada

```
* collada2eus_urdfmodel: append :provide on bottom; force flush (#219 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/219>)
* Contributors: Yuki Furuta
```

## eusurdf

- No changes

## jsk_model_tools

- No changes
