### PR TITLE
jsk_model_tools: 0.4.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4543,7 +4543,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_model_tools-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     status: developed
   jsk_planning:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.4.2-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.4.1-0`

## eus_assimp

- No changes

## euscollada

```
* collada2eus_urdfmodel: append :provide on bottom; force flush (#219 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/219>)
* Contributors: Yuki Furuta
```

## eusurdf

- No changes

## jsk_model_tools

- No changes
