### PR TITLE
navigation_experimental: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2346,6 +2346,31 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: melodic-devel
     status: maintained
+  navigation_experimental:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_experimental.git
+      version: melodic-devel
+    release:
+      packages:
+      - assisted_teleop
+      - goal_passer
+      - navigation_experimental
+      - pose_base_controller
+      - pose_follower
+      - sbpl_lattice_planner
+      - sbpl_recovery
+      - twist_recovery
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_experimental-release.git
+      version: 0.3.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation_experimental.git
+      version: melodic-devel
+    status: maintained
   navigation_layers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.3.0-0`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## assisted_teleop

```
* Convert to TF2 + new navigation API (for melodic)
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## goal_passer

```
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## navigation_experimental

- No changes

## pose_base_controller

```
* Convert to TF2 + new navigation API (for melodic)
* Contributors: Martin Günther
```

## pose_follower

```
* Convert to TF2 + new navigation API (for melodic)
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## sbpl_lattice_planner

```
* sbpl_lattice_planner: Update to tf2, add dependency
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## sbpl_recovery

```
* Convert to TF2 + new navigation API (for melodic)
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## twist_recovery

```
* Convert to TF2 + new navigation API (for melodic)
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```
