### PR TITLE
view_controller_msgs: 0.1.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5353,6 +5353,17 @@ repositories:
       url: https://github.com/ros-drivers/video_stream_opencv.git
       version: master
     status: maintained
+  view_controller_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/view_controller_msgs.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/view_controller_msgs-release.git
+      version: 0.1.3-0
+    status: unmaintained
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `view_controller_msgs` to `0.1.3-0`:

- upstream repository: https://github.com/ros-visualization/view_controller_msgs.git
- release repository: https://github.com/ros-gbp/view_controller_msgs-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## view_controller_msgs

```
* Merge pull request #5 <https://github.com/ros-visualization/view_controller_msgs/issues/5> from k-okada/lunar-devel
  change maintainer to ROS Orphaned Package Maintainers
* change maintainer to ROS Orphaned Package Maintainers
* Merge pull request #4 <https://github.com/ros-visualization/view_controller_msgs/issues/4> from k-okada/add_travis
  update travis.yml
* update travis.yml
* Contributors: Kei Okada
```
