### PR TITLE
ivcon: 0.1.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1479,6 +1479,17 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  ivcon:
+    doc:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/ivcon-release.git
+      version: 0.1.7-0
+    status: unmaintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ivcon` to `0.1.7-0`:

- upstream repository: https://github.com/ros/ivcon.git
- release repository: https://github.com/ros-gbp/ivcon-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ivcon

```
* Merge pull request #6 <https://github.com/ros/ivcon/issues/6> from k-okada/add_travis
  Add travis.yml
* update maintainer to ROS Orphaned Package Maintainers
* mv readme -> README.md
* update travis.yml
* Contributors: Kei Okada
```
