### PR TITLE
libmynteye-release: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5044,6 +5044,14 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2016.4.24-0
     status: maintained
+  libmynteye-release:
+    release:
+      packages:
+      - libmynteye
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/harjeb/libmynteye-release.git
+      version: 0.0.1-0
   librealsense:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5044,7 +5044,11 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2016.4.24-0
     status: maintained
-  libmynteye-release:
+  libmynteye:
+    doc:
+      type: git
+      url: https://github.com/harjeb/libmynteye.git
+      version: master
     release:
       packages:
       - libmynteye
@@ -5052,6 +5056,12 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/harjeb/libmynteye-release.git
       version: 0.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/harjeb/libmynteye.git
+      version: master
+    status: developed
   librealsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libmynteye-release` to `0.0.1-0`:

- upstream repository: https://github.com/harjeb/libmynteye.git
- release repository: https://github.com/harjeb/libmynteye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
