### PR TITLE
add empty rule for debian julius-voxforge

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1358,6 +1358,7 @@ jq:
   ubuntu: [jq]
 julius-voxforge:
   arch: [voxforge-am-julius]
+  debian: []
   fedora: [julius-voxforge]
   ubuntu: [julius-voxforge]
 jython:


### PR DESCRIPTION
are we allow to add empty rule? https://pkgs.org/download/julius-voxforge

we can not find julius-voxforge for debian

- https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=voxforge
- https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=julius
- https://pkgs.org/download/julius-voxforge