### PR TITLE
navigation_2d: 0.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2412,6 +2412,10 @@ repositories:
       version: lunar
     status: maintained
   navigation_2d:
+    doc:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: lunar
     release:
       packages:
       - nav2d

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2411,6 +2411,27 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: lunar
     status: maintained
+  navigation_2d:
+    release:
+      packages:
+      - nav2d
+      - nav2d_exploration
+      - nav2d_karto
+      - nav2d_localizer
+      - nav2d_msgs
+      - nav2d_navigator
+      - nav2d_operator
+      - nav2d_remote
+      - nav2d_tutorials
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/skasperski/navigation_2d-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: lunar
+    status: maintained
   navigation_experimental:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.4.0-0`:

- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
