### PR TITLE
navigation_experimental: 0.3.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2375,7 +2375,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_experimental-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.3.1-0`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.0-0`

## assisted_teleop

```
* assisted_teleop: Don't link against Eigen_LIBRARIES
  That variable is not set. Eigen is a header-only library.
* Contributors: Martin Günther
```

## goal_passer

- No changes

## navigation_experimental

- No changes

## pose_base_controller

- No changes

## pose_follower

- No changes

## sbpl_lattice_planner

- No changes

## sbpl_recovery

```
* sbpl_recovery: Ignore SBPL compile warning
* Contributors: Martin Günther
```

## twist_recovery

```
* twist_recovery: Add missing dependency
  Actually, this is a workaround for the following bug: https://github.com/ros/geometry2/issues/275
* Contributors: Martin Günther
```
