### PR TITLE
rospack: 2.5.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3832,7 +3832,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.5.1-0
+      version: 2.5.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.5.2-0`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.5.1-0`

## rospack

```
* add delete whitespace settings for backward compatibility, regression from 2.4.0 (#94 <https://github.com/ros/rospack/issues/94>)
* fix build issue on Windows (#90 <https://github.com/ros/rospack/issues/90>)
* use namespace to avoid name conflict between tinyxml2 and msxml (#89 <https://github.com/ros/rospack/issues/89>)
```
