### PR TITLE
p2os: 2.1.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2697,6 +2697,24 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth
       version: default
     status: maintained
+  p2os:
+    release:
+      packages:
+      - p2os_doc
+      - p2os_driver
+      - p2os_launch
+      - p2os_msgs
+      - p2os_teleop
+      - p2os_urdf
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/allenh1/p2os-release.git
+      version: 2.1.1-3
+    source:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
+    status: maintained
   pacmod3:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.1.1-3`:

- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## p2os_doc

- No changes

## p2os_driver

- No changes

## p2os_launch

- No changes

## p2os_msgs

- No changes

## p2os_teleop

- No changes

## p2os_urdf

```
* Kill it with fire (#50 <https://github.com/allenh1/p2os/issues/50>)
* Contributors: Hunter Allen
```
