### PR TITLE
sainsmart_relay_usb: 0.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4428,6 +4428,21 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: melodic-devel
     status: developed
+  sainsmart_relay_usb:
+    doc:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
+      version: default
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
+      version: 0.0.2-0
+    source:
+      type: hg
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
+      version: default
+    status: maintained
   sbg_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sainsmart_relay_usb` to `0.0.2-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb
- release repository: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## sainsmart_relay_usb

```
* Added build dependency on roslib, needed for the ROS_DISTRO environment variable
* Contributors: Kevin Hallenbeck
```
