### PR TITLE
moveit_visual_tools: 3.2.1-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2178,7 +2178,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/moveit_visual_tools-release.git
-      version: 3.2.1-2
+      version: 3.2.1-4
     source:
       type: git
       url: https://github.com/PickNikRobotics/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.2.1-4`:

- upstream repository: https://github.com/PickNikRobotics/moveit_visual_tools.git
- release repository: https://github.com/PickNikRobotics/moveit_visual_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.2.1-2`

## moveit_visual_tools

```
* New publishTrajectoryPath() functions
* New publishTrajectoryLine() functions
* getRobotState() return by reference
* Trajectory path has smaller vertices
* IMarkerRobotState: added isStateValid()
* Contributors: Dave Coleman
```
