### PR TITLE
libmynteye: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5044,6 +5044,21 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2016.4.24-0
     status: maintained
+  libmynteye:
+    doc:
+      type: git
+      url: https://github.com/harjeb/libmynteye.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/harjeb/libmynteye-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/harjeb/libmynteye.git
+      version: master
   librealsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libmynteye` to `0.1.1-1`:

- upstream repository: https://github.com/harjeb/libmynteye.git
- release repository: https://github.com/harjeb/libmynteye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## libmynteye

```
* modify package version
```
