### PR TITLE
gscam: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1271,6 +1271,17 @@ repositories:
       url: https://github.com/CogRob/catkin_grpc.git
       version: master
     status: developed
+  gscam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/gscam-release.git
+      version: 1.0.1-0
+    status: unmaintained
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `1.0.1-0`:

- upstream repository: git://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros-drivers-gbp/gscam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## gscam

```
* Merge pull request #52 <https://github.com/ros-drivers/gscam/issues/52> from k-okada/add_travis
  update travis.yml
* Update README.md
  gscam -> GSCam
* update travis.yml
* Merge pull request #40 <https://github.com/ros-drivers/gscam/issues/40> from ros-drivers/mikaelarguedas-patch-1
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Contributors: Kei Okada, Mikael Arguedas
```
