### PR TITLE
moveit_resources: 0.6.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5962,7 +5962,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.4-0`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.6.3-0`

## moveit_resources

```
* Added Franka Emika's Panda robot (#19 <https://github.com/ros-planning/moveit_resources/issues/19>)
* Contributors: Mohmmad Ayman
```
