### PR TITLE
navigation_layers: 0.4.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2395,7 +2395,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wu-robotics/navigation_layers_release.git
-      version: 0.4.0-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/DLu/navigation_layers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_layers` to `0.4.2-0`:

- upstream repository: https://github.com/DLu/navigation_layers.git
- release repository: https://github.com/wu-robotics/navigation_layers_release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.4.0-0`
