### PR TITLE
dataspeed_can: 1.0.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1866,7 +1866,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.10-0
+      version: 1.0.11-0
     source:
       type: hg
       url: https://bitbucket.org/dataspeedinc/dataspeed_can


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.11-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.10-0`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

- No changes

## dataspeed_can_tools

```
* Added support for multiple DBC files
* Added support for multiplexed signals
* Many changes to the command line arguments
* Fixed bug with signals greater than 31 bits
* Set CXX_STANDARD to C++11 when necessary
* Contributors: Kevin Hallenbeck, Eric Myllyoja
```

## dataspeed_can_usb

```
* Added option to connect to a specific USB device by MAC address
* Added normal/listen-only mode options
* Only subscribe to can_tx in normal mode, listen-only mode cannot transmit
* Updated module firmware to 10.4.0
* Contributors: Kevin Hallenbeck
```
