### PR TITLE
convex_decomposition: 0.1.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -498,6 +498,17 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: kinetic-devel
     status: maintained
+  convex_decomposition:
+    doc:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/convex_decomposition-release.git
+      version: 0.1.12-0
+    status: unmaintained
   costmap_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `convex_decomposition` to `0.1.12-0`:

- upstream repository: https://github.com/ros/convex_decomposition.git
- release repository: https://github.com/ros-gbp/convex_decomposition-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## convex_decomposition

```
* Merge pull request #8 <https://github.com/ros/convex_decomposition/issues/8> from k-okada/add_travis
  update travis.yml
* Change maintainer to ROS Orphaned Package
* update travis.yml
* mv readme to README.md
* Contributors: Kei Okada
```
