### PR TITLE
teraranger: 1.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12427,7 +12427,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     status: maintained
   teraranger_array:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `1.2.1-0`:

- upstream repository: git@github.com:Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.2.0-0`

## teraranger

```
* Update Readme for Evo 3m
* Add Evo 3m compatibility to the driver
* Update installation instructions in Readme
* Contributors: BaptistePotier, Mateusz Sadowski, pl-kabaradjian
```
