### PR TITLE
teraranger_array: 1.3.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12434,7 +12434,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git
-      version: 1.3.2-0
+      version: 1.3.3-0
     status: maintained
   teraranger_array_converter:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `1.3.3-0`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.3.2-0`

## teraranger_array

```
* Update Readme for Evo 3m
* Add Evo 3m type to the list of available Evo's
* Contributors: BaptistePotier, Pierre-Louis Kabaradjian
```
