### PR TITLE
oxford_gps_eth: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9194,7 +9194,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 0.0.6-0
+      version: 1.0.0-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `1.0.0-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.6-0`

## oxford_gps_eth

```
* Use C++11 or newer
* Publish a sensor_msgs/TimeReference message with GPS time converted to UTC
* Publish a position type string more detailed than the NavSatStatus in the fix message
* Added UTM position and heading to odometry output; Odometry twist now in local frame
* Contributors: Micho Radovnikovich, Kevin Hallenbeck
```
