### PR TITLE
Making rail_face_detection and rail_object_detection metapackages

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10880,7 +10880,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_object_detection-release.git
-      version: 3.0.0-0
+      version: 3.0.1-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_object_detection.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10867,19 +10867,23 @@ repositories:
       url: https://github.com/GT-RAIL/rail_maps.git
       version: develop
     status: maintained
-  rail_object_detector:
+  rail_object_detection:
     doc:
       type: git
-      url: https://github.com/GT-RAIL/rail_object_detector.git
-      version: master
+      url: https://github.com/GT-RAIL/rail_object_detection.git
+      version: indigo-devel
     release:
+      packages:
+      - rail_object_detection
+      - rail_object_detection_msgs
+      - rail_object_detector
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/gt-rail-release/rail_object_detector-release.git
-      version: 2.0.1-0
+      url: https://github.com/gt-rail-release/rail_object_detection-release.git
+      version: 3.0.0-0
     source:
       type: git
-      url: https://github.com/GT-RAIL/rail_object_detector.git
+      url: https://github.com/GT-RAIL/rail_object_detection.git
       version: develop
     status: developed
   rail_pick_and_place:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10840,7 +10840,7 @@ repositories:
       type: git
       url: https://github.com/GT-RAIL/rail_face_detection.git
       version: develop
-    status: maintained
+    status: developed
   rail_manipulation_msgs:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10822,20 +10822,24 @@ repositories:
       url: https://github.com/GT-RAIL/rail_collada_models.git
       version: develop
     status: maintained
-  rail_face_detector:
+  rail_face_detection:
     doc:
       type: git
-      url: https://github.com/GT-RAIL/rail_face_detector.git
-      version: master
+      url: https://github.com/GT-RAIL/rail_face_detection.git
+      version: indigo-devel
     release:
+      packages:
+      - rail_face_detection
+      - rail_face_detection_msgs
+      - rail_face_detector
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/gt-rail-release/rail_face_detector-release.git
-      version: 0.0.2-0
+      url: https://github.com/gt-rail-release/rail_face_detection-release.git
+      version: 1.0.1-0
     source:
       type: git
-      url: https://github.com/GT-RAIL/rail_face_detector.git
-      version: publishable_face_det
+      url: https://github.com/GT-RAIL/rail_face_detection.git
+      version: develop
     status: maintained
   rail_manipulation_msgs:
     doc:


### PR DESCRIPTION
Updates are part of a slow upgrade of these packages in prep for melodic.

The old release repositories for `rail_object_detector` and `rail_face_detector` will still be around until the metapackages are built and released.