### PR TITLE
velodyne_simulator: 1.0.8-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5437,7 +5437,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 1.0.7-0
+      version: 1.0.8-0
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.8-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.7-0`

## velodyne_description

- No changes

## velodyne_gazebo_plugins

```
* Changed iteration order to more closely represent the live velodyne driver
* Contributors: Kevin Hallenbeck
```

## velodyne_simulator

- No changes
