### PR TITLE
libmynteye: 0.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5053,12 +5053,13 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/harjeb/libmynteye-release.git
-      version: 0.1.1-1
+      version: 0.1.2-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/harjeb/libmynteye.git
       version: master
+    status: developed
   librealsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libmynteye` to `0.1.2-0`:

- upstream repository: https://github.com/harjeb/libmynteye.git
- release repository: https://github.com/harjeb/libmynteye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.1-1`

## libmynteye

```
* change libopencv to Opencv3
```
