### PR TITLE
pr2_common: 1.12.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2990,6 +2990,23 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
       version: 0.3.0-0
     status: maintained
+  pr2_common:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: melodic-devel
+    release:
+      packages:
+      - pr2_common
+      - pr2_dashboard_aggregator
+      - pr2_description
+      - pr2_machine
+      - pr2_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common-release.git
+      version: 1.12.3-0
+    status: unmaintained
   pr2_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.3-0`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pr2_common

- No changes

## pr2_dashboard_aggregator

- No changes

## pr2_description

```
* Merge pull request #272 <https://github.com/pr2/pr2_common/issues/272> from k-okada/add_travis
  update travis.yml
* ModelInterfaceSharedPtr is only available on newer urdfdom
* fix for urdfmodel 1.0.0 (melodic)
* test_urdf uses rosrun within the code
* Merge pull request #270 <https://github.com/pr2/pr2_common/issues/270> from TAMS-Group/pr-kinetic-fixed-xmlns
  xmlns should include www
* xmlns should include www
  According to the tutorials:
  http://wiki.ros.org/urdf/Tutorials/Using%20Xacro%20to%20Clean%20Up%20a%20URDF%20File
  xacro complains when some xacro components specify the URL
  as http://www.ros.org/wiki/xacro and others
  as http://ros.org/wiki/xacro.
* Contributors: Kei Okada, v4hn
```

## pr2_machine

- No changes

## pr2_msgs

- No changes
