### PR TITLE
rosjava_core: 0.3.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10422,7 +10422,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_core-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_core` to `0.3.6-0`:

- upstream repository: https://github.com/rosjava/rosjava_core
- release repository: https://github.com/rosjava-release/rosjava_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.5-0`

## rosjava_core

```
* Using time=0 by default; prevents NullPointerException when using sim_time.
* Fix: waiting for master before getting /use_sim_time.
* Gradle upgraded to 3.5.1.
* Added Bazel build support.
* Supporting XMLRPC multicalls - prevents ROS master from shutting down when a launchfile is launched.
* Fix for race condition in RetryingExecutorService.
* Improved error checking and tests for rosjava_helpers.
* Contributors: Juan Ignacio Ubeira, Rodrigo Queiro, Wojciech Mlynarczyk.
```
