### PR TITLE
fcl_catkin: 0.5.94-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -884,6 +884,12 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/fanuc_post_processor.git
       version: melodic
     status: developed
+  fcl_catkin:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wxmerkt/fcl_catkin-release.git
+      version: 0.5.94-0
   fetch_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl_catkin` to `0.5.94-0`:

- upstream repository: https://github.com/wxmerkt/fcl_catkin.git
- release repository: https://github.com/wxmerkt/fcl_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
