### PR TITLE
mynteye-roswrapper: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6284,6 +6284,24 @@ repositories:
       url: https://github.com/robotpilot/myahrs_driver.git
       version: kinetic-devel
     status: maintained
+  mynteye-roswrapper:
+    doc:
+      type: git
+      url: https://github.com/slightech/MYNT-EYE-ROS-Wrapper.git
+      version: master
+    release:
+      packages:
+      - mynt_eye_ros_wrapper
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/harjeb/mynt_eye_ros_wrapper-release.git
+      version: 0.1.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/harjeb/mynt_eye_ros_wrapper.git
+      version: master
+    status: developed
   nao_dcm_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mynteye-roswrapper` to `0.1.1-0`:

- upstream repository: https://github.com/harjeb/mynt_eye_ros_wrapper.git
- release repository: https://github.com/harjeb/mynt_eye_ros_wrapper-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## mynt_eye_ros_wrapper

```
* Initial release
```
