### PR TITLE
pr2_mechanism: 1.8.18-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3266,7 +3266,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_mechanism-release.git
-      version: 1.8.17-0
+      version: 1.8.18-0
     status: unmaintained
   pr2_mechanism_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.18-0`:

- upstream repository: https://github.com/pr2/pr2_mechanism.git
- release repository: https://github.com/pr2-gbp/pr2_mechanism-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.8.17-0`

## pr2_controller_interface

- No changes

## pr2_controller_manager

- No changes

## pr2_hardware_interface

- No changes

## pr2_mechanism

- No changes

## pr2_mechanism_diagnostics

- No changes

## pr2_mechanism_model

```
* Merge pull request #338 <https://github.com/pr2/pr2_mechanism/issues/338> from k-okada/add_travis
  update travis.yml
* fix urdf::JointConstSharedPtr for test directory
* fix for urdfmodel >= 1.0.0 (melodic)
* to pass catkin run_tests, partially copied from https://github.com/PR2/pr2_mechanism/pull/329
* Contributors: Kei Okada
```
