### PR TITLE
move_base_flex: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2223,7 +2223,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.0-0`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.0-0`

## mbf_abstract_core

```
* Update copyright and 3-clause-BSD license
```

## mbf_abstract_nav

```
* Update copyright and 3-clause-BSD license
* Concurrency for planners, controllers and recovery behaviors
* New class structure, allowing multiple executoin instances
* Fixes minor bugs
```

## mbf_costmap_core

```
* Concurrency for planners, controllers and recovery behaviors
```

## mbf_costmap_nav

```
* Update copyright and 3-clause-BSD license
* Concurrency for planners, controllers and recovery behaviors
```

## mbf_msgs

```
* Concurrency for planners, controllers and recovery behaviors
* Adds concurrency slots to actions
```

## mbf_simple_nav

```
* Update copyright and 3-clause-BSD license
* Concurrency for planners, controllers and recovery behaviors
```

## mbf_utility

```
* Update copyright and 3-clause-BSD license
```

## move_base_flex

```
* Update copyright and 3-clause-BSD license of the Move Base Flex stack
* Concurrency for planners, controllers and recovery behaviors
* New class structure, allowing multiple executoin instances
* Fixes minor bugs
```
