### PR TITLE
slam_karto: 0.8.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4602,7 +4602,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/slam_karto-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/ros-perception/slam_karto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.8.1-0`:

- upstream repository: https://github.com/ros-perception/slam_karto.git
- release repository: https://github.com/ros-gbp/slam_karto-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.8.0-0`

## slam_karto

```
* set C++11 if std not specified
  This is mainly for building on Lunar
* Contributors: Michael Ferguson
```
