### PR TITLE
sophus: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4613,7 +4613,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus-release.git
-      version: 1.0.1-0
+      version: 1.0.1-1
     status: maintained
   sparse_bundle_adjustment:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.0.1-1`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.1-0`
