### PR TITLE
ecl_manipulation: 0.60.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -779,7 +779,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_manipulation-release.git
-      version: 0.60.2-0
+      version: 0.60.3-0
     source:
       type: git
       url: https://github.com/stonier/ecl_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_manipulation` to `0.60.3-0`:

- upstream repository: https://github.com/stonier/ecl_manipulation.git
- release repository: https://github.com/yujinrobot-release/ecl_manipulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.60.2-0`
