### PR TITLE
Adding r12_hardware_interface to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3271,6 +3271,11 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
+  r12_hardware_interface:
+    doc:
+      type: git
+      url: https://github.com/ST-ROBOTICS/r12_hardware_interface.git
+      version: master
   radar_omnipresense:
     release:
       tags:


### PR DESCRIPTION
Package includes hardware drivers for the r12 robot arm