### PR TITLE
pr2_power_drivers: 1.1.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3074,6 +3074,22 @@ repositories:
       url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
       version: 1.8.2-0
     status: unmaintained
+  pr2_power_drivers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_power_drivers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ocean_battery_driver
+      - power_monitor
+      - pr2_power_board
+      - pr2_power_drivers
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
+      version: 1.1.6-0
+    status: unmaintained
   prbt_grippers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_power_drivers` to `1.1.6-0`:

- upstream repository: https://github.com/pr2/pr2_power_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_power_drivers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ocean_battery_driver

```
* change maintainer to ROS orphaned package maintaner
* Contributors: Kei Okada
```

## power_monitor

```
* change maintainer to ROS orphaned package maintaner
* Contributors: Kei Okada
```

## pr2_power_board

```
* change maintainer to ROS orphaned package maintaner
* pr2_power_board: add missing include dirs
* Contributors: Furushchev, Kei Okada
```

## pr2_power_drivers

```
* change maintainer to ROS orphaned package maintaner
* Contributors: Kei Okada
```
