### PR TITLE
capitalization fixed

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2269,7 +2269,7 @@ libopenni-dev:
   arch: [openni]
   debian: [libopenni-dev]
   fedora: [openni-devel]
-  gentoo: [dev-libs/OpenNi]
+  gentoo: [dev-libs/OpenNI]
   ubuntu: [libopenni-dev]
 libopenni-nite-dev:
   arch: [primesense-nite]


### PR DESCRIPTION
In Gentoo, there is only OpenNI, not OpenNi. I don't know if that changed only recently or the spelling here was a typo.