### PR TITLE
openni_camera: 1.11.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2704,6 +2704,25 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: indigo-devel
     status: maintained
+  openni_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: indigo-devel
+    release:
+      packages:
+      - openni_camera
+      - openni_description
+      - openni_launch
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/openni_camera-release.git
+      version: 1.11.1-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni_camera.git
+      version: indigo-devel
+    status: maintained
   openrtm_aist:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.11.1-0`:

- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## openni_camera

```
* [improve] Python 3 conformity #67 <https://github.com/ros-drivers/openni_camera/issues/67>
* Contributors: Isaac I.Y. Saito, cclauss
```

## openni_description

```
* Remove a test_depend on pkg that are not guaranteed to be available in newer distro. #70 <https://github.com/ros-drivers/openni_camera/issues/70>
* Contributors: Isaac I.Y. Saito
```

## openni_launch

- No changes
