### PR TITLE
openni_camera: 1.11.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2866,11 +2866,12 @@ repositories:
     release:
       packages:
       - openni_camera
+      - openni_description
       - openni_launch
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/openni_camera-release.git
-      version: 1.10.0-0
+      version: 1.11.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_camera` to `1.11.1-0`:

- upstream repository: https://github.com/ros-drivers/openni_camera.git
- release repository: https://github.com/ros-gbp/openni_camera-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.10.0-0`

## openni_camera

```
* [improve] Python 3 conformity #67 <https://github.com/ros-drivers/openni_camera/issues/67>
* Contributors: Isaac I.Y. Saito, cclauss
```

## openni_description

```
* Remove a test_depend on pkg that are not guaranteed to be available in newer distro. #70 <https://github.com/ros-drivers/openni_camera/issues/70>
* Contributors: Isaac I.Y. Saito
```

## openni_launch

- No changes
