### PR TITLE
pr2_controllers: 1.10.15-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3232,6 +3232,28 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pr2_controllers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: melodic-devel
+    release:
+      packages:
+      - ethercat_trigger_controllers
+      - joint_trajectory_action
+      - pr2_calibration_controllers
+      - pr2_controllers
+      - pr2_controllers_msgs
+      - pr2_gripper_action
+      - pr2_head_action
+      - pr2_mechanism_controllers
+      - robot_mechanism_controllers
+      - single_joint_position_action
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_controllers-release.git
+      version: 1.10.15-0
+    status: unmaintained
   pr2_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.15-0`:

- upstream repository: https://github.com/pr2/pr2_controllers.git
- release repository: https://github.com/pr2-gbp/pr2_controllers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ethercat_trigger_controllers

- No changes

## joint_trajectory_action

- No changes

## pr2_calibration_controllers

- No changes

## pr2_controllers

- No changes

## pr2_controllers_msgs

- No changes

## pr2_gripper_action

- No changes

## pr2_head_action

- No changes

## pr2_mechanism_controllers

```
* Merge pull request #390 <https://github.com/pr2/pr2_controllers/issues/390> from k-okada/add_travis
  update travis.yml
* add fix for urdfmodel 1.0.0(melodic),
  since 12.04 have urdfmodel < 1.0.0, it will fail to compile on indigo, so we need to chaeck URDFDOM_version
* Contributors: Kei Okada
```

## robot_mechanism_controllers

- No changes

## single_joint_position_action

- No changes
