### PR TITLE
radar_omnipresense: 0.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3457,7 +3457,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
-      version: 0.1.0-1
+      version: 0.3.0-0
     status: developed
   random_numbers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_omnipresense` to `0.3.0-0`:

- upstream repository: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
- release repository: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.0-1`

## radar_omnipresense

```
* Remove use of rapidjson
* make compatible with OPS241 (API v 1.0-1-1) and OPS242 (v1.2 and beyond)
* Contributors: Jim Whitfield
```
