### PR TITLE
radar_omnipresense: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3276,7 +3276,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     status: developed
   random_numbers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_omnipresense` to `0.3.0-0`:

- upstream repository: https://github.com/SCU-RSL-ROS/radar_omnipresense.git
- release repository: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.0-0`

## radar_omnipresense

```
* Remove use of rapidjson
* make compatible with OPS241 (API v 1.0-1-1) and OPS242 (v1.2 and beyond)
* Contributors: Jim Whitfield
```
