### PR TITLE
pilz_industrial_motion: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7895,6 +7895,27 @@ repositories:
       url: https://bitbucket.org/AndyZe/pid.git
       version: master
     status: maintained
+  pilz_industrial_motion:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/pilz_industrial_motion.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pilz_extensions
+      - pilz_industrial_motion
+      - pilz_industrial_motion_testutils
+      - pilz_msgs
+      - pilz_trajectory_generation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/PilzDE/pilz_industrial_motion-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/PilzDE/pilz_industrial_motion.git
+      version: kinetic-devel
+    status: developed
   pilz_robots:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.1.0-0`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pilz_extensions

```
* extension to joint_limits_interface::JointLimits
* Contributors: Pilz GmbH and Co. KG
```

## pilz_industrial_motion

```
* Initial release
* Contributors: Pilz GmbH and Co. KG
```

## pilz_industrial_motion_testutils

```
* xml test data loader.
* Contributors: Pilz GmbH and Co. KG
```

## pilz_msgs

```
* Added msg definition for blend request and response
* Contributors: Pilz GmbH and Co. KG
```

## pilz_trajectory_generation

```
* Created trajectory generation package with ptp, lin, circ and blend planner
* Contributors: Pilz GmbH and Co. KG
```
