### PR TITLE
pilz_industrial_motion: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2955,6 +2955,27 @@ repositories:
       url: https://bitbucket.org/AndyZe/pid.git
       version: master
     status: maintained
+  pilz_industrial_motion:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/pilz_industrial_motion.git
+      version: melodic-devel
+    release:
+      packages:
+      - pilz_extensions
+      - pilz_industrial_motion
+      - pilz_industrial_motion_testutils
+      - pilz_msgs
+      - pilz_trajectory_generation
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PilzDE/pilz_industrial_motion-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/PilzDE/pilz_industrial_motion.git
+      version: kinetic-devel
+    status: developed
   pilz_robots:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.2.0-0`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

- No changes

## pilz_msgs

- No changes

## pilz_trajectory_generation

```
* Changes for melodic
* Contributors: Pilz GmbH and Co. KG
```
