### PR TITLE
pr2_self_test: 1.0.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8350,6 +8350,28 @@ repositories:
       url: https://github.com/pr2/pr2_robot.git
       version: kinetic-devel
     status: maintained
+  pr2_self_test:
+    doc:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_self_test.git
+      version: indigo-devel
+    release:
+      packages:
+      - joint_qualification_controllers
+      - pr2_bringup_tests
+      - pr2_counterbalance_check
+      - pr2_motor_diagnostic_tool
+      - pr2_self_test
+      - pr2_self_test_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/PR2-prime/pr2_self_test-release.git
+      version: 1.0.12-0
+    source:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_self_test.git
+      version: indigo-devel
+    status: maintained
   pr2_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.12-0`:

- upstream repository: https://github.com/UNR-RoboticsResearchLab/pr2_self_test.git
- release repository: https://github.com/PR2-prime/pr2_self_test-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
