### PR TITLE
Add a rosdep key for python-can

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -620,12 +620,16 @@ python-can:
     pip:
       packages: [python-can]
   debian:
-    '*':
+    '*': [python-can]
+    jessie:
       pip:
         packages: [python-can]
-    buster: [python-can]
-    sid: [python-can]
-    stretch: [python-can]
+    squeeze:
+      pip:
+        packages: [python-can]
+    wheezy:
+      pip:
+        packages: [python-can]
   fedora:
     pip:
       packages: [python-can]
@@ -633,12 +637,52 @@ python-can:
     pip:
       packages: [python-can]
   ubuntu:
-    '*':
+    '*': [python-can]
+    lucid:
       pip:
         packages: [python-can]
-    artful: [python-can]
-    bionic: [python-can]
-    cosmic: [python-can]
+    maverick:
+      pip:
+        packages: [python-can]
+    natty:
+      pip:
+        packages: [python-can]
+    oneiric:
+      pip:
+        packages: [python-can]
+    precise:
+      pip:
+        packages: [python-can]
+    quantal:
+      pip:
+        packages: [python-can]
+    raring:
+      pip:
+        packages: [python-can]
+    saucy:
+      pip:
+        packages: [python-can]
+    trusty:
+      pip:
+        packages: [python-can]
+    utopic:
+      pip:
+        packages: [python-can]
+    vivid:
+      pip:
+        packages: [python-can]
+    wily:
+      pip:
+        packages: [python-can]
+    xenial:
+      pip:
+        packages: [python-can]
+    yakkety:
+      pip:
+        packages: [python-can]
+    zesty:
+      pip:
+        packages: [python-can]
 python-cantools-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -680,9 +680,6 @@ python-can:
     yakkety:
       pip:
         packages: [python-can]
-    zesty:
-      pip:
-        packages: [python-can]
 python-cantools-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -612,6 +612,22 @@ python-cairo:
     slackpkg:
       packages: [pycairo]
   ubuntu: [python-cairo]
+python-can-pip:
+  alpine:
+    pip:
+      packages: [python-can]
+  debian:
+    pip:
+      packages: [python-can]
+  fedora:
+    pip:
+      packages: [python-can]
+  osx:
+    pip:
+      packages: [python-can]
+  ubuntu:
+    pip:
+      packages: [python-can]
 python-cantools-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -620,9 +620,9 @@ python-can:
     '*':
       pip:
         packages: [python-can]
-    stretch: [python-can]
     buster: [python-can]
     sid: [python-can]
+    stretch: [python-can]
   fedora:
     pip:
       packages: [python-can]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -612,13 +612,17 @@ python-cairo:
     slackpkg:
       packages: [pycairo]
   ubuntu: [python-cairo]
-python-can-pip:
+python-can:
   alpine:
     pip:
       packages: [python-can]
   debian:
-    pip:
-      packages: [python-can]
+    '*':
+      pip:
+        packages: [python-can]
+    stretch: [python-can]
+    buster: [python-can]
+    sid: [python-can]
   fedora:
     pip:
       packages: [python-can]
@@ -626,8 +630,12 @@ python-can-pip:
     pip:
       packages: [python-can]
   ubuntu:
-    pip:
-      packages: [python-can]
+    '*':
+      pip:
+        packages: [python-can]
+    artful: [python-can]
+    bionic: [python-can]
+    cosmic: [python-can]
 python-cantools-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -616,6 +616,9 @@ python-can:
   alpine:
     pip:
       packages: [python-can]
+  arch:
+    pip:
+      packages: [python-can]
   debian:
     '*':
       pip:


### PR DESCRIPTION
This will add a rosdep key to install python-can via pip,
a Python module that provides a suite of utilities for interfacing
with Controller Area Network (CAN) buses.

Documentation: https://python-can.readthedocs.io/en/2.2.0/index.html