### PR TITLE
rosdoc_lite: 0.2.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3965,7 +3965,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rosdoc_lite-release.git
-      version: 0.2.7-0
+      version: 0.2.8-0
     source:
       type: git
       url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.8-0`:

- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.7-0`

## rosdoc_lite

```
* fix top bar on recent doxygen versions
  * on recent doxygen topbar requires jquery
  * fixes documentation generation on ROS melodic
  * see https://www.stack.nl/~dimitri/doxygen/manual/changelog.html#log_1_8_1
* add use_mdfile_as_mainpage option
  This makes it possible/easier to use a markdown file as mainpage, e.g. the README.md
* remove unsupported option latex_paper_size (#79 <https://github.com/ros-infrastructure/rosdoc_lite/issues/79>)
* Expose doxygen parameter GENERATE_QHP
* Contributors: Dirk Thomas, Felix Ruess, Jack O'Quin, Jiri Horner, Levi Armstrong, Tully Foote
```
