### PR TITLE
phidgets_drivers: 0.7.7-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3122,7 +3122,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.6-0
+      version: 0.7.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.7-0`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.7.6-0`

## libphidget21

- No changes

## phidgets_api

- No changes

## phidgets_drivers

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_imu

```
* Add parameter use_imu_time (default true) (#27 <https://github.com/ros-drivers/phidgets_drivers/issues/27>)
  Setting use_imu_time to false will disable the imu time calibration and
  always use the Host time, i.e. ros::Time::now().
* Contributors: Jochen Sprickerhof
```
