### PR TITLE
velodyne: 1.4.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5447,6 +5447,27 @@ repositories:
       url: https://github.com/beltransen/velo2cam_gazebo.git
       version: master
     status: maintained
+  velodyne:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: master
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/velodyne-release.git
+      version: 1.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: master
+    status: developed
   velodyne_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.4.0-0`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## velodyne

```
* Merge pull request #160 <https://github.com/ros-drivers/velodyne/issues/160> from ros-drivers/maint/updating_package_xml_to_v2
* Updated all package.xmls to ver 2. Cleaned up catkin_lint errors.
  All package.xml files are now compatible with version 2 of the
  package.xml specification in REP 140. Removed some unnecessary
  execute permissions on a few files. Fixed a missing test_depend.
* Contributors: Andre Volk, Joshua Whitley
```

## velodyne_driver

```
* Merge pull request #178 <https://github.com/ros-drivers/velodyne/issues/178> from sts-thm/bugfix_issue_`#174 <https://github.com/ros-drivers/velodyne/issues/174>`_
  Bugfix issue #174 <https://github.com/ros-drivers/velodyne/issues/174>
* Removed debug outputs
* Changes fixing deadlock for specific cut_angle values.
* Merge pull request #135 <https://github.com/ros-drivers/velodyne/issues/135> from cfneuhaus/bugfix
  Bugfix: when no device ip is set, we still want to filter by udp port.
* Merge pull request #170 <https://github.com/ros-drivers/velodyne/issues/170> from ros-drivers/maint/move_header_files
  Moving header files to traditional location inside include folders.
* Merge pull request #160 <https://github.com/ros-drivers/velodyne/issues/160> from ros-drivers/maint/updating_package_xml_to_v2
* Updated all package.xmls to ver 2. Cleaned up catkin_lint errors.
  All package.xml files are now compatible with version 2 of the
  package.xml specification in REP 140. Removed some unnecessary
  execute permissions on a few files. Fixed a missing test_depend.
* Merge pull request #151 <https://github.com/ros-drivers/velodyne/issues/151> from Axel13fr/feature/No_Communication_Diag_Update
* Fix packet rate for the Velodyne 32C
* Conventions: adding name for unused method parameter.
* Added a periodic update of the diagnostics so that when no data is received at all from the Velodyne, a diagnostic information will be published. The previous implementation would publish diagnostics only on packet reception.
* Merge pull request #139 <https://github.com/ros-drivers/velodyne/issues/139> from ASDeveloper00/vlp32
  Adding support for VLP-32C.
* Merge pull request #138 <https://github.com/ros-drivers/velodyne/issues/138> from volkandre/cut_at_specified_angle_feature
* cut_angle parameter is now in rad according to REP 103
* Fixed timestamp related bug found by @cfneuhaus, which was described here: https://github.com/ros-drivers/velodyne/pull/126#discussion_r154137793
* bugfix: when no device ip is set, we still want to filter by udp port.
* Contributors: Andre Volk, CNR, Denis Dillenberger, Frank Neuhaus, Jack O'Quin, Joshua Whitley, Sammy Pfeiffer, Tobias Athmer, axd, kennouni
```

## velodyne_laserscan

```
* Merge pull request #170 <https://github.com/ros-drivers/velodyne/issues/170> from ros-drivers/maint/move_header_files
* Moving header files to traditional location inside include folders.
* Merge pull request #160 <https://github.com/ros-drivers/velodyne/issues/160> from ros-drivers/maint/updating_package_xml_to_v2
* Updated all package.xmls to ver 2. Cleaned up catkin_lint errors.
  All package.xml files are now compatible with version 2 of the
  package.xml specification in REP 140. Removed some unnecessary
  execute permissions on a few files. Fixed a missing test_depend.
* Merge pull request #146 <https://github.com/ros-drivers/velodyne/issues/146> from stsundermann/patch-2
  Use std::abs instead of fabsf
* Merge pull request #150 <https://github.com/ros-drivers/velodyne/issues/150> from ros-drivers/mikaelarguedas-patch-1
* update to use non deprecated pluginlib macro
* Use std::abs instead of fabsf
  cfg_.resolution is double but fabsf takes a float which may cause truncation of value.
* Contributors: Andre Volk, CNR, Joshua Whitley, Mikael Arguedas, Stephan Sundermann
```

## velodyne_msgs

```
* Updated all package.xmls to ver 2. Cleaned up catkin_lint errors.
  All package.xml files are now compatible with version 2 of the
  package.xml specification in REP 140. Removed some unnecessary
  execute permissions on a few files. Fixed a missing test_depend.
* Updated cut_at_specified_angle_feature with latest master version.
* Contributors: Andre Volk, Joshua Whitley
```

## velodyne_pointcloud

```
* Merge pull request #178 <https://github.com/ros-drivers/velodyne/issues/178> from sts-thm/bugfix_issue_`#174 <https://github.com/ros-drivers/velodyne/issues/174>`_
  Bugfix issue #174 <https://github.com/ros-drivers/velodyne/issues/174>
* Merge pull request #177 <https://github.com/ros-drivers/velodyne/issues/177> from C-NR/feature/WrapPointcloudData
  Feature/wrap pointcloud data
* Changes fixing deadlock for specific cut_angle values.
* moved definition of VPoint and VPointCloud back to namespace rawdata in rawdata.h
* put a wrapper around pointcloud data including a generic setter method to enable the use of arbitrary data structures  (pcl pointcloud, depth image, octomaps and so on) to be filled by just using RawData::unpack method with the wrapper object as parameter
* Merge pull request #170 <https://github.com/ros-drivers/velodyne/issues/170> from ros-drivers/maint/move_header_files
  Moving header files to traditional location inside include folders.
* Merge pull request #160 <https://github.com/ros-drivers/velodyne/issues/160> from ros-drivers/maint/updating_package_xml_to_v2
* Updated all package.xmls to ver 2. Cleaned up catkin_lint errors.
  All package.xml files are now compatible with version 2 of the
  package.xml specification in REP 140. Removed some unnecessary
  execute permissions on a few files. Fixed a missing test_depend.
* Merge pull request #136 <https://github.com/ros-drivers/velodyne/issues/136> from stsundermann/patch-1
  Use std::abs instead of abs
* Adding missing 32C configuration file.
* Merge pull request #139 <https://github.com/ros-drivers/velodyne/issues/139> from ASDeveloper00/vlp32
  Adding support for VLP-32C.
* Merge pull request #138 <https://github.com/ros-drivers/velodyne/issues/138> from volkandre/cut_at_specified_angle_feature
  Cut at specified angle feature
* Updated default cut_angle parameters in launch files after switching from deg to rad.
* Use std::abs instead of abs
  abs is the c version which returns an integer. This is probably not intended here, so use the templated std::abs function.
* Contributors: Andre Volk, Autonomoustuff Developer, CNR, Joshua Whitley, Kyle Rector, Stephan Sundermann, Tobias Athmer, kennouni
```
