### PR TITLE
rosmon: 1.0.9-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4162,7 +4162,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.8-0
+      version: 1.0.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.9-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.8-0`

## rosmon

```
* Fix race condition in integration test (issue #42, PR #54)
* Clean namespace names properly to fix double slashes (issue #49, PR #53)
* Respect ROS_NAMESPACE for nested launches (issue #46, PR #51)
* gui: Sort Memory column correctly (issue #48, PR #50)
* Try to find an executable *file* for nodes (issue #45, PR #47)
* Add --stop-timeout option and launch file attribute (PR #37)
* Handle params with leading slashes inside nodes (PR #40)
* Add --no-start option (PR #39)
* gui: Fix index bug in showContextMenu (PR #38)
* Contributors: Max Schwarz, Nikos Skalkotos, Romain Reignier
```
