### PR TITLE
mrpt_slam: 0.1.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2347,7 +2347,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.6-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.8-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.6-0`

## mrpt_ekf_slam_2d

```
* Make catkin_lint clean
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_ekf_slam_3d

```
* Make catkin_lint clean
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_graphslam_2d

```
* Make catkin_lint clean
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_icp_slam_2d

```
* Make catkin_lint clean
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_rbpf_slam

```
* Make catkin_lint clean
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_slam

```
* Make catkin_lint clean
* Contributors: Jose Luis Blanco Claraco
```
