### PR TITLE
Added libevdev, a wrapper system library for interacting with evdev devices

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1685,7 +1685,7 @@ libev-dev:
 libevdev-dev:
   arch: [libevdev]
   debian: [libevdev-dev]
-  fedora: [libevdev]
+  fedora: [libevdev-devel]
   ubuntu: [libevdev-dev]
 libexpat1-dev:
   arch: [expat]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1682,6 +1682,8 @@ libev-dev:
   fedora: [libev-devel]
   gentoo: [dev-libs/libev]
   ubuntu: [libev-dev]
+libevdev-dev:
+  ubuntu: [libevdev-dev]
 libexpat1-dev:
   arch: [expat]
   debian: [libexpat1-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1686,6 +1686,7 @@ libevdev-dev:
   arch: [libevdev]
   debian: [libevdev-dev]
   fedora: [libevdev-devel]
+  gentoo: [dev-libs/libevdev]
   ubuntu: [libevdev-dev]
 libexpat1-dev:
   arch: [expat]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1683,6 +1683,9 @@ libev-dev:
   gentoo: [dev-libs/libev]
   ubuntu: [libev-dev]
 libevdev-dev:
+  arch: [libevdev]
+  debian: [libevdev-dev]
+  fedora: [libevdev]
   ubuntu: [libevdev-dev]
 libexpat1-dev:
   arch: [expat]


### PR DESCRIPTION
libevdev is a library for handling evdev kernel devices. It abstracts the evdev ioctls through type-safe interfaces and provides functions to change the appearance of the device.

https://www.freedesktop.org/software/libevdev/doc/latest/
