### PR TITLE
rail_segmentation: 0.1.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10921,7 +10921,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_segmentation.git
-      version: 0.1.10-0
+      version: 0.1.11-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.11-0`:

- upstream repository: https://github.com/GT-RAIL/rail_segmentation.git
- release repository: https://github.com/gt-rail-release/rail_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.10-0`

## rail_segmentation

```
* Segmenter.h: Fix compilation error with -std=c++11.
  This commit fixes compilation errors due to compilation with std=c++11,
  such as:
  include/rail_segmentation/Segmenter.h:82:23: error: ‘constexpr’ needed for
  in-class initialization of static data member
  ‘const double rail::segmentation::Segmenter::SAC_EPS_ANGLE’ of
  non-integral type [-fpermissive]
  static const double SAC_EPS_ANGLE = 0.15;
  ^~~~~~~~~~~~~
  Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>
* Fixing a small bug so that the segment_objects service matches the topic data
* Better bounding box calculation, added average rgb and cielab color to segmented object messages as they are calculated anyway, and added an alternative service api, segment_objects, that returns the segmented object list in the service response (while still broadcasting the segmented object list on the topic)
* Constant definition fix for functions with reference parameters
* Added option for euclidean + RGB clustering instead of solely euclidean distance
* Contributors: David Kent, Elvis Dowson, Levon Avagyan, Russell Toris, Siddhartha Banerjee
```
