### PR TITLE
rail_manipulation_msgs: 0.0.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3371,6 +3371,22 @@ repositories:
       url: https://github.com/SCU-RSL-ROS/radar_omnipresense-release.git
       version: 0.3.0-0
     status: developed
+  rail_manipulation_msgs:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rail_manipulation_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
+      version: 0.0.12-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/GT-RAIL/rail_manipulation_msgs.git
+      version: melodic-devel
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.12-0`:

- upstream repository: https://github.com/GT-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rail_manipulation_msgs

```
* Added better bounding volumes and some other features to segmented object message, added alternative API for object segmentation that acts more like a service
* Contributors: David Kent
```
