### PR TITLE
yaml_cpp_0_6: 0.6.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14197,6 +14197,17 @@ repositories:
       url: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
       version: 0.3.1-0
     status: maintained
+  yaml_cpp_0_6:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com:cody-c/yaml_cpp_0_6-release.git
+      version: 0.6.3-0
+    source:
+      type: git
+      url: git@github.com:cody-c/yaml_cpp_0_6.git
+      version: devel
+    status: maintained
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Source repo: [yaml_cpp_0_6](https://github.com/cody-c/yaml_cpp_0_6.git)
Release repo: [yaml_cpp_0_6-release](https://github.com/cody-c/yaml_cpp_0_6-release.git)
Based on: [yaml_cpp_0_3](https://github.com/stonier/yaml_cpp_0_3.git)
[Yaml-cpp version 0.6.2](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.6.2)

- Adds ros support for yaml-cpp 0.6.2
- Apt repository does not provide support past version [0.5.2-4](https://launchpad.net/ubuntu/xenial/+source/yaml-cpp)
- Allows traceback on yaml errors.
- distro file: `kinetic/distribution.yaml`