### PR TITLE
yaml_cpp_0_6: 0.6.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14197,6 +14197,13 @@ repositories:
       url: https://github.com/yujinrobot-release/yaml_cpp_0_3-release.git
       version: 0.3.1-0
     status: maintained
+  yaml_cpp_0_6:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/cody-c/yaml_cpp_0_6-release.git
+      version: 0.6.3-1
+    status: maintained
   yocs_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_0_6` to `0.6.3-1`:

- upstream repository: https://github.com/cody-c/yaml_cpp_0_6.git
- release repository: https://github.com/cody-c/yaml_cpp_0_6-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## yaml_cpp_0_6

```
* Update library to use yaml-cpp-0.6.2
* Renamespaced library and headers (yaml-0.3->yaml-0.6)
* Contributors: cody-c
```
