### PR TITLE
pr2_common_actions: 0.0.11-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3233,6 +3233,25 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: kinetic-devel
     status: maintained
+  pr2_common_actions:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common_actions.git
+      version: kinetic-devel
+    release:
+      packages:
+      - joint_trajectory_action_tools
+      - joint_trajectory_generator
+      - pr2_arm_move_ik
+      - pr2_common_action_msgs
+      - pr2_common_actions
+      - pr2_tilt_laser_interface
+      - pr2_tuck_arms_action
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common_actions-release.git
+      version: 0.0.11-0
+    status: unmaintained
   pr2_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common_actions` to `0.0.11-0`:

- upstream repository: https://github.com/PR2/pr2_common_actions.git
- release repository: https://github.com/pr2-gbp/pr2_common_actions-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## joint_trajectory_action_tools

- No changes

## joint_trajectory_generator

```
* Merge pull request #38 <https://github.com/pr2/pr2_common_actions/issues/38> from k-okada/add_travis
  update travis.yml
* fix for urdfdom versoin > 1.0.0 (melodic)
* Contributors: Kei Okada
```

## pr2_arm_move_ik

- No changes

## pr2_common_action_msgs

- No changes

## pr2_common_actions

- No changes

## pr2_tilt_laser_interface

- No changes

## pr2_tuck_arms_action

- No changes
