### PR TITLE
rospilot: 1.5.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4091,7 +4091,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.5.1-0
+      version: 1.5.2-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.5.2-0`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.5.1-0`

## rospilot

```
* Fix compiler warnings
* Fix SPS & PPS ordering when using MFC encoder
  SPS should always be before PPS, as PPS references the SPS packet
* Remove unnecessary C++11 compiler flag
* Fix undefined behavior in AVPacket buffer management
  Use the provided av_new_packet() and av_packet_unref()
  functions instead of manual management of .data field
* Fix undefined behavior in memory deallocation
  This buffer is an array, and therefore must be deallocated with delete[]
* Contributors: Christopher Berner
```
