### PR TITLE
pilz_industrial_motion: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7910,7 +7910,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.1.1-0`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.0-0`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

- No changes

## pilz_msgs

- No changes

## pilz_trajectory_generation

```
* port to melodic
* drop unused dependencies
* Contributors: Pilz GmbH and Co. KG
```
