### PR TITLE
leap_motion: 0.0.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4983,7 +4983,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.11-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.13-0`:

- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.11-0`

## leap_motion

```
* Reimplementation of the entire Leap Motion driver for ROS
* Old implementation of the driver is now deprecated and will be removed in a year.
* Contributors: Isaac I.Y. Saito, nowittyusername
```
