### PR TITLE
leap_motion: 0.0.13-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1810,6 +1810,23 @@ repositories:
       url: https://github.com/ros-perception/laser_proc.git
       version: melodic-devel
     status: maintained
+  leap_motion:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: hydro
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/leap_motion-release.git
+      version: 0.0.13-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/leap_motion.git
+      version: hydro
+    status: developed
+    status_description: Slow development
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leap_motion` to `0.0.13-0`:

- upstream repository: https://github.com/ros-drivers/leap_motion
- release repository: https://github.com/ros-gbp/leap_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## leap_motion

```
* Reimplementation of the entire Leap Motion driver for ROS
* Old implementation of the driver is now deprecated and will be removed in a year.
* Contributors: Isaac I.Y. Saito, nowittyusername
```
