### PR TITLE
hsr_meshes: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3790,6 +3790,21 @@ repositories:
       url: https://github.com/fkanehiro/hrpsys-base.git
       version: master
     status: developed
+  hsr_meshes:
+    doc:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/hsr_meshes.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ToyotaResearchInstitute/hsr_meshes-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/hsr_meshes.git
+      version: master
+    status: maintained
   hugin_panorama:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hsr_meshes` to `1.1.0-0`:

- upstream repository: https://github.com/ToyotaResearchInstitute/hsr_meshes.git
- release repository: https://github.com/ToyotaResearchInstitute/hsr_meshes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## hsr_meshes

```
* Initial commit
* Contributors: Akiyoshi Ochiai
```
