### PR TITLE
mynteye-roswrapper: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6295,7 +6295,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/harjeb/mynt_eye_ros_wrapper-release.git
-      version: 0.1.1-0
+      version: 0.1.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mynteye-roswrapper` to `0.1.3-0`:

- upstream repository: https://github.com/harjeb/mynt_eye_ros_wrapper.git
- release repository: https://github.com/harjeb/mynt_eye_ros_wrapper-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.1-0`

## mynt_eye_ros_wrapper

```
* fix opencv detect
```
