### PR TITLE
pr2_apps: 0.6.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3212,6 +3212,25 @@ repositories:
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
       version: master
     status: maintained
+  pr2_apps:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_apps.git
+      version: melodic-devel
+    release:
+      packages:
+      - pr2_app_manager
+      - pr2_apps
+      - pr2_mannequin_mode
+      - pr2_position_scripts
+      - pr2_teleop
+      - pr2_teleop_general
+      - pr2_tuckarm
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_apps-release.git
+      version: 0.6.1-0
+    status: unmaintained
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_apps` to `0.6.1-0`:

- upstream repository: https://github.com/PR2/pr2_apps.git
- release repository: https://github.com/pr2-gbp/pr2_apps-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pr2_app_manager

- No changes

## pr2_apps

- No changes

## pr2_mannequin_mode

- No changes

## pr2_position_scripts

- No changes

## pr2_teleop

- No changes

## pr2_teleop_general

```
* Merge pull request #36 <https://github.com/pr2/pr2_apps/issues/36> from k-okada/add_travis
  update travis.yml
* fix urdf::JointConstSharedPtr for melodic
* Contributors: Kei Okada
```

## pr2_tuckarm

- No changes
