### PR TITLE
hsr_description: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3794,6 +3794,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/ToyotaResearchInstitute/hsr_description.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ToyotaResearchInstitute/hsr_description-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/hsr_description.git
+      version: master
+    status: maintained
   hsr_meshes:
     doc:
       type: git
@@ -3802,13 +3813,6 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ToyotaResearchInstitute/hsr_description-release.git
-      version: 1.1.0-0
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ToyotaResearchInstitute/hsr_description.git
-      version: 1.1.0
       url: https://github.com/ToyotaResearchInstitute/hsr_meshes-release.git
       version: 1.1.0-0
     source:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3790,6 +3790,22 @@ repositories:
       url: https://github.com/fkanehiro/hrpsys-base.git
       version: master
     status: developed
+  hsr_description:
+    doc:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/hsr_description.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ToyotaResearchInstitute/hsr_description-release.git
+      version: 1.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/hsr_description.git
+      version: 1.1.0
+    status: maintained
   hugin_panorama:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hsr_description` to `1.1.0-0`:

- upstream repository: https://github.com/ToyotaResearchInstitute/hsr_description.git
- release repository: https://github.com/ToyotaResearchInstitute/hsr_description-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## hsr_description

```
* Support Wavefront OBJ format meshes
  Fixed CMakeLists for install
* Initial commit
* Contributors: Akiyoshi Ochiai, Yutaka Takaoka
```
