### PR TITLE
Adding raspicat_ros to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8855,6 +8855,16 @@ repositories:
       url: https://github.com/bberrevoets/raspi_temperature.git
       version: master
     status: maintained
+  raspicat_ros:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspicat_ros.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/rt-net/raspicat_ros.git
+      version: kinetic-devel
+    status: developed
   raspigibbon_apps:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspicat_ros for ROS Kinetic to be doc'd and indexed.