### PR TITLE
Add python-bcrypt to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -478,6 +478,12 @@ python-backports.ssl-match-hostname:
     wily: [python-backports.ssl-match-hostname]
     xenial: [python-backports.ssl-match-hostname]
     yakkety: [python-backports.ssl-match-hostname]
+python-bcrypt:
+  arch: [python-bcrypt]
+  debian: [python-bcrypt]
+  fedora: [python-bcrypt]
+  gentoo: [dev-python/bcrypt]
+  ubuntu: [python-bcrypt]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -479,7 +479,7 @@ python-backports.ssl-match-hostname:
     xenial: [python-backports.ssl-match-hostname]
     yakkety: [python-backports.ssl-match-hostname]
 python-bcrypt:
-  arch: [python-bcrypt]
+  arch: [python2-bcrypt]
   debian: [python-bcrypt]
   fedora: [python-bcrypt]
   gentoo: [dev-python/bcrypt]


### PR DESCRIPTION
We use [bcrypt](https://github.com/pyca/bcrypt/) to generate salted blowfish hashes in one of our projects. Would be grate to have it via rosdep.

[arch](https://www.archlinux.org/packages/community/x86_64/python-bcrypt/)
[debian](https://packages.debian.org/jessie/python-bcrypt)
[fedora](http://rpms.famillecollet.com/rpmphp/zoom.php?rpm=python-bcrypt)
[gentoo](https://packages.gentoo.org/packages/dev-python/bcrypt)
[ubuntu](https://packages.ubuntu.com/search?keywords=python-bcrypt&searchon=names&suite=all&section=all)

Thanks!