### PR TITLE
Add python-sympy-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3830,6 +3830,16 @@ python-sympy:
     wily_python3: [python3-sympy]
     xenial: [python-sympy]
     xenial_python3: [python3-sympy]
+python-sympy-pip:
+  debian:
+    pip:
+      packages: [sympy]
+  fedora:
+    pip:
+      packages: [sympy]
+  ubuntu:
+    pip:
+      packages: [sympy]
 python-sysv-ipc:
   debian: [python-sysv-ipc]
   fedora: [python2-sysv-ipc]


### PR DESCRIPTION
apt provides an outdated version of sympy. pip has the most recent

Example where this is a problem: https://answers.ros.org/question/304466/rosdep-pip-instead-of-apt/