### PR TITLE
[lunar] revert move_base_flex to 0.1.0...

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2223,7 +2223,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.2.0-1
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
... as 0.2.0 does [not compile on Debian Stretch](https://github.com/magazino/move_base_flex/issues/90)

@corot @spuetz FYI