### PR TITLE
vmrc: 0.3.0-1 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13820,6 +13820,11 @@ repositories:
       url: https://bitbucket.org/osrf/vmrc
       version: default
     release:
+      packages:
+      - usv_gazebo_plugins
+      - vmrc_gazebo
+      - wamv_description
+      - wamv_gazebo
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/osrf/vmrc-release

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13814,6 +13814,21 @@ repositories:
       type: git
       url: https://github.com/uos/volksbot_driver.git
       version: kinetic
+  vmrc:
+    doc:
+      type: hg
+      url: https://bitbucket.org/osrf/vmrc
+      version: default
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://bitbucket.org/osrf/vmrc-release
+      version: 0.3.0-1
+    source:
+      type: hg
+      url: https://bitbucket.org/osrf/vmrc
+      version: default
+    status: maintained
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
Initial release:

* Upstream repository: https://bitbucket.org/osrf/vmrc
* Release repository: https://bitbucket.org/osrf/vmrc-release
* distro file: `kinetic/distribution.yaml`