### PR TITLE
igvc_self_drive_sim: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1427,6 +1427,17 @@ repositories:
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
     status: developed
+  igvc_self_drive_sim:
+    release:
+      packages:
+      - igvc_self_drive_description
+      - igvc_self_drive_gazebo
+      - igvc_self_drive_gazebo_plugins
+      - igvc_self_drive_sim
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/robustify/igvc_self_drive_sim-release.git
+      version: 0.1.0-0
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `igvc_self_drive_sim` to `0.1.0-0`:

- upstream repository: https://github.com/robustify/igvc_self_drive_sim.git
- release repository: https://github.com/robustify/igvc_self_drive_sim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## igvc_self_drive_description

```
* Migrated existing simulator into new repository
* Contributors: Micho Radovnikovich
```

## igvc_self_drive_gazebo

```
* Migrated existing simulator into new repository
* Contributors: Micho Radovnikovich
```

## igvc_self_drive_gazebo_plugins

```
* Migrated existing simulator into new repository
* Contributors: Micho Radovnikovich
```

## igvc_self_drive_sim

```
* Migrated existing simulator into new repository
* Contributors: Micho Radovnikovich
```
