### PR TITLE
Increased rtabmap and rtabmap_ros packages version 

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13947,7 +13947,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.1-0
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -13962,7 +13962,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.0-1
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11432,7 +11432,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.1-0
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -11447,7 +11447,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.0-1
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4801,7 +4801,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.0-1
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -4816,7 +4816,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.0-1
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4694,7 +4694,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.1-0
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increased rtabmap and rtabmap_ros packages version to 0.17.6 on indigo/kinetic/lunar/melodic