### PR TITLE
ros_control: 0.15.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3830,7 +3830,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.15.0-0
+      version: 0.15.1-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Hola from ROSCon2018

Increasing version of package(s) in repository `ros_control` to `0.15.1-0`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.15.0-0`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

```
* Updated for compatibility with Python2 or Python3
* Initialize controller_manager node using init_node.
* back to Python3 prints, add '-s to remaining places
* pep8 styling
* added quotes in python code too, also changed python prints to rosconsole
* added quotes for controller name and controller type in warnings and errors
* Contributors: Daniel Ingram, Jasper Güldenstein, Stefan Profanter, Gennaro Raiola, Bence Magyar
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Added quotes for controller name and controller type in warnings and errors
* Update expected text in tests to have '' around controller names
* Contributors: Bence Magyar, Gennaro Raiola
```

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
