### PR TITLE
Revert leap_motion package back to 0.0.11-0

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4998,7 +4998,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.14-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/ros-drivers/leap_motion.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1830,7 +1830,6 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.11-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1830,7 +1830,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/leap_motion-release.git
-      version: 0.0.13-0
+      version: 0.0.11-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Make the buildfarm use version 0.0.11 again. Reverts pull requests https://github.com/ros/rosdistro/pull/19173 https://github.com/ros/rosdistro/pull/19172
