### PR TITLE
audibot: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -580,6 +580,16 @@ repositories:
       type: git
       url: https://github.com/joaoquintas/auction_methods_stack.git
       version: master
+  audibot:
+    release:
+      packages:
+      - audibot
+      - audibot_description
+      - audibot_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/robustify/audibot-release.git
+      version: 0.1.0-0
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audibot` to `0.1.0-0`:

- upstream repository: https://github.com/robustify/audibot.git
- release repository: https://github.com/robustify/audibot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## audibot

```
* First release
* Contributors: Micho Radovnikovich
```

## audibot_description

```
* First release
* Contributors: Micho Radovnikovich
```

## audibot_gazebo

```
* First release
* Contributors: Micho Radovnikovich
```
