### PR TITLE
audibot: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -176,6 +176,16 @@ repositories:
       url: https://github.com/gt-rail-release/async_web_server_cpp-release.git
       version: 0.0.3-0
     status: unmaintained
+  audibot:
+    release:
+      packages:
+      - audibot
+      - audibot_description
+      - audibot_gazebo
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/robustify/audibot-release.git
+      version: 0.1.0-1
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audibot` to `0.1.0-1`:

- upstream repository: https://github.com/robustify/audibot.git
- release repository: https://github.com/robustify/audibot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## audibot

```
* First release
* Contributors: Micho Radovnikovich
```

## audibot_description

```
* First release
* Contributors: Micho Radovnikovich
```

## audibot_gazebo

```
* First release
* Contributors: Micho Radovnikovich
```
