### PR TITLE
[py_trees] source testing branch switch

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8494,7 +8494,7 @@ repositories:
     source:
       type: git
       url: https://github.com/stonier/py_trees.git
-      version: devel
+      version: release/0.5-kinetic
     status: developed
   py_trees_msgs:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3265,7 +3265,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/stonier/py_trees.git
-      version: devel
+      version: release/0.6-melodic
     status: maintained
   py_trees_msgs:
     doc:


### PR DESCRIPTION
No longer applicable to 'devel' branch.