### PR TITLE
vmrc: 0.3.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13850,6 +13850,17 @@ repositories:
       url: https://github.com/JdeRobot/VisualStates.git
       version: master
     status: developed
+  vmrc:
+    release:
+      packages:
+      - usv_gazebo_plugins
+      - vmrc_gazebo
+      - wamv_description
+      - wamv_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/vmrc-release
+      version: 0.3.0-2
   volksbot_driver:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13859,7 +13859,7 @@ repositories:
       - wamv_gazebo
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/vmrc-release
+      url: https://github.com/ros-gbp/vmrc-release.git
       version: 0.3.0-2
   volksbot_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `vmrc` to `0.3.0-2`:

- upstream repository: https://bitbucket.org/osrf/vmrc
- release repository: https://github.com/ros-gbp/vmrc-release
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## usv_gazebo_plugins

```
* vmrc metapackage and spring cleaning.
* adding publication of forces/moments
* trying to get wamv to be static using a fixed joint
* Adding publication from dynamics plugin for wave height at USV CG for Josh's thesis work
* Tweak
* Changelog and minor tweaks.
* Remove extra dependency.
* Merged in generalize-thruster-desc (pull request #34)
  Generalize thruster desc
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* merging changes from PR branch into development branch
* resolving merge conflict
* Adding bits to repond to PR comments
* adding examples for T and X thruster configurations - accessible as args to sandisland.launch. Prototype - too much redundancy in the various urdf.xacro file hierarchy, but functional.
* Tweaks.
* Tabs -> spaces
* Initial style pass
* props now spinning, removed old method of thrust implementation, removed custome UsvDrive message
* working prototype - next remove old method
* prior to splitting thruster into its own header
* increment - builds, but need to go home
* catching up with default
* increment, pushing to work from home
* first steps towards new structure
* Drop log level to DEBUG for imformation unimportant to user
* Minor style changes in the gazebo_ros_color plugin.
* Tweak
* Move log message to DEBUG.
* adding a bit more doxygen, including link to Theory of Operation document
* Tweaks.
* adding doxygen comments
* Doxygen and cleaning up
* Rename buoyLinks to buoyancyLinks and remove debug output.
* More style.
* More tweaks.
* Initial style changes.
* Merge from default.
* Apply Gazebo style.
* Move some ROS_INFO messages to ROS_DEBUG and remove ros::init().
* More tweaks.
* Tweaks
* Tweaks
* Initial work
* Publish joint_states from thrust plugin
* Tweak
* Refactor wind plugin.
* Split the wamv xacro file.
* Generate messages before building the Thrust plugin.
* More modular model with spinning propellers.
* Merge from default
* Add message_generation.
* Backed out changeset 8023d94fc0e1
* Add light buoy challenge
* Remove unsused buoyancy plugin (already in gazebo)
* Boostrap usv_gazebo_plugins
* Move gazebo plugins to usv_gazebo_plugins
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:caguero@osrfoundation.org>, Kevin Allen <mailto:kallen@osrfoundation.org>
```

## vmrc_gazebo

```
* Tweak
* Rename robotx_gazebo to vmrc_gazebo and remove metapackage.
* Contributors: Carlos Agüero <mailto:caguero@osrfoundation.org>
```

## wamv_description

```
* vmrc metapackage and spring cleaning.
* Static model and fog.
* Merge from default.
* Merged in holonomic-example-refactored (pull request #40)
  Holonomic example refactored
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Refactor thruster layout customization
* adding blank world for photo shoot of propulsion
* adding examples for T and X thruster configurations - accessible as args to sandisland.launch. Prototype - too much redundancy in the various urdf.xacro file hierarchy, but functional.
* Integrate the placards into the docks.
* Install config/launch files
* Remove references to the Gazebo 8 wind plugin.
* Do not generate anything from engine.xacro.
* Restore wind
* Split the wamv xacro file.
* More modular model with spinning propellers.
* Merged in packages (pull request #4)
  Packages
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Remove unused properties.urdf
* Remove unused PROPELLER.dae
* Merged in kevin-refactor (pull request #3)
  Various cleanups / refactors
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
  Approved-by: Kevin Allen <mailto:kallen@osrfoundation.org>
* Remove unused spreadsheets and thrust_curve_fit program
* Remove autogenerated files
* Build xacro files as install targets
* Remove platform specific features from wamv base
* Delete unused/broken launch files in wamv_description
* Delete unused blender param files
* Merge from default
* Simplified collisions
* Simplified collisions
* Small cleanup of old comments.
* Updated WAM-V model.
* Merge from waves/master usv_gazebo_plugins.
* Initial version of the code.
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Kevin Allen <mailto:kallen@osrfoundation.org>
```

## wamv_gazebo

```
* Tweak
* vmrc metapackage and spring cleaning.
* Static model and fog.
* trying to get wamv to be static using a fixed joint
* Merge from default.
* reverting example rviz config back to original to be consistent with existing tutorial
* adding launch/config files for running the example
* adding examples to the sensors tutorial for the T and X propulsion configuration
* Create a standard sensor configuration for VMRC.
* Merged in 3dlaser (pull request #41)
  Add 3D laser xacro
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Merge from default.
* Merged in holonomic-example-refactored (pull request #40)
  Holonomic example refactored
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Add 3D laser xacro
* Refactor thruster layout customization
* Enable on/off arguments for sensors xacro
* Fix multibeam laser xacro
* adding examples for T and X thruster configurations - accessible as args to sandisland.launch. Prototype - too much redundancy in the various urdf.xacro file hierarchy, but functional.
* Tabs -> spaces
* Initial style pass
* props now spinning, removed old method of thrust implementation, removed custome UsvDrive message
* working prototype - next remove old method
* increment - builds, but need to go home
* Add changelog.
* Merge from default
* Removing superfluous SDF for thrust
* More tweaks.
* Merge from default.
* Merged in sensor-examples (pull request #12)
  Add sensor macros and example
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Add multibeam to example sensor urdf
* Add simple visuals for sensors
* Move multibream -> multibeam
* Remove unneeded robot_description param from localization_example.launch
* Add optical frame for proper camera visualization
* Install config/launch files
* Merge default into sensor-examples
* Simplify wamv_gazebo macros
* Simplify xacro macros
* Refactor wind plugin.
* Split the wamv xacro file.
* More modular model with spinning propellers.
* Add example rviz config/launch
* Tweak
* Tweak
* Add sensor macros and example localization config
* Fix issues after wamv_gazebo migration
* Boostrap wamv_gazebo
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Kevin Allen <mailto:kallen@osrfoundation.org>
```
