### PR TITLE
dynamic_reconfigure: 1.5.50-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2165,7 +2165,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.49-0
+      version: 1.5.50-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.5.50-0`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.5.49-0`

## dynamic_reconfigure

```
* final-keyword (#113 <https://github.com/ros/dynamic_reconfigure/issues/113>)
  * Add final keyword to child class since parent has virtual methods and grand parent doesn't have a virtual destructor. This allows the code to be compiled by clang version 6.0 and above.
* [indentation fixups]
  * Use textwrap dedent for multiline strings
  * Remove extra indentation in wikidoc
  * Use textwrap.dedent to form the error message
* [test fix] call shutdown to prevent test from hanging (#119 <https://github.com/ros/dynamic_reconfigure/issues/119>)
* Modernize Python code (#102 <https://github.com/ros/dynamic_reconfigure/issues/102>)
  * Use new-style classes
  * Use with statement to ensure files are closed
* Python 3 compatibility (#105 <https://github.com/ros/dynamic_reconfigure/issues/105>)
  * some randon python cleanup
  * remove iter* method for their 2/3 compatible equivalent
* Contributors: Eric Wieser, Jason Mercer, Mikael Arguedas
```
