### PR TITLE
dynamic_reconfigure: 1.6.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -642,7 +642,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.5.49-1
+      version: 1.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.6.0-0`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.5.49-1`

## dynamic_reconfigure

```
* fix check preventing range for string and bool parameters (#122 <https://github.com/ros/dynamic_reconfigure/issues/122>)
* Fix build issue on Windows (#114 <https://github.com/ros/dynamic_reconfigure/issues/114>)
* Contributors: Johnson Shih, Mikael Arguedas
```
