### PR TITLE
bond_core: 1.8.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -242,7 +242,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.8.2-0
+      version: 1.8.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.3-0`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.8.2-0`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Argument to Boost Milliseconds must be integral in Boost >= 1.67 (#37 <https://github.com/ros/bond_core/issues/37>)
  * Argument to Boost milliseconds  must be integral
  * Fix style
  * More consistent type
* Contributors: Paul-Edouard Sarlin
```

## bondpy

- No changes

## smclib

- No changes
