### PR TITLE
Adding rule to install pytides pip Python package.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2939,6 +2939,10 @@ python-pytest-qt-pip:
   ubuntu:
     pip:
       packages: [pytest-qt]
+python-pytides-pip:
+  ubuntu:
+    pip:
+      packages: [pytides]
 python-pytz-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
# Availability

The pytides package is only available via pip: https://pypi.org/project/pytides/

It is not available via apt.

# Testing - resolve

I updated my rosdep sources using the forked branch for this PR and tested that I could find pytides with the following commands:

    rosdep resolve python-pytides-pip --os=ubuntu:trusty
    rosdep resolve python-pytides-pip --os=ubuntu:precise
    rosdep resolve python-pytides-pip --os=ubuntu:xenial
    rosdep resolve python-pytides-pip --os=ubuntu:bionic

All of those commands returned:

    #pip
    pytides

# Testing - Nose

I ran `nosetests` in the repository root and did not get any errors.

    Ran 6 tests in 104.859s
    OK