### PR TITLE
move_base_flex: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5895,7 +5895,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.1-0`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.2.0-0`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Fix memory leak
* Fix uninitialized value for cost
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_costmap_core

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_costmap_nav

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_msgs

- No changes

## mbf_simple_nav

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_utility

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## move_base_flex

- No changes
