### PR TITLE
move_base_flex: 0.2.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2223,7 +2223,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.1.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.1-0`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.1.0-0`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Fix memory leak
* Fix uninitialized value for cost
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_costmap_core

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_costmap_nav

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_msgs

- No changes

## mbf_simple_nav

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_utility

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## move_base_flex

- No changes
