### PR TITLE
move_base_flex: 0.2.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2162,6 +2162,30 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: melodic-devel
     status: maintained
+  move_base_flex:
+    doc:
+      type: git
+      url: https://github.com/magazino/move_base_flex.git
+      version: melodic
+    release:
+      packages:
+      - mbf_abstract_core
+      - mbf_abstract_nav
+      - mbf_costmap_core
+      - mbf_costmap_nav
+      - mbf_msgs
+      - mbf_simple_nav
+      - mbf_utility
+      - move_base_flex
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/move_base_flex-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/magazino/move_base_flex.git
+      version: melodic
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.1-0`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Fix memory leak
* Fix uninitialized value for cost
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_costmap_core

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_costmap_nav

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_msgs

- No changes

## mbf_simple_nav

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## mbf_utility

```
* Make MBF melodic and indigo compatible
* Fix GoalHandle references bug in callbacks
```

## move_base_flex

- No changes
