### PR TITLE
Increased rtabmap and rtabmap_ros version for Indigo

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13971,7 +13971,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.1-0
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -13986,7 +13986,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.0-1
+      version: 0.17.6-0
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increased rtabmap and rtabmap_ros version to 0.17.6 on Indigo