### PR TITLE
nanomsg: 0.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6353,6 +6353,17 @@ repositories:
       url: https://github.com/harjeb/mynt_eye_ros_wrapper.git
       version: master
     status: developed
+  nanomsg:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/nanomsg-release.git
+      version: 0.4.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/nanomsg.git
+      version: release/0.4-kinetic-melodic
+    status: maintained
   nao_dcm_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanomsg` to `0.4.1-0`:

- upstream repository: https://github.com/stonier/nanomsg.git
- release repository: https://github.com/yujinrobot-release/nanomsg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
