### PR TITLE
astuff_sensor_msgs: 2.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -537,7 +537,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 2.2.2-0
+      version: 2.3.0-0
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `2.3.0-0`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `2.2.2-0`

## astuff_sensor_msgs

- No changes

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

- No changes

## delphi_srr_msgs

- No changes

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

```
* PACMod: Add COMPONENT_RPT and CLEAR_FAULTS flag. (#28 <https://github.com/astuff/astuff_sensor_msgs/issues/28>)
* Merge pull request #27 <https://github.com/astuff/astuff_sensor_msgs/issues/27> from astuff/fix/turn_signal_values
* PACMod: Making message def. match DBC.
* Contributors: Joshua Whitley, Zach Oakes
```

## radar_msgs

- No changes
