### PR TITLE
bagger: 0.1.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -697,7 +697,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
-      version: 0.1.2-0
+      version: 0.1.3-2
+    source:
+      type: git
+      url: https://github.com/squarerobot/bagger.git
+      version: master
     status: maintained
   baldor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.3-2`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.1.2-0`

## bagger

```
* Infer and publish bag names and directories for each bag profile
* Add CL option to not decompress bags.  Fixes #4 <https://github.com/squarerobot/bagger/issues/4>
* Contributors: Brenden Gibbons
```
