### PR TITLE
bagger: 0.1.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -216,6 +216,12 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: developed
+  bagger:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/squarerobot/bagger-release.git
+      version: 0.1.3-0
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.3-0`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## bagger

```
* Infer and publish bag names and directories for each bag profile
* Add CL option to not decompress bags.  Fixes #4 <https://github.com/squarerobot/bagger/issues/4>
* Contributors: Brenden Gibbons
```
