### PR TITLE
playful: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9755,6 +9755,22 @@ repositories:
       url: https://github.com/pal-robotics/play_motion.git
       version: indigo-devel
     status: developed
+  playful:
+    doc:
+      type: git
+      url: https://github.com/vincentberenz/playful.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/vincentberenz/playful-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/vincentberenz/playful.git
+      version: master
+    status: maintained
+    status_description: maintained
   plot_util:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `playful` to `1.0.1-0`:

- upstream repository: https://github.com/vincentberenz/playful.git
- release repository: https://github.com/vincentberenz/playful-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## playful

```
* Merge branch 'master' of https://github.com/vincentberenz/playful
* updated license in package.xml
* added gitignore file
* Update README.md
* initial commit
* Contributors: Vincent Berenz
```
