### PR TITLE
vmrc: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13866,6 +13866,10 @@ repositories:
       version: master
     status: developed
   vmrc:
+    doc:
+      type: hg
+      url: https://bitbucket.org/osrf/vmrc
+      version: default
     release:
       packages:
       - usv_gazebo_plugins
@@ -13875,7 +13879,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vmrc-release.git
-      version: 0.3.0-2
+      version: 0.3.1-0
+    source:
+      type: hg
+      url: https://bitbucket.org/osrf/vmrc/
+      version: default
+    status: developed
   volksbot_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vmrc` to `0.3.1-0`:

- upstream repository: https://bitbucket.org/osrf/vmrc
- release repository: https://github.com/ros-gbp/vmrc-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.3.0-2`

## usv_gazebo_plugins

```
* Decleare eigen as dependency for usv_gazebo_plugins
* modifying grid spacing
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## vmrc_gazebo

- No changes

## wamv_description

- No changes

## wamv_gazebo

- No changes
