### PR TITLE
igvc_self_drive_sim: 0.1.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3978,7 +3978,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/robustify/igvc_self_drive_sim-release.git
-      version: 0.1.0-0
+      version: 0.1.4-1
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `igvc_self_drive_sim` to `0.1.4-1`:

- upstream repository: https://github.com/robustify/igvc_self_drive_sim.git
- release repository: https://github.com/robustify/igvc_self_drive_sim-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.1.0-0`

## igvc_self_drive_description

- No changes

## igvc_self_drive_gazebo

- No changes

## igvc_self_drive_gazebo_plugins

```
* Restructured tests to avoid deleting Gazebo model
* Contributors: Micho Radovnikovich
```

## igvc_self_drive_sim

- No changes
