### PR TITLE
ros_pytest: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10306,7 +10306,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/machinekoder/ros_pytest-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/machinekoder/ros_pytest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_pytest` to `0.1.0-1`:

- upstream repository: https://github.com/machinekoder/ros_pytest.git
- release repository: https://github.com/machinekoder/ros_pytest-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.0-0`
