### PR TITLE
ros_pytest: 0.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3982,6 +3982,21 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: melodic
     status: maintained
+  ros_pytest:
+    doc:
+      type: git
+      url: https://github.com/machinekoder/ros_pytest.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/machinekoder/ros_pytest-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/machinekoder/ros_pytest.git
+      version: melodic-devel
+    status: developed
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_pytest` to `0.1.1-0`:

- upstream repository: https://github.com/machinekoder/ros_pytest.git
- release repository: https://github.com/machinekoder/ros_pytest-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## ros_pytest

```
* *Release for melodic
```
