### PR TITLE
Add python-cairosvg rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -612,6 +612,12 @@ python-cairo:
     slackpkg:
       packages: [pycairo]
   ubuntu: [python-cairo]
+python-cairosvg:
+  arch: [python2-cairosvg]
+  debian: [python-cairosvg]
+  fedora: [python-cairosvg]
+  gentoo: [media-gfx/cairosvg]
+  ubuntu: [python-cairosvg]
 python-can:
   alpine:
     pip:


### PR DESCRIPTION
Provides svg rendering functions https://cairosvg.org/ 