### PR TITLE
flatbuffers: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1011,6 +1011,13 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: melodic-devel
     status: maintained
+  flatbuffers:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/flatbuffers-release.git
+      version: 1.1.0-0
+    status: maintained
   fmi_adapter:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `flatbuffers` to `1.1.0-0`:

- upstream repository: https://github.com/stonier/flatbuffers
- release repository: https://github.com/yujinrobot-release/flatbuffers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
