### PR TITLE
teraranger: 1.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12581,7 +12581,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
-      version: 1.2.1-1
+      version: 1.3.0-0
+    source:
+      type: git
+      url: https://github.com/Terabee/teraranger.git
+      version: master
     status: maintained
   teraranger_array:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `1.3.0-0`:

- upstream repository: git@github.com:Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.2.1-1`

## teraranger

```
* Update maintainer list
* Update Readme for Evo 64px
* Add driver node for Evo 64px
* Contributors: Baptiste Potier, Pierre-Louis Kabaradjian
```
