### PR TITLE
teraranger_array: 1.3.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12588,7 +12588,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_array-release.git
-      version: 1.3.3-0
+      version: 1.3.4-0
+    source:
+      type: git
+      url: https://github.com/Terabee/teraranger_array.git
+      version: ros-release
     status: maintained
   teraranger_array_converter:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `1.3.4-0`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.3.3-0`

## teraranger_array

```
* Update maintainer list
* Fix reconfigure infos
* Make sure processAck always returns something
* Mention dependency on serial package in readme
* Avoid narrowing cast in switch case
* Contributors: Morten Fyhn Amundsen, Pierre-Louis Kabaradjian
```
