### PR TITLE
teraranger_description: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12602,7 +12602,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger_description-release.git
-      version: 1.0.2-0
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/Terabee/teraranger_description.git
+      version: ros-release
+    status: maintained
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_description` to `1.1.0-0`:

- upstream repository: https://github.com/Terabee/teraranger_description.git
- release repository: https://github.com/Terabee/teraranger_description-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.0.2-0`

## teraranger_description

```
* Update README for Tower Evo
* Add files for Tower Evo
* Contributors: Baptiste Potier, Kabaradjian Pierre-Louis
```
