### PR TITLE
flatbuffers: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2748,6 +2748,13 @@ repositories:
       url: https://github.com/pyros-dev/flask-reverse-proxy-rosrelease.git
       version: 0.2.0-0
     status: maintained
+  flatbuffers:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/flatbuffers-release.git
+      version: 1.1.0-0
+    status: maintained
   flir_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flatbuffers` to `1.1.0-0`:

- upstream repository: https://github.com/stonier/flatbuffers
- release repository: https://github.com/yujinrobot-release/flatbuffers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
