### PR TITLE
message_multiplexing: 0.2.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5690,6 +5690,28 @@ repositories:
       url: https://github.com/ros/message_generation.git
       version: kinetic-devel
     status: maintained
+  message_multiplexing:
+    doc:
+      type: git
+      url: https://github.com/stonier/message_multiplexing.git
+      version: release/0.2-kinetic-melodic
+    release:
+      packages:
+      - message_multiplexing
+      - mm_core_msgs
+      - mm_eigen_msgs
+      - mm_messages
+      - mm_mux_demux
+      - mm_radio
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/message_multiplexing-release.git
+      version: 0.2.4-0
+    source:
+      type: git
+      url: https://github.com/stonier/message_multiplexing.git
+      version: release/0.2-kinetic-melodic
+    status: maintained
   message_runtime:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_multiplexing` to `0.2.4-0`:

- upstream repository: https://github.com/stonier/message_multiplexing.git
- release repository: https://github.com/yujinrobot-release/message_multiplexing-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## mm_messages

```
* debug macro to enable/disable message registration logs to stdout (default disable)
```

## mm_radio

```
* bugfix for socket closing - was leaving sockets with id=0 hanging.
```
