### PR TITLE
nanomsg: 0.4.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2470,6 +2470,13 @@ repositories:
       url: https://github.com/ual-arm-ros-pkg/mvsim.git
       version: master
     status: maintained
+  nanomsg:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/nanomsg-release.git
+      version: 0.4.1-0
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanomsg` to `0.4.1-0`:

- upstream repository: https://github.com/stonier/nanomsg.git
- release repository: https://github.com/yujinrobot-release/nanomsg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
