### PR TITLE
vmrc: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13921,7 +13921,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vmrc-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: hg
       url: https://bitbucket.org/osrf/vmrc/


### PR DESCRIPTION
Increasing version of package(s) in repository `vmrc` to `0.3.2-0`:

- upstream repository: https://bitbucket.org/osrf/vmrc
- release repository: https://github.com/ros-gbp/vmrc-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.3.1-0`

## usv_gazebo_plugins

```
* Include jrivero as maintainer of the ROS packages
* Include headers in the installation of usv_gazebo_plugins
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## vmrc_gazebo

```
* Include jrivero as maintainer of the ROS packages
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## wamv_description

```
* Include jrivero as maintainer of the ROS packages
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## wamv_gazebo

```
* Include jrivero as maintainer of the ROS packages
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```
