### PR TITLE
rosdep: adding python-fysom-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1355,6 +1355,16 @@ python-fysom:
   ubuntu:
     pip:
       packages: [fysom]
+python-fysom-pip:
+  debian:
+    pip:
+      packages: [fysom]
+  fedora:
+    pip:
+      packages: [fysom]
+  ubuntu:
+    pip:
+      packages: [fysom]
 python-gTTS-pip:
   debian:
     pip:


### PR DESCRIPTION
Adds the pip version for Fysom.