### PR TITLE
marti_messages: 0.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5551,7 +5551,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.6.0-0
+      version: 0.7.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.7.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.6.0-0`

## marti_can_msgs

```
* Update Maintainers
* Contributors: P. J. Reed
```

## marti_common_msgs

- No changes

## marti_nav_msgs

```
* Add RouteArray.msg file
* Contributors: Daniel-Stanek, P. J. Reed
```

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
