### PR TITLE
novatel_gps_driver: 3.6.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2692,7 +2692,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 3.5.0-0
+      version: 3.6.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.6.0-0`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `3.5.0-0`

## novatel_gps_driver

```
* Allow setting the serial baud rate through serial_baud ROS parameter
* Add support for BESTUTM log
* Add support for INSPVAX log (#27)
* Contributors: Ellon Paiva Mendes, Sagnik Basu
```

## novatel_gps_msgs

```
* Add NovatelUtmPosition message
* Add Inspvax message (#27)
* Contributors: Ellon Paiva Mendes, Sagnik Basu
```
