### PR TITLE
move_base_flex: 0.2.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2214,7 +2214,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.2-0`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.2.1-0`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Add outcome and message to the action's feedback in ExePath and MoveBase
```

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* Do not use MultiThreadedSpinner, as costmap updates can crash when combining laser scans and point clouds
* Make start/stop costmaps mutexed, since concurrent calls to start can lead to segfaults
```

## mbf_msgs

```
* Add outcome and message to the action's feedback in ExePath and MoveBase
```

## mbf_simple_nav

- No changes

## mbf_utility

- No changes

## move_base_flex

- No changes
