### PR TITLE
Fix python-qt5-bindings dep for Fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3041,7 +3041,7 @@ python-qt5-bindings:
     buster: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
     jessie: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
     stretch: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
-  fedora: [python-qt5, sip]
+  fedora: [python-qt5-devel, sip]
   freebsd: [py27-qt5]
   gentoo: [dev-python/PyQt5]
   opensuse: [python-qt5]


### PR DESCRIPTION
The development files are provided by the associated debs, and packages seem to have a dependency on those files. This breaks `qt_gui_cpp` builds on Fedora.