### PR TITLE
[dep] Add ack-grep.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3,6 +3,12 @@ ace:
   debian: [libace-dev]
   gentoo: [dev-libs/ace]
   ubuntu: [libace-dev]
+ack-grep:
+  arch: [ack]
+  debian: [ack-grep]
+  fedora: [ack]
+  gentoo: [sys-apps/ack]
+  ubuntu: [ack-grep]
 acpi:
   debian: [acpi]
   fedora: [acpi]


### PR DESCRIPTION
- Arch https://www.archlinux.org/packages/community/any/ack/
- Debian https://packages.debian.org/search?keywords=ack-grep
- Gentoo https://packages.gentoo.org/packages/sys-apps/ack
- Fedora http://rpmfind.net/linux/rpm2html/search.php?query=ack
- Ubuntu https://packages.ubuntu.com/search?keywords=ack-grep