### PR TITLE
topic_switch: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12850,6 +12850,13 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
       version: master
+  topic_switch:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/hakuturu583/topic_switch-release.git
+      version: 0.0.1-1
+    status: maintained
   topics_rviz_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_switch` to `0.0.1-1`:

- upstream repository: https://github.com/hakuturu583/topic_switch.git
- release repository: https://github.com/hakuturu583/topic_switch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## topic_switch

```
* fix depends
* update README.md
* add README.md
* add node_checker_switch
* initial commit
* Contributors: Masaya Kataoka
```
