### PR TITLE
rosserial: 0.8.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4278,7 +4278,6 @@ repositories:
       - rosserial_msgs
       - rosserial_python
       - rosserial_server
-      - rosserial_test
       - rosserial_tivac
       - rosserial_vex_cortex
       - rosserial_vex_v5

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4263,6 +4263,37 @@ repositories:
       url: https://github.com/rospilot/rospilot.git
       version: melodic
     status: developed
+  rosserial:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rosserial.git
+      version: melodic-devel
+    release:
+      packages:
+      - rosserial
+      - rosserial_arduino
+      - rosserial_client
+      - rosserial_embeddedlinux
+      - rosserial_mbed
+      - rosserial_msgs
+      - rosserial_python
+      - rosserial_server
+      - rosserial_test
+      - rosserial_tivac
+      - rosserial_vex_cortex
+      - rosserial_vex_v5
+      - rosserial_windows
+      - rosserial_xbee
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rosserial-release.git
+      version: 0.8.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/rosserial.git
+      version: melodic-devel
+    status: maintained
   rplidar_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.8.0-0`:

- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rosserial

- No changes

## rosserial_arduino

```
* Enhance ArduinoTcpHardware (#379 <https://github.com/ros-drivers/rosserial/issues/379>)
  - Add support to check for current TCP connection status to reconnect
  - stop tcp before re-connecting
* Changed hardcoded pin 13 to LED_BUILTIN (#328 <https://github.com/ros-drivers/rosserial/issues/328>)
  To make the code work on an Arduino Nano V3 clone board.
  (might need to be updated in BlinkM as well, but I didnt try that example)
* Added service to force an Arduino hard reset in serial_node.py (#349 <https://github.com/ros-drivers/rosserial/issues/349>)
  * Added hard_reset service call to serial_node
  * Refactored SerialClient to use a write thread, working around deadlock when both Arduino and serial_node.py get stuck writing to each other.
  * Updated cmakelists and package.xml to include dependencies. Removed unnecessary tcp functionality from arduino-specific serial_node.py
* Added ESP32 support (#345 <https://github.com/ros-drivers/rosserial/issues/345>)
* In rosserial_arduino, changed embedded type size for ROS uint64 to 8 bytes from 4. (#312 <https://github.com/ros-drivers/rosserial/issues/312>)
* Contributors: Bo Chen, Chris Spencer, Pornthep Preechayasomboon, Tom O'Connell, blubbi321
```

## rosserial_client

```
* Add an empty newline to the generated headers. (#389 <https://github.com/ros-drivers/rosserial/issues/389>)
* Add support for boolean parameters (#355 <https://github.com/ros-drivers/rosserial/issues/355>)
* Contributors: Miklós Márton, Pikrass
```

## rosserial_embeddedlinux

- No changes

## rosserial_mbed

```
* Use the ! prefix introduced in gcc4mbed for mbed examples (#304 <https://github.com/ros-drivers/rosserial/issues/304>)
  Follows the changes introduced in the following commit:
  https://github.com/adamgreen/gcc4mbed/commit/7d79ef307e65f4f913bed655c887a632352c286c
  Refer to adamgreen/gcc4mbed#64 <https://github.com/adamgreen/gcc4mbed/issues/64> for more details.
* Contributors: Naoki Mizuno
```

## rosserial_msgs

- No changes

## rosserial_python

```
* fix no attribute message_cache issue in message_info_service (#393 <https://github.com/ros-drivers/rosserial/issues/393>)
* Added service to force an Arduino hard reset in serial_node.py (#349 <https://github.com/ros-drivers/rosserial/issues/349>)
  * Added hard_reset service call to serial_node
  * Refactored SerialClient to use a write thread, working around deadlock when both Arduino and serial_node.py get stuck writing to each other.
  * Updated cmakelists and package.xml to include dependencies. Removed unnecessary tcp functionality from arduino-specific serial_node.py
* Add support for boolean parameters (#355 <https://github.com/ros-drivers/rosserial/issues/355>)
* [python] fix an unboundlocalerror (#346 <https://github.com/ros-drivers/rosserial/issues/346>)
* Retry opening the serial port every 3 seconds (#342 <https://github.com/ros-drivers/rosserial/issues/342>)
  * Retry opening the serial port every 3 seconds
  * Break out of the retry loop if we've been shut down
* Contributors: Chris Spencer, Kenta Yonekura, Pikrass, dlguo-cpr
```

## rosserial_server

```
* Fix compiling on boost > 1.66 (#362 <https://github.com/ros-drivers/rosserial/issues/362>)
  Reflective of changes made to boost::asio noted here:
  http://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html
* Contributors: Fan Jiang
```

## rosserial_test

- No changes

## rosserial_tivac

- No changes

## rosserial_vex_cortex

```
* VEX Cortex Usage improvements and VEX V5 Support (#385 <https://github.com/ros-drivers/rosserial/issues/385>)
* Re-attempting rosserial for VEX Cortex (#380 <https://github.com/ros-drivers/rosserial/issues/380>)
* Contributors: CanyonTurtle
```

## rosserial_vex_v5

```
* VEX Cortex Usage improvements and VEX V5 Support (#385 <https://github.com/ros-drivers/rosserial/issues/385>)
* Contributors: CanyonTurtle
```

## rosserial_windows

- No changes

## rosserial_xbee

- No changes
