### PR TITLE
fmi_adapter: 1.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1019,6 +1019,10 @@ repositories:
       version: 1.1.0-0
     status: maintained
   fmi_adapter:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: 1.0.2
     release:
       packages:
       - fmi_adapter
@@ -1026,7 +1030,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `1.0.2-0`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/boschresearch/fmi_adapter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.0.1-0`

## fmi_adapter

```
* Added parameter to configure update period of fmi_adapter node.
* Introduced functions for single step and replaced calcUntil with doStepsUntil.
* Enable automatic use of default experiment step-size from FMU in FMIAdapter ctor.
* Added function to query default experiment step-size given in the FMU.
* Added step_size parameter and function to query whether the FMU supports a variable communication step size.
```

## fmi_adapter_examples

```
* Added two sample FMUs with corresponding launch files.
```
