### PR TITLE
rail_segmentation: 0.1.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8905,6 +8905,22 @@ repositories:
       url: https://github.com/GT-RAIL/rail_manipulation_msgs.git
       version: kinetic-devel
     status: maintained
+  rail_segmentation:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rail_segmentation.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gt-rail-release/rail_segmentation.git
+      version: 0.1.12-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/GT-RAIL/rail_segmentation.git
+      version: kinetic-devel
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.12-0`:

- upstream repository: https://github.com/GT-RAIL/rail_segmentation.git
- release repository: https://github.com/gt-rail-release/rail_segmentation.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rail_segmentation

```
* Replacing deprecated pcl call to upgrade ROS versions
* Contributors: David Kent
```
