### PR TITLE
fiducials: 0.10.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2698,7 +2698,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.8.4-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.10.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.8.4-0`

## aruco_detect

```
* Dramatically speed up create_markers using cairosvg and joblib
* Overhaul aruco marker generation (calculate svg values)
* Ddd new 2 tag test image
* Add params to ignore some fiducial Ids and override sizes
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducial_msgs

- No changes

## fiducial_slam

```
* use sum in quadrature by default
* Disable multifiducial estimate by default
* Added a tool for fitting a plane
* Add map_read_only param, publish camera_pose
* Contributors: Jim Vaughan, Rohan Agrawal
```

## fiducials

- No changes
