### PR TITLE
warehouse_ros: 0.9.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5716,7 +5716,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.9.0-0
+      version: 0.9.1-0
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.1-0`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.9.0-0`

## warehouse_ros

```
* fix missing return value (#40 <https://github.com/ros-planning/warehouse_ros/issues/40>)
* update include statements to use new pluginlib and class_loader headers (#38 <https://github.com/ros-planning/warehouse_ros/issues/38>)
* Contributors: Mikael Arguedas, Robert Haschke
```
