### PR TITLE
lusb: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6764,7 +6764,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/lusb-release.git
-      version: 1.0.10-0
+      version: 1.1.0-0
     source:
       type: hg
       url: https://bitbucket.org/dataspeedinc/lusb


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `1.1.0-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.0.10-0`

## lusb

```
* Added support for list of USB IDs (VID and PID)
* Contributors: Kevin Hallenbeck, Lincoln Lorenz
```
