### PR TITLE
topic_switch: 0.0.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12886,6 +12886,22 @@ repositories:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/topic_proxy.git
       version: master
+  topic_switch:
+    doc:
+      type: git
+      url: https://github.com/hakuturu583/topic_switch.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/hakuturu583/topic_switch-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/hakuturu583/topic_switch.git
+      version: master
+    status: developed
+    status_description: just developed and write README.md
   topics_rviz_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_switch` to `0.0.1-2`:

- upstream repository: https://github.com/hakuturu583/topic_switch.git
- release repository: https://github.com/hakuturu583/topic_switch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## topic_switch

```
* fix depends
* update README.md
* add README.md
* add node_checker_switch
* initial commit
* Contributors: Masaya Kataoka
```
