### PR TITLE
franka_ros: 0.6.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1051,6 +1051,23 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: master
     status: maintained
+  franka_ros:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/franka_ros.git
+      version: melodic-devel
+    release:
+      packages:
+      - franka_description
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/frankaemika/franka_ros-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/frankaemika/franka_ros.git
+      version: melodic-devel
+    status: developed
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.6.0-0`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
