### PR TITLE
marti_messages: 0.8.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2053,7 +2053,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 0.7.0-0
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `0.8.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.7.0-0`

## marti_can_msgs

- No changes

## marti_common_msgs

```
* Merge pull request #96 <https://github.com/swri-robotics/marti_messages/issues/96> from matt-attack/add-psuedo-service
* Add ServiceHeader message
* Contributors: Matthew Bries, P. J. Reed
```

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
