### PR TITLE
velodyne: 1.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5568,7 +5568,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 1.4.0-0
+      version: 1.5.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.5.0-0`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.4.0-0`

## velodyne

- No changes

## velodyne_driver

```
* Merge pull request #187 <https://github.com/ros-drivers/velodyne/issues/187> from moooeeeep/master
  Fixed sign error in return value of InputSocket::getPacket()
* bugfix: getPacket() function is expected to return negative value on error
* Contributors: Fabian Maas, Joshua Whitley
```

## velodyne_laserscan

- No changes

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Merge pull request #164 <https://github.com/ros-drivers/velodyne/issues/164> from ros-drivers/maint/vlp_32c_support
  Adding VLP-32C support.
  This was tested by AutonomouStuff and several external users. Though it does not include new information that I've learned (it appears that the distance resolution is different <50m vs >=50m), it is a good start.
* Merge pull request #189 <https://github.com/ros-drivers/velodyne/issues/189> from kveretennicov/patch-1
* Fix malformed plugin description XML
  ROS pluginlib only recognizes multiple <library> elements if they are under
  <class_libraries> XML root. It silently ignores malformed XMLs with multiple
  <library> "root"s and just reads the first one, due to relaxed way tinyxml2 does
  parsing. Though if you do rosrun nodelet declared_nodelets, the issue is
  reported properly.
  See also similar issue in https://github.com/ros-perception/perception_pcl/issues/131
* Adding distance_resolution to test yaml files.
* Adding VLP-32C support.
  Based on work done by @rockcdr. Adds distance_resolution calibration
  value to support 0.004m distance resolution for VLP-32C.
* Contributors: Joshua Whitley, Konstantin Veretennicov
```
