### PR TITLE
openni2_camera: 0.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9033,7 +9033,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `0.4.1-0`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.4.0-0`

## openni2_camera

- No changes

## openni2_launch

```
* [fix] [roswtf plugin] Accept vendor and product IDs (fix #88 <https://github.com/ros-drivers/openni2_camera/issues/88>).
* [improve] Remove unused ROS Parameters. #76 <https://github.com/ros-drivers/openni2_camera/issues/76>
* [improve] Add roslaunch check.
* Contributors: Isaac I.Y. Saito
```
