### PR TITLE
teleop_twist_keyboard: 0.6.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12625,7 +12625,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `0.6.2-0`:

- upstream repository: https://github.com/ros-teleop/teleop_twist_keyboard.git
- release repository: https://github.com/ros-gbp/teleop_twist_keyboard-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.6.1-0`

## teleop_twist_keyboard

```
* Replace tabs with spaces, fixes #15 <https://github.com/ros-teleop/teleop_twist_keyboard/issues/15>
* Merge pull request #13 <https://github.com/ros-teleop/teleop_twist_keyboard/issues/13> from asukiaaa/patch-3
  Add rosrun command to specify values
* Add rosrun command to specify values
* Contributors: Asuki Kono, Austin, trainman419
```
