### PR TITLE
Add libgdal-dev rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1857,6 +1857,10 @@ libgconf2:
   fedora: [GConf2]
   gentoo: ['gnome-base/gconf:2']
   ubuntu: [libgconf-2-4]
+libgdal-dev:
+  debian: [libgdal-dev]
+  opensuse: [gdal]
+  ubuntu: [libgdal-dev]
 libgeographiclib-dev:
   debian:
     wheezy: [libgeographiclib-dev]


### PR DESCRIPTION
GDAL is a translator library for raster and vector geospatial data formats. libgdal-dev includes the development libraries for GDAL (as opposed to the utilities included by gdal-bin).

Documentation: https://www.gdal.org/

- Debian: 
  - Jessie: https://packages.debian.org/jessie/libgdal-dev
  - Stretch: https://packages.debian.org/stretch/libgdal-dev
  - Buster: https://packages.debian.org/buster/libgdal-dev
  - Sid: https://packages.debian.org/sid/libgdal-dev
- Fedora: "Fedora, since release 7, includes GDAL binaries." https://rpmfind.net/linux/rpm2html/search.php?query=libgdal-devel
- OpenSuSE: https://software.opensuse.org/package/gdal
- Ubuntu: 
  - Trusty: https://packages.ubuntu.com/trusty/libgdal-dev
  - Xenial: https://packages.ubuntu.com/xenial/libgdal-dev
  - Artful: https://packages.ubuntu.com/artful/libgdal-dev
  - Bionic: https://packages.ubuntu.com/bionic/libgdal-dev
