### PR TITLE
Change dependency to libqwt6 for Ubuntu Xenial

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2983,7 +2983,7 @@ libqwt6:
     utopic: [libqwt-dev]
     vivid: [libqwt-dev]
     wily: [libqwt-qt5-dev]
-    xenial: [libqwt-qt5-dev]
+    xenial: [libqwt-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]


### PR DESCRIPTION
This change is made in order to use same Qt version (eg: qt4) than [artful bionic cosmic trusty] distros
https://packages.ubuntu.com/xenial/libqwt-dev