### PR TITLE
ros_controllers: 0.14.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3996,7 +3996,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.14.1-0
+      version: 0.14.2-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.14.2-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.14.1-0`

## diff_drive_controller

- No changes

## effort_controllers

```
* Update maintainers
* Contributors: Bence Magyar
```

## force_torque_sensor_controller

```
* Update maintainers
* Contributors: Bence Magyar
```

## forward_command_controller

```
* Update maintainers
* Contributors: Bence Magyar
```

## four_wheel_steering_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

```
* Update maintainers
* Contributors: Bence Magyar
```

## joint_state_controller

```
* Update maintainers
* Contributors: Bence Magyar
```

## joint_trajectory_controller

```
* Report errors in updateTrajectoryCommand back though action result error_string
* Remove redundant warning messages
* Return error string when failing to initialize trajectory from message
* Changes to allow inheritance from JointTrajectoryController.
* Update maintainers
* Contributors: Alexander Gutenkunst, Miguel Prada, Mathias Lüdtke, Bence Magyar
```

## position_controllers

```
* Update maintainers
* Contributors: Bence Magyar
```

## ros_controllers

```
* Update maintainers
* Contributors: Bence Magyar
```

## rqt_joint_trajectory_controller

```
* Update maintainers
* Contributors: Bence Magyar
```

## velocity_controllers

```
* Update maintainers
* Contributors: Bence Magyar
```
