### PR TITLE
Add libqwt6 package for ubuntu/bionic

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2975,7 +2975,7 @@ libqwt6:
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
   ubuntu:
-    bionic: [libqwt-qt5-dev]
+    bionic: [libqwt-dev]
     precise: [libqwt-dev]
     quantal: [libqwt-dev]
     raring: [libqwt-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2975,6 +2975,7 @@ libqwt6:
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
   ubuntu:
+    bionic: [libqwt-qt5-dev]
     precise: [libqwt-dev]
     quantal: [libqwt-dev]
     raring: [libqwt-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2974,17 +2974,7 @@ libqwt6:
   debian: [libqwt-dev]
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
-  ubuntu:
-    bionic: [libqwt-dev]
-    precise: [libqwt-dev]
-    quantal: [libqwt-dev]
-    raring: [libqwt-dev]
-    saucy: [libqwt-dev]
-    trusty: [libqwt-dev]
-    utopic: [libqwt-dev]
-    vivid: [libqwt-dev]
-    wily: [libqwt-qt5-dev]
-    xenial: [libqwt-qt5-dev]
+  ubuntu: [libqwt-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]


### PR DESCRIPTION
Not sure about using *libqwt-dev* as suggested in #19327 since ROS melodic uses Qt5.