### PR TITLE
ros_chainercv_gpu: 0.0.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3876,6 +3876,23 @@ repositories:
       url: https://github.com/ros-industrial/ros_canopen.git
       version: melodic-devel
     status: maintained
+  ros_chainercv_gpu:
+    doc:
+      type: git
+      url: https://github.com/knorth55/ros_chainercv_gpu.git
+      version: master
+    release:
+      packages:
+      - chainercv_gpu
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/knorth55/ros_chainercv_gpu-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/knorth55/ros_chainercv_gpu.git
+      version: master
+    status: developed
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_chainercv_gpu` to `0.0.4-0`:

- upstream repository: https://github.com/knorth55/ros_chainercv_gpu
- release repository: https://github.com/knorth55/ros_chainercv_gpu-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## chainercv_gpu

```
* update package name
* Contributors: Shingo Kitagawa
```
