### PR TITLE
dbw_fca_ros: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1922,7 +1922,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `0.0.2-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.1-0`

## dbw_fca

```
* Added SDK and demo scripts
* Contributors: Kevin Hallenbeck
```

## dbw_fca_can

```
* Updated firmware versions
* Added platform FCA_WK2 (Jeep Grand Cherokee)
* Force forwarding of brake command type when ABS module is present (instead of BPEC module)
* Disengage on any fault for brake/throttle/steering (change AND to OR)
* Added cruise control buttons
* Latch firmware version on any change (previously only latched once)
* Changed pedal_luts default from true to false (forward command type by default now)
* Disregard overrides on unused subsystems using the TIMEOUT bit
* Removed cruise control related buttons that are not implemented by firmware at this time
* Fixed typo in nodelets.xml of dbw_fca_can
* Renamed steering CMD_TYPE and TMODE
* Set CXX_STANDARD to C++11 only when necessary
* Use sign of wheel speeds to set sign of vehicle speed
* Removed unused dependencies and includes
* Removed steering debug message
* Handle version message with a map/database of several platform/module combinations (ported from dbw_mkz_can)
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_fca_description

```
* Removed outdated dependency on dbw_mkz_description
* Contributors: Kevin Hallenbeck
```

## dbw_fca_joystick_demo

```
* Added option to command steering torque instead of position
* Added option to enable/disable each command topic
* Contributors: Kevin Hallenbeck
```

## dbw_fca_msgs

```
* Added cruise control buttons
* Removed cruise control related buttons that are not implemented by firmware at this time
* Removed steering debug message
* Contributors: Kevin Hallenbeck
```
