### PR TITLE
rc_genicam_api: 2.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11213,7 +11213,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 1.3.12-0
+      version: 2.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.0.0-0`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.3.12-0`

## rc_genicam_api

```
NOTE: Including multipart support required minor changes of the existing API. See readme for more
information. Attention: The provided GenTL layer does not yet support multipart!
* Extended Buffer and Image classes as well as the examples for handling multi-part buffers as well
  (NOTE: The provided GenTL producer does not yet support multipart!)
* gc_stream: Using component name for storing individual images and ensuring that files are not
  overwritten
* gc_pointcloud: Using component name for identifying images and try enabling synchronization on
  device
* Add libs of GenICam reference implementation to external cmake dependencies of shared
  genicam_api library
* Upgrading GenICam reference implementation to v3.1
* Add libs of GenICam reference implementation to external dependencies of shared genicam_api
  library
```
