### PR TITLE
rc_visard: 2.4.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9203,13 +9203,14 @@ repositories:
       version: master
     release:
       packages:
+      - rc_hand_eye_calibration_client
       - rc_visard
       - rc_visard_description
       - rc_visard_driver
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.3.0-0
+      version: 2.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.4.0-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `2.3.0-0`

## rc_hand_eye_calibration_client

```
* first release
```

## rc_visard

```
* rc_hand_eye_calibration_client package added
```

## rc_visard_description

- No changes

## rc_visard_driver

```
* added depth_acquisition_mode parameter
* added depth_acquisition_trigger service call
* Reduced latency for passing changes of dynamic parameters and topic discriptions to GenICam
* Fixed using wrong disparity range in disparity color publisher
* now depends on rc_genicam_api >= 2.0.0
```
