### PR TITLE
[Indigo] Remove moveit_full_pr2 temporarily

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7458,7 +7458,6 @@ repositories:
       - moveit_core
       - moveit_fake_controller_manager
       - moveit_full
-      - moveit_full_pr2
       - moveit_kinematics
       - moveit_planners
       - moveit_planners_ompl
@@ -7543,6 +7542,7 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - moveit_full_pr2
       - moveit_pr2
       - pr2_moveit_config
       - pr2_moveit_plugins

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7542,7 +7542,6 @@ repositories:
       version: indigo-devel
     release:
       packages:
-      - moveit_full_pr2
       - moveit_pr2
       - pr2_moveit_config
       - pr2_moveit_plugins


### PR DESCRIPTION
`moveit_full_pr2` source repo moved in https://github.com/ros-planning/moveit_pr2/pull/98.