### PR TITLE
moveit: 0.9.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5982,13 +5982,16 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - chomp_motion_planner
       - moveit
       - moveit_commander
       - moveit_controller_manager_example
       - moveit_core
+      - moveit_experimental
       - moveit_fake_controller_manager
       - moveit_kinematics
       - moveit_planners
+      - moveit_planners_chomp
       - moveit_planners_ompl
       - moveit_plugins
       - moveit_ros
@@ -6008,7 +6011,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.12-1
+      version: 0.9.14-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.14-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.9.12-1`

## chomp_motion_planner

- No changes

## moveit

```
* [fix] Text refrences to MoveIt! (#1020 <https://github.com/ros-planning/moveit/issues/1020>)
* [fix] Eigen alignment issuses due to missing aligned allocation (#1039 <https://github.com/ros-planning/moveit/issues/1039>)
* [fix][chomp] changelogs: migration from tf -> tf2 only accidentally became part of 0.9.12's changelog
* [fix] Chomp package handling issue #1086 <https://github.com/ros-planning/moveit/issues/1086> that was introduced in ubi-agni/hotfix-#1012 <https://github.com/ubi-agni/hotfix-/issues/1012>
* [fix] PlanningSceneMonitor lock #1033 <https://github.com/ros-planning/moveit/issues/1033>: Fix #868 <https://github.com/ros-planning/moveit/issues/868> (#1057 <https://github.com/ros-planning/moveit/issues/1057>)
* [fix] optional namespace args (#929 <https://github.com/ros-planning/moveit/issues/929>)
* [fix] CurrentStateMonitor update callback for floating joints to handle non-identity joint origins #984 <https://github.com/ros-planning/moveit/issues/984>
* [fix] reset moveit_msgs::RobotState.is_diff to false (#968 <https://github.com/ros-planning/moveit/issues/968>) This fixes a regression introduced in #939 <https://github.com/ros-planning/moveit/issues/939>.
* [fix][chomp] needs to depend on cmake_modules. (#976 <https://github.com/ros-planning/moveit/issues/976>)
* [fix][moveit_ros_visualization] build issue in boost/thread/mutex.hpp (#1055 <https://github.com/ros-planning/moveit/issues/1055>)
* [fix][moveit_ros_perception] planning scene lock when octomap updates too quickly (#920 <https://github.com/ros-planning/moveit/issues/920>)
* [fix][moveit_fake_controller_manager] latch initial pose published by fake_controller_manager (#1092 <https://github.com/ros-planning/moveit/issues/1092>)
* [fix][moveit_setup_assistant] Some bugs (#1022 <https://github.com/ros-planning/moveit/issues/1022>, #1013 <https://github.com/ros-planning/moveit/issues/1013>)
* [fix] continous joint limits are always satisfied (#729 <https://github.com/ros-planning/moveit/issues/729>)
* [capability] Include chomp packages in a list of released package suite (addressing https://github.com/ros-planning/moveit/issues/1083#issuecomment-432737000). #1127 <https://github.com/ros-planning/moveit/issues/1127>
* [capability] adaptions for OMPL 1.4 (#903 <https://github.com/ros-planning/moveit/issues/903>)
* [capability][chomp] Failure recovery options for CHOMP by tweaking parameters (#987 <https://github.com/ros-planning/moveit/issues/987>)
* [capability] New screen for automatically generating interfaces to low level controllers(#951 <https://github.com/ros-planning/moveit/issues/951>, #994 <https://github.com/ros-planning/moveit/issues/994>, #908 <https://github.com/ros-planning/moveit/issues/908>)
* [capability][moveit_setup_assistant] Perception screen for using laser scanner point clouds. (#969 <https://github.com/ros-planning/moveit/issues/969>)
* [enhancement][GUI][moveit_setup_assistant] Logo for MoveIt! 2.0, cleanup appearance (#1059 <https://github.com/ros-planning/moveit/issues/1059>)
* [enhancement][GUI][moveit_setup_assistant] added a setup assistant window icon (#1028 <https://github.com/ros-planning/moveit/issues/1028>)
* [capability][chomp] Addition of CHOMP planning adapter for optimizing result of other planners (#1012 <https://github.com/ros-planning/moveit/issues/1012>)
* [capability][chomp] Failure recovery options for CHOMP by tweaking parameters (#987 <https://github.com/ros-planning/moveit/issues/987>)
* [capability][chomp] cleanup of unused parameters and code + addition of trajectory initialization methods (linear, cubic, quintic-spline) (#960 <https://github.com/ros-planning/moveit/issues/960>)
* [capability][moveit_ros_planning] new dynamic-reconfigure parameter wait_for_trajectory_completion to disable waiting for convergence independently from start-state checking. (#883 <https://github.com/ros-planning/moveit/issues/883>)
* [capability][moveit_ros_planning] Option for controller-specific duration parameters (#785 <https://github.com/ros-planning/moveit/issues/785>)
* [capability] Added plan_only flags to pick and place (#862 <https://github.com/ros-planning/moveit/issues/862>)
* [capability][moveit_kinematics] add IKP_Translation{X,Y,Z}AxisAngle4D to the cpp template, see https://github.com/ros-planning/moveit/issues/548#issuecomment-316298918
* [capability] Benchmarking with different Motion Planners (STOMP, CHOMP, OMPL) (#992 <https://github.com/ros-planning/moveit/issues/992>)
* [enhancement][warehouse] added params for timeout + #retries (#1008 <https://github.com/ros-planning/moveit/issues/1008>)
* [enhancement][moveit_ros_planning] do not wait for robot convergence, when trajectory_execution_manager finishes with status != SUCCEEDED (#1011 <https://github.com/ros-planning/moveit/issues/1011>)
* [enhancement][moveit_ros_planning] allow execution of empty trajectories (#940 <https://github.com/ros-planning/moveit/issues/940>)
* [enhancement][moveit_ros_planning] avoid warning spam: "Unable to update multi-DOF joint" (#935 <https://github.com/ros-planning/moveit/issues/935>)
* [enhancement] Add info messages to pick and place routine (#1004 <https://github.com/ros-planning/moveit/issues/1004>)
* [maintenance] Python3 support (#1103 <https://github.com/ros-planning/moveit/issues/1103>, #1054 <https://github.com/ros-planning/moveit/issues/1054>)
* [maintenance] various compiler warnings (#1038 <https://github.com/ros-planning/moveit/issues/1038>)
* [maintenance] add minimum required pluginlib version (#927 <https://github.com/ros-planning/moveit/issues/927>)
2scholz, Adrian Zwiener, Alexander Guten kunst, Andrey Troitskiy, Chris Lalancette, d-walsh, Dave Coleman, David Watkins, dcconner, dg-shadow, Felix von Drigalski, Isaac Saito, Jonathan Binney, Kei Okada, Martin Guenther, Michael Goerner, Mikael Arguedas, Mike Lautman, Mohmmad Ayman, Raghavender Sahdev, Ridhwan Luthra, Robert Haschke, Simon Schmeisser, Sohieb Abdelrahman, srsidd, Timon Engelke, Xaver Kroischke
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

- No changes

## moveit_experimental

- No changes

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

```
* Include chomp packages in a list of released package suite (addressing https://github.com/ros-planning/moveit/issues/1083#issuecomment-432737000). #1127 <https://github.com/ros-planning/moveit/issues/1127>
* Contributors: Isaac I.Y. Saito
```

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

- No changes

## moveit_simple_controller_manager

- No changes
