### PR TITLE
moveit_pr2: 0.7.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7542,13 +7542,14 @@ repositories:
       version: indigo-devel
     release:
       packages:
+      - moveit_full_pr2
       - moveit_pr2
       - pr2_moveit_config
       - pr2_moveit_plugins
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ros-gbp/moveit_pr2-release.git
-      version: 0.6.6-0
+      version: 0.7.15-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_pr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.7.15-0`:

- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.6.6-0`

## moveit_full_pr2

```
* Moved a repository from https://github.com/ros-planning/moveit to https://github.com/ros-planning/moveit_pr2 #98 <https://github.com/ros-planning/moveit_pr2/issues/98>
* Contributors: Isaac I.Y. Saito, Robert Haschke
```

## moveit_pr2

```
* Package version aligning with a newly added moveit_full_pr2. This is needed for the release into rosdistro.
* Contributors: Isaac I.Y. Saito
```

## pr2_moveit_config

```
* Package version aligning with a newly added moveit_full_pr2. This is needed for the release into rosdistro.
* Contributors: Isaac I.Y. Saito
```

## pr2_moveit_plugins

```
* Package version aligning with a newly added moveit_full_pr2. This is needed for the release into rosdistro.
* Contributors: Isaac I.Y. Saito
```
