### PR TITLE
Add rosdep rule for python-math3d

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1955,6 +1955,10 @@ python-marshmallow:
   ubuntu:
     pip:
       packages: [marshmallow]
+python-math3d-pip:
+  ubuntu:
+    pip:
+      packages: [math3d]
 python-matplotlib:
   arch: [python2-matplotlib]
   debian: [python-matplotlib]


### PR DESCRIPTION
Added a rosdep rule to resolve the [python-math3d](https://github.com/mortlind/pymath3d) package using [pip](https://pypi.org/project/math3d/) for installation.