### PR TITLE
indoor_positioning: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4188,7 +4188,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/metratec/indoor_positioning-release.git
-      version: 1.0.3-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/metratec/indoor_positioning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `indoor_positioning` to `1.1.0-0`:

- upstream repository: https://github.com/metratec/indoor_positioning.git
- release repository: https://github.com/metratec/indoor_positioning-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.3-0`

## indoor_positioning

```
* Trilatered positions are only published now if they are inside a polygon spanned by the beacons
* Revamped launch files
```
