### PR TITLE
Add USE flags for ceres-solver

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1557,7 +1557,7 @@ libceres-dev:
     buster: [libceres-dev]
     stretch: [libceres-dev]
   fedora: [ceres-solver-devel]
-  gentoo: [sci-libs/ceres-solver]
+  gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   ubuntu: [libceres-dev]
 libcoin60-dev:
   arch: [coin]


### PR DESCRIPTION
This adds the proper `USE` flags for Gentoo people.

connects to ros/ros-overlay#696