### PR TITLE
qt_metapackages: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10710,6 +10710,24 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: groovy-devel
     status: maintained
+  qt_metapackages:
+    release:
+      packages:
+      - libqt_concurrent
+      - libqt_core
+      - libqt_dev
+      - libqt_gui
+      - libqt_network
+      - libqt_opengl
+      - libqt_opengl_dev
+      - libqt_svg_dev
+      - libqt_widgets
+      - qt_qmake
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/qt_metapackages-release.git
+      version: 0.0.2-0
+    status: developed
   qt_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_metapackages` to `0.0.2-0`:

- upstream repository: https://github.com/swri-robotics/qt_metapackages.git
- release repository: https://github.com/swri-robotics-gbp/qt_metapackages-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## libqt_concurrent

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_core

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_dev

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_gui

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_network

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_opengl

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_opengl_dev

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_svg_dev

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## libqt_widgets

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```

## qt_qmake

```
* Initial ROS indigo set of each package
* Contributors: Matthew Bries
```
