### PR TITLE
qt_metapackages: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3537,6 +3537,24 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: kinetic-devel
     status: maintained
+  qt_metapackages:
+    release:
+      packages:
+      - libqt_concurrent
+      - libqt_core
+      - libqt_dev
+      - libqt_gui
+      - libqt_network
+      - libqt_opengl
+      - libqt_opengl_dev
+      - libqt_svg_dev
+      - libqt_widgets
+      - qt_qmake
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/qt_metapackages-release.git
+      version: 1.0.1-0
+    status: developed
   qwt_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_metapackages` to `1.0.1-0`:

- upstream repository: https://github.com/swri-robotics/qt_metapackages.git
- release repository: https://github.com/swri-robotics-gbp/qt_metapackages-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## libqt_concurrent

- No changes

## libqt_core

- No changes

## libqt_dev

- No changes

## libqt_gui

- No changes

## libqt_network

- No changes

## libqt_opengl

- No changes

## libqt_opengl_dev

- No changes

## libqt_svg_dev

```
* Fix libqt5-svg-dev key
* Contributors: P. J. Reed
```

## libqt_widgets

- No changes

## qt_qmake

- No changes
