### PR TITLE
remove catkin_pkg entry just for gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -59,8 +59,6 @@ casadi-pip:
   ubuntu:
     pip:
       packages: [casadi]
-catkin_pkg:
-  gentoo: [dev-python/catkin_pkg]
 cmakelint-pip:
   debian:
     pip:


### PR DESCRIPTION
This key should have never been introduced: https://github.com/Alessandro-Barbieri/rosdistro/commit/89fc25706931afe469e0114cf096aba432b71232#diff-acba1c75aeaa27ae4af7a5e0a5b78c08R390

The "right" rosdep key is `python-catkin-pkg`.