### PR TITLE
Adding python3-pygraphviz

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4582,6 +4582,18 @@ python3-pydot:
   debian: [python3-pydot]
   gentoo: [dev-python/pydot]
   ubuntu: [python3-pydot]
+python3-pygraphviz:
+  arch: [python2-pygraphviz]
+  debian: [python3-pygraphviz]
+  fedora: [python3-pygraphviz]
+  freebsd: [py-pygraphviz]
+  gentoo: [dev-python/pygraphviz]
+  opensuse: [python-pygraphviz]
+  osx:
+    pip:
+      packages: [pygraphviz]
+  slackware: [pygraphviz]
+  ubuntu: [python3-pygraphviz]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]


### PR DESCRIPTION
This adds a key for python3 compatible pygraphviz. For several distros it appears their packages support both python versions. For some reason, arch decided to keep the same name (python2-pygraphviz), despite the fact that it does support python3 as well.