### PR TITLE
dbw_mkz_ros: 1.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2548,7 +2548,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.0.13-0
+      version: 1.0.17-0
     source:
       type: hg
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_mkz_ros` to `1.0.17-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
- release repository: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.0.13-0`

## dbw_mkz

- No changes

## dbw_mkz_can

```
* Updated firmware versions
* Updated list of platforms
* Disengage on any fault for brake/throttle/steering (change AND to OR)
* Added outside air temperature to Misc1Report
* Latch firmware version on any change (previously only latched once)
* Changed pedal_luts default from true to false (forward command type by default now)
* Fixed handling of all the firmware/module requrements for brake command type CMD_TORQUE_RQ
* Disregard overrides on unused subsystems using the TIMEOUT bit
* Fixed typo in nodelets.xml of dbw_mkz_can
* Finished unit tests of PlatformMap
* Use sign of wheel speeds to set sign of vehicle speed, fixes issue #24
* Set CXX_STANDARD to C++11 only when necessary
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_mkz_description

- No changes

## dbw_mkz_joystick_demo

```
* Added option to enable/disable each command topic
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_msgs

```
* Added outside air temperature to Misc1Report
* Fixed copy-paste mistake in old bag migration rule
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_twist_controller

- No changes
