### PR TITLE
rdl: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9303,7 +9303,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/jlack/rdl_release.git
-      version: 0.10.6-1
+      version: 1.0.0-0
     source:
       type: git
       url: https://gitlab.com/jlack/rdl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rdl` to `1.0.0-0`:

- upstream repository: https://gitlab.com/jlack/rdl.git
- release repository: https://gitlab.com/jlack/rdl_release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.10.6-1`
