### PR TITLE
Add python-graphitesend-pip and python-statsd

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1579,6 +1579,13 @@ python-gpxpy:
     zesty:
       pip:
         packages: [gpxpy]
+python-graphitesend-pip:
+  debian:
+    pip:
+      packages: [graphitesend]
+  ubuntu:
+    pip:
+      packages: [graphitesend]
 python-graphviz-pip:
   debian:
     pip:
@@ -3811,6 +3818,9 @@ python-sqlalchemy:
     wily: [python-sqlalchemy]
     xenial: [python-sqlalchemy]
     xenial_python3: [python3-sqlalchemy]
+python-statsd:
+  debian: [python-statsd]
+  ubuntu: [python-statsd]
 python-subprocess32:
   debian:
     '*': [python-subprocess32]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3820,6 +3820,7 @@ python-sqlalchemy:
     xenial_python3: [python3-sqlalchemy]
 python-statsd:
   debian: [python-statsd]
+  fedora: [python-statsd]
   ubuntu: [python-statsd]
 python-subprocess32:
   debian:


### PR DESCRIPTION
https://pypi.org/project/graphitesend/
https://packages.debian.org/search?searchon=sourcenames&keywords=python-statsd
https://packages.ubuntu.com/search?keywords=python-statsd

These are dependencies for https://github.com/pal-robotics/pal_statistics used to gather statistics in the graphite framework.