### PR TITLE
rc_visard: 2.4.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3684,7 +3684,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.4.0-0
+      version: 2.4.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.4.2-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `2.4.0-0`

## rc_hand_eye_calibration_client

```
* depend on curl
```

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

- No changes
