### PR TITLE
moveit: 0.10.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2286,7 +2286,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.10.2-0
+      version: 0.10.3-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.10.3-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.10.2-0`

## chomp_motion_planner

- No changes

## moveit

```
* [fix] Build regression (#1134 <https://github.com/ros-planning/moveit/issues/1134>)
* [fix] compiler warnings (#1089 <https://github.com/ros-planning/moveit/issues/1089>)
* [capability] Get available planning group names from MoveGroup C++ (#1159 <https://github.com/ros-planning/moveit/issues/1159>)
* [maintenance] Store more settings of rviz' PlanningFrame (#1135 <https://github.com/ros-planning/moveit/issues/1135>)
* [code] cleanup, improvements (#1107 <https://github.com/ros-planning/moveit/issues/1107>, #1099 <https://github.com/ros-planning/moveit/issues/1099>, #1108 <https://github.com/ros-planning/moveit/issues/1108>, #1144 <https://github.com/ros-planning/moveit/issues/1144>, #1099 <https://github.com/ros-planning/moveit/issues/1099>)
* Contributors: Alexander Gutenkunst, Dave Coleman, Robert Haschke, Simon Schmeisser
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix] compiler warnings (#1089 <https://github.com/ros-planning/moveit/issues/1089>)
* [code] cleanup (#1107 <https://github.com/ros-planning/moveit/issues/1107>, #1099 <https://github.com/ros-planning/moveit/issues/1099>, #1108 <https://github.com/ros-planning/moveit/issues/1108>)
* Contributors: Robert Haschke, Simon Schmeisser
```

## moveit_experimental

```
* [fix] Build regression (#1134 <https://github.com/ros-planning/moveit/issues/1134>)
* [fix] compiler warnings (#1089 <https://github.com/ros-planning/moveit/issues/1089>)
* Contributors: Robert Haschke
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

```
* [fix] Build regression (#1134 <https://github.com/ros-planning/moveit/issues/1134>)
* [fix] compiler warnings (#1089 <https://github.com/ros-planning/moveit/issues/1089>)
* Contributors: Robert Haschke
```

## moveit_planners_ompl

```
* [maintenance] Use locale independent conversion from double to string (#1099 <https://github.com/ros-planning/moveit/issues/1099>)
* Contributors: Simon Schmeisser
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [maintenance] Use locale independent conversion from double to string (#1099 <https://github.com/ros-planning/moveit/issues/1099>)
* Contributors: Simon Schmeisser
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

```
* [fix] compiler warnings (#1089 <https://github.com/ros-planning/moveit/issues/1089>)
* Contributors: Robert Haschke
```

## moveit_ros_planning

```
* [fix] Build regression (#1134 <https://github.com/ros-planning/moveit/issues/1134>)
* Contributors: Robert Haschke
```

## moveit_ros_planning_interface

```
* [capability] Get available planning group names from MoveGroup C++ (#1159 <https://github.com/ros-planning/moveit/issues/1159>)
* Contributors: Dave Coleman
```

## moveit_ros_robot_interaction

```
* [fix] compiler warnings (#1089 <https://github.com/ros-planning/moveit/issues/1089>)
* Contributors: Robert Haschke
```

## moveit_ros_visualization

```
* [maintenance] Store more settings of rviz' PlanningFrame (#1135 <https://github.com/ros-planning/moveit/issues/1135>)
* [maintenance] Lint visualization (#1144 <https://github.com/ros-planning/moveit/issues/1144>)
* Contributors: Alexander Gutenkunst, Dave Coleman
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix] compiler warnings (#1089 <https://github.com/ros-planning/moveit/issues/1089>)
* Contributors: Robert Haschke
```

## moveit_simple_controller_manager

- No changes
