### PR TITLE
moveit: 0.9.15-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6011,7 +6011,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.14-0
+      version: 0.9.15-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.15-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.9.14-0`

## chomp_motion_planner

- No changes

## moveit

```
* [fix] Build regression (#1134 <https://github.com/ros-planning/moveit/issues/1134>)
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* [code] cleanup, improvements (#1141 <https://github.com/ros-planning/moveit/issues/1141>, #1099 <https://github.com/ros-planning/moveit/issues/1099>, #1108 <https://github.com/ros-planning/moveit/issues/1108>)
* Contributors: Alexander Gutenkunst, Jonathan Hechtbauer, Robert Haschke, Simon Schmeisser
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* [code] cleanup, improvements (#1099 <https://github.com/ros-planning/moveit/issues/1099>, #1108 <https://github.com/ros-planning/moveit/issues/1108>)
* Contributors: Robert Haschke, Simon Schmeisser
```

## moveit_experimental

```
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* Contributors: Robert Haschke
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

```
* [fix] Build regression (#1134 <https://github.com/ros-planning/moveit/issues/1134>)
* Contributors: Robert Haschke
```

## moveit_planners_ompl

```
* [code] cleanup, improvements (#1099 <https://github.com/ros-planning/moveit/issues/1099>)
* Contributors: Simon Schmeisser
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [code] cleanup, improvements (#1099 <https://github.com/ros-planning/moveit/issues/1099>)
* Contributors: Simon Schmeisser
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

```
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* Contributors: Robert Haschke
```

## moveit_ros_move_group

- No changes

## moveit_ros_perception

```
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* Contributors: Robert Haschke
```

## moveit_ros_planning

```
* [fix] Build regression (#1134 <https://github.com/ros-planning/moveit/issues/1134>)
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* Contributors: Robert Haschke
```

## moveit_ros_planning_interface

```
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* Contributors: Robert Haschke
```

## moveit_ros_robot_interaction

```
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* Contributors: Robert Haschke
```

## moveit_ros_visualization

```
* [improvement] Exploit the fact that our transforms are isometries (instead of general affine transformations). #1091 <https://github.com/ros-planning/moveit/issues/1091>
* [maintenance] Store more settings of rviz' PlanningFrame (#1135 <https://github.com/ros-planning/moveit/issues/1135>)
* [code] cleanup, improvements (#1141 <https://github.com/ros-planning/moveit/issues/1141>)
* Contributors: Alexander Gutenkunst, Jonathan Hechtbauer, Robert Haschke
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

- No changes

## moveit_simple_controller_manager

- No changes
