### PR TITLE
rosfmt: 5.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10635,6 +10635,22 @@ repositories:
       url: https://github.com/rosflight/rosflight.git
       version: master
     status: developed
+  rosfmt:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosfmt.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/xqms/rosfmt-release.git
+      version: 5.2.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/xqms/rosfmt.git
+      version: master
+    status: developed
   rosjava:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosfmt` to `5.2.2-0`:

- upstream repository: https://github.com/xqms/rosfmt.git
- release repository: https://github.com/xqms/rosfmt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## rosfmt

```
* README: syntax highlighting
* add README.md, LICENSE.txt
* initial commit - basics are working
* Contributors: Max Schwarz
```
