### PR TITLE
rosmon: 1.0.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10772,7 +10772,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       type: git
       url: https://github.com/xqms/rosmon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `1.0.10-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.0.9-0`

## rosmon

```
* main: exit gracefully on SIGTERM and SIGHUP as well (issue #59, PR #60)
* launch: allow <arg default="XY"> in <include> tags (issue #57, PR #58)
  roslaunch allows this, so we should as well. Since it seems a bit
  confusing, we issue a warning when this happens.
  In these cases, <arg value="XY"> should be applicable and is much clearer.
* Contributors: Max Schwarz
```
