### PR TITLE
Add Fedora deps necessary to build Bouncy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -404,6 +404,7 @@ clang-format:
   debian:
     buster: [clang-format]
     stretch: [clang-format]
+  fedora: [clang]
   gentoo: [sys-devel/clang]
   ubuntu: [clang-format]
 clang-tidy:
@@ -1797,6 +1798,7 @@ libfreetype6:
   ubuntu: [libfreetype6]
 libfreetype6-dev:
   debian: [libfreetype6-dev]
+  fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
   ubuntu: [libfreetype6-dev]
 libftdi-dev:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -172,6 +172,7 @@ pydocstyle:
   debian:
     buster: [pydocstyle]
     stretch: [pydocstyle]
+  fedora: [python3-pydocstyle]
   gentoo: [dev-python/pydocstyle]
   ubuntu:
     artful: [pydocstyle]
@@ -182,6 +183,7 @@ pyflakes3:
   debian:
     buster: [pyflakes3]
     stretch: [pyflakes3]
+  fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]
   ubuntu:
     artful: [pyflakes3]
@@ -4514,6 +4516,7 @@ python3-empy:
     buster: [python3-empy]
     jessie: [python3-empy]
     stretch: [python3-empy]
+  fedora: [python3-empy]
   gentoo: [dev-python/empy]
   ubuntu: [python3-empy]
 python3-flake8:
@@ -4521,6 +4524,7 @@ python3-flake8:
     buster: [python3-flake8]
     jessie: [python3-flake8]
     stretch: [python3-flake8]
+  fedora: [python3-flake8]
   gentoo: [dev-python/flake8]
   ubuntu: [python3-flake8]
 python3-gitlab:
@@ -4569,10 +4573,12 @@ python3-pep8:
     buster: [python3-pep8]
     jessie: [python3-pep8]
     stretch: [python3-pep8]
+  fedora: [python3-pep8]
   gentoo: [dev-python/pep8]
   ubuntu: [python3-pep8]
 python3-pkg-resources:
   debian: [python3-pkg-resources]
+  fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
   ubuntu: [python3-pkg-resources]
 python3-pydot:
@@ -4601,6 +4607,7 @@ python3-pyparsing:
 python3-pytest:
   arch: [python-pytest]
   debian: [python3-pytest]
+  fedora: [python3-pytest]
   gentoo: [dev-python/pytest]
   ubuntu: [python3-pytest]
 python3-qt5-bindings:
@@ -4624,6 +4631,7 @@ python3-ruamel.yaml:
     zesty: [python3-ruamel.yaml]
 python3-setuptools:
   debian: [python3-setuptools]
+  fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
   ubuntu: [python3-setuptools]
 python3-sphinx:
@@ -4640,6 +4648,7 @@ python3-venv:
   ubuntu: [python3-venv]
 python3-yaml:
   debian: [python3-yaml]
+  fedora: [python3-PyYAML]
   gentoo: [dev-python/pyyaml]
   ubuntu: [python3-yaml]
 rosbag-metadata-pip:


### PR DESCRIPTION
How-verified: Added this PR to my rosdep index and ran:
```
$ rosdep install --from-paths src --ignore-src --rosdistro bouncy -y --skip-keys "console_bridge fastcdr fastrtps libopensplice67 rti-connext-dds-5.3.1 urdfdom_headers"
#All required rosdeps installed successfully
```