### PR TITLE
moveit: 0.10.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2286,7 +2286,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.10.3-0
+      version: 0.10.4-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.10.4-0`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.10.3-0`

## chomp_motion_planner

- No changes

## moveit

```
* [fix] Build regression (#1170 <https://github.com/ros-planning/moveit/issues/1170>)
* Contributors: Robert Haschke
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

- No changes

## moveit_experimental

- No changes

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* [fix] Build regression (#1170 <https://github.com/ros-planning/moveit/issues/1170>)
* Contributors: Robert Haschke
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [fix] Build regression (#1170 <https://github.com/ros-planning/moveit/issues/1170>)
* Contributors: Robert Haschke
```

## moveit_simple_controller_manager

- No changes
