### PR TITLE
Add python-pytorch-pip to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2974,6 +2974,19 @@ python-pytides-pip:
   ubuntu:
     pip:
       packages: [pytides]
+python-pytorch-pip:
+  debian:
+    pip:
+      packages: [torch, torchvision]
+  fedora:
+    pip:
+      packages: [torch, torchvision]
+  osx:
+    pip:
+      packages: [torch, torchvision]
+  ubuntu:
+    pip:
+      packages: [torch, torchvision]
 python-pytz-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
This adds torch/torchvision to the `python.yaml` file. This is for example used by https://github.com/jsk-ros-pkg/jsk_recognition/pull/2041 and seeing the popularity of pyTorch probably in more repositories in the future. Since the old pull request for pyTorch (https://github.com/ros/rosdistro/pull/14398), the packages have become available in the standard pip.