### PR TITLE
agni_tf_tools: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -125,7 +125,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
-      version: 0.1.0-1
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agni_tf_tools` to `0.1.1-0`:

- upstream repository: https://github.com/ubi-agni/agni_tf_tools.git
- release repository: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.1.0-1`

## agni_tf_tools

```
* install header files for rviz properties
* Contributors: Robert Haschke
```
