### PR TITLE
agni_tf_tools: 0.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -55,6 +55,21 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: indigo-devel
     status: maintained
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: master
+    status: maintained
   angles:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agni_tf_tools` to `0.1.1-0`:

- upstream repository: https://github.com/ubi-agni/agni_tf_tools.git
- release repository: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## agni_tf_tools

```
* install header files for rviz properties
* Contributors: Robert Haschke
```
