### PR TITLE
Add rosdep rules for the matio library.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3783,6 +3783,10 @@ mapnik-utils:
   debian: [mapnik-utils]
   fedora: [mapnik-utils]
   ubuntu: [mapnik-utils]
+matio:
+  debian: [libmatio-dev]
+  fedora: [matio-devel]
+  ubuntu: [libmatio-dev]
 maven:
   arch: [maven]
   debian: [maven]


### PR DESCRIPTION
Add rosdep rules to resolve the [matio](https://sourceforge.net/projects/matio/) library on [debian](https://packages.debian.org/jessie/libmatio-dev), [fedora](https://apps.fedoraproject.org/packages/matio-devel) and [ubuntu](https://packages.ubuntu.com/trusty/libmatio-dev)