### PR TITLE
jsk_visualization: 2.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4720,7 +4720,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.3-0
+      version: 2.1.4-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.4-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.1.3-0`

## jsk_interactive

```
* Fix install destination (#717 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/717>)
  * Update comment about installation
  * Add comment for install destination
* Contributors: Yuto Uchimi
```

## jsk_interactive_marker

```
* replace boost::shared_ptr by std::shared_ptr (#710 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/710>)
  * manual urdf typedefs
  * add headers for urdf shared_ptr typedefs
  * use 'isnan' from 'std' namespace
  * use urdf typedefs for shared_ptr
  * enable C++11
  * replace boost pointers by std pointers
* Fix install destination (#717 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/717>)
  * Call USE_SOURCE_PERMISSIONS before PATTERN
  * Update comment about installation
  * Install 'scripts' into SHARE_DESTINATION
  * Add comment for install destination
  * Fix installation destination
* fix typo in jsk_interactive_marker (#718 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/718>)
* Remove newline and leading spaces from package.xml (#706 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/706>)
* Explicitly resolve dependency for jsk_recognition_utils in package.xml (#699 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/699>)
* Object 3d annotation using transformable interactive marker (#668 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/668>)
  * do not compile transformable_marker_operator.cpp for jsk_recognition_msgs < 1.2.0
  * need 1.2.0 of jsk_recognition_msgs for Objects.msg
  * Update for updated Object.msg
  * Make object array topic editable and searched automatically
  * Insert mesh models dynamically by rviz panel
  * Change interactive_mode using dynamic reconfigure
* Contributors: Christian Rauch, Kei Okada, Kentaro Wada, Masaki Murooka, Shingo Kitagawa, Yuto Uchimi, Naoki Mizuno
```

## jsk_interactive_test

```
* Fix install destination (#717 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/717>)
  * Update comment about installation
  * Install 'scripts' into SHARE_DESTINATION
  * Add comment for install destination
  * Fix installation destination
* Contributors: Yuto Uchimi
```

## jsk_rqt_plugins

```
* Fix install destination (#717 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/717>)
  * Update comment about installation
  * Add comment for install destination
  * Install missing test/ as well
  * Use source permission when installing executables
  * Fix installation destination
* [jsk_rqt_plugins] Fix for working correctly on kinetic + qt5 (#708 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/708>)
  * Add sample for rqt_image_view2
  * Update test for rqt_drc_mini_maxwell
  * Add sample for rqt_drc_mini_maxwell
  * Update test for rqt_3d_plot
  * Add sample for rqt_3d_plot
  * Fix for substituting to 'intercept'
  * Specify version of image_pipeline
  * Support matplotlib backend for qt5
  * Support qt>=5 in rqt plugins
  * Add dependency for test
  * Set retry=3 for test
  * Install all programs in jsk_rqt_plugins/bin/
  * Add test for program in jsk_rqt_plugins
  * use matplotlib.backends.backend_qt5agg in Qt5
  * add queue_size in publishers
  * check opencv version for kinetic
  * follow new sklearn ranac linear regression
  * use correct module for qt5
  * refactor plot_2d.py
* [jsk_rqt_plugins] fix hist.py to work on kinetic (#707 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/707>)
* Revert "[jsk_rqt_plugins/HistogramPlot] modify to correctly run on kinetic (#688 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/688>)" (#704 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/704>)
  This reverts commit 79dcedf7fd761fc638f1cffc1cfaa46a7bb4f1a2.
* [jsk_rqt_plugins/HistogramPlot] modify to correctly run on kinetic (#688 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/688>)
  * refactor codes in hist.py
  * use correct module of qt5 for kinetic
  * check opencv version for kinetic
  * add queue_size in publisher
* [jsk_rqt_plugins] Add dependency of sklearn (#701 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/701>)
* Add <url> to package.xml to add link to README (#681 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/681>)
* Contributors: Kei Okada, Kentaro Wada, Masaki Murooka, Shingo Kitagawa, Yuto Uchimi, Iory Yanokura
```

## jsk_rviz_plugins

```
* [jsk_rviz_plugins/target_visualize] Add visualizer_ initilized flags (#720 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/720>)
* replace boost::shared_ptr by std::shared_ptr (#710 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/710>)
  * enable C++11
  * replace boost pointers by std pointers
* add error message to status (#715 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/715>)
* Fix install destination (#717 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/717>)
  * Update comment about installation
  * Add comment for install destination
  * Fix path to headers for installation
  * Install missing test/ as well
  * Use source permission when installing executables
  * Fix installation destination
* [jsk_rviz_plugins/camera_info_display] Check fx and fy are not equal to zero. (#1 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/1>)
* [jsk_rviz_plugins] Optimize camera info displaying (#709 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/709>)
  * Split and merge image matrix channels instead of slow pixel-by-pixel copying while renderind camera info.
* [jsk_rviz_plugins] add segment_array_display (#666 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/666>)
  * Add doc and sample of segment_array
  * add segment_array_display rviz plugin.
* [jsk_rviz_plugins] use QScreen::grabWindow() instead of QPixmap::grabWindow (#700 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/700>)
  * [jsk_rviz_plugins] use QScreen::grabWindow() instead of QPixmap::grabWindow
* add enable lighitng property in polygon_array_display (#686 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/686>)
* add jsk_rviz_plugins library to catkin_package LIBRARIES, use  instea… (#696 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/696>)
  * add jsk_rviz_plugins library to catkin_package LIBRARIES
* Add #include <boost/format.hpp> (#695 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/695>)
* jsk_rviz_plugins: warn on missing frame_id (#698 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/698>)
* Suppress warnings of jsk_rviz_plugins for non-existent targets (#693 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/693>)
  Support catkin_make also.
  Ref: https://github.com/jsk-ros-pkg/jsk_visualization/pull/692#issuecomment-390873758
* [jsk_rviz_plugins] fix std::isnan to make it compile under Ubuntu 16.04 / gcc 5 (#687 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/687>)
  * fix std::isnan to make it compile under Ubuntu 16.04 / gcc 5
  * revert whitespace changes (adding trailing whitespace again)
* add enable lighitng property in polygon_array_display
* jsk_rviz_plugins: class_result_vis: add more types to vislalize (#684 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/684>)
* jsk_rviz_plugins: add missing deps (#683 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/683>)
* Add <url> to package.xml to add link to README (#681 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/681>)
* Contributors: Aleksandr Rozhdestvenskii, Christian Rauch, Daniel Neumann, Yuki Furuta, Jan Carius, Kei Okada, Kentaro Wada, Laurenz, Masaki Murooka, Tamaki Nishino, Yuto Uchimi, Iori Yanokura
```

## jsk_visualization

- No changes
