### PR TITLE
jsk_common: 2.2.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1696,6 +1696,28 @@ repositories:
       url: https://github.com/tork-a/jsk_3rdparty-release.git
       version: 2.1.11-0
     status: developed
+  jsk_common:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
+    release:
+      packages:
+      - dynamic_tf_publisher
+      - image_view2
+      - jsk_common
+      - jsk_data
+      - jsk_network_tools
+      - jsk_tilt_laser
+      - jsk_tools
+      - jsk_topic_tools
+      - multi_map_server
+      - virtual_force_publisher
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jsk_common-release.git
+      version: 2.2.8-1
+    status: developed
   jsk_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.8-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## dynamic_tf_publisher

```
* Add comment about installation (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* Contributors: Yuto Uchimi
```

## image_view2

```
* Add comment about installation (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* [image_view2/image_view2.cpp] Correct grammer. 'could not found' -> could not find' (#1606 <https://github.com/jsk-ros-pkg/jsk_common/issues/1606>)
* Contributors: Yuto Uchimi, Iori Yanokura
```

## jsk_common

- No changes

## jsk_data

```
* Fix installation destination (install node_scripts to CATKIN_PACKAGE_BIN_DESTINATION) (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* Enable method: all in test_data_collection_server.py (#1600 <https://github.com/jsk-ros-pkg/jsk_common/issues/1600>)
  * Enable method: all in test_data_collection_server.pyI missed this in https://github.com/jsk-ros-pkg/jsk_common/pull/1599#issuecomment-418374578.
* Add test for data_collection_server (#1599 <https://github.com/jsk-ros-pkg/jsk_common/issues/1599>)
  * Re-enable test of data_collection_server with method=all
  * Add name to <test>
  * Disable test with static_image_publisher.py
  * Add test for data_collection_server
  * Rename to method: all from None since null is not supported in roslaunch<string>:17: (INFO/1) Unexpected possible title overline or transition.
  Treating it as ordinary text because it's so short.
  
  ```
  
  <string>:17: (WARNING/2) Inline literal start-string without end-string.
  
  <string>:17: (WARNING/2) Inline interpreted text or phrase reference start-string without end-string.... logging to /home/wkentaro/.ros/log/rostest-hoop-18427.log
  [ROSUNIT] Outputting test results to /home/wkentaro/.ros/test_results/jsk_data/rostest-tests_data_collection_server.xml
  [Testcase: testtest_data_collection_server] ... ERROR!
  ERROR: cannot marshal None unless allow_none is enabled
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
  testMethod()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rostest/runner.py", line 120, in fn
  succeeded, failed = self.test_parent.launch()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rostest/rostest_parent.py", line 122, in launch
  return self.runner.launch()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/launch.py", line 657, in launch
  self._setup()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/launch.py", line 644, in _setup
  self._load_parameters()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/launch.py", line 338, in _load_parameters
  r  = param_server_multi()
  File "/usr/lib/python2.7/xmlrpclib.py", line 1006, in __call__
  return MultiCallIterator(self.__server.system.multicall(marshalled_list))
  File "/usr/lib/python2.7/xmlrpclib.py", line 1243, in __call__
  return self.__send(self.__name, args)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1596, in __request
  allow_none=self.__allow_none)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1094, in dumps
  data = m.dumps(params)
  File "/usr/lib/python2.7/xmlrpclib.py", line 638, in dumps
  dump(v, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 660, in __dump
  f(self, value, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 719, in dump_array
  dump(v, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 660, in __dump
  f(self, value, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 741, in dump_struct
  dump(v, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 660, in __dump
  f(self, value, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 719, in dump_array
  dump(v, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 660, in __dump
  f(self, value, write)
  File "/usr/lib/python2.7/xmlrpclib.py", line 664, in dump_nil
  raise TypeError, "cannot marshal None unless allow_none is enabled"<string>:60: (INFO/1) Unexpected possible title overline or transition.
  Treating it as ordinary text because it's so short.
  
  ```
  
  <string>:60: (WARNING/2) Inline literal start-string without end-string.
  
  <string>:60: (WARNING/2) Inline interpreted text or phrase reference start-string without end-string.
  
    * add test for data_collection_server.test
  
* [jsk_data] Add re-download code. Fix #1574 <https://github.com/jsk-ros-pkg/jsk_common/issues/1574> (#1589 <https://github.com/jsk-ros-pkg/jsk_common/issues/1589>)
  * [jsk_data] Add n_times option to try download
  * [jsk_data] Add download_data.py's test
  * [jsk_data] Add return value
  * [jsk_data] Add re-download code. Fix #1574 <https://github.com/jsk-ros-pkg/jsk_common/issues/1574>
* update jsk_travis to 0.4.38 add lunar and melodic (#1594 <https://github.com/jsk-ros-pkg/jsk_common/issues/1594>)
  * run pr2_play.launch test only when pr2_description_FOUND
* Fix mkdir in if isabs block in download_data (#1593 <https://github.com/jsk-ros-pkg/jsk_common/issues/1593>)
* Contributors: Kei Okada, Kentaro Wada, Yohei Kakiuchi, Yuto Uchimi, Iori Yanokura
```

## jsk_network_tools

```
* Install missing launch/ and test/ as well (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* Contributors: Yuto Uchimi
```

## jsk_tilt_laser

```
* add tilt laser pipeline for jsk_tilt_laser (#1605 <https://github.com/jsk-ros-pkg/jsk_common/issues/1605>)
  * [jsk_tilt_laser] add new version of launch script for tilt laser
  * [jsk_tilt_laser] change joint name of tilt_laser
* Add comment about installation (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* update jsk_travis to 0.4.38 add lunar and melodic (#1594 <https://github.com/jsk-ros-pkg/jsk_common/issues/1594>)
  * use find_package(Eigen3) instead of find_package(Eigen)
  * use find_package(multisense_lib QUIET) to check multisense_lib
* Contributors: Kei Okada, Yohei Kakiuchi, Yuto Uchimi
```

## jsk_tools

```
* Add comment for install destination (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* jsk_tools/src/jsk_tools/bag_plotter.py: Correct a line mistaken, easy but critical (#1602 <https://github.com/jsk-ros-pkg/jsk_common/issues/1602>)
* jsk_tools/src/jsk_tools/bag_plotter.py: Add style option for line color and font size (#1601 <https://github.com/jsk-ros-pkg/jsk_common/issues/1601>)
* [jsk_tools] add python-progressbar to run_depend (#1588 <https://github.com/jsk-ros-pkg/jsk_common/issues/1588>)
* Contributors: Kei Okada, Ryosuke Tajima, Yuto Uchimi
```

## jsk_topic_tools

```
* Fix to install 'scripts' directory (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* Add reset to Timer in ConnectionBasedTransport (#1597 <https://github.com/jsk-ros-pkg/jsk_common/issues/1597>)
  * Check if >=kinetic to pass reset arg to Timer
* Add test for data_collection_server (#1599 <https://github.com/jsk-ros-pkg/jsk_common/issues/1599>)
  * Stop using cv2 in static_image_publisher.pyTo fix
  https://github.com/jsk-ros-pkg/jsk_common/pull/1599#issuecomment-417908500
  
    * Add reset to Timer in ConnectionBasedTransport
      To fix below:
      ```
  [ERROR] [1535796247.786932, 1535792085.063646]: [/get_heightmap] [sleep] ROS time moved backwards: 1.407559397s
  Exception in thread Thread-4:
  Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
  self.run()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 226, in run
  r.sleep()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 103, in sleep
  sleep(self._remaining(curr_time))
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 164, in sleep
  raise rospy.exceptions.ROSTimeMovedBackwardsException(time_jump)
  ROSTimeMovedBackwardsException: ROS time moved backwards
  Exception in thread Thread-4:
  Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
  self.run()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 226, in run
  r.sleep()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 103, in sleep
  sleep(self._remaining(curr_time))
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/timer.py", line 164, in sleep
  raise rospy.exceptions.ROSTimeMovedBackwardsException(time_jump)
  ROSTimeMovedBackwardsException: ROS time moved backwards
  ^C[image_view-9] killing on exit
  [tile_image-8] killing on exit
  [get_heightmap/output/depth_view-7] killing on exit
  [get_heightmap-6] killing on exit
  [heightmap_frame_publisher-5] killing on exit
  [bbox_to_tf-4] killing on exit
  [bbox_array_to_bbox-3] killing on exit
  [rosbag_play-2] killing on exit
  [rosout-1] killing on exit
  [master] killing on exit
  shutting down processing monitor...
  ... shutting down processing monitor complete
  done<string>:54: (INFO/1) Unexpected possible title overline or transition.
  Treating it as ordinary text because it's so short.
  
  ```
  
  <string>:54: (WARNING/2) Inline literal start-string without end-string.
  
  <string>:54: (WARNING/2) Inline interpreted text or phrase reference start-string without end-string.
* [jsk_topic_tools] Fixed use_warn option (#1592 <https://github.com/jsk-ros-pkg/jsk_common/issues/1592>)
* use PROJECT_NAME instad of __NODENAME_PREFIX (RANDOM) (#1591 <https://github.com/jsk-ros-pkg/jsk_common/issues/1591>)
  * https://github.com/jsk-ros-pkg/jsk_common/pull/1586/files#r207146300
* jsk_topic_tools/cmake/nodelet.cmake: add random prefix before _single  (``#1586 <https://github.com/jsk-ros-pkg/jsk_common/issues/1586>`_)
* Contributors: Kei Okada, Kentaro Wada, Yohei Kakiuchi, Yuto Uchimi, Iori Yanokura
```

## multi_map_server

```
* Add comment about installation (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* Contributors: Yuto Uchimi
```

## virtual_force_publisher

```
* Add comment about installation (#1604 <https://github.com/jsk-ros-pkg/jsk_common/issues/1604>)
* Contributors: Yuto Uchimi
```
