### PR TITLE
jsk_common: 2.2.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4561,7 +4561,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.8-0
+      version: 2.2.9-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.9-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `2.2.8-0`

## dynamic_tf_publisher

- No changes

## image_view2

- No changes

## jsk_common

- No changes

## jsk_data

```
* check if the pkg exists and path is writable (#1608 <https://github.com/jsk-ros-pkg/jsk_common/issues/1608>)
  * fix http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__jsk_pcl_ros_utils__ubuntu_xenial_amd64__binary/132/console
* Contributors: Kei Okada
```

## jsk_network_tools

- No changes

## jsk_tilt_laser

- No changes

## jsk_tools

- No changes

## jsk_topic_tools

- No changes

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
