### PR TITLE
jsk_recognition: 1.2.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4677,7 +4677,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.5-0
+      version: 1.2.6-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.6-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.2.5-0`

## checkerboard_detector

```
* Fix Cmake indent (#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
* Fix warnings: gencpp -> generate_messsage_cpp (#2296 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2296>)
* Contributors: Kentaro Wada, Yuto Uchimi
```

## imagesift

```
* Install 'sample' and 'test' dir into CATKIN_PACKAGE_SHARE_DESTINATION (#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
* fix for jsk-ros-pkg/jsk_common/pull/1586 (#2311 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2311>)
  * use lib_ instaed of  for add_library to avoid conflict
  * add version_gte for jsk_topic_tools
  * imagesift: fix for jsk-ros-pkg/jsk_common/pull/1586
* Refactor CMakeLists.txt and package.xml of jsk_perception (#2279 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2279>)
* Contributors: Fuki Furuta, Kei Okada, Kentaro Wada
```

## jsk_pcl_ros

```
* [octomap_server_contact] add callback function to insert proximity sensor pointcloud (#2328 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2328>)
  * [octomap_server_contact] add rosparam to select using vertex in insertContactSensor()
  * [octomap_server_contact] add callback function to insert proximity sensor pointcloud
  * [octomap_server_contact] add rosparam to select publishing unknown marker array
* kinfu.h depends on jsk_rviz_plugins (#2310 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2310>)
* Add detect_graspable_poses_pcabase.py and its sample (#2297 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2297>)
  * delete unnecessary try except block
  * move rospy.init_node and rospy.spin into the block of if __name__ == '__main__'
  * if else is set so that z value of grasp poses' y axies become positive.
  * delete unncessary import, change variables to snake case, put spaces
  * modify axis so that a robot can grasp object more naturally
  * fix a problem that this program does not provide correct axies when x option is selected
  * add test for detect_graspable_poses_pcabase
  * files needed to run sample of detect_graspable_poses_pcabase
  * detect_graspable_poses_pca_base.py produce graspable poses using input point cloud data, hand width, and grasp direction.
* [jsk_pcl_ros/multi_plane_extraction] Initialize viewpoint by zeros to avoid flip of surface normal direction (#2343 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2343>)
* [jsk_pcl_ros][organized_pass_through] add remove_nan (#2039 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2039>)
* Install 'scripts' into SHARE_DESTINATION (#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
* [jsk_pcl_ros/package.xml] Add checkerborad_detecotr's dependency (#2319 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2319>)
* [jsk_pcl_ros/cluster_point_indices_decomposer] Modified publishNegativeIndices to make it fast (#2326 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2326>)
  * [jsk_pcl_ros/cluster_point_indice_decomposer] Monitor num of subscriber and if equal less than 0, return.
  * [jsk_pcl_ros/cluster_point_indice_decomposer] Make publishNegativeIndices fast by fixing algorithm
* [jsk_perception] Retrain bof data for sklearn==0.2.0 version and modified jsk_pcl_ros/utils's test for kinetic travis (#2337 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2337>)
  * [jsk_pcl_ros/test_pointcloud_screenpoint.test] Check a topic published by using jsk_tools/test_topic_published.py
  * [jsk_pcl_ros/color_histogram.test] Check topics published by using jsk_tools/test_topic_published.py
  * [jsk_pcl_ros/color_histogram.test] Refactored rosbag play by using common file
* [jsk_pcl_ros] Delete subclass's updateDiagnostic method (#2323 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2323>)
  * [jsk_pcl_ros] Add diagnostics update
* [jsk_pcl_ros/openni2_remote.launch] Add use_warn option (#2322 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2322>)
  * [jsk_pcl_ros/openni2_remote.launch] Add use_warn option
  * [jsk_pcl_ros/openni2_remote.launch] Modified use_warn false
  * [jsk_pcl_ros/openni2_remote.launch] Add use_warn option
* Fix typos (#2313 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2313>)
  * Fix typo in cfg of OrganizedMultiPlaneSegmentation
* [jsk_pcl_ros/package.xml] Delete duplication of cv_bridge (#2318 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2318>)
  * [jsk_pcl_ros/package.xml] Add checkerborad_detecotr's dependency
  * [jsk_pcl_ros/package.xml] Delete duplication of cv_bridge
* fix for jsk-ros-pkg/jsk_common/pull/1586 (#2311 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2311>)
  * to avoid add_custom_target cannot create target install_sample_data because  another target with the same name already exists errors
* Use diagnostic nodelet for EuclideanClustering and other nodelets (#2301 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2301>)
* [jsk_pcl_ros/openni2_remote.launch] Modified namespace (#2302 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2302>)
  * [jsk_pcl_ros/openni2_remote] Add depth args
  * [jsk_pcl_ros/openni2_remote] Fixed rgb_frame_id because this not changed
  * [jsk_pcl_ros/openni2_remote] Modified rgb namespace
  * [jsk_pcl_ros/openni2_remote] Changed that you can change the camera source
* [jsk_pcl_ros] Modified openni2_remote.launch to change camera namespace (#2299 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2299>)
  * [jsk_pcl_ros] Modified openni2_remote.launch to change camera namespace
* Fix warnings about <pcl/ros/conversions.h> and printf format (#2291 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2291>)
  * Fix printf format in tilt_laser_listener_nodelet
  * Fix warnings about <pcl/ros/conversions.h>
* Describe the hierachy of rosparams of ClusterPointIndicesDecomposer (#2285 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2285>)
  * cluster_point_indices_decomposer: ROS_XXX -> NODELET_XXX
  * Show warning for unused rosparams
* jsk_pcl_ros: primitive_shape_classifier: fix typo (#2283 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2283>)
  * jsk_pcl_ros: color_histogram_filter: fix typo
  * jsk_pcl_ros: primitive_shape_classifier: fix typo
* jsk_pcl_ros: support lazy mode for pointcloud_screenpoint nodelet (#2277 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2277>)
  * jsk_pcl_ros: support lazy mode for pointcloud_screenpoint nodelet
* fix travia and reduce dependency for jsk_pcl_ros (#2276 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2276>)
  * sort run/build depends
  * remove unnesessary depends as reported on https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/140, building jsk_pcl_ros on ros buildfarm takes too much time.  This PR cleans dependencies.
  * add wkentaro to maintainer
* Fix warnings for jsk_pcl_ros package (#2266 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2266>)
* Fix missing pkg_name in install_sample_data.py (#2267 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2267>)
* [jsk_pcl_ros/test_extract_indices.cpp] use std::isnan in test_extract_indices (#2251 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2251>)
  * use std::isnan in test_extract_indices
  * [jsk_pcl_ros][organized_pass_through] add remove_nan
* Contributors: Kei Okada, Kentaro Wada, Naoya Yamaguchi, Riku Shigematsu, Shingo Kitagawa, Shun Hasegawa, Yuki Furuta, Yuto Uchimi, Iori Yanokura
```

## jsk_pcl_ros_utils

```
* [jsk_pcl_ros_utils/cluster_point_indices_to_point_indices] Concatenate all indices in case of index==-1 (#2330 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2330>)
* [jsk_pcl_ros_utils/package.xml] Add dependencies for compressed_image/depth_image_transport to run sample launch files (#2341 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2341>)
* Install 'sample', 'scripts', 'test' into SHARE_DESTINATION (#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
* [jsk_perception] Retrain bof data for sklearn==0.2.0 version and modified jsk_pcl_ros/utils's test for kinetic travis (#2337 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2337>)
  * [jsk_pcl_ros_utils] Ignore test for pointcloud_to_pcd.test
* Add --pkg-path option to install_sample_data.py not to use rospack (#2314 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2314>)
  * Close https://github.com/jsk-ros-pkg/jsk_recognition/pull/2303
* fix for jsk-ros-pkg/jsk_common/pull/1586 (#2311 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2311>)
  * to avoid add_custom_target cannot create target install_sample_data because another target with the same name already exists errors
* Use diagnostic nodelet for EuclideanClustering and other nodelets (#2301 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2301>)
  * jsk_pcl_ros: euclidean_clustering: use dianogistc nodeletUse DiagnosticNodelet::updateDiagnostic preferrably
* Fix warnings for jsk_pcl_ros_utils (#2265 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2265>)
  * Fix warnings for jsk_pcl_ros_utils<string>:25: (INFO/1) Unexpected possible title overline or transition.
  Treating it as ordinary text because it's so short.
  
  ```
  
  <string>:25: (WARNING/2) Inline literal start-string without end-string.
  
  <string>:25: (WARNING/2) Inline interpreted text or phrase reference start-string without end-string.CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'pcl' but neither 'pcl_INCLUDE_DIRS' nor
  'pcl_LIBRARIES' is defined.
  Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:220 (catkin_package)
  CMake Warning (dev) at CMakeLists.txt:214 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.
  The dependency target "jsk_pcl_ros_utils_gencpp" of target
  "jsk_pcl_ros_utils" does not exist.
  This warning is for project developers.  Use -Wno-dev to suppress it.<string>:39: (INFO/1) Unexpected possible title overline or transition.
  Treating it as ordinary text because it's so short.
  
  ```
  
  <string>:39: (WARNING/2) Inline literal start-string without end-string.
  
  <string>:39: (WARNING/2) Inline interpreted text or phrase reference start-string without end-string.
* Contributors: Yuki Furuta, Kei Okada, Kentaro Wada, Yuto Uchimi, Iori Yanokura
```

## jsk_perception

```
* Add hand pose detection (#2324 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2324>)
  * [jsk_perception/people_pose_estimation.py] Fixed for cpu inference
  * [jsk_perception/people_pose_estimation.py] Diable train and enable_backprop
  * [jsk_perception/people_pose_estimation_2d] Add hand width offset
  * pointit: add handle exception on tf2
  * pointit: add min threshold
  * jsk_perception: add pointit
  * people_pose_estimation_2d: support hand detection
* [jsk_perception] Add human mesh recovery(estimate people 3d pose from 2d image) (#2332 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2332>)
  * clean up jsk_perception/scripts/install_trained_data.py around if _chainer_available
  * [jsk_perception/human_mesh_recovery] Refactor
  * [jsk_perception/human_mesh_recovery] Add test
  * [jsk_perception/human_mesh_recovery] Add sample
  * [jsk_perception/human_mesh_recovery] Add install model file code
  * [jsk_perception/human_mesh_recovery] Add node
* [jsk_perception/openpose] Add resize image (#2300 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2300>)
  * [jsk_perception/openpose] Fixed logic
  * [jsk_perception/openpose] Add warning
  * [jsk_perception/openpose] Add resize image
* [jsk_perception/ssd_object_detector] Add hand pretrained model (#2333 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2333>)
* Fix install destination (#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
  * Install 'node_scripts', 'scripts', 'test' into SHARE_DESTINATION
* [jsk_perception/sample_mask_rcnn] Fixed typo. fps -> rate (#2353 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2353>)
* [jsk_perception/mask_rcnn_instance_segmentation.py] Publish rects and class (#2350 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2350>)
* [jsk_perception/point_pose_extractor.cpp] Correct grammer. 'could not found' -> 'could not find' (#2349 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2349>)
* [jsk_perception/image_publisher.py] Add fov parameter for publishing valid camera info parameters (#2340 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2340>)
  * [jsk_perception/image_publisher.py] Add warning when not specified fovx and fovy at the same time
  * [jsk_perception/sample_image_publisher.launch] Add fov parameter for kinectv2
  * [jsk_perception/image_publisher.py] Add fov parameter for camera info
* [jsk_perception/sample_bof_object_recognition.launch] Fixed path of trained bof data(#2337 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2337>)
  * [jsk_perception/install_trained_data.py] Add trained bof data for sklearn==0.20.0
* fix for jsk-ros-pkg/jsk_common/pull/1586 (#2311 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2311>)
  * to avoid add_custom_target cannot create target install_sample_data because another target with the same name already exists errors
* Use diagnostic nodelet for EuclideanClustering and other nodelets (#2301 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2301>)
  * jsk_pcl_ros: euclidean_clustering: use dianogistc nodeletUse DiagnosticNodelet::updateDiagnostic preferrably
* support SSD512 for ssd_object_detector (#2305 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2305>)
  * move ssd_train_dataset to scripts
* [jsk_perception/face_pose_estimation] Fixed orientation of face pose (#2304 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2304>)
  * [jsk_perception/face] Modified rviz
  * [jsk_perception/face] Add debug image of face pose
  * [jsk_perception/face] Fixed orientation of publish pose
  * [jsk_perception/face] Fixed pretrained model loader
* Enable Openpose Node for chainer 4.0.0 (#2295 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2295>)
  * [jsk_perception/scripts] Modified url
  * [jsk_perception/scripts] Modified format
  * [jsk_perception/scripts] Modified openpose's weight
  * [jsk_perception] Modified openpose
* [jsk_perception] install config dir (#2294 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2294>)
* Update chainer_mask_rcnn to 0.3.0 (#2293 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2293>
* Fix for AssertionError in fast_rcnn.py (#2281 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2281>)
  * Ignore whether cuda is available or not in fast_rcnn.py
  * Allow ~gpu as rosparam in fast_rcnn
  * Fix for AssertionError in fast_rcnn.py
* Re-enable tests which use chainer inside them (#2280 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2280>)
  * Re-enable all tests which use chainer
  * Re-enable tests which use chainer inside them
* Set required=true for samples to fast finish in testsMerge pull request (#2274 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2274>)
* Refactor cmake of jsk_perception (#2275 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2275>)
  * Apply Eigen -> Eigen3 migration (Eigen also works)  http://wiki.ros.org/jade/Migration
  * Remove no need libsiftfast dependency
* fix travia and reduce dependency for jsk_pcl_ros (#2276 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2276>)
  * skip test for #2272 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2272>
  * Set required=true for samples to fast finish in testsSometimes the test fails because of unexpected errors.
  In that case, it is better that the test quickly finish with errors.
  
    * skip more tests
  
* Contributors: Yuki Furuta, Kei Okada, Kentaro Wada, Riku Shigematsu, Shingo Kitagawa, Yuto Uchimi, Iori Yanokura
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

```
* Install sample and test  into SHARE_DESTINATION (#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
* jsk_pcl_ros: support lazy mode for pointcloud_screenpoint nodelet (#2277 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2277>)p
  * add 'bool no_update' to TransformScreenpoint.srv
* Contributors: Yuki Furuta, Yuto Uchimi
```

## jsk_recognition_utils

```
* Install 'sample' and 'test'into SHARE_DESTINATION (#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
* Use diagnostic nodelet for EuclideanClustering and other nodelets (#2301 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2301>)
  * jsk_pcl_ros: euclidean_clustering: use dianogistc nodeletUse DiagnosticNodelet::updateDiagnostic preferrably
* Describe the hierachy of rosparams of ClusterPointIndicesDecomposer (#2285 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2285>)
  * Fix test of add_bounding_box_array The input topics are slow (~1Hz), so slop should be larger (it was 0.1 before).
* Fix for AssertionError in fast_rcnn.py (#2281 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2281>)
  * Use roi_pooling_2d defined in chainer for fast_rcnn on CPU mode
* Re-enable tests which use chainer inside them (#2280 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2280>)
  * Looser timeout for test of add_bounding_box_array
* Node to concatenate BoundingBoxArray (#2264 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2264>)
  * Doc for add_bounding_box_array.py
  * Node to concatenate BoundingBoxArray
  * Move <test> section to the sample launch files
* Contributors: Yuki Furuta, Kei Okada, Kentaro Wada
```

## resized_image_transport

```
* Call USE_SOURCE_PERMISSIONS before PATTERN(#2345 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2345>)
* [resized_image_transport] Changed diagnostic error level (#2312 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2312>)
  * add version_gte for jsk_topic_tools
* fix for jsk-ros-pkg/jsk_common/pull/1586 (#2311 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2311>)
* Contributors: Yuki Furuta, Yuto Uchimi, Iori Yanokura
```
