### PR TITLE
rail_object_detection: 3.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10936,7 +10936,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_object_detection-release.git
-      version: 3.0.1-0
+      version: 3.0.2-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_object_detection.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10940,7 +10940,7 @@ repositories:
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_object_detection.git
-      version: develop
+      version: indigo-devel
     status: developed
   rail_pick_and_place:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_object_detection` to `3.0.2-0`:

- upstream repository: https://github.com/GT-RAIL/rail_object_detection.git
- release repository: https://github.com/gt-rail-release/rail_object_detection-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.0.1-0`

## rail_object_detection

```
* Update the default branch
```

## rail_object_detection_msgs

```
* Update the default branch name
```

## rail_object_detector

```
* Update the default branch
```
