### PR TITLE
rail_face_detection: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10887,7 +10887,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/gt-rail-release/rail_face_detection-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_face_detection.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10891,7 +10891,7 @@ repositories:
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_face_detection.git
-      version: develop
+      version: indigo-devel
     status: developed
   rail_manipulation_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_face_detection` to `1.0.2-0`:

- upstream repository: https://github.com/GT-RAIL/rail_face_detection.git
- release repository: https://github.com/gt-rail-release/rail_face_detection-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.1-0`

## rail_face_detection

```
* Renamed the default branch
```

## rail_face_detection_msgs

```
* Renamed the default branch
```

## rail_face_detector

```
* Renamed the default branch
```
