### PR TITLE
marti_common: 2.6.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2030,7 +2030,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.5.0-0
+      version: 2.6.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.6.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `2.5.0-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Check for valid polygons before calculating intersection area. (#529 <https://github.com/swri-robotics/marti_common/issues/529>)
* Add polygon utility functions. (#526 <https://github.com/swri-robotics/marti_common/issues/526>)
* Add function to test if two line segments intersect. (#525 <https://github.com/swri-robotics/marti_common/issues/525>)
* Contributors: Marc Alban, P. J. Reed
```

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

```
* Remove incorrect translation of object geometry (#527 <https://github.com/swri-robotics/marti_common/issues/527>)
* Contributors: agyoungs
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes

## swri_yaml_util

- No changes
