### PR TITLE
add index-v4.yaml file with additional metadata

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+# ROS index file
+# see REP 153: http://ros.org/reps/rep-0153.html
+---
+distributions:
+  groovy:
+    distribution: [groovy/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz
+    distribution_status: end-of-life
+    distribution_type: ros1
+  hydro:
+    distribution: [hydro/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/hydro-cache.yaml.gz
+    distribution_status: end-of-life
+    distribution_type: ros1
+  indigo:
+    distribution: [indigo/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/indigo-cache.yaml.gz
+    distribution_status: active
+    distribution_type: ros1
+  jade:
+    distribution: [jade/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/jade-cache.yaml.gz
+    distribution_status: end-of-life
+    distribution_type: ros1
+  kinetic:
+    distribution: [kinetic/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/kinetic-cache.yaml.gz
+    distribution_status: active
+    distribution_type: ros1
+  lunar:
+    distribution: [lunar/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/lunar-cache.yaml.gz
+    distribution_status: active
+    distribution_type: ros1
+  melodic:
+    distribution: [melodic/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/melodic-cache.yaml.gz
+    distribution_status: active
+    distribution_type: ros1
+type: index
+version: 4


### PR DESCRIPTION
Related to ros-infrastructure/rosdistro#124.

**Update:** the test to ensure both indexes don't diverge has been moved into a separate PR (#19416) since ros-infrastructure/rosdistro#124 needs the new index v4 to pass its own tests but this repo needs a new release of `python-rosdistro` to pass CI.