### PR TITLE
geometry2: 0.6.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1285,7 +1285,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.6.3-0
+      version: 0.6.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.6.4-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.6.3-0`

## geometry2

- No changes

## tf2

```
* Resolved pedantic warnings
* fix issue #315 <https://github.com/ros/geometry2/issues/315>
* fixed nan interpoaltion issue
* Contributors: Keller Fabian Rudolf (CC-AD/EYC3), Kuang Fangjun, Martin Ganeff
```

## tf2_bullet

- No changes

## tf2_eigen

```
* improve comments
* add Eigen::Isometry3d conversions
* normalize quaternions to be in half-space w >= 0 as in tf1
* improve computation efficiency
* Contributors: Robert Haschke
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* fix translation vs rotation typo
  Fixes #324 <https://github.com/ros/geometry2/issues/324>
* Add python3.7 compatibility.
* Contributors: Hans Gaiser, Tully Foote
```

## tf2_ros

```
* fix(buffer-client): Use actionlib api for obtaining result
  Use the API provided by actionlib for waiting for result. This will improve the response time and prevent problems with custom solutions (see #178 <https://github.com/ros/geometry2/issues/178>). This change makes constructor parameter check_frequency obsolute and deprecates it.
* Add check to buffer_client.py to make sure result is available
  Related issue: #178 <https://github.com/ros/geometry2/issues/178>
* Add check to reset buffer when rostime goes backwards
* Fixed the value of expected_success_count_
* Added a tf2_ros message filter unittest with multiple target frames and non-zero time tolerance
* Contributors: Ewoud Pool, Jørgen Borgesen, Stephen Williams
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
