### PR TITLE
timed_roslaunch: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12932,7 +12932,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MoriKen254/timed_roslaunch-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `timed_roslaunch` to `0.1.3-0`:

- upstream repository: https://github.com/MoriKen254/timed_roslaunch.git
- release repository: https://github.com/MoriKen254/timed_roslaunch-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.1.2-0`

## timed_roslaunch

```
* Merge pull request #14 <https://github.com/MoriKen254/timed_roslaunch/issues/14> from MoriKen254/mk/mod-cmake-kinetic
  Modify CMakeLists for launch and test dir install
* Modify CMakeLists for launch and test dir install
* Contributors: Mori, MoriKen254
```
