### PR TITLE
rosconsole: 1.13.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4212,7 +4212,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole-release.git
-      version: 1.13.7-0
+      version: 1.13.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole` to `1.13.8-0`:

- upstream repository: https://github.com/ros/rosconsole.git
- release repository: https://github.com/ros-gbp/rosconsole-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `1.13.7-0`

## rosconsole

```
* fix double index increment in rosconsole_glog (#15 <https://github.com/ros/rosconsole/issues/15>)
* trigger LOG_THROTTLE when time goes backwards (#12 <https://github.com/ros/rosconsole/issues/12>)
* add deregistry function for LogAppender. (#17 <https://github.com/ros/rosconsole/issues/17>)
* replaced zero for NULL for null pointer constants (#14 <https://github.com/ros/rosconsole/issues/14>)
* fix rosconsole build issue when built on Windows (#13 <https://github.com/ros/rosconsole/issues/13>)
```
