### PR TITLE
mavros: 0.26.3-4 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5622,7 +5622,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.26.3-0
+      version: 0.26.3-4
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.26.3-4`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.26.3-0`

## libmavconn

```
* Prevent MAVConnTCPClient::do_recv and MAVConnTCPServer::do_accept from running after destruction has begun
* libmavconn/CMakeLists.txt: link mavconn-test against pthread
* Contributors: mlvov
```

## mavros

```
* test: Fix sensor orientation. RPY 315 was removed in recent mavlink.
  https://github.com/mavlink/mavlink/commit/3d94bccfedc5fc7f2ffad247adecff0c2dc03501
* lib: update generated entries
* Contributors: Vladimir Ermakov
```

## mavros_extras

```
* fixup! b43279058a3029c67ea75b1ecb86442c9dc991d4
* mavros_extras/log_transfer: Log transfer plugin
* Contributors: mlvov
```

## mavros_msgs

```
* fixup! 5a4344a2dcedc157f93b620cebd2e0b273ec24be
* mavros_msgs: Add msg and srv files related to log transfer
* Contributors: mlvov
```

## test_mavros

- No changes
