### PR TITLE
openrtm_aist_python: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2924,6 +2924,17 @@ repositories:
       url: https://github.com/tork-a/openrtm_aist-release.git
       version: 1.1.2-3
     status: developed
+  openrtm_aist_python:
+    doc:
+      type: git
+      url: https://github.com/tork-a/openrtm_aist_python-release.git
+      version: release/hydro/openrtm_aist_python
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/openrtm_aist_python-release.git
+      version: 1.1.0-0
+    status: maintained
   orb_slam2_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_python` to `1.1.0-0`:

- upstream repository: http://svn.openrtm.org/OpenRTM-aist-Python/tags/RELEASE_1_1_0_RC1/OpenRTM-aist-Python/
- release repository: https://github.com/tork-a/openrtm_aist_python-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`
