### PR TITLE
python-imaging: 'python-imaging' is not available in Debian buster

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1722,7 +1722,10 @@ python-hypothesis:
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
-  debian: [python-imaging]
+  debian:
+    buster: [python-pil]
+    stretch: [python-imaging]
+    jessie: [python-imaging]
   fedora:
     '21': [python-pillow, python-pillow-qt]
     '22': [python-pillow, python-pillow-qt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1724,8 +1724,8 @@ python-imaging:
   arch: [python2-pillow]
   debian:
     buster: [python-pil]
-    stretch: [python-imaging]
     jessie: [python-imaging]
+    stretch: [python-imaging]
   fedora:
     '21': [python-pillow, python-pillow-qt]
     '22': [python-pillow, python-pillow-qt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1722,10 +1722,7 @@ python-hypothesis:
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
-  debian:
-    buster: [python-pil]
-    jessie: [python-imaging]
-    stretch: [python-imaging]
+  debian: [python-pil]
   fedora:
     '21': [python-pillow, python-pillow-qt]
     '22': [python-pillow, python-pillow-qt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1722,7 +1722,10 @@ python-hypothesis:
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
-  debian: [python-pil]
+  debian:
+    '*': [python-pil]
+    jessie:  [python-imaging]
+    stretch: [python-imaging]
   fedora:
     '21': [python-pillow, python-pillow-qt]
     '22': [python-pillow, python-pillow-qt]
@@ -1748,8 +1751,8 @@ python-imaging:
     slackpkg:
       packages: [python-pillow]
   ubuntu:
+    '*': [python-pil]
     artful: [python-imaging]
-    bionic: [python-pil]
     lucid: [python-imaging]
     maverick: [python-imaging]
     natty: [python-imaging]


### PR DESCRIPTION
AFAIK the package 'python-imaging' is deprecated and not supported in Debian/buster and future releases.
See also: https://packages.debian.org/ja/stretch/python-imaging