### PR TITLE
mavros: 0.27.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2156,7 +2156,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.26.3-0
+      version: 0.27.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.27.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.26.3-0`

## libmavconn

```
* bind should be called after reuse_address is set
* Contributors: Shahar Kosti
```

## mavros

```
* fix: a typing error "alredy" to "already"
* plugins #1110 <https://github.com/mavlink/mavros/issues/1110> #1111 <https://github.com/mavlink/mavros/issues/1111>: add eigen aligment to plugins with eigen-typed members
* plugins: fix style
* with this fix ,it will avoid eigen error on 32 bits system
* Add service to send mavlink TRIGG_INTERVAL commands
  Adapt trigger_control service to current mavlink cmd spec. Add a new service to change trigger interval and integration time
* launch: fix #1080 <https://github.com/mavlink/mavros/issues/1080>: APM now support mocap messages
* Contributors: Gaogeolone, Moritz Zimmermann, Vladimir Ermakov, rapsealk
```

## mavros_extras

```
* extras #1110 <https://github.com/mavlink/mavros/issues/1110> #1111 <https://github.com/mavlink/mavros/issues/1111>: add eigen aligment to plugins with eigen-typed members
* Fix odom message to use covariance from msg
* Contributors: Dion Gonano, Vladimir Ermakov
```

## mavros_msgs

```
* Add service to send mavlink TRIGG_INTERVAL commands
  Adapt trigger_control service to current mavlink cmd spec. Add a new service to change trigger interval and integration time
* Contributors: Moritz Zimmermann
```

## test_mavros

- No changes
