### PR TITLE
adi_driver: 1.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -55,6 +55,21 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: indigo-devel
     status: maintained
+  adi_driver:
+    doc:
+      type: git
+      url: https://github.com/tork-a/adi_driver.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/adi_driver-release.git
+      version: 1.0.3-0
+    source:
+      type: git
+      url: https://github.com/tork-a/adi_driver.git
+      version: master
+    status: developed
   agni_tf_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_driver` to `1.0.3-0`:

- upstream repository: https://github.com/tork-a/adi_driver.git
- release repository: https://github.com/tork-a/adi_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`

## adi_driver

```
* Change to depend on imu_tools(#19 <https://github.com/tork-a/adi_driver/issues/19>)
  - Depend on imu_filter_madgwick and rviz_imu_plugin
* Add bias estimation service document(#20 <https://github.com/tork-a/adi_driver/issues/20>)
  - Update README.md
  - Fix incorrect sentence.
* Contributors: Ryosuke Tajima
```
