### PR TITLE
adi_driver: 1.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -129,7 +129,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/adi_driver-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/tork-a/adi_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_driver` to `1.0.3-0`:

- upstream repository: https://github.com/tork-a/adi_driver.git
- release repository: https://github.com/tork-a/adi_driver-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `1.0.2-0`

## adi_driver

```
* Change to depend on imu_tools(#19 <https://github.com/tork-a/adi_driver/issues/19>)
  - Depend on imu_filter_madgwick and rviz_imu_plugin
* Add bias estimation service document(#20 <https://github.com/tork-a/adi_driver/issues/20>)
  - Update README.md
  - Fix incorrect sentence.
* Contributors: Ryosuke Tajima
```
