### PR TITLE
novatel_span_driver: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2765,6 +2765,24 @@ repositories:
       url: https://github.com/swri-robotics/novatel_gps_driver.git
       version: master
     status: developed
+  novatel_span_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/novatel_span_driver.git
+      version: master
+    release:
+      packages:
+      - novatel_msgs
+      - novatel_span_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/novatel_span_driver.git
+      version: master
+    status: maintained
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_span_driver` to `1.1.0-0`:

- upstream repository: https://github.com/ros-drivers/novatel_span_driver.git
- release repository: https://github.com/ros-drivers-gbp/novatel_span_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## novatel_msgs

```
* Adding new maintainers.
* Contributors: Joshua Whitley
```

## novatel_span_driver

```
* Merge pull request #27 <https://github.com/ros-drivers/novatel_span_driver/issues/27> from michaelhsmart/ellipsoidal_from_orthometric
  Fix orthometric to ellipsoidal conversion
  Merged based on recommendations from @mikepurvis and @icolwell.
* Deleted extra ')' (#31 <https://github.com/ros-drivers/novatel_span_driver/issues/31>)
* Fix ellipsoidal altitude to use correct conversion from orthometric + undulation.
* Merge pull request #10 <https://github.com/ros-drivers/novatel_span_driver/issues/10> from prclibo/fix_rpy
  possibly fixed rpy interpretation
* Merge pull request #20 <https://github.com/ros-drivers/novatel_span_driver/issues/20> from astuff/master
  Adding new maintainers.
* Latch navsat/origin so that it is available to nodes that start after the NovAtel driver (#12 <https://github.com/ros-drivers/novatel_span_driver/issues/12>)
* Fix bad == when publishing IMU message (#19 <https://github.com/ros-drivers/novatel_span_driver/issues/19>)
* Merge pull request #9 <https://github.com/ros-drivers/novatel_span_driver/issues/9> from lemiant/patch-1
  Update diagnostics.py
  diagnostic_msgs has not been imported, must use DiagnosticStatus directly.
* Contributors: AnkilP, Joshua Whitley, Michael Smart, Mike Purvis, P. J. Reed, lemiant, libo24
```
