### PR TITLE
plotjuggler: 1.9.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3191,7 +3191,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 1.8.4-0
+      version: 1.9.0-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `1.9.0-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.8.4-0`

## plotjuggler

```
* version bump
* Spurious DragLeave fixed? (The worst and most annoying bug of PlotJuggler)
* adjust font size in left panel
* CMAKE_INSTALL_PREFIX flag fix for non-ROS user (#114)
* adding improvements from @aeudes , issue #119
  1) Improved RemoveCurve dialog (colors and immediate replot)
  2) Fixed QMenu actions zoom horizontally and vertically
  3) Fix issue with panner and added Mouse Middle Button
* minor changes
* Merge branch 'master' of https://github.com/facontidavide/PlotJuggler
* speed up loading rosbags (5%-10%)
* custom qFileDialog to save the Layout
* minor changes
* Contributors: Davide Faconti, Mat&I
```
