### PR TITLE
openhrp3: 3.1.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2918,7 +2918,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/openhrp3-release.git
-      version: 3.1.9-0
+      version: 3.1.9-1
     status: maintained
   openni2_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openhrp3` to `3.1.9-1`:

- upstream repository: https://github.com/fkanehiro/openhrp3.git
- release repository: https://github.com/tork-a/openhrp3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `3.1.9-0`

## openhrp3

```
* supports OpenRTM-aist 1.2.0 (c04e9293 <https://github.com/fkanehiro/openhrp3/commit/c04e92930af318d6566213dd173c34331eb18898>)
* supports trunk version of OpenRTM-aist (#104 <https://github.com/fkanehiro/openhrp3/issues/104>)
  * hrplib/{hrpModel/ModelNodeSet.h, TriangleMeshShaper.h} uses signals2 for BOOST_VERSION >= 103900 (#103 <https://github.com/fkanehiro/openhrp3/issues/103>)
* add configuration for openrtm ver-1.1.2 (#84 <https://github.com/fkanehiro/openhrp3/issues/84>)
* SUpport ARM64: aarch64(ARMv8) is also 64bit machine (#100 <https://github.com/fkanehiro/openhrp3/issues/100>)
  * hrplib/hrpPlanner/TimeUtil.cpp : fix get_tick() for arm processors (#99 <https://github.com/fkanehiro/openhrp3/issues/99> )
* Support clang and Fix some memory leaks (conservative fixes only) (#113 <https://github.com/fkanehiro/openhrp3/issues/113>)
* supports ubuntu 16.04 (2faa042f0 <https://github.com/fkanehiro/openhrp3/commit/2faa042f0ce5e2b8ac6b03c94feb3e95ab076e1d>)
* CMakeLists.txt: fix to work on Boost 1.34.0 (#89 <https://github.com/fkanehiro/openhrp3/issues/89> )
* .traivs.yml: add to check if this work with current hrpsys (#70 <https://github.com/fkanehiro/openhrp3/issues/70>)
* layout python stub to right place (#69 <https://github.com/fkanehiro/openhrp3/issues/69> )
  * idl_py_files to lib/python${python_version}/dist-packages
  * module_py_files to lib/python${python_version}/dist-packages/OpenHRP
  * module_poa_py_files to lib/python${python_version}/dist-packages/OpenHRP__POA
* installPackages
  * util/installPackages.sh: Fixes on the script (#96 <https://github.com/fkanehiro/openhrp3/issues/96>)Fix the tests on empty strings
  
  Fix shebang for better compatibility
  
    * util/installPackages.sh: fixes a typo (#95 <https://github.com/fkanehiro/openhrp3/issues/95>)
    * util/packages.list.ubuntu.15.04 : adds a package list for ubuntu15.04 (ce8dc77f <https://github.com/fkanehiro/openhrp3/commit/ce8dc77f20f2f755f242b0c8ca3c9af7da278bf9>)
  
* Fix many compile warning
  * fixes some of warnings detected by -Wall (#118 <https://github.com/fkanehiro/openhrp3/issues/118> )
  * fixes warnings detected by -Wsign-compare / restores return type of calcSRInverse() (#117 <https://github.com/fkanehiro/openhrp3/issues/117>)
  * fixes warnings detected by -Wreorder (#114 <https://github.com/fkanehiro/openhrp3/issues/114>)
  * Reduce Warnings (#102 <https://github.com/fkanehiro/openhrp3/issues/102>)Reorder includes for clang
  Clang doesn't allow the overloaded operator <<= used in the template
  function CORBA_Util::typecode::id() to be declared after that point of
  use.  It seems to be a bug in clang.
  
  Add missing cases
  
  Remove "this != null" checks
  These conditionals are never true in valid C++ programs.
  
  Add abort to "impossible" paths
  
  Add parens to indicate intentional assignment
  
  Fix comparison where it should be assignment
  
  Streamline definition of PI and PI_2
  C++ standard (at least prior to C++11) specifies that static const
  double members cannot be initialized within the class definition.  Move
  the initialization of PI and PI_2 outside the class; also, update
  
  <string>:49: (ERROR/3) Unexpected indentation.
  
  feature test macros to use M_PI and M_PI_2 whenever they're available.
  
  Disambiguate if-else
  
  Fix friend declarations
  friend declarations can't contain default parameters unless the function
  body is defined at the same site.
  
    * hrplib/hrpModel/Body.cpp, ModelLoaderUtil.cpp, fixes warnings (false -> NULL) (#101 <https://github.com/fkanehiro/openhrp3/issues/101>)
  
* hrplib/hrpModel
  * hrplib/hrpModel/World.h: changes return type of World::numBodies() from int to unsinged int (#116 <https://github.com/fkanehiro/openhrp3/issues/116> )
  * hrplib/hrpModel/{Body.h,JointPath.h,LinkTraverse.h} : changes return types of numXXX() (#115 <https://github.com/fkanehiro/openhrp3/issues/115> )
  * hrplib/hrpModel/Body.cpp: supports slide joints (Link:SLIDE_JOINT) in calcCMJacobian() (7b674f88 <https://github.com/fkanehiro/openhrp3/commit/7b674f88af1100ae0d85bdc6c45cb1f18ae648ea>)
  * hrplib/hrpModel/Body.cpp: fixes a bug in calcInverseKinematics (1ce8d36d7 <https://github.com/fkanehiro/openhrp3/commit/1ce8d36d72685e4bfe92912ec13cced754c0240a>)
  * hrplib/hrpModel/ModelNodeSet.cpp: PROTO Surfaceのあるモデルが読み込めないバグの修正 (#66 <https://github.com/fkanehiro/openhrp3/issues/66>)
* hrplib/hrpPlanner
  * Extend planner (#112 <https://github.com/fkanehiro/openhrp3/issues/112>, #111 <https://github.com/fkanehiro/openhrp3/issues/111>)removes redundant way point in a path /
  
  changes type of extraConnectionCheckFunc
  
  enables to add an extra connection check between trees
  
  adds == and != operators
  
    * hrplib/hrpPlanner/Algorithm.cpp: adds Algorithm::ignoreCollisionAtStart() and Algorithm::ignoreCollisionAtGoal() (#110 <https://github.com/fkanehiro/openhrp3/issues/110>)
    * hrplib/hrpPlanner/PathPlanner.cpp : Fix bugs, uses attitude() instead of R ( #109 <https://github.com/fkanehiro/openhrp3/issues/109>)
    * hrplib/hrpPlanner/PathPlanner.cpp: outputs debug messages to stderr not to stdout (#108 <https://github.com/fkanehiro/openhrp3/issues/108>)
    * hrplib/hrpPlanner/Algorithm.cpp: makes error messages more informative (#107 <https://github.com/fkanehiro/openhrp3/issues/107>)
  
* hrplib/hrpCollision
  * hrplib/hrpCollision/Opcode/OPC_Common.h: modifies CreateSSV() to prevent Zero Div.(#106 <https://github.com/fkanehiro/openhrp3/issues/106>)
  * hrplib/hrpCollision/ColdetModel.cpp: 隣接する三角形の判断を修正 (#75 <https://github.com/fkanehiro/openhrp3/issues/75>)
* hrplib/hrpUtil
  * hrplib/hrpUtil/TriangleMeshShaper.cpp: checks values to prevent NaN (#105 <https://github.com/fkanehiro/openhrp3/issues/105>)
  
    * {hrplib/hrpModel/ModelNodeSet.h, server/ModelLoader/BodyInfo_impl.cpp} uses aligned allocator (b6b03af8 <https://github.com/fkanehiro/openhrp3/commit/b6b03af8c9d122f891d94387a5cbb8c8f00f9ef6>)
    * hrplib/hrpModel: Add angular momentum jacobian (#98 <https://github.com/fkanehiro/openhrp3/issues/98>)
      * [hrplib/hrpModel/Body.cpp,Body.h] Add calcTotalMomentumFromJacobian and calcAngularMomentumJacobian
      * [hrplib/hrpModel/Link.cpp,Link.h] Add subIw (inertia tensor)
    * hrplib/hrpUtil/{Eigen3d.cpp,testEigen3d.cpp}: add the correction of floating point error (#85 <https://github.com/fkanehiro/openhrp3/issues/85>)
      * display input matrix
      * add the correction of floating point error
    * hrplib/hrpUtil/testEigen3d.cpp : add google test for Eigen3d.cpp (#64 <https://github.com/fkanehiro/openhrp3/issues/64>)
  
* server/ModelLoader
  * server/ModelLoader/ColladaWriter.h: check that a base link and an effector links exist, Fix #93 <https://github.com/fkanehiro/openhrp3/issues/93> (#94 <https://github.com/fkanehiro/openhrp3/issues/94>)
  * server/ModelLoader/exportCollada.cpp: fix help message for adding information of manipulator to collada file, Fix #91 <https://github.com/fkanehiro/openhrp3/issues/91>  (#92 <https://github.com/fkanehiro/openhrp3/issues/92> )
  * server/ModelLoader/BodyInfo_impl.cpp: set default mass properties (#90 <https://github.com/fkanehiro/openhrp3/issues/90>)
  * server/ModelLoader/projectGenerator.cpp: Add outport for root link actual pos and rot. (#81 <https://github.com/fkanehiro/openhrp3/issues/81>)
  * [server/ModelLoader/projectGenerator.cpp, REAME.md] Add integration method (EULER, RUNGE_KUTTA...) argument and update readme (#79 <https://github.com/fkanehiro/openhrp3/issues/79> )
  * server/ModelLoader/projectGenerator.cpp: generating default outport:dq in project file by projectGenerator (#74 <https://github.com/fkanehiro/openhrp3/issues/74>)
  * server/ModelLoader/ModelLoader_impl.cpp: fix ModelLoader to enable the compile without collada (#73 <https://github.com/fkanehiro/openhrp3/issues/73>)
  * server/ModelLoader/ModelLoader_impl.cpp: support PROJECT_DIR in ModelLoader, Fix #55 <https://github.com/fkanehiro/openhrp3/issues/55> (#68 <https://github.com/fkanehiro/openhrp3/issues/68>)
  * server/ModelLoader/ColladaWriter.h: fix for reducing CORBA communication on 32bit machine on models with many shapes (#63 <https://github.com/fkanehiro/openhrp3/issues/63>)
  * server/ModelLoader/README.md: add README.md with options and an example for projectGenerator (#62 <https://github.com/fkanehiro/openhrp3/issues/62>, #60 <https://github.com/fkanehiro/openhrp3/issues/60>)
* sample
  * [sample/example/customizer/sample1_bush_customizer_param.conf, sample/model/sample1_bush.wrl] Add hand bush for sample1_bush.wrl. Currently do not fix indent to check diff. Update bush parameters. (#82 <https://github.com/fkanehiro/openhrp3/issues/82>)
  * [sample/model/sample_special_joint_robot.wrl] Add sample robot to check special joints (#80 <https://github.com/fkanehiro/openhrp3/issues/80> )
  
    * Fix sample4legrobot conf robot name (#78 <https://github.com/fkanehiro/openhrp3/issues/78>)
      * [sample/model/sample_4leg_robot*.wrl] Fix leg origin pos left/right
      * [sample/example/customizer/sample_4leg_robot_bush_customizer_param.conf] Fix sample4legrobot conf robot name
  
* Add 4leg robot (#77 )
  
  [sample/example/customizer/CMakeLists.txt] Install bush customizer file for sample_4leg_robot_bush
  
  [sample/model/sample_4leg_robot*, sample/example/customizer/sample_4leg_robot_bush_customizer_param.conf] Add 4legged robot and bush setting
  
    * [sample/model/sample1_bush.wrl,sample1.wrl] Add vlimit for sample1 and sample1_bush (#72 <https://github.com/fkanehiro/openhrp3/issues/72>)
    * Add bush customizer (#71 <https://github.com/fkanehiro/openhrp3/issues/71>)
      * [sample/example/customizer/CMakeLists.txt] Install BUSH_CUSTOMIZER_CONFIG file
      * [sample/example/customizer/sample1*.conf] Add example config file for sample1_bush.wrl param
      * [sample/example/customizer/CMakeLists.txt,sample/example/customizer/bush_customizer.cpp] Add customizer for rubber bush.
      * [sample/model/sample1_bush.wrl] Add sample1 model with rubber bush.
  
* Contributors: Eisoku Kuroiwa, Fumio Kanehiro, Shizuko Hattori, Jun Inoue, Kei Okada, Mehdi Benallegue, Shin'ichiro Nakaoka, Shunichi Nozawa, Takasugi Noriaki, Yohei Kakiuchi, Yosuke Matsusaka
```
