### PR TITLE
panda_moveit_config: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3072,6 +3072,21 @@ repositories:
       url: https://github.com/astuff/pacmod_game_control.git
       version: master
     status: developed
+  panda_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/panda_moveit_config.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/panda_moveit_config-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/panda_moveit_config.git
+      version: melodic-devel
+    status: maintained
   parrot_arsdk:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.1.0-0`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`

## panda_moveit_config

```
* initial release of Panda MoveIt config, including OMPL, CHOMP and STOMP configs
* Contributors: Dave Coleman, Florian Walch, Mike Lautman, Raghavender Sahdev
```
