### PR TITLE
franka_ros: 0.6.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2863,11 +2863,10 @@ repositories:
       - franka_msgs
       - franka_ros
       - franka_visualization
-      - panda_moveit_config
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.6.0-0
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.6.0-1`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.6.0-0`

Removed `panda_moveit_config` as it will be released from `ros-planning` in the future (https://github.com/ros-planning/panda_moveit_config/issues/11).

cc @rhaschke 