### PR TITLE
Adding python3-psutil

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4647,6 +4647,18 @@ python3-pkg-resources:
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
   ubuntu: [python3-pkg-resources]
+python3-psutil:
+  arch: [python-psutil]
+  debian: [python3-psutil]
+  fedora: [python3-psutil]
+  gentoo: [dev-python/psutil]
+  macports: [py36-psutil]
+  opensuse: [python3-psutil]
+  osx:
+    pip:
+      packages: [psutil]
+  slackware: [psutil]
+  ubuntu: [python3-psutil]
 python3-pydot:
   arch: [python-pydot]
   debian: [python3-pydot]


### PR DESCRIPTION
This PR adds a key for python3-psutil which is used by the rqt_top plugin. I checked that all the packages below exist for their respective distros.