### PR TITLE
move_base_flex: 0.2.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2296,7 +2296,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.3-0`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.2.2-0`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Do not publish path from MBF
* Single publisher for controller execution objects
* Ignore max_retries if value is negative and patience if 0
* Avoid annoying INFO log msg on recovery
```

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* single publisher for controller execution objects
```

## mbf_msgs

```
* Add outcome and message to the action's feedback in ExePath and MoveBase
```

## mbf_simple_nav

- No changes

## mbf_utility

```
* Fix getRobotPose in melodic
```

## move_base_flex

- No changes
