### PR TITLE
panda_moveit_config: 0.7.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7735,6 +7735,21 @@ repositories:
       url: https://github.com/astuff/pacmod_game_control.git
       version: release
     status: developed
+  panda_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/panda_moveit_config.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/panda_moveit_config-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/panda_moveit_config.git
+      version: kinetic-devel
+    status: maintained
   parameter_pa:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.0-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`

## panda_moveit_config

```
* Initial release of panda_moveit_config into Melodic, including OMPL, CHOMP and STOMP configs
  We moved/merged this repo from https://github.com/frankaemika/franka_ros.
* Contributors: Dave Coleman, Florian Walch, Mike Lautman, Raghavender Sahdev
```
