### PR TITLE
rosfmt: 6.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10660,7 +10660,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosfmt-release.git
-      version: 5.2.2-0
+      version: 6.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosfmt` to `6.0.0-0`:

- upstream repository: https://github.com/xqms/rosfmt.git
- release repository: https://github.com/xqms/rosfmt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `5.2.2-0`

## rosfmt

```
* Major release bump to decouple rosfmt and fmt versions
* rosfmt.h: produce nicer error message if C++11 is not available
* cmake: add transitive rosconsole / roscpp deps
* README: add CMake example
* Contributors: Max Schwarz
```
