### PR TITLE
moveit_visual_tools: 3.5.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2413,7 +2413,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/moveit_visual_tools-release.git
-      version: 3.2.1-4
+      version: 3.5.1-0
     source:
       type: git
       url: https://github.com/PickNikRobotics/moveit_visual_tools.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2407,16 +2407,16 @@ repositories:
   moveit_visual_tools:
     doc:
       type: git
-      url: https://github.com/PickNikRobotics/moveit_visual_tools.git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
       version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/PickNikRobotics/moveit_visual_tools-release.git
+      url: https://github.com/ros-gbp/moveit_visual_tools-release.git
       version: 3.5.1-0
     source:
       type: git
-      url: https://github.com/PickNikRobotics/moveit_visual_tools.git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
       version: melodic-devel
     status: developed
   mrpt1:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.5.1-0`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/PickNikRobotics/moveit_visual_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `3.2.1-4`

## moveit_visual_tools

```
* Adding trigger call to animations when batch_publishing_enabled_ is enabled (#36 <https://github.com/ros-planning/moveit_visual_tools/issues/36>)
* Contributors: Mike Lautman
```
