### PR TITLE
moveit_visual_tools: 3.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6108,7 +6108,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbd/moveit_visual_tools-release.git
+      url: https://github.com/ros-gbp/moveit_visual_tools-release.git
       version: 3.4.1-0
     source:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6109,7 +6109,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/moveit_visual_tools-release.git
-      version: 3.4.0-0
+      version: 3.4.1-0
     source:
       type: git
       url: https://github.com/davetcoleman/moveit_visual_tools.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6103,16 +6103,16 @@ repositories:
   moveit_visual_tools:
     doc:
       type: git
-      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
       version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/davetcoleman/moveit_visual_tools-release.git
+      url: https://github.com/ros-gbd/moveit_visual_tools-release.git
       version: 3.4.1-0
     source:
       type: git
-      url: https://github.com/davetcoleman/moveit_visual_tools.git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
       version: kinetic-devel
     status: developed
   movidius_ncs:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.4.1-0`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/davetcoleman/moveit_visual_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `3.4.0-0`

## moveit_visual_tools

```
* Adding trigger call to animations when batch_publishing_enabled_ is enabled (#36 <https://github.com/ros-planning/moveit_visual_tools/issues/36>)
* Changing variable names for consistency and clang (#33 <https://github.com/ros-planning/moveit_visual_tools/issues/33>)
* Additional visualization (#31 <https://github.com/ros-planning/moveit_visual_tools/issues/31>)
  * adding a visualization for publishing a box with width, height, and depth
  * adding additional publishCollisionCuboid method overloads
  * changing x,y,z to width, depth, height
* Fixup CMakeLists and package.xml (#30 <https://github.com/ros-planning/moveit_visual_tools/issues/30>)
* No spinOnce when triggering (#32 <https://github.com/ros-planning/moveit_visual_tools/issues/32>)
* Allow setting joint values for end-effector marker
* Fix API compatibility by providing a default empty list of end-effector joints
* Fix Continuous Integration
* Allow setting joint values for end-effector marker
  currently end-effector markers are based on the default robot state (ie all zero),
  this allows passing a vector of doubles for all active joint in the end-effector group
  Passing a new set of joint values will invalidate the cache but for our use-case this is
  neglectible and could be optimized later
* Contributors: Dave Coleman, Mike Lautman, Simon Schmeisser
```
