### PR TITLE
Adding crane_x7_ros to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1776,7 +1776,7 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
       version: kinetic-devel
     status: developed
-  crane_x7_ros:
+  crane_x7:
     doc:
       type: git
       url: https://github.com/rt-net/crane_x7_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1776,6 +1776,12 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
       version: kinetic-devel
     status: developed
+  crane_x7_ros:
+    doc:
+      type: git
+      url: https://github.com/rt-net/crane_x7_ros.git
+      version: master
+    status: developed
   crazyflie:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add crane_x7_ros for ROS Kinetic to be doc'd and indexed.