### PR TITLE
rosfmt: 6.0.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4183,6 +4183,21 @@ repositories:
       url: https://github.com/rosflight/rosflight.git
       version: master
     status: developed
+  rosfmt:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosfmt.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/xqms/rosfmt-release.git
+      version: 6.0.0-0
+    source:
+      type: git
+      url: https://github.com/xqms/rosfmt.git
+      version: master
+    status: developed
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosfmt` to `6.0.0-0`:

- upstream repository: https://github.com/xqms/rosfmt.git
- release repository: https://github.com/xqms/rosfmt-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`

## rosfmt

```
* Major release bump to decouple rosfmt and fmt versions
* rosfmt.h: produce nicer error message if C++11 is not available
* cmake: add transitive rosconsole / roscpp deps
* README: add CMake example
* Contributors: Max Schwarz
```
