### PR TITLE
mapviz: 0.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1997,7 +1997,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.2.6-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `0.3.0-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.2.6-0`

## mapviz

```
* Merge all -devel branches into a single master branch
* Add function to lock canvas movement (#596 <https://github.com/swri-robotics/mapviz/issues/596>)
* Contributors: P. J. Reed
```

## mapviz_plugins

```
* Merge all -devel branches into a single master branch
* Don't transform laser scans twice (#544 <https://github.com/swri-robotics/mapviz/issues/544>)
* Improving point_drawing plugins and bug fix of tf_plugin (#557 <https://github.com/swri-robotics/mapviz/issues/557>)
* OpenGL rendering of PointClouds  (2X speedup) (#558 <https://github.com/swri-robotics/mapviz/issues/558>)
* Occupancy grid (new plugin) (#568 <https://github.com/swri-robotics/mapviz/issues/568>)
* Bug fix in image plugin (#563 <https://github.com/swri-robotics/mapviz/issues/563>)
* Fix Indigo build, clean up warnings (#597 <https://github.com/swri-robotics/mapviz/issues/597>)
* Create Coordinate Picker plugin (#593 <https://github.com/swri-robotics/mapviz/issues/593>)
* Contributors: Davide Faconti, Ed Venator, Edward Venator, Elliot Johnson, Jerry Towler, Marc Alban, Matthew, Matthew Bries, Mikael Arguedas, Neal Seegmiller, Nicholas Alton, P. J. Reed, Vincent Rousseau
```

## multires_image

```
* Merge all -devel branches into a single master branch
* Contributors: P. J. Reed
```

## tile_map

```
* Merge all -devel branches into a single master branch
* Contributors: P. J. Reed
```
