### PR TITLE
robot_recorder: 1.0.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9589,6 +9589,21 @@ repositories:
       url: https://github.com/GT-RAIL/robot_pose_publisher.git
       version: develop
     status: maintained
+  robot_recorder:
+    release:
+      packages:
+      - recordit
+      - robot_recorder
+      - rviz_recorder_buttons
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa-jfh/robot_recorder-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ipa-jfh/robot_recorder.git
+      version: master
+    status: maintained
   robot_self_filter:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_recorder` to `1.0.0-2`:

- upstream repository: https://github.com/ipa-jfh/robot_recorder.git
- release repository: https://github.com/ipa-jfh/robot_recorder-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`
