### PR TITLE
geometry2: 0.6.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1300,7 +1300,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.6.5-0`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.6.4-0`

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* Fix python3 import error
* Contributors: Timon Engelke
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Protect the time reset logic from a race condition.
  Fixes #341 <https://github.com/ros/geometry2/issues/341>
  This could incorrectly trigger a buffer clear if two concurrent callbacks were invoked.
* Contributors: Tully Foote
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
