### PR TITLE
tuw_marker_detection: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5493,6 +5493,27 @@ repositories:
       url: https://github.com/tuw-robotics/tuw_geometry.git
       version: master
     status: developed
+  tuw_marker_detection:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_marker_detection.git
+      version: melodic
+    release:
+      packages:
+      - tuw_aruco
+      - tuw_checkerboard
+      - tuw_ellipses
+      - tuw_marker_detection
+      - tuw_marker_pose_estimation
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tuw-robotics/tuw_marker_detection-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_marker_detection.git
+      version: melodic
+    status: maintained
   tuw_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_marker_detection` to `0.1.1-1`:

- upstream repository: https://github.com/tuw-robotics/tuw_marker_detection.git
- release repository: https://github.com/tuw-robotics/tuw_marker_detection-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`
