### PR TITLE
pacmod3: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7714,7 +7714,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/pacmod3-release.git
-      version: 1.1.1-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/astuff/pacmod3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod3` to `1.2.0-0`:

- upstream repository: https://github.com/astuff/pacmod3.git
- release repository: https://github.com/astuff/pacmod3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.1.1-0`

## pacmod3

```
* Merge pull request #41 <https://github.com/astuff/pacmod3/issues/41> from astuff/fix/vector_comp_dbc_file
  Removing unnecessary line preventing Vector CANdb++ editor from opening
* Merge pull request #39 <https://github.com/astuff/pacmod3/issues/39> from astuff/feat/add_comp_rpt
  Feature add component report for each PACMod component.
* DBC: Fixing errors. CI: Adding DBC validation to workflow.
* DBC: Typo on two lines.
* Adding encoding for CLEAR_FAULTS flag.
* Adding parsing and publishing for COMPONENT_RPT.
* DBC: Add COMPONENT_RPT and CLEAR_FAULTS flag.
* Merge pull request #38 <https://github.com/astuff/pacmod3/issues/38> from astuff/feature/add_veh_6
  Adding VEHICLE_6.
* Contributors: Daniel-Stanek, Joshua Whitley, Mike Lemm, Nate Imig
```
