### PR TITLE
franka_ros: 0.6.0-2 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -952,6 +952,15 @@ repositories:
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git
       version: kinetic-devel
     status: developed
+  franka_ros:
+    release:
+      packages:
+      - franka_description
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/frankaemika/franka_ros-release.git
+      version: 0.6.0-2
+    status: unmaintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.6.0-2`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`

As https://github.com/ros/rosdistro/pull/19307, this is to unblock MoveIt tutorials. This only releases the `franka_description` package, which is intentional.