### PR TITLE
ibeo_core: 2.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4934,11 +4934,15 @@ repositories:
       version: master
     status: maintained
   ibeo_core:
+    doc:
+      type: git
+      url: https://github.com/astuff/ibeo_core.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/astuff/ibeo_core-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/astuff/ibeo_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_core` to `2.0.1-0`:

- upstream repository: https://github.com/astuff/ibeo_core.git
- release repository: https://github.com/astuff/ibeo_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.0.0-0`

## ibeo_core

```
* Merge pull request #7 <https://github.com/astuff/ibeo_core/issues/7> from astuff/maint/add_urls
  Adding URL to package.xml and updating README.
* Merge pull request #6 <https://github.com/astuff/ibeo_core/issues/6> from astuff/fix/bad_alloc
  Fix bad_alloc SEGSIV error.
* Merge pull request #4 <https://github.com/astuff/ibeo_core/issues/4> from ShepelIlya/patch-1
  Fix for reading of object_box_orientation_angle
  Byte order for object bounding box orientation angle changed from little-endian to big-endian. According to the document "Interface Specification for ibeo LUX, ibeo LUX systems and ibeo Evaluation Suite", version 1.48 from 30.05.2017 there is big-endian byte order for all fields in Object2280. If i am using original code orientation of objects orientation changes abruptly. With that fix it seems to work correct.
* Contributors: Joshua Whitley, Rinda Gunjala, Sam Rustan, ShepelIlya, Zach Oakes
```
