### PR TITLE
add python3-lark-parser key for Ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4631,6 +4631,8 @@ python3-gitlab:
     xenial:
       pip:
         packages: [python-gitlab]
+python3-lark-parser:
+  ubuntu: [python3-lark-parser]
 python3-mock:
   debian: [python3-mock]
   fedora: [python3-mock]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4632,7 +4632,8 @@ python3-gitlab:
       pip:
         packages: [python-gitlab]
 python3-lark-parser:
-  ubuntu: [python3-lark-parser]
+  ubuntu:
+    bionic: [python3-lark-parser]
 python3-mock:
   debian: [python3-mock]
   fedora: [python3-mock]


### PR DESCRIPTION
Required for ros2/rosidl#326.