### PR TITLE
laser_assembler: 1.7.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1854,7 +1854,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/laser_assembler-release.git
-      version: 1.7.5-0
+      version: 1.7.6-0
     source:
       type: git
       url: https://github.com/ros-perception/laser_assembler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_assembler` to `1.7.6-0`:

- upstream repository: https://github.com/ros-perception/laser_assembler.git
- release repository: https://github.com/ros-gbp/laser_assembler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.7.5-0`

## laser_assembler

```
* Fix compilation issues with new boost
  See https://github.com/ros/actionlib/issues/104
* Contributors: Tobias Fischer
```
