### PR TITLE
Add svgpathtools pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4780,6 +4780,10 @@ sphinxcontrib-bibtex-pip:
   ubuntu:
     pip:
       packages: [sphinxcontrib-bibtex]
+svgpathtools:
+  ubuntu:
+    pip:
+      packages: [svgpathtools]
 tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4780,7 +4780,7 @@ sphinxcontrib-bibtex-pip:
   ubuntu:
     pip:
       packages: [sphinxcontrib-bibtex]
-svgpathtools:
+svgpathtools-pip:
   ubuntu:
     pip:
       packages: [svgpathtools]


### PR DESCRIPTION
- https://pypi.org/project/svgpathtools/
- https://github.com/mathandy/svgpathtools

I'm going to use this package to parse SVG files that are exported from CAD programs (SolidWorks, FreeCAD) and interpret them as additive manufacturing trajectories.

There is already `python-svg.path`which does similar things but it has a lot less features.