### PR TITLE
variant: 0.1.4-0 in 'melodic/distribution.yaml [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5731,6 +5731,17 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  variant:
+    release:
+      packages:
+      - variant
+      - variant_msgs
+      - variant_topic_test
+      - variant_topic_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/anybotics/variant-release.git
+      version: 0.1.4-0
   velodyne:
     doc:
       type: git


### PR DESCRIPTION
add new package to melodic

For some reasons I cannot create this pull request anymore with bloom:

```
Aborting pull request: HTTP Error 401: Unauthorized (https://api.github.com/repos/ros/rosdistro/forks)
The release of your packages was successful, but the pull request failed.
Please manually open a pull request by editing the file here: 'https://raw.githubusercontent.com/ros/rosdistro/master/melodic/distribution.yaml'
<== No pull request opened.
```

Does anyone has an idea what could be the reason?
