### PR TITLE
rqt_multiplot_plugin: 0.0.8-0 in 'kinetic/distribution.yaml [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11240,7 +11240,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/anybotics/rqt_multiplot_plugin-release.git
-      version: 0.0.7-2
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/anybotics/rqt_multiplot_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository rqt_multiplot_plugin to 0.0.8-0: