### PR TITLE
Update rosdep rule guidelines for python 3 style.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,26 @@ Guidelines for rosdep rules
        However please don't target 'sid' as it's a rolling target and when the keys change our database gets out of date.
   * Keep everything in alphabetical order for better merging.
   * No trailing whitespace.
-   
+
+### Python 3 rules
+
+When adding rules for python 3 packages, create a separate entry prefixed with `python3-` rather than `python`
+For example:
+
+```yaml
+python-foobar:
+  debian: [python-foobar]
+  fedora: [python2-foobar]
+  ubuntu: [python-foobar]
+...
+python3-foobar:
+  debian: [python3-foobar]
+  fedora: [python3-foobar]
+  ubuntu: [python3-foobar]
+```
+
+You may see existing rules that use `_python3`-suffixed distribution codenames.
+These were trialed as a possible style of Python 3 rules and should not be used for newly added definitions.
 
 How to submit pull requests
 ---------------------------


### PR DESCRIPTION
We've had a handful of contributions come in using the `_python3`-suffixed distro codenames rather than the separate python3 rosdep keys. This updates our rosdep contribution guidelines with our current preferred python3 style.

[:scroll: Rendered preview](https://github.com/nuclearsandwich/rosdistro/blob/3d1e919cdc3f8e4d2301d724d3ceaa9fe56401cc/CONTRIBUTING.md#python-3-rules) of the modified guidelines.