### PR TITLE
Fix package name of raspicat on documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9019,7 +9019,7 @@ repositories:
       url: https://github.com/bberrevoets/raspi_temperature.git
       version: master
     status: maintained
-  raspicat_ros:
+  raspicat:
     doc:
       type: git
       url: https://github.com/rt-net/raspicat_ros.git


### PR DESCRIPTION
I'd like to rename raspicat package for ROS Kinetic to conform REP 144.

previous PR: https://github.com/ros/rosdistro/pull/19187
https://github.com/rt-net/raspicat_ros/issues/3