### PR TITLE
teleop_tools: 0.2.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5312,6 +5312,17 @@ repositories:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
       version: melodic-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_tools-release.git
+      version: 0.2.6-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.2.6-0`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## joy_teleop

```
* Support using buttons and axis in the same message
* Contributors: Tim Clephas
```

## key_teleop

- No changes

## mouse_teleop

- No changes

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
