### PR TITLE
ros_pytest: 0.1.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4172,7 +4172,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/machinekoder/ros_pytest-release.git
-      version: 0.1.1-0
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/machinekoder/ros_pytest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_pytest` to `0.1.2-2`:

- upstream repository: https://github.com/machinekoder/ros_pytest.git
- release repository: https://github.com/machinekoder/ros_pytest-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.1.1-0`

## ros_pytest

```
* Added add_pytests cmake macro
* enable passing of additional commands
* Contributors: Alexander Rössler, Markus Grimm
```
