### PR TITLE
ros_pytest: 0.1.2-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10445,7 +10445,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/machinekoder/ros_pytest-release.git
-      version: 0.1.0-1
+      version: 0.1.2-3
     source:
       type: git
       url: https://github.com/machinekoder/ros_pytest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_pytest` to `0.1.2-3`:

- upstream repository: https://github.com/machinekoder/ros_pytest.git
- release repository: https://github.com/machinekoder/ros_pytest-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.1.0-1`

## ros_pytest

```
* Added add_pytests cmake macro
* enable passing of additional commands
* Contributors: Alexander Rössler, Markus Grimm
```
