### PR TITLE
robot_self_filter: 0.1.31-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3764,6 +3764,17 @@ repositories:
     status_description: The robot_model metapackage is deprecated and will be removed
       in ROS M. The packages it includes will continue to be maintained, but will
       be moved to new repositories.
+  robot_self_filter:
+    doc:
+      type: git
+      url: https://github.com/PR2/robot_self_filter.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
+      version: 0.1.31-0
+    status: unmaintained
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_self_filter` to `0.1.31-0`:

- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## robot_self_filter

```
* Merge pull request #16 <https://github.com/PR2/robot_self_filter/issues/16> from mikaelarguedas/tinyxml_dependency
  depends on tinyxml and link against it
* Merge branch 'indigo-devel' into tinyxml_dependency
* Merge pull request #18 <https://github.com/PR2/robot_self_filter/issues/18> from k-okada/add_travis
  update travis.yml
* update travis.yml
* depend on tinyxml and link against it
* Merge pull request #14 <https://github.com/PR2/robot_self_filter/issues/14> from traclabs/indigo-devel
  Minor changes to indigo-devel CMake allow this to be used in kinetic and indigo
* Changes for kinetic
* Contributors: Devon Ash, Kei Okada, Mikael Arguedas, Patrick Beeson
```
