### PR TITLE
rviz_visual_tools: 3.7.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5067,7 +5067,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 3.6.1-0
+      version: 3.7.0-0
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.7.0-0`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `3.6.1-0`

## rviz_visual_tools

```
* Fix Eigen::Affine3d for Melodic (using Eigen::Isometry3d) (#105 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/105>)
* Improve documentation (#100 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/100>)
* Fix some catkin_lint warnings and rename targets output (#98 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/98>)
* Update README Kinetic to Melodic (#102 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/102>)
* Add Melodic build farm badges (#99 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/99>)
* Add ccache support (#93 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/93>)
* no ros::spinOnce() (#82 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/82>)
* Deprecate old functions for ROS Melodic (#91 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/91>)
* Improve package with catkin_lint (#89 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/89>)
* Add OGRE dependency (#88 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/88>)
* Automoc requires at least cmake version 2.8.6 (#86 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/86>)
* Fix Travis badge (#84 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/84>)
* The code already uses AUTOMOC (#76 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/76>)
* Contributors: Dave Coleman, Jochen Sprickerhof, Michael Görner, Simon Schmeisser, Victor Lamoine
```
