### PR TITLE
aws_common: 1.0.0-5 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -669,7 +669,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/aws_common-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       type: git
       url: https://github.com/aws-robotics/utils-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_common` to `1.0.0-5`:

- upstream repository: https://github.com/aws-robotics/utils-common.git
- release repository: https://github.com/aws-gbp/aws_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.0-4`
