### PR TITLE
ros_monitoring_msgs: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10593,7 +10593,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/monitoringmessages-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_monitoring_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/aws-robotics/monitoringmessages-ros1.git
- release repository: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.0-0`
