### PR TITLE
tts: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13288,7 +13288,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/tts-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/tts-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tts` to `1.0.0-1`:

- upstream repository: https://github.com/aws-robotics/tts-ros1.git
- release repository: https://github.com/aws-gbp/tts-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.0-0`
