### PR TITLE
kinesis_manager: 1.0.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4938,7 +4938,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_manager-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinesis_manager` to `1.0.0-2`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-common.git
- release repository: https://github.com/aws-gbp/kinesis_manager-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.0-1`
