### PR TITLE
Add rosdep keys for libopensplice69.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2492,6 +2492,10 @@ libopensplice67:
   ubuntu:
     bionic: [libopensplice67]
     xenial: [libopensplice67]
+libopensplice69:
+  ubuntu:
+    bionic: [libopensplice69]
+    xenial: [libopensplice69]
 libopenvdb:
   arch: [openvdb]
   debian:


### PR DESCRIPTION
@allenh1 I took the gentoo key out because I couldn't find any opensplice packages in sci-libs, let alone tone for 6.9. Is there a separate overlay where the gentoo packages live?