### PR TITLE
robot_navigation: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11760,7 +11760,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/locusrobotics/robot_navigation-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/locusrobotics/robot_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.2.1-0`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/locusrobotics/robot_navigation-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.0-0`
