### PR TITLE
Add Gentoo Opensplice 6.9 definition

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2493,6 +2493,7 @@ libopensplice67:
     bionic: [libopensplice67]
     xenial: [libopensplice67]
 libopensplice69:
+  gentoo: [=sci-libs/opensplice-6.9.*]
   ubuntu:
     bionic: [libopensplice69]
     xenial: [libopensplice69]


### PR DESCRIPTION
ebuild present on ROS-Overlay