### PR TITLE
python3-matplotlib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4618,6 +4618,19 @@ python3-gitlab:
 python3-lark-parser:
   ubuntu:
     bionic: [python3-lark-parser]
+python3-matplotlib:
+  arch: [python-matplotlib]
+  debian: [python3-matplotlib]
+  fedora: [python3-matplotlib]
+  gentoo: [dev-python/matplotlib]
+  opensuse: [python3-matplotlib]
+  osx:
+    pip:
+      depends: [pkg-config, freetype, libpng12-dev]
+      packages: [matplotlib]
+  rhel: [python3-matplotlib]
+  slackware: [python3-matplotlib]
+  ubuntu: [python3-matplotlib]
 python3-mock:
   debian: [python3-mock]
   fedora: [python3-mock]


### PR DESCRIPTION
Adding python3 key for matplotlib.

Links to source packages
https://www.archlinux.org/packages/community/x86_64/python-matplotlib/
https://packages.debian.org/stretch/python3-matplotlib
https://rpmfind.net/linux/rpm2html/search.php?query=python3-matplotlib
https://packages.gentoo.org/packages/dev-python/matplotlib
https://software.opensuse.org/package/python3-matplotlib
https://slackbuilds.org/repository/14.2/development/python3-matplotlib/
https://packages.ubuntu.com/bionic/python3-matplotlib