### PR TITLE
uuv_simulator: 0.6.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13982,6 +13982,45 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  uuv_simulator:
+    doc:
+      type: git
+      url: https://github.com/uuvsimulator/uuv_simulator.git
+      version: master
+    release:
+      packages:
+      - uuv_assistants
+      - uuv_auv_control_allocator
+      - uuv_control_cascaded_pid
+      - uuv_control_msgs
+      - uuv_control_utils
+      - uuv_descriptions
+      - uuv_gazebo
+      - uuv_gazebo_plugins
+      - uuv_gazebo_ros_plugins
+      - uuv_gazebo_ros_plugins_msgs
+      - uuv_sensor_plugins_ros_msgs
+      - uuv_sensor_ros_plugins
+      - uuv_simulator
+      - uuv_teleop
+      - uuv_thruster_manager
+      - uuv_trajectory_control
+      - uuv_tutorial_disturbances
+      - uuv_tutorial_dp_controller
+      - uuv_tutorial_seabed_world
+      - uuv_tutorials
+      - uuv_world_plugins
+      - uuv_world_ros_plugins
+      - uuv_world_ros_plugins_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uuvsimulator/uuv_simulator.git
+      version: 0.6.1-0
+    source:
+      type: git
+      url: https://github.com/uuvsimulator/uuv_simulator.git
+      version: master
+    status: developed
   uwsim_bullet:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_simulator` to `0.6.1-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_simulator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## uuv_assistants

- No changes

## uuv_auv_control_allocator

- No changes

## uuv_control_cascaded_pid

- No changes

## uuv_control_msgs

- No changes

## uuv_control_utils

- No changes

## uuv_descriptions

- No changes

## uuv_gazebo

- No changes

## uuv_gazebo_plugins

- No changes

## uuv_gazebo_ros_plugins

```
* ADD xacro dependency for ROS tests
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_gazebo_ros_plugins_msgs

- No changes

## uuv_sensor_plugins_ros_msgs

- No changes

## uuv_sensor_ros_plugins

- No changes

## uuv_simulator

```
* FIX List of dependencies with the new transfer
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_teleop

- No changes

## uuv_thruster_manager

- No changes

## uuv_trajectory_control

- No changes

## uuv_tutorial_disturbances

- No changes

## uuv_tutorial_dp_controller

- No changes

## uuv_tutorial_seabed_world

- No changes

## uuv_tutorials

- No changes

## uuv_world_plugins

- No changes

## uuv_world_ros_plugins

- No changes

## uuv_world_ros_plugins_msgs

- No changes
