### PR TITLE
uuv_plume_simulator: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13982,6 +13982,25 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  uuv_plume_simulator:
+    doc:
+      type: git
+      url: https://github.com/uuvsimulator/uuv_plume_simulator.git
+      version: master
+    release:
+      packages:
+      - uuv_cpc_sensor
+      - uuv_plume_msgs
+      - uuv_plume_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uuvsimulator/uuv_plume_simulator-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/uuvsimulator/uuv_plume_simulator.git
+      version: master
+    status: developed
   uwsim_bullet:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_plume_simulator` to `0.3.0-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_plume_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_plume_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## uuv_cpc_sensor

```
* UPDATE CHANGELOG files
* Contributors: Musa Morena Marcusso Manhaes, Musa Morena Marcusso Manhães
```

## uuv_plume_msgs

```
* 0.3.0
* UPDATE CHANGELOG files
* ADD Service configuration for current velocity server
* RM Unnecessary log messages
* UPDATE CHANGELOG files
* ADD CHANGELOG and bump version to 0.2.1
* ADD Service files to create a passive scalar plume
* Contributors: Musa Morena Marcusso Manhaes, Musa Morena Marcusso Manhães
```

## uuv_plume_simulator

```
* UPDATE CHANGELOG files
* RM python-logging dependency
* FIX Error message for service exceptions
* ADD Current configuration using Gauss-Markov process
* CHANGE Buoyancy flux parameter for the demo plume configuration
* ADD Error messages
* UPDATE RViz configuration for example scenario
* ADD Namespace for current velocity server node
* ADD Current velocity server node, launch files and demo scripts
* ADD Python ROS node for simulation of current velocity
* Contributors: Musa Morena Marcusso Manhaes, Musa Morena Marcusso Manhães
```
