### PR TITLE
add libqwt6-qt5 rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2987,7 +2987,9 @@ libqwt6-qt5-dev:
   debian: [libqwt-qt5-dev]
   fedora: [qwt-qt5-devel]
   gentoo: ['x11-libs/qwt:6']
-  ubuntu: [libqwt-qt5-dev]
+  ubuntu:
+    '*': [libqwt-qt5-dev]
+    trusty: null
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2970,6 +2970,14 @@ libqtwebkit-dev:
   fedora: [qtwebkit-devel]
   gentoo: [dev-qt/qtwebkit]
   ubuntu: [libqtwebkit-dev]
+libqwt-qt5-dev:
+  arch: [qwt]
+  debian: [libqwt-qt5-dev]
+  fedora: [qwt-qt5-devel]
+  gentoo: ['x11-libs/qwt:6']
+  ubuntu:
+    '*': [libqwt-qt5-dev]
+    trusty: null
 libqwt5-qt4-dev:
   arch: [qwt5]
   debian: [libqwt5-qt4-dev]
@@ -2982,14 +2990,6 @@ libqwt6:
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
   ubuntu: [libqwt-dev]
-libqwt-qt5-dev:
-  arch: [qwt]
-  debian: [libqwt-qt5-dev]
-  fedora: [qwt-qt5-devel]
-  gentoo: ['x11-libs/qwt:6']
-  ubuntu:
-    '*': [libqwt-qt5-dev]
-    trusty: null
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2982,6 +2982,12 @@ libqwt6:
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
   ubuntu: [libqwt-dev]
+libqwt6-qt5:
+  arch: [qwt]
+  debian: [libqwt-qt5-dev]
+  fedora: [qwt-qt5-devel]
+  gentoo: ['x11-libs/qwt:6']
+  ubuntu: [libqwt-qt5-dev]
 libqwtplot3d-qt4-dev:
   arch: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2982,7 +2982,7 @@ libqwt6:
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
   ubuntu: [libqwt-dev]
-libqwt6-qt5-dev:
+libqwt-qt5-dev:
   arch: [qwt]
   debian: [libqwt-qt5-dev]
   fedora: [qwt-qt5-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2982,7 +2982,7 @@ libqwt6:
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:6']
   ubuntu: [libqwt-dev]
-libqwt6-qt5:
+libqwt6-qt5-dev:
   arch: [qwt]
   debian: [libqwt-qt5-dev]
   fedora: [qwt-qt5-devel]


### PR DESCRIPTION
This is needed since commit https://github.com/ros/rosdistro/commit/25747529d24ca067c148149cb6c6fc34f676be84 removed the qt5 packages.