### PR TITLE
pilz_robots: 0.4.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8264,7 +8264,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.4.2-0
+      version: 0.4.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.4.3-0`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.4.2-0`

## pilz_control

- No changes

## pilz_robots

- No changes

## prbt_hardware_support

- No changes

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* load pilz capabilities for command_planner by default
* adjust rviz config
```

## prbt_support

```
* Update readme
```
