### PR TITLE
pilz_robots: 0.5.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3253,14 +3253,16 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - pilz_control
       - pilz_robots
+      - prbt_hardware_support
       - prbt_ikfast_manipulator_plugin
       - prbt_moveit_config
       - prbt_support
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.3.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.1-0`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.3.0-0`

## pilz_control

```
* melodic release based on kinetic version 0.4.3
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## prbt_hardware_support

```
* melodic release based on kinetic version 0.4.3
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

```
* melodic release based on kinetic version 0.4.3
* Contributors: Pilz GmbH and Co. KG
```

## prbt_moveit_config

```
* melodic release based on kinetic version 0.4.3
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

```
* melodic release based on kinetic version 0.4.3
* Contributors: Pilz GmbH and Co. KG
```
