### PR TITLE
pilz_industrial_motion: 0.3.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8238,11 +8238,12 @@ repositories:
       - pilz_industrial_motion
       - pilz_industrial_motion_testutils
       - pilz_msgs
+      - pilz_robot_programming
       - pilz_trajectory_generation
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.1.1-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.3.0-0`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.1.1-0`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

```
* rename get_current_joint_values -> get_current_joint_states
```

## pilz_msgs

```
* Renaming blend -> sequence
```

## pilz_robot_programming

```
* Release Python-API
* Contributors: Pilz GmbH and Co. KG
```

## pilz_trajectory_generation

```
* add append method for avoiding duplicate points in robot_trajectory trajectories
* Relax the precondition on trajectory generators from v_start==0 to |v_start| < 1e-10 to gain robustness
* Set last point of generated trajectories to have vel=acc=0 to match the first point.
* add sequence action and service capabilities to concatenate multiple requests
* Contributors: Pilz GmbH and Co. KG
```
