### PR TITLE
flexbe: 1.1.0-0 in 'indigo/distribution.yaml'

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3590,6 +3590,31 @@ repositories:
       url: https://github.com/yujinrobot-release/flatbuffers-release.git
       version: 1.1.0-1
     status: maintained
+  flexbe:
+    doc:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    release:
+      packages:
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    status: developed
   flir_ptu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.1.0-0`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## flexbe_behavior_engine

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* Merge pull request #55 <https://github.com/team-vigir/flexbe_behavior_engine/issues/55> from alireza-hosseini/add-metapackage
  feat: Add flexbe_behavior_engine metapackage
* feat: Add flexbe_behavior_engine metapackage
* Contributors: Philipp Schillinger, alireza
```

## flexbe_core

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* State logger is optional and off by default
* Merge remote-tracking branch 'origin/action_client_remove_feedback' into feature/flexbe_app
* Merge pull request #62 <https://github.com/team-vigir/flexbe_behavior_engine/issues/62> from team-vigir/action_client_remove_feedback
  Added remove_feedback function to ensure new feedback is received
* Added remove_feedback function to ensure new feedback is received
* Merge pull request #58 <https://github.com/team-vigir/flexbe_behavior_engine/issues/58> from alireza-hosseini/feat-action-client-wait-param
  feat: Add wait_duration parameter to ProxyActionClient
* feat: Add wait_duration parameter to ProxyActionClient
  - So that the wait duration can be specified in the states definition
* [flexbe_core] Allow to use behavior default userdata (see #38 <https://github.com/team-vigir/flexbe_behavior_engine/issues/38>)
* [flexbe_core] Update behavior lib if behavior is not found (see Flexbe/flexbe_app#4 <https://github.com/Flexbe/flexbe_app/issues/4>)
* Merge branch 'develop' into feature/flexbe_app
  Conflicts:
  flexbe_mirror/src/flexbe_mirror/flexbe_mirror.py
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
  flexbe_widget/bin/flexbe_app
  flexbe_widget/src/flexbe_widget/behavior_action_server.py
* Merge remote-tracking branch 'origin/master' into develop
  Conflicts:
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
* Merge remote-tracking branch 'origin/develop'
  Conflicts:
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
* Merge pull request #31 <https://github.com/team-vigir/flexbe_behavior_engine/issues/31> from fmauch/reset_entering
  reset entering of currently active state when exiting a state machine
* reset entering member of currently active state when exiting a state machine
* Find behaviors by export tag and execute via checksum
* Merge branch 'automatic_reload' into develop
* allow locking and unlocking of current state without knowing the current path
* remove manual reloading code, as this is done already by the reload importer
* Merge pull request #26 <https://github.com/team-vigir/flexbe_behavior_engine/issues/26> from jgdo/automatic_reload
  Automatic reload
* automatic reload of imported behaviors upon sm creation
* Reload class definition before instantiating a contained behavior inside a behavior
* Merge remote-tracking branch 'origin/master' into develop
* [flexbe_core] Fixed event triggering in concurrency container (resolve #18 <https://github.com/team-vigir/flexbe_behavior_engine/issues/18>)
* Merge remote-tracking branch 'origin/master'
* Merge remote-tracking branch 'origin/develop'
* [flexbe_core] Only call on_exit on cc leave for states which are still looping (fix #17 <https://github.com/team-vigir/flexbe_behavior_engine/issues/17>)
* Merge branch 'develop'
* [flexbe_core] Fixed sm on_exit to propagate own ud instead of parent ud
* Merge branch 'master' into cnurobotics
* Merge remote-tracking branch 'origin/develop'
* [flexbe_core] Properly reset current state when leaving state machine (fix #7 <https://github.com/team-vigir/flexbe_behavior_engine/issues/7>)
* Merge remote-tracking branch 'origin/develop'
* [flexbe_core] Fixed reset of current state on leave in cc and related concurrency userdata problems
* [flexbe_core] Use aggregated diagnostics topic instead of raw
* [flexbe_core] Correctly execute concurrency inside priority container
* [flexbe_core] Can always preempt behavior even if not supervised
* Merge remote-tracking branch 'origin/develop'
* Provide option to set userdata input on behavior action calls
* [flexbe_core] Fixed occasional problems to resume a paused state
* [flexbe_core] [flexbe_mirror] Improved robustness of fast repeated synchronization
* Merge branch 'feature/late_connect' into develop
* [flexbe_core] Added command to attach to running behavior execution
* Merge branch 'feature/pause_repeat' into develop
* [flexbe_core] Handle pause and repeat commands
* [flexbe_core] Propagate skipped notification on pause in order to react on preemption commands even if paused
* [flexbe_core] Added function to check if a goal is already active on a proxy client
* [flexbe_core] Fix for backup sync
* [flexbe_core] Fixed sync issues after leaving CC by explicitly syncing automatically
* [flexbe_core] Fixed calling on_exit on all states in CC
* Merge remote-tracking branch 'origin/feature/multirobot'
* Merge remote-tracking branch 'origin/master' into feature/multirobot
  Conflicts:
  flexbe_core/src/flexbe_core/core/monitoring_state.py
  flexbe_core/src/flexbe_core/core/operatable_state.py
* [flexbe_core] Added availability checks to proxies
* [flexbe_core] Added onboard debug topic for current state
* [flexbe_core] Convert all logged messages to string before sending ros message in logger
* [flexbe_core] Added priority container
* [flexbe_core] Added some more documentation
* [flexbe_core] Fixed initialization of input userdata in inner statemachines
* [flexbe_core] Correctly preempt auxilliary control flows in concurrency container
* [flexbe_core] Fixed a bug with concurrent execution:
  State machines inside state machine inside concurrency containers still blocked during execution.
* [flexbe_core] Slightly reworked monitoring state
* [flexbe_core] Fixed preemption of concurrency container
* [flexbe_core] Added container for concurrent execution
* Changed absolute topic references to relative
* [flexbe_core] Improved proxy interface
* [flexbe_core] Reverted last change, will only publish state updates when being controlled
* [flexbe_core] Always send outcome update, even if not being controlled
* Removed some old and unused project files
* Initial commit of software
* Contributors: Alberto, Alireza, David Conner, Dorian Scholz, DorianScholz, Felix Mauch, Mark Prediger, Philipp Schillinger
```

## flexbe_input

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* State logger is optional and off by default
* Merge remote-tracking branch 'origin/feature/multirobot'
* Changed absolute topic references to relative
* updated to work with changes to rest of behaviors
* [flexbe_input] Use generic behavior input topic
* [flexbe_input] Added refactored but still ocs-specific version of the input package
* Contributors: Benjamin Waxler, Philipp, Philipp Schillinger
```

## flexbe_mirror

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* Merge branch 'develop' into feature/flexbe_app
  Conflicts:
  flexbe_mirror/src/flexbe_mirror/flexbe_mirror.py
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
  flexbe_widget/bin/flexbe_app
  flexbe_widget/src/flexbe_widget/behavior_action_server.py
* Merge remote-tracking branch 'origin/develop'
  Conflicts:
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
* Find behaviors by export tag and execute via checksum
* Merge branch 'automatic_reload' into develop
* flexbe mirror: small fix of mission member variable initialization
* Merge pull request #27 <https://github.com/team-vigir/flexbe_behavior_engine/issues/27> from jgdo/automatic_reload
  fix of behavior_mirror: both switch and requesting the newest sm structure works now
* fix of behavior_mirror: both switch and requesting the newest sm structure works now
* Merge pull request #26 <https://github.com/team-vigir/flexbe_behavior_engine/issues/26> from jgdo/automatic_reload
  Automatic reload
* removed auto-starting behavior after structure callback
* Merge remote-tracking branch 'origin/master' into develop
* Merge pull request #10 <https://github.com/team-vigir/flexbe_behavior_engine/issues/10> from team-vigir/cnurobotics
  Fix #11 <https://github.com/team-vigir/flexbe_behavior_engine/issues/11>
* fix some shutdown issues on ctrl-c
* Merge branch 'master' into cnurobotics
* Merge remote-tracking branch 'origin/develop'
* [flexbe_mirror] Skip synchronization if mirror gets preempted
* Merge remote-tracking branch 'origin/develop'
* [flexbe_core] [flexbe_mirror] Improved robustness of fast repeated synchronization
* [flexbe_mirror] Fixed mirror rate sleep to reduce CPU load
* Merge remote-tracking branch 'origin/feature/multirobot'
* Merge remote-tracking branch 'origin/master' into feature/multirobot
  Conflicts:
  flexbe_core/src/flexbe_core/core/monitoring_state.py
  flexbe_core/src/flexbe_core/core/operatable_state.py
* Changed absolute topic references to relative
* [flexbe_onboard] [flexbe_mirror] Hide default SMACH transition log spamming
* Removed some old and unused project files
* Initial commit of software
* Contributors: David C. Conner, David Conner, Dorian Scholz, DorianScholz, Mark Prediger, Philipp Schillinger
```

## flexbe_msgs

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* Merge remote-tracking branch 'origin/develop'
* Merge remote-tracking branch 'origin/develop' into feature/flexbe_app
* Merge pull request #52 <https://github.com/team-vigir/flexbe_behavior_engine/issues/52> from ruvu/fix/catkin_lint_errors_and_warnings
  chore: ran catkin_lint and fixed warnings and errors
* chore: ran catkin_lint and fixed warnings and errors
* Find behaviors by export tag and execute via checksum
* Merge remote-tracking branch 'origin/develop'
* [flexbe_msgs] Increase field size of behavior modification index
* Provide option to set userdata input on behavior action calls
* Merge remote-tracking branch 'origin/master' into feature/multirobot
  Conflicts:
  flexbe_core/src/flexbe_core/core/monitoring_state.py
  flexbe_core/src/flexbe_core/core/operatable_state.py
* [flexbe_msgs] Added priority container to state class options
* [flexbe_msgs] Changed autonomy encoding in StateInstantation to prevent Python issues
* [flexbe_msgs] Extended behavior synthesis interface
  * Added support for concurrency container
  * Can now set input and output keys for containers, including root
  * Can now specify positions of states in the editor for improved visualization
* [flexbe_msgs] Added new message type for UI commands from ROS
* [flexbe_msgs] Added default synthesis message types
* [flexbe_msgs] Added action message for behavior execution
* Removed some old and unused project files
* Initial commit of software
* Contributors: Philipp Schillinger, Rein Appeldoorn
```

## flexbe_onboard

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* State logger is optional and off by default
* Merge pull request #59 <https://github.com/team-vigir/flexbe_behavior_engine/issues/59> from synapticon/feat_make_installable
  Fix issues of installed packages
* fix: Change tmp directory to "/tmp"
  Do not store temporary files inside the package directory but in "/tmp".
  This is needed since the package directory is not writeable without root
  permission when the package is installed.
* Merge branch 'develop' into feature/flexbe_app
  Conflicts:
  flexbe_mirror/src/flexbe_mirror/flexbe_mirror.py
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
  flexbe_widget/bin/flexbe_app
  flexbe_widget/src/flexbe_widget/behavior_action_server.py
* Merge remote-tracking branch 'origin/master' into develop
  Conflicts:
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
* Merge remote-tracking branch 'origin/develop'
  Conflicts:
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
* Merge pull request #30 <https://github.com/team-vigir/flexbe_behavior_engine/issues/30> from ckchow/feature/json_decode
  use json parser to load data, remove whitespace, javascript object style
* iterate over subdictionary to make sure sub-subdictionaries are converted
* [flexbe_onboard] Remove dependency on addict and preserve conversion of primitive types
* add javascript-style object conversion
* use json parser to load data
* [flexbe_onboard] [flexbe_widget] Removed old launch files
* Find behaviors by export tag and execute via checksum
* Merge branch 'automatic_reload' into develop
* allow onboard reloading of the current behavior
* flexbe_onboard: catch xml parsing error for manifests
* Added comment suggestion to fix checksum mismatch error
* Merge pull request #26 <https://github.com/team-vigir/flexbe_behavior_engine/issues/26> from jgdo/automatic_reload
  Automatic reload
* automatic reload of imported behaviors upon sm creation
* Merge remote-tracking branch 'origin/develop'
* [flexbe_onboard] Show info on traceback when a behavior fails
* Merge remote-tracking branch 'origin/master' into develop
* Merge remote-tracking branch 'origin/master'
* Merge remote-tracking branch 'origin/develop'
* [flexbe_onboard] Publish execution result in status args if FINISHED
* Merge remote-tracking branch 'origin/master' into develop
* Merge pull request #10 <https://github.com/team-vigir/flexbe_behavior_engine/issues/10> from team-vigir/cnurobotics
  Fix #11 <https://github.com/team-vigir/flexbe_behavior_engine/issues/11>
* modify to read and allow parameterizing default behaviors_package in launch files
* Merge remote-tracking branch 'origin/develop'
* [flexbe_onboard] Skip empty parameter keys on behavior start
* Provide option to set userdata input on behavior action calls
* [flexbe_onboard] Fixed setting of namespaced behavior parameters
* Merge remote-tracking branch 'origin/feature/multirobot'
* Merge remote-tracking branch 'origin/master' into feature/multirobot
  Conflicts:
  flexbe_core/src/flexbe_core/core/monitoring_state.py
  flexbe_core/src/flexbe_core/core/operatable_state.py
* [flexbe_onboard] Handle parameter keys without namespace specification
* [flexbe_onboard] [flexbe_widget] Improved support for yaml files
* [flexbe_onboard] Removed deprecated launch file
* Changed absolute topic references to relative
* [flexbe_onboard] [flexbe_mirror] Hide default SMACH transition log spamming
* [flexbe_onboard] Removed deprecated flexbe_behaviors dependency and allow to set package name as parameter
* Removed some old and unused project files
* Initial commit of software
* Contributors: Alberto Romay, Chris Chow, David Conner, Dorian Scholz, DorianScholz, Felix Widmaier, Mark Prediger, Philipp Schillinger
```

## flexbe_states

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* Merge remote-tracking branch 'origin/fix/state_tests' into feature/flexbe_app
* [flexbe_states] Add pose test for subscriber state
* Merge remote-tracking branch 'origin/develop' into feature/flexbe_app
* Merge pull request #52 <https://github.com/team-vigir/flexbe_behavior_engine/issues/52> from ruvu/fix/catkin_lint_errors_and_warnings
  chore: ran catkin_lint and fixed warnings and errors
* Merge branch 'develop' into feature/flexbe_app
* Merge branch 'develop'
* [flexbe_states] Explicitly set message to None in SubscriberState if unavailable
* Merge remote-tracking branch 'origin/develop' into feature/flexbe_app
* Merge pull request #42 <https://github.com/team-vigir/flexbe_behavior_engine/issues/42> from alireza-hosseini/feat-string-publisher
  feat: Add String publisher state
* feat: Add String publisher state
* Merge remote-tracking branch 'origin/develop'
* [flexbe_states] Fixed documentation of text format
* Merge branch 'develop' into feature/flexbe_app
  Conflicts:
  flexbe_mirror/src/flexbe_mirror/flexbe_mirror.py
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
  flexbe_widget/bin/flexbe_app
  flexbe_widget/src/flexbe_widget/behavior_action_server.py
* Merge remote-tracking branch 'origin/tudarmstadt' into develop
  Conflicts:
  flexbe_widget/src/flexbe_widget/behavior_action_server.py
* Changed value parameter to input key
* Created bool publisher state
* Merge remote-tracking branch 'origin/develop'
  Conflicts:
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
* Added new state for publishing an empty message in a given topic
* Added new state to log data key
* [flexbe_states] Add state export tag
* Added a flexible check condition state to evaluate a predicate with multiple userdata
* Merge remote-tracking branch 'origin/develop'
* [flexbe_states] Added option to subscriber state to initially drop older messages
* [flexbe_states] Do not set subscriber to None in subscriber state if topic is not available
* [flexbe_states] Fixed subscriber state
* Merge remote-tracking branch 'origin/feature/multirobot'
* Merge remote-tracking branch 'origin/master' into feature/multirobot
  Conflicts:
  flexbe_core/src/flexbe_core/core/monitoring_state.py
  flexbe_core/src/flexbe_core/core/operatable_state.py
* [flexbe_states] Use rostest interface of flexbe_testing
* [flexbe_states] Added generic state for getting a message from any topic
* [flexbe_states] Moved logging states to flexbe_utility_states (repo: generic_flexbe_states)
* [flexbe_states] Set concurrent state to deprecated in favor of concurrency container
* [flexbe_states] Added flexbe_testing test cases for all common states
* [flexbe_states] Completed documentation of flexible_calculation_state
* Changed absolute topic references to relative
* Removed some old and unused project files
* Initial commit of software
* Contributors: Alberto Romay, Alireza, Philipp Schillinger
```

## flexbe_testing

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* Update maintainer information
* Merge remote-tracking branch 'origin/fix/state_tests' into feature/flexbe_app
* [flexbe_testing] Let "pass" test fail if preparation fails
* [flexbe_testing] Install rostest files for install-space testing
* Merge branch 'develop' into feature/flexbe_app
* Merge branch 'develop'
* [flexbe_testing] Correct states for selftest (fix #49 <https://github.com/team-vigir/flexbe_behavior_engine/issues/49>)
* Merge remote-tracking branch 'origin/master' into develop
* Merge pull request #24 <https://github.com/team-vigir/flexbe_behavior_engine/issues/24> from fmauch/7-state_test_output_data_missing
  [flexbe_testing] complain if output data is requested inside the test but not given
* complain if output data is requested inside the test, but not given
  from the state
* Merge remote-tracking branch 'origin/develop'
* [flexbe_testing] Added optional waiting condition for attached launch files
* Merge remote-tracking branch 'origin/master'
* fix bug in state_tester.py
* Merge remote-tracking branch 'origin/master' into feature/multirobot
  Conflicts:
  flexbe_core/src/flexbe_core/core/monitoring_state.py
  flexbe_core/src/flexbe_core/core/operatable_state.py
* [flexbe_testing] Added self tests
* [flexbe_testing] Added test case for passing flexbe tests
* [flexbe_testing] Only require package arg if performing rostest
* [flexbe_testing] Added rostest integration
* [flexbe_testing] Start launchfile before importing the state
* [flexbe_testing] Added feature to specify launch files in test cases
* [flexbe_testing] Set correct file permissions for testing node
* [flexbe_testing] Call on_start and on_stop events of states
* [flexbe_testing] Added import_only option for tests
* [flexbe_testing] Added launch file for running a set of test cases
* [flexbe_testing] Added parameters for output format configuration
* [flexbe_testing] Removed temporary example files
* [flexbe_testing] Correctly shut down on ctrl+c during a test
* [flexbe_testing] Added initial version of unit testing framework for evaluation
* Contributors: David Conner, Felix Mauch, Philipp Schillinger
```

## flexbe_widget

```
* Merge branch 'develop'
* Merge branch 'feature/flexbe_app' into develop
* [flexbe_widget] Fix: Remove launch install rule
* Update maintainer information
* [flexbe_widget] Remove deprecated Chrome app files
* State logger is optional and off by default
* [flexbe_widget] Update create_repo script to rename behaviors package
* Merge remote-tracking branch 'origin/develop'
* Merge remote-tracking branch 'origin/develop' into feature/flexbe_app
* [flexbe_widget] be_launcher ignores standard roslaunch args
* Merge remote-tracking branch 'origin/develop'
* Merge branch 'develop' into feature/flexbe_app
  Conflicts:
  flexbe_mirror/src/flexbe_mirror/flexbe_mirror.py
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
  flexbe_widget/bin/flexbe_app
  flexbe_widget/src/flexbe_widget/behavior_action_server.py
* Merge remote-tracking branch 'origin/tudarmstadt' into develop
  Conflicts:
  flexbe_widget/src/flexbe_widget/behavior_action_server.py
* Merge remote-tracking branch 'origin/develop'
  Conflicts:
  flexbe_onboard/src/flexbe_onboard/flexbe_onboard.py
* [flexbe_widget] Launcher accepts behavior params via command line
* [flexbe_widget] Use behavior lib for action server
* behavior action server: fixed race condition between execute_cb and status_cb
  - sorted member variable initialization before subscriber and action server startup
  - moved preempt check to allow preempting behavior even if behavior did not start for some reason
* behavior action server: allow clean exit on ros shutdown
* [flexbe_widget] Updated minimum ui version to flexbe_app version
* [flexbe_widget] Marked chrome launcher as deprecated
* [flexbe_onboard] [flexbe_widget] Removed old launch files
* [flexbe_widget] Updated create_repo to initialize new layout
* Find behaviors by export tag and execute via checksum
* [flexbe_widget] revert action server autonomy level
* [flexbe_widget] Reverted App ID in flexbe_app script
* Merge branch 'automatic_reload' into develop
* behavior action server: remove "special" autonomy level "255" so behaviors will enable ros control by default
* [flexbe_widget] Removed debugging launchfile
* Merge pull request #26 <https://github.com/team-vigir/flexbe_behavior_engine/issues/26> from jgdo/automatic_reload
  Automatic reload
* automatic reload of imported behaviors upon sm creation
* fixed timing issue on behavior engine start by waiting for engine status
* updated flexbe_app start script to allow for locally set app-id
* Merge remote-tracking branch 'origin/develop'
* [flexbe_widget] Catch missing behavior package and give helpful error message
* Merge remote-tracking branch 'origin/master' into develop
* Merge remote-tracking branch 'origin/master'
* Merge remote-tracking branch 'origin/develop'
* [flexbe_widget] Set correct behavior outcome in action result
* Merge branch 'develop'
* [flexbe_widget] Print warning if new repo is not on pkg path (address #13 <https://github.com/team-vigir/flexbe_behavior_engine/issues/13>)
* Merge remote-tracking branch 'origin/master' into develop
* Merge pull request #10 <https://github.com/team-vigir/flexbe_behavior_engine/issues/10> from team-vigir/cnurobotics
  Fix #11 <https://github.com/team-vigir/flexbe_behavior_engine/issues/11>
* Merge pull request #9 <https://github.com/team-vigir/flexbe_behavior_engine/issues/9> from icemanx/master
  Added behavior stopping feature for behavior action server (resolve #8 <https://github.com/team-vigir/flexbe_behavior_engine/issues/8>)
* Added behavior stopping feature for behavior action server.
* Merge branch 'master' into cnurobotics
* Merge remote-tracking branch 'origin/develop'
* [flexbe_widget] Only require sudo in create_repo if pkg needs to be installed (resolve #4 <https://github.com/team-vigir/flexbe_behavior_engine/issues/4>)
* Merge branch 'master' into cnurobotics
* Merge remote-tracking branch 'origin/develop'
* [flexbe_widget] Use behavior prefix in clear_cache script
* modify to read and allow parameterizing default behaviors_package in launch files
* [flexbe_widget] Fix #3 <https://github.com/team-vigir/flexbe_behavior_engine/issues/3>: consider correct ros distro in create_repo
* Merge remote-tracking branch 'origin/develop'
* [flexbe_widget] Fix #2 <https://github.com/team-vigir/flexbe_behavior_engine/issues/2>
* Provide option to set userdata input on behavior action calls
* Merge remote-tracking branch 'origin/develop' into feature/pause_repeat
* [flexbe_widget] Fixed handling of YAML parameters
* [flexbe_widget] Check UI version against a minimum required one
* [flexbe_widget] Accept rosbridge port as launch arg
* [flexbe_widget] Notify GUI when behavior to launch is not found
* Merge remote-tracking branch 'origin/feature/multirobot'
* [FlexBE] Updated App to 0.21.4
  * Added support for namespace via param
* Merge remote-tracking branch 'origin/master' into feature/multirobot
  Conflicts:
  flexbe_core/src/flexbe_core/core/monitoring_state.py
  flexbe_core/src/flexbe_core/core/operatable_state.py
* [flexbe_widget] Correctly resolve file params of embedded behaviors
* [flexbe_widget] Behavior action server now correctly detects errors on behavior start
* [flexbe_onboard] [flexbe_widget] Improved support for yaml files
* Changed absolute topic references to relative
* [flexbe_widget] Added a simple action server for executing a behavior
* [flexbe_widget] Added references to the example states in create_repo script
* [flexbe_widget] Added a script to create a new project repo
* [flexbe_widget] Use environment variable for behaviors package in behavior launcher as well
* Removed some old and unused project files
* [flexbe_widget] Added input package to ocs launch file
* Initial commit of software
* Contributors: Bolkar Altuntas, David Conner, Dorian Scholz, DorianScholz, Mark Prediger, Philipp, Philipp Schillinger
```