### PR TITLE
robot_navigation: 0.2.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3802,6 +3802,42 @@ repositories:
     status_description: The robot_model metapackage is deprecated and will be removed
       in ROS M. The packages it includes will continue to be maintained, but will
       be moved to new repositories.
+  robot_navigation:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/robot_navigation.git
+      version: master
+    release:
+      packages:
+      - costmap_queue
+      - dlux_global_planner
+      - dlux_plugins
+      - dwb_critics
+      - dwb_local_planner
+      - dwb_msgs
+      - dwb_plugins
+      - global_planner_tests
+      - locomotor
+      - locomotor_msgs
+      - locomove_base
+      - nav_2d_msgs
+      - nav_2d_utils
+      - nav_core2
+      - nav_core_adapter
+      - nav_grid
+      - nav_grid_iterators
+      - nav_grid_pub_sub
+      - robot_navigation
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/locusrobotics/robot_navigation-release.git
+      version: 0.2.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/robot_navigation.git
+      version: master
+    status: developed
   robot_self_filter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.2.2-0`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/locusrobotics/robot_navigation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
