### PR TITLE
Add python-packaging rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2390,6 +2390,10 @@ python-openssl:
   debian: [python-openssl]
   gentoo: [dev-python/pyopenssl]
   ubuntu: [python-openssl]
+python-packaging:
+  debian: [python-packaging]
+  fedora: [python-packaging]
+  ubuntu: [python-packaging]
 python-paho-mqtt-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Available as listed:

https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python-packaging&searchon=names
https://apps.fedoraproject.org/packages/python-packaging