### PR TITLE
uuv_simulator: 0.6.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14017,23 +14017,19 @@ repositories:
       - uuv_gazebo_plugins
       - uuv_gazebo_ros_plugins
       - uuv_gazebo_ros_plugins_msgs
-      - uuv_sensor_plugins_ros_msgs
       - uuv_sensor_ros_plugins
+      - uuv_sensor_ros_plugins_msgs
       - uuv_simulator
       - uuv_teleop
       - uuv_thruster_manager
       - uuv_trajectory_control
-      - uuv_tutorial_disturbances
-      - uuv_tutorial_dp_controller
-      - uuv_tutorial_seabed_world
-      - uuv_tutorials
       - uuv_world_plugins
       - uuv_world_ros_plugins
       - uuv_world_ros_plugins_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uuvsimulator/uuv_simulator-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_simulator` to `0.6.2-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.6.1-0`

## uuv_assistants

```
* CHANGE Name of plugins with uuv_ prefix
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX rospy dependency
  Remove rospy from components list.
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX rospy dependencies
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_auv_control_allocator

```
* FIX ROS message dependency
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_control_cascaded_pid

```
* FIX rospy dependency
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX rospy dependencies
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_control_msgs

- No changes

## uuv_control_utils

```
* FIX rospy dependency
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX rospy dependencies
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_descriptions

```
* ADD uuv_ prefix to plugin names
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_gazebo

- No changes

## uuv_gazebo_plugins

```
* ADD rosunit to test dependency
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX Compilation configuration
  * Move add_livrary for Gazebo Protobuf messages after catkin_package (fix catkin lint output)
  * Add uuv_ prefix to all plugins generated
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_gazebo_ros_plugins

```
* ADD uuv_ prefix to plugin names
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX Circular dependency for uuv_descriptions
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX Compilation configuration
  * Add `uuv_`prefix to all plugins
  * Add missing REQUIRED option to test dependencies (fix catkin lint error)
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_gazebo_ros_plugins_msgs

- No changes

## uuv_sensor_ros_plugins

```
* CHANGE Name of the ROS sensor messages package
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* CHANGE Name of the ROS sensor message package
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* CHANGE Compilation configuration
  * Add COMPONENTS option to find_package(catkin) (fix catkin lint error)
  * Change name of uuv_sensor_plugins_ros_msgs  to uuv_sensor_ros_plugins_msgs
  * Move add library command for Gazebo Protobuf messages
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_sensor_ros_plugins_msgs

```
* CHANGE Sensor ROS plugins package name
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* CHANGE Name of ROS sensor plugins package
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_simulator

```
* FIX Sensor ROS plugins package name
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_teleop

```
* FIX rospy dependency
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_thruster_manager

```
* FIX rospy dependency
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* FIX rospy dependencies
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_trajectory_control

- No changes

## uuv_world_plugins

```
* RM Ogre dependency from world plugins
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_world_ros_plugins

- No changes

## uuv_world_ros_plugins_msgs

- No changes
