### PR TITLE
dbw_fca_ros: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2040,7 +2040,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 0.0.2-0
+      version: 1.0.0-0
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `1.0.0-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.2-0`

## dbw_fca

- No changes

## dbw_fca_can

```
* Updated firmware versions
* Added BTYPE (brake type) bit
* Added CMD_DECEL brake command type (only for non-hybrid platforms)
* Added dataspeed_ulc_can to dbw.launch
* Added throttlePercentFromPedal lookup table function and corresponding test
* Use the ${catkin_EXPORTED_TARGETS} macro for target dependencies
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_fca_description

```
* Restructured dbw_fca_description package
* Contributors: Micho Radovnikovich
```

## dbw_fca_joystick_demo

```
* Use the ${catkin_EXPORTED_TARGETS} macro for target dependencies
* Removed joystick deadzone
* Added parameters for brake and throttle gains (sanitized from 0 to 1)
* Contributors: Kevin Hallenbeck
```

## dbw_fca_msgs

```
* Added CMD_DECEL brake command type (only for non-hybrid platforms)
* Changed maximum brake torque command from 3412 Nm to 5000 Nm
* Contributors: Kevin Hallenbeck
```
