### PR TITLE
dbw_mkz_ros: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2582,7 +2582,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.0.17-0
+      version: 1.1.0-0
     source:
       type: hg
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_mkz_ros` to `1.1.0-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
- release repository: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.17-0`

## dbw_mkz

```
* Deprecated the dbw_mkz_twist_controller package and removed from the dbw_mkz metapackage
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_can

```
* Updated firmware versions
* Removed all BOO control options and manually implemented auto BOO control for legacy firmware (brake lights)
* Added BTYPE (brake type) bit
* Added CMD_DECEL brake command type (only for non-hybrid platforms)
* Replaced dbw_mkz_twist_controller with dataspeed_ulc_can in dbw.launch
* Added throttlePercentFromPedal lookup table function and corresponding test
* Use the ${catkin_EXPORTED_TARGETS} macro for target dependencies
* Added DriverAssistReport message
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## dbw_mkz_description

- No changes

## dbw_mkz_joystick_demo

```
* Use the ${catkin_EXPORTED_TARGETS} macro for target dependencies
* Removed joystick deadzone
* Added parameters for brake and throttle gains (sanitized from 0 to 1)
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_msgs

```
* Removed boo_cmd from BrakeCommand message
* Fixed old bag migration rule
* Added CMD_DECEL brake command type (only for non-hybrid platforms)
* Added DriverAssistReport message
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_twist_controller

```
* Deprecated the dbw_mkz_twist_controller package
* Use the ${catkin_EXPORTED_TARGETS} macro for target dependencies
* Contributors: Kevin Hallenbeck
```
