### PR TITLE
robot_navigation: 0.2.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3981,7 +3981,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/locusrobotics/robot_navigation-release.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.2.4-0`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/locusrobotics/robot_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.3-0`
