### PR TITLE
behaviortree_cpp: 2.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1112,12 +1112,13 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 2.3.0-0
+      version: 2.4.0-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
+    status: developed
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `2.4.0-0`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.3.0-0`

## behaviortree_cpp

```
* Merge pull request #27 from mjeronimo/bt-12-4-2018
  Add support for ament/colcon build
* updated documentation
* Merge pull request #25 from BehaviorTree/include_xml
  Add the ability to include an XML from another one
* <include> supports ROS package getPath (issue #17)
* Trying to fix writeXML (issue #24)
* New feature: include XMl from other XMLs (issue #17)
* more verbose error message
* adding unit tests for Repeat and Retry nodes #23
* Bug fix in Retry and Repeat Decorators (needs unit test)
* Throw if the parameter in blackboard can't be read
* Try to prevent error #22 in user code
* changed the protocol of the XML
* fixing issue #22
* Contributors: Davide Faconti, Michael Jeronimo
```
