### PR TITLE
behaviortree_cpp: 2.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1112,12 +1112,13 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 2.3.0-0
+      version: 2.4.1-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
+    status: developed
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `2.4.1-0`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.3.0-0`

## behaviortree_cpp

```
* fix warnings and dependencies in ROS, mainly related to ZMQ
* Contributors: Davide Faconti
```
