### PR TITLE
behaviortree_cpp: 2.4.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -298,12 +298,13 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 2.3.0-0
+      version: 2.4.1-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
+    status: developed
   bfl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `2.4.1-0`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.3.0-0`

## behaviortree_cpp

```
* fix warnings and dependencies in ROS, mainly related to ZMQ
* Contributors: Davide Faconti
```
