### PR TITLE
Add libunwind-dev for Ubuntu Xenial and above

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3293,6 +3293,7 @@ libunwind-dev:
   fedora: [libunwind-devel]
   gentoo: [sys-libs/libunwind]
   ubuntu:
+    '*': [libunwind-dev]
     precise: [libunwind7-dev]
     quantal: [libunwind8-dev]
     raring: [libunwind8-dev]


### PR DESCRIPTION
All currently-supported versions of Ubuntu above Wily contain a
metapackage called libunwind-dev. This metapackage depends on the
appropriate version of libunwind.

 - Xenial: https://packages.ubuntu.com/xenial/libunwind-dev
 - Bionic: https://packages.ubuntu.com/bionic/libunwind-dev
 - Cosmic: https://packages.ubuntu.com/cosmic/libunwind-dev
 - Disco: https://packages.ubuntu.com/disco/libunwind-dev