### PR TITLE
teraranger: 2.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13023,7 +13023,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
-      version: 1.3.0-0
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/Terabee/teraranger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `2.0.0-1`:

- upstream repository: git@github.com:Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.3.0-0`

## teraranger

```
* Update roswiki and Readme file for Evo Thermal
* Fix error in Evo64 px parsing
* Add frame_id in rgb image message
* Change topic naming
* Fix rosparam default value type
* Prevent header desynchronization in Thermal driver
* Add CRC check to ACK reading
* Prevent node from sending VCP commands to UART backboard
  Based on baudrate speed
* Refactor Evo 64px driver
* Remove fps estimation in Evo 64px driver
* Rename python node file
* Publish temperature array
* Add publisher for PTAT
* Take into account cases when commands are failing
* Refactor colormap loading
* Add Evo Thermal driver
* Contributors: Baptiste Potier, Pierre-Louis Kabaradjian
```
