### PR TITLE
dataspeed_ulc_ros: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2025,7 +2025,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_ulc_ros` to `0.0.2-0`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.1-0`

## dataspeed_ulc

- No changes

## dataspeed_ulc_can

```
* Cleanup and test updates
* Contributors: Kevin Hallenbeck
```

## dataspeed_ulc_msgs

- No changes
