### PR TITLE
catkin_virtualenv: 0.2.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -414,7 +414,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.2.0-0
+      version: 0.2.2-0
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.2.2-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.0-0`

## catkin_virtualenv

```
* Merge repeated requirements (#32 <https://github.com/locusrobotics/catkin_virtualenv/issues/32>)
* Enable extra_pip_args #31 <https://github.com/locusrobotics/catkin_virtualenv/issues/31> from locusrobotics/add-extra-pip-args
* Contributors: Brian Barnes, Paul Bovbel, Shingo Kitagawa
```
