### PR TITLE
Fix proposal for libprotobuf depends. 

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4334,8 +4334,8 @@ protobuf:
   slackware: [protobuf]
   ubuntu:
     artful: [libprotobuf10]
-    cosmic: [libprotobuf10]
     bionic: [libprotobuf10]
+    cosmic: [libprotobuf10]
     precise: [libprotobuf7]
     raring: [libprotobuf7]
     saucy: [libprotobuf7]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4321,7 +4321,7 @@ proj:
 protobuf:
   arch: [protobuf]
   debian:
-    buster: [libprotobuf10]
+    buster: [libprotobuf17]
     jessie: [libprotobuf9]
     squeeze: [libprotobuf7]
     stretch: [libprotobuf10]
@@ -4334,6 +4334,7 @@ protobuf:
   slackware: [protobuf]
   ubuntu:
     artful: [libprotobuf10]
+    cosmic: [libprotobuf10]
     bionic: [libprotobuf10]
     precise: [libprotobuf7]
     raring: [libprotobuf7]


### PR DESCRIPTION
Fix wrong definition in libprotobuf / Debian buster and a new definition for Ubuntu 18.10.

BTW, I came up with the solution less complicated than now. Is it possible for libprotobuf* to be replaced with "libprotobuf-dev" in all debian items?