### PR TITLE
ibeo_core: 2.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5015,7 +5015,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/astuff/ibeo_core-release.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/astuff/ibeo_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_core` to `2.0.2-0`:

- upstream repository: https://github.com/astuff/ibeo_core.git
- release repository: https://github.com/astuff/ibeo_core-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.0.1-0`

## ibeo_core

```
* Merge pull request #8 <https://github.com/astuff/ibeo_core/issues/8> from ShepelIlya/master
* Deleted redunant conditions & fixed offset in ObjectData2280. It works!
* Contributors: Rinda Gunjala, Шепель Илья Олегович
```
