### PR TITLE
pacmod3: 1.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7938,7 +7938,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/pacmod3-release.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/astuff/pacmod3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod3` to `1.2.1-0`:

- upstream repository: https://github.com/astuff/pacmod3.git
- release repository: https://github.com/astuff/pacmod3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.2.0-0`

## pacmod3

```
* Merge pull request #43 <https://github.com/astuff/pacmod3/issues/43> from astuff/maint/add_urls
* Adding URLs to package.xml and upadating README.
* Contributors: Daniel-Stanek, Joshua Whitley
```
