### PR TITLE
ibeo_lux: 2.0.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1418,11 +1418,15 @@ repositories:
       version: release
     status: developed
   ibeo_lux:
+    doc:
+      type: git
+      url: https://github.com/astuff/ibeo_lux.git
+      version: master
     release:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/astuff/ibeo_lux-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/astuff/ibeo_lux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_lux` to `2.0.1-0`:

- upstream repository: https://github.com/astuff/ibeo_lux
- release repository: https://github.com/astuff/ibeo_lux-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.0.0-0`

## ibeo_lux

```
* Merge pull request #5 <https://github.com/astuff/ibeo_lux/issues/5> from astuff/maint/add_urls
  Adding website URL to package.xml. Fixing changelog.
* Merge pull request #6 <https://github.com/astuff/ibeo_lux/issues/6> from ShepelIlya/patch-1
* Added filling of number_of_objects field to ObjectData2280 message
  Now uint16 field with number of objects in message is filling in IbeoLuxRosMsgHandler::fill2280 function.
* Contributors: Joshua Whitley, Rinda Gunjala, Sam Rustan, ShepelIlya, Zach Oakes
```
