### PR TITLE
automotive_autonomy_msgs: 2.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -250,7 +250,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 2.0.2-0
+      version: 2.0.3-0
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automotive_autonomy_msgs` to `2.0.3-0`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.0.2-0`

## automotive_autonomy_msgs

```
* Merge pull request #13 <https://github.com/astuff/automotive_autonomy_msgs/issues/13> from astuff/maint/add_urls
* Adding URLs to package.xml files.
* Contributors: Joshua Whitley, Rinda Gunjala
```

## automotive_navigation_msgs

```
* Merge pull request #13 <https://github.com/astuff/automotive_autonomy_msgs/issues/13> from astuff/maint/add_urls
* Adding URLs to package.xml files.
* Contributors: Joshua Whitley, Rinda Gunjala
```

## automotive_platform_msgs

```
* Merge pull request #13 <https://github.com/astuff/automotive_autonomy_msgs/issues/13> from astuff/maint/add_urls
* Adding URLs to package.xml files.
* Contributors: Joshua Whitley, Rinda Gunjala
```
