### PR TITLE
warehouse_ros: 0.9.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6112,7 +6112,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.9.1-0
+      version: 0.9.2-0
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.2-0`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.9.1-0`

## warehouse_ros

```
* Fix various smaller issues. (#41 <https://github.com/ros-planning/warehouse_ros/issues/41>)
  * fix guard name
  * virtual destructor for abstract class
  * use managed pointers - createUniqueInstance()
  * switch to C++11
  * clang-tidy modernize-use-override
* Contributors: Robert Haschke
```
