### PR TITLE
add python-gi-cairo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1454,6 +1454,11 @@ python-gi:
   fedora: [pygobject3]
   gentoo: [dev-python/pygobject]
   ubuntu: [python-gi]
+python-gi-cairo:
+  debian: [python-gi-cairo]
+  fedora: [pygobject3]
+  gentoo: [dev-python/pygobject]
+  ubuntu: [python-gi-cairo]
 python-git:
   arch: [python2-gobject]
   debian: [python-git]


### PR DESCRIPTION
deb: https://pkgs.org/download/python-gi-cairo
fedra : https://apps.fedoraproject.org/packages/python2-gobject/contents/
gentoo: https://packages.gentoo.org/packages/dev-python/pygobject