### PR TITLE
multimaster_fkie: 0.8.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2621,7 +2621,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.8.2-0
+      version: 0.8.4-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.8.4-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.8.2-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

```
* master_discovery_fkie: fix zeroconf to avoid request loop in master_sync
  see issue #90 <https://github.com/fkie/multimaster_fkie/issues/90>
* Contributors: Alexander Tiderko
```

## master_sync_fkie

- No changes

## multimaster_fkie

```
* master_discovery_fkie: fix zeroconf to avoid request loop in master_sync
  see issue #90 <https://github.com/fkie/multimaster_fkie/issues/90>
* Contributors: Alexander Tiderko
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

- No changes
