### PR TITLE
Add tensorflow-hub as python-tensorflow-hub-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3988,6 +3988,19 @@ python-tensorflow-gpu-pip:
   ubuntu:
     pip:
       packages: [tensorflow-gpu]
+python-tensorflow-hub-pip:
+  debian:
+    pip:
+      packages: [tensorflow-hub]
+  fedora:
+    pip:
+      packages: [tensorflow-hub]
+  osx:
+    pip:
+      packages: [tensorflow-hub]
+  ubuntu:
+    pip:
+      packages: [tensorflow-hub]
 python-tensorflow-pip:
   debian:
     pip:


### PR DESCRIPTION
According to https://www.tensorflow.org/hub/installation