### PR TITLE
dockeros: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2248,6 +2248,17 @@ repositories:
       url: https://github.com/UbiquityRobotics/dnn_detect.git
       version: kinetic-devel
     status: developed
+  dockeros:
+    doc:
+      type: git
+      url: https://github.com/ct2034/dockeROS.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ct2034/dockeros-release.git
+      version: 1.0.0-0
+    status: developed
   dr_base:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `dockeros` to `1.0.0-0`:

- upstream repository: https://github.com/ct2034/dockeROS.git
- release repository: https://github.com/ct2034/dockeros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
