### PR TITLE
geometric_shapes: 0.6.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1311,7 +1311,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.6.1-0`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.6.0-0`

## geometric_shapes

```
* Limit minimum number of cylinder vertices (on circumference) to 6 (#92 <https://github.com/ros-planning/geometric_shapes/issues/92>)
* Eigen::Affine3d -> Eigen::Isometry3d (#88 <https://github.com/ros-planning/geometric_shapes/issues/88>)
* Contributors: Robert Haschke, eisoku9618
```
