### PR TITLE
moveit_visual_tools: 3.5.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2497,7 +2497,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_visual_tools-release.git
-      version: 3.5.1-0
+      version: 3.5.2-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.5.2-0`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/ros-gbp/moveit_visual_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `3.5.1-0`

## moveit_visual_tools

```
* Use LOGNAME for named logging (#42 <https://github.com/ros-planning/moveit_visual_tools/issues/42>)
* Eigen::Affine3d -> Eigen::Isometry3d (#39 <https://github.com/ros-planning/moveit_visual_tools/issues/39>)
* Contributors: Dave Coleman
```
