### PR TITLE
panda_moveit_config: 0.7.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3165,7 +3165,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/panda_moveit_config-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.1-0`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.7.0-0`

## panda_moveit_config

```
* CHOMP: remove "Hybrid" collision detector (#16 <https://github.com/ros-planning/panda_moveit_config/pull/16>)
* Contributors: Robert Haschke
```
