### PR TITLE
velodyne: 1.5.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5671,7 +5671,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 1.5.0-0
+      version: 1.5.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.5.1-0`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.5.0-0`

## velodyne

- No changes

## velodyne_driver

- No changes

## velodyne_laserscan

- No changes

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Merge pull request #194 <https://github.com/ros-drivers/velodyne/issues/194> from ros-drivers/avoid_unnecessary_computation
  Avoid unnecessary computation - causes approximately 20% performance increase on VLP-32C - should be similar for other sensors
* std::vector<>::reserve is your friend
* add static to avoid frequence memory allocation
* avoid unecesary calculations in unpack()
* Contributors: Davide Faconti, Joshua Whitley
```
