### PR TITLE
dockeros: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2259,7 +2259,6 @@ repositories:
       url: https://github.com/ct2034/dockeros-release.git
       version: 1.0.2-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ct2034/dockeROS.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2257,7 +2257,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ct2034/dockeros-release.git
-      version: 1.0.0-0
+      version: 1.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ct2034/dockeROS.git
+      version: master
     status: developed
   dr_base:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `dockeros` to `1.0.2-0`:

- upstream repository: https://github.com/ct2034/dockeROS.git
- release repository: https://github.com/ct2034/dockeros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.0-0`

## dockeros

```
* this is almost binary
* jou
* refactoring
* finding user defined Dockerfile
* curiousity
* now with rosdep :)
* Contributors: ct2034
```
