### PR TITLE
Revert "rotors_simulator: 2.2.1-0 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13432,7 +13432,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 2.2.1-0
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git


### PR DESCRIPTION
Reverts ros/rosdistro#19665

This failed to build on indigo due to what looks like a missing dependency

http://build.ros.org/job/Ibin_uT64__rotors_gazebo_plugins__ubuntu_trusty_amd64__binary/63/console
```
16:34:18 -- Using Python nosetests: /usr/bin/nosetests-2.7
16:34:18 -- catkin 0.6.19
16:34:18 CMake Warning at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
16:34:18   Could not find a package configuration file provided by "gazebo_plugins"
16:34:18   with any of the following names:
16:34:18 
16:34:18     gazebo_pluginsConfig.cmake
16:34:18     gazebo_plugins-config.cmake
16:34:18 
16:34:18   Add the installation prefix of "gazebo_plugins" to CMAKE_PREFIX_PATH or set
16:34:18   "gazebo_plugins_DIR" to a directory containing one of the above files.  If
16:34:18   "gazebo_plugins" provides a separate development package or SDK, be sure it
16:34:18   has been installed.
16:34:18 Call Stack (most recent call first):
16:34:18   CMakeLists.txt:98 (find_package)
16:34:18 
16:34:18 
```

I'm going to roll this release back to prepare for a sync. If there's a new fix we can merge it in the testing period.