### PR TITLE
Adding ipr_extern to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4527,6 +4527,11 @@ repositories:
       url: https://github.com/alireza-hosseini/ipcamera_driver.git
       version: master
     status: developed
+  ipr_extern:
+    doc:
+      type: git
+      url: https://github.com/KITrobotics/ipr_extern.git
+      version: kinetic-devel
   ira_laser_tools:
     doc:
       type: git


### PR DESCRIPTION
I'd like ipr_extern to be indexed and documented on ros.org.