### PR TITLE
Adding find_moving_objects to documentation and source for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2858,6 +2858,16 @@ repositories:
       url: https://github.com/ros/filters.git
       version: hydro-devel
     status: maintained
+  find_moving_objects:
+    doc:
+      type: git
+      url: https://github.com/andreasgustavsson/find_moving_objects.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/andreasgustavsson/find_moving_objects.git
+      version: kinetic-devel
+    status: maintained
   find_object_2d:
     doc:
       type: git


### PR DESCRIPTION
I would like find_moving_objects to be indexed and documented on ros.org.