### PR TITLE
multimaster_fkie: 0.8.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7900,7 +7900,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.8.4-0
+      version: 0.8.5-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.8.5-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.8.4-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

- No changes

## master_sync_fkie

```
* master_sync_fkie: added a simple node to sync parameter
  Original code from
  https://github.com/jhu-lcsr-forks/multimaster_fkie/tree/param-sync
  adapted to change only local ROS Parameter Server
* Contributors: Alexander Tiderko
```

## multimaster_fkie

```
* node_manager_fkie: removed install author warning
* node_manager_fkie: fixed navigation in topic and service view
  do not open echo/call dialog on activate namespace group
* master_sync_fkie: added a simple node to sync parameter
  Original code from
  https://github.com/jhu-lcsr-forks/multimaster_fkie/tree/param-sync
  adapted to change only local ROS Parameter Server
* Contributors: Alexander Tiderko
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: removed install author warning
* node_manager_fkie: fixed navigation in topic and service view
  do not open echo/call dialog on activate namespace group
* Contributors: Alexander Tiderko
```
