### PR TITLE
Add python3-lark-parser for gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4619,6 +4619,7 @@ python3-lark-parser:
   fedora:
     '*': [python-lark-parser]
     '28': null
+  gentoo: [dev-python/lark]
   ubuntu:
     bionic: [python3-lark-parser]
 python3-matplotlib:


### PR DESCRIPTION
Added ebuild to ROS Overlay in commit 98f9546c61f6d14a49efa3f66c2960d7f4f9d5c2.