### PR TITLE
rqt_multiplot_plugin: 0.0.9-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4656,13 +4656,22 @@ repositories:
       version: master
     status: maintained
   rqt_multiplot_plugin:
+    doc:
+      type: git
+      url: https://github.com/anybotics/rqt_multiplot_plugin.git
+      version: master
     release:
       packages:
       - rqt_multiplot
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/anybotics/rqt_multiplot_plugin-release.git
-      version: 0.0.8-0
+      version: 0.0.9-1
+    source:
+      type: git
+      url: https://github.com/anybotics/rqt_multiplot_plugin.git
+      version: master
+    status: developed
   rqt_nav_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.9-1`:

- upstream repository: https://github.com/anybotics/rqt_multiplot_plugin.git
- release repository: https://github.com/anybotics/rqt_multiplot_plugin-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.8-0`

## rqt_multiplot

```
* fix rosdep key
* Contributors: Samuel Bachmann
```
