### PR TITLE
rqt_multiplot_plugin: 0.0.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4849,13 +4849,22 @@ repositories:
       version: master
     status: maintained
   rqt_multiplot_plugin:
+    doc:
+      type: git
+      url: https://github.com/anybotics/rqt_multiplot_plugin.git
+      version: master
     release:
       packages:
       - rqt_multiplot
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/anybotics/rqt_multiplot_plugin-release.git
-      version: 0.0.8-1
+      version: 0.0.9-0
+    source:
+      type: git
+      url: https://github.com/anybotics/rqt_multiplot_plugin.git
+      version: master
+    status: developed
   rqt_nav_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.9-0`:

- upstream repository: https://github.com/anybotics/rqt_multiplot_plugin.git
- release repository: https://github.com/anybotics/rqt_multiplot_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.8-1`

## rqt_multiplot

```
* fix rosdep key
* Contributors: Samuel Bachmann
```
