### PR TITLE
dockeros: 1.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2259,6 +2259,7 @@ repositories:
       url: https://github.com/ct2034/dockeros-release.git
       version: 1.0.3-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ct2034/dockeROS.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2257,7 +2257,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ct2034/dockeros-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/ct2034/dockeROS.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dockeros` to `1.0.3-0`:

- upstream repository: https://github.com/ct2034/dockeROS.git
- release repository: https://github.com/ct2034/dockeros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.2-0`

## dockeros

```
* removing rospy from CMakeLists
* documentation
* Contributors: Christian Henkel, ct2034
```
