### PR TITLE
rotors_simulator: 2.2.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4639,7 +4639,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git
-      version: 2.2.2
+      version: master
     release:
       packages:
       - rotors_comm
@@ -4655,11 +4655,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 2.2.2-0
+      version: 2.2.3-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git
-      version: 2.2.2
+      version: master
   rplidar_ros:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4639,7 +4639,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git
-      version: master
+      version: feature/gazebo9-autobackport
     release:
       packages:
       - rotors_comm
@@ -4659,7 +4659,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git
-      version: master
+      version: feature/gazebo9-autobackport
   rplidar_ros:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4635,6 +4635,31 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: melodic-devel
     status: maintained
+  rotors_simulator:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/rotors_simulator.git
+      version: 2.2.2
+    release:
+      packages:
+      - rotors_comm
+      - rotors_control
+      - rotors_description
+      - rotors_evaluation
+      - rotors_gazebo
+      - rotors_gazebo_plugins
+      - rotors_hil_interface
+      - rotors_joy_interface
+      - rotors_simulator
+      - rqt_rotors
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ethz-asl/rotors_simulator-release.git
+      version: 2.2.2-0
+    source:
+      type: git
+      url: https://github.com/ethz-asl/rotors_simulator.git
+      version: 2.2.2
   rplidar_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `2.2.3-0`:

- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## rotors_comm

- No changes

## rotors_control

- No changes

## rotors_description

- No changes

## rotors_evaluation

- No changes

## rotors_gazebo

- No changes

## rotors_gazebo_plugins

```
* Added dependencies to gazebo_plugins
* Fixes issues with build on buildfarm and old ubuntu systems (added MAVROS dependencies, version checking, protobuf-dev etc)
* Contributors: michaelpantic
```

## rotors_hil_interface

```
* Merge branch 'feature/hil_mavros_fix' into feature/gazebo9-autobackport
* fix not including message types
* Contributors: Zachary Taylor, michaelpantic
```

## rotors_joy_interface

- No changes

## rotors_simulator

- No changes

## rqt_rotors

- No changes
