### PR TITLE
ipr_extern: 0.8.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4207,6 +4207,18 @@ repositories:
       type: git
       url: https://github.com/KITrobotics/iirob_filters.git
       version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/KITrobotics/iirob_filters.git
+      version: kinetic-devel
+    status: developed
+    release:
+      packages:
+      -iirob_filters
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/KITrobotics/iirob_filters-release.git
+      version: 0.8.1-1
   image_common:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4220,7 +4220,7 @@ repositories:
     status: developed
     release:
       packages:
-      -iirob_filters
+      - iirob_filters
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/iirob_filters-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4552,6 +4552,21 @@ repositories:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git
       version: kinetic-devel
+    release:
+      packages:
+      - ipr_extern
+      - libmodbus
+      - libreflexxestype2
+      - ros_reflexxes
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/KITrobotics/ipr_extern-release.git
+      version: 0.8.7-0
+    source:
+      type: git
+      url: https://github.com/KITrobotics/ipr_extern.git
+      version: '''0.8.8'''
+    status: developed
   ira_laser_tools:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4565,7 +4565,7 @@ repositories:
     source:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git
-      version: '''0.8.8'''
+      version: kinetic-devel
     status: developed
   ira_laser_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ipr_extern` to `0.8.7-0`:

- upstream repository: https://github.com/KITrobotics/ipr_extern.git
- release repository: https://github.com/KITrobotics/ipr_extern-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## ipr_extern

- No changes

## libmodbus

```
* removed previously generated .la files
* Contributors: Gilbert Groten
```

## libreflexxestype2

- No changes

## ros_reflexxes

- No changes
