### PR TITLE
pacmod_game_control: 2.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3059,7 +3059,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/astuff/pacmod_game_control-release.git
-      version: 2.2.0-0
+      version: 2.3.0-0
     source:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod_game_control` to `2.3.0-0`:

- upstream repository: https://github.com/astuff/pacmod_game_control.git
- release repository: https://github.com/astuff/pacmod_game_control-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.2.0-0`

## pacmod_game_control

```
* Merge pull request #54 <https://github.com/astuff/pacmod_game_control/issues/54> from astuff/maint/hri_remap_part_two
* A comment explaining the axes
* Fixed not publishing turn signal command on board rev 2
* Handle HRI turn signals seperately from the other controllers
* Merge pull request #53 <https://github.com/astuff/pacmod_game_control/issues/53> from astuff/maint/hri_remap
* Changed mapping of HRI enable/disable from U/D to R/L
  This fixes some aberrant behavior that we were seeing with
  EMI in the remote system
* Merge pull request #51 <https://github.com/astuff/pacmod_game_control/issues/51> from astuff/maint/update_url
* Updating README and adding URLs to package.xml.
* Merge pull request #48 <https://github.com/astuff/pacmod_game_control/issues/48> from astuff/feature/clear_fault
* Refactoring of how we're handling the shifter command
  Mostly just to get rid of repeated code, but also I think
  it's significantly more readable this way.
* When sending clear_overrides, also send clear_faults
  This update is req'd for Lexus 1.1 and later
* Merge pull request #47 <https://github.com/astuff/pacmod_game_control/issues/47> from astuff/maint/add_veh_6
* Contributors: Daniel-Stanek, Joshua Whitley, Mike Lemm, Sam Rustan, Zach Oakes
```
