### PR TITLE
rqt_multiplot_plugin: 0.0.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4666,7 +4666,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/anybotics/rqt_multiplot_plugin-release.git
-      version: 0.0.9-1
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/anybotics/rqt_multiplot_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.10-0`:

- upstream repository: https://github.com/anybotics/rqt_multiplot_plugin.git
- release repository: https://github.com/anybotics/rqt_multiplot_plugin-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.9-1`

## rqt_multiplot

```
* add missing dependency and use format 2 in package.xml
* Contributors: Samuel Bachmann
```
