### PR TITLE
rotors_simulator: 2.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13432,7 +13432,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/rotors_simulator-release.git
-      version: 2.2.2-0
+      version: 2.2.3-0
     source:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rotors_simulator` to `2.2.3-0`:

- upstream repository: https://github.com/ethz-asl/rotors_simulator.git
- release repository: https://github.com/ethz-asl/rotors_simulator-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.2.2-0`

## rotors_comm

- No changes

## rotors_control

- No changes

## rotors_description

- No changes

## rotors_evaluation

- No changes

## rotors_gazebo

- No changes

## rotors_gazebo_plugins

```
* Added dependencies to gazebo_plugins
* Contributors: michaelpantic
```

## rotors_hil_interface

- No changes

## rotors_joy_interface

- No changes

## rotors_simulator

- No changes

## rqt_rotors

- No changes
