### PR TITLE
flir_boson_usb: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2905,6 +2905,21 @@ repositories:
       url: https://github.com/yujinrobot-release/flatbuffers-release.git
       version: 1.1.0-0
     status: maintained
+  flir_boson_usb:
+    doc:
+      type: git
+      url: https://github.com/astuff/flir_boson_usb.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/astuff/flir_boson_usb-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/flir_boson_usb.git
+      version: master
+    status: developed
   flir_camera_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_boson_usb` to `1.0.0-0`:

- upstream repository: https://github.com/astuff/flir_boson_usb.git
- release repository: https://github.com/astuff/flir_boson_usb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## flir_boson_usb

```
* Adding LICENSE.
* Adding status badge to README.
* Adding launch file.
* Initial commit.
* Contributors: Joshua Whitley
```
