### PR TITLE
uuv_plume_simulator: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14147,10 +14147,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uuvsimulator/uuv_plume_simulator-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_plume_simulator.git
+    status: developed
   uuv_simulator:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14151,6 +14151,7 @@ repositories:
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_plume_simulator.git
+      version: master
     status: developed
   uuv_simulator:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_plume_simulator` to `0.3.1-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_plume_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_plume_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.3.0-0`

## uuv_cpc_sensor

- No changes

## uuv_plume_msgs

- No changes

## uuv_plume_simulator

```
* CHANGE Set build dependencies
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```
