### PR TITLE
melfa_robot: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6005,6 +6005,27 @@ repositories:
       url: https://github.com/ros/media_export.git
       version: indigo-devel
     status: maintained
+  melfa_robot:
+    doc:
+      type: git
+      url: https://github.com/tork-a/melfa_robot.git
+      version: master
+    release:
+      packages:
+      - melfa_description
+      - melfa_driver
+      - melfa_robot
+      - rv4fl_moveit_config
+      - rv7fl_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/7675t/melfa_robot-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/tork-a/melfa_robot.git
+      version: master
+    status: developed
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `melfa_robot` to `0.0.1-0`:

- upstream repository: https://github.com/tork-a/melfa_robot.git
- release repository: https://github.com/7675t/melfa_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## melfa_description

```
* Remove catkin_lint error from melfa_description
* Add copyright holder of mesh files in README.md
* Reorganize URDF for RV4FL to be re-usable
* Add additional joints(#13 <https://github.com/tork-a/melfa_robot/issues/13>)
* Organize rv7fl.urdf.xacro using xacro
* Add use_joint7 and use_joint8 parameters
  - Remove dummy joints from rv7fl.urdf.xacro
* Add RV4FL mesh data(#11 <https://github.com/tork-a/melfa_robot/issues/11>)
* Add missing dependencies
* Add mesh license and README.md
* Modify the package meta files
* Add mesh files for RV7FL
  - They are modified its origin, rotation in mesh
  - Scale are modified in URDF
* Modify URDF to adopt the package structure
  - Add robot argument to specify target robot
* Add RV4FL mesh data
* Pull request for the first delivery(#5 <https://github.com/tork-a/melfa_robot/issues/5>)
* Remove mesh related files from melfa_description
* Add dummy joint7 and joint8 for actual robot
* Add use_gui argument and default is false
* Add URDF and mesh files (#1 <https://github.com/tork-a/melfa_robot/issues/1>)
* Modify joint limits to fit the spec sheet
* Fix mesh orientation, colors
* Change driver to use melfa_description
* Fix mesh size unit, urdf
* Contributors: KazukiHiraizumi, Ryosuke Tajima
```

## melfa_driver

```
* Remove check.sh for eliminating catkin_lint warning
* Add jointx_is_linear parameter for the linear base(#17 <https://github.com/tork-a/melfa_robot/issues/17>)
* rename melfa_ros to melfa_robot
* Add additional joints(#13 <https://github.com/tork-a/melfa_robot/issues/13>)
* Add use_joint7 and use_joint8 parameters
* Pull request for the first delivery(#5 <https://github.com/tork-a/melfa_robot/issues/5>)
* Change author email
* Expand joint number to 8 only for acutal robot check
* Add realtime feature and docs(#3 <https://github.com/tork-a/melfa_robot/issues/3>)
* Improve driver and loopback node, add diagnostics
  - Make loopback node periodic considering the hardware specs
  - Add diagnotics to see period over-run
* Disable realtime in tests
* Make loopback node realtime
* Add realtime feature and docs
* Change test to wait topic for 30s
* Add more dependencies
* Check node list before test
* Add package dependencies
* Add .travis.yml for CI
* Add moveit configuration files(#2 <https://github.com/tork-a/melfa_robot/issues/2>)
  - Confirmed to work with RT-ToolBox
* Add URDF and mesh files(#1 <https://github.com/tork-a/melfa_robot/issues/1>)
* Change driver to use melfa_description
* Add ROS_INFO for robot_ip
* Improve UDP error handling not to abort
* Add first test
* Fix integer size incompatibility of the packet
* Add melfa_loopbacknode for test
* First commit
  - Proof of function
  - This can control RT-Toolbox3 simulator
  - All parameters are hard-coded
* Contributors: Ryosuke Tajima
```

## melfa_robot

```
* Switch to industrial-ci(#16 <https://github.com/tork-a/melfa_robot/issues/16>)
* Add melfa_robot metapackage
* Contributors: Ryosuke Tajima
```

## rv4fl_moveit_config

```
* rename melfa_ros to melfa_robot
* Add rv4fl_moveit_config package(#12 <https://github.com/tork-a/melfa_robot/issues/12>)
* Contributors: Ryosuke Tajima
```

## rv7fl_moveit_config

```
* Add additional joints(#13 <https://github.com/tork-a/melfa_robot/issues/13>)
  - Update rv7fl_moveit_config for urdf update
* Add moveit configuration files(#2 <https://github.com/tork-a/melfa_robot/issues/2>)
  - Confirmed to work with RT-ToolBox
* Contributors: Ryosuke Tajima
```
