### PR TITLE
Adding to Gentoo qtbase5-dev keys widgets & qttest

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4415,7 +4415,7 @@ qtbase5-dev:
   debian: [qtbase5-dev]
   fedora: [qt5-qtbase-devel]
   freebsd: [qt5-core]
-  gentoo: ['dev-qt/qtcore:5']
+  gentoo: ['dev-qt/qtcore:5', 'dev-qt/widgets:5', 'dev-qt/qttest:5']
   opensuse: [libqt5-qtbase-common-devel, libqt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qtbase5-dev]


### PR DESCRIPTION
As arised in https://github.com/ros/ros-overlay/issues/725 `qt_gui_cpp` expects Qt to have the widgets and qttest modules.
But in Gentoo `dev-qt/qtcore` does not come with much, we need to add the other two keys to have all dependencies satisfied automatically.