### PR TITLE
rosbridge_suite: 0.10.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10937,7 +10937,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.9.0-0
+      version: 0.10.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.10.0-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.9.0-0`

## rosapi

```
* Drop use of ros Python module (#374 <https://github.com/RobotWebTools/rosbridge_suite/issues/374>)
* Fixes passing of globs to proxy (#355 <https://github.com/RobotWebTools/rosbridge_suite/issues/355>)
  * Fixes handling and passing of globs to proxy
  * Removes some confusing imports
* Fix a few problems (#350 <https://github.com/RobotWebTools/rosbridge_suite/issues/350>)
  * xrange is not available in Python3, range works for both Python versions
  * the variable v is undefined in search_param, comparing the implementation with the sibling functions I expect name to be the intended variable
  * The module udp_handler is using the Authentication service but wasn't importing the module
* use package format 2, remove unnecessary dependencies (#348 <https://github.com/RobotWebTools/rosbridge_suite/issues/348>)
* Contributors: Anwar, Dirk Thomas, Jochen Sprickerhof
```

## rosbridge_library

```
* CBOR encoding (#364 <https://github.com/RobotWebTools/rosbridge_suite/issues/364>)
  * Add CBOR encoding
  * Fix value extraction performance regression
  Extract message values once per message.
  * Fix typed array tags
  Was using big-endian tags and encoding little-endian.
  Always use little-endian for now since Intel is prevalent for desktop.
  Add some comments to this effect.
  * Update CBOR protocol documentation
  More information about draft typed arrays and when to use CBOR.
  * Fix 64-bit integer CBOR packing
  Use an actual 64-bit format.
* use package format 2, remove unnecessary dependencies (#348 <https://github.com/RobotWebTools/rosbridge_suite/issues/348>)
* removing has_key for python3, keeping backwards compatibility (#337 <https://github.com/RobotWebTools/rosbridge_suite/issues/337>)
  * removing has_key for python3, keeping backwards compatibility
  * py3 change for itervalues, keeping py2 compatibility
* Contributors: Andreas Klintberg, Dirk Thomas, Matt Vollrath
```

## rosbridge_server

```
* CBOR encoding (#364 <https://github.com/RobotWebTools/rosbridge_suite/issues/364>)
  * Add CBOR encoding
  * Fix value extraction performance regression
  Extract message values once per message.
  * Fix typed array tags
  Was using big-endian tags and encoding little-endian.
  Always use little-endian for now since Intel is prevalent for desktop.
  Add some comments to this effect.
  * Update CBOR protocol documentation
  More information about draft typed arrays and when to use CBOR.
  * Fix 64-bit integer CBOR packing
  Use an actual 64-bit format.
* Add param to enable ws per-message deflate (#365 <https://github.com/RobotWebTools/rosbridge_suite/issues/365>)
  * Add param to enable ws per-message deflate
  Tornado has its own per-message deflate compression option, which
  compresses each WebSocket message.  The compression level should be
  roughly equivalent to PNG compression, depending on whether the message is
  JSON or binary (CBOR).  The encoding/decoding time will be much faster
  than protocol PNG compression.
  This param should be enabled when wire size is important, e.g. not
  connecting to localhost.
* rosbridge_server: Publish number of connected clients on latched topic. (#359 <https://github.com/RobotWebTools/rosbridge_suite/issues/359>)
* Fix a few problems (#350 <https://github.com/RobotWebTools/rosbridge_suite/issues/350>)
  * xrange is not available in Python3, range works for both Python versions
  * the variable v is undefined in search_param, comparing the implementation with the sibling functions I expect name to be the intended variable
  * The module udp_handler is using the Authentication service but wasn't importing the module
* use package format 2, remove unnecessary dependencies (#348 <https://github.com/RobotWebTools/rosbridge_suite/issues/348>)
* Adding bson support for websockets (#327 <https://github.com/RobotWebTools/rosbridge_suite/issues/327>)
  * removed message that bson isn't supported. setting the bson only mode class attribute
  * added auth package inspection for bson only mode
* Contributors: Dirk Thomas, Hans-Joachim Krauch, Matt Vollrath, Sanic
```

## rosbridge_suite

```
* use package format 2, remove unnecessary dependencies (#348 <https://github.com/RobotWebTools/rosbridge_suite/issues/348>)
* Contributors: Dirk Thomas
```
