### PR TITLE
pilz_robots: 0.5.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3363,7 +3363,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.1-0
+      version: 0.5.1-2
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.1-2`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.5.1-0`

* disable deprecation warnings to fix failing build (see discussion in [pilz_industrial_motion comment](https://github.com/PilzDE/pilz_industrial_motion/pull/38#issuecomment-446523198) )