### PR TITLE
Fedora dependencies for Crystal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -882,6 +882,8 @@ gazebo9:
   debian:
     buster: [gazebo9]
     stretch: [gazebo9]
+  fedora:
+    '30': [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
   ubuntu:
     artful: [gazebo9]
@@ -1913,6 +1915,7 @@ libglew-dev:
     zesty: [libglew-dev]
 libglfw3-dev:
   debian: [libglfw3-dev]
+  fedora: [glfw-devel]
   gentoo: [media-libs/glfw]
   ubuntu:
     '*': [libglfw3-dev]
@@ -3588,6 +3591,7 @@ libxml2:
   ubuntu: [libxml2-dev]
 libxml2-utils:
   debian: [libxml2-utils]
+  fedora: [libxml2]
   ubuntu: [libxml2-utils]
 libxmlrpc-c++:
   arch: [xmlrpc-c]
@@ -3646,7 +3650,6 @@ libxxf86vm:
   ubuntu: [libxxf86vm-dev]
 libzmq3-dev:
   debian: [libzmq3-dev]
-  fedora: [zeromq3-devel]
   gentoo: [net-libs/cppzmq]
   ubuntu: [libzmq3-dev]
 libzmqpp3:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4659,11 +4659,13 @@ python3-nose-yanc:
   ubuntu: [python3-nose-yanc]
 python3-numpy:
   debian: [python3-numpy]
+  fedora: [python3-numpy]
   gentoo: [dev-python/numpy]
   ubuntu: [python3-numpy]
 python3-opencv:
   debian:
     buster: [python3-opencv]
+  fedora: [python3-opencv]
   ubuntu:
     bionic: [python3-opencv]
 python3-pep8:
@@ -4697,6 +4699,7 @@ python3-psutil:
 python3-pydot:
   arch: [python-pydot]
   debian: [python3-pydot]
+  fedora: [python3-pydot]
   gentoo: [dev-python/pydot]
   ubuntu: [python3-pydot]
 python3-pygraphviz:


### PR DESCRIPTION
gazebo9: https://apps.fedoraproject.org/packages/gazebo (Rawhide will become f30 when it forks)
libglfw3-dev: https://apps.fedoraproject.org/packages/glfw-devel
libxml2-utils: https://apps.fedoraproject.org/packages/libxml2
libzmq3-dev: Dropped from Fedora starting in f26
python3-numpy: https://apps.fedoraproject.org/packages/numpy **
python3-opencv: https://apps.fedoraproject.org/packages/python3-opencv
python3-pydot: https://apps.fedoraproject.org/packages/python3-pydot

All keys are valid for all supported Fedora releases (28 and 29).

** The UI is a little bit broken for this one - there is a source package for `python3-numpy` that targets only EPEL, so it can't display the page for the subpackage `python3-numpy` from source package `numpy`. It does display it in the right pane, though.