### PR TITLE
marti_common: 2.7.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7011,7 +7011,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.7.0-0
+      version: 2.7.1-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.7.1-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.7.0-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Fix masked image normalization. (#531 <https://github.com/swri-robotics/marti_common/issues/531>)
* Contributors: Marc Alban
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Fix conditional causing exists to not work properly. (#533 <https://github.com/swri-robotics/marti_common/issues/533>)
* Remove non ascii character to please python (#530 <https://github.com/swri-robotics/marti_common/issues/530>)
* Contributors: Matthew
```

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes

## swri_yaml_util

- No changes
