### PR TITLE
Add to Gentoo python-qt5-bindings USE flags gui & widgets

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3127,7 +3127,7 @@ python-qt5-bindings:
     stretch: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
   fedora: [python-qt5-devel, sip]
   freebsd: [py27-qt5]
-  gentoo: [dev-python/PyQt5]
+  gentoo: ['dev-python/PyQt5[gui,widgets]']
   opensuse: [python-qt5]
   slackware: [PyQt5]
   ubuntu:


### PR DESCRIPTION
As discussed here: https://github.com/ros/ros-overlay/issues/729 python-qt5-bindings in other platforms than Gentoo comes with a bunch of modules, in between those, gui (for QtGui) and widgets (for QtWidget). In Gentoo you need to specifically add them as USE keys. The ROS packages that build upon the python-qt5-bindings (rqt stuff) all expect those modules to exist, at a minimum.