### PR TITLE
Add to boost key for Gentoo python USE flag

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -284,7 +284,7 @@ boost:
     wheezy: [libboost-all-dev]
   fedora: [boost-devel]
   freebsd: [boost-python-libs]
-  gentoo: [dev-libs/boost]
+  gentoo: ['dev-libs/boost[python]']
   macports: [boost]
   opensuse: [boost-devel]
   rhel: [boost-devel]


### PR DESCRIPTION
As discussed in https://github.com/ros/ros-overlay/issues/581 in Gentoo boost does not come with boost_python without adding a USE flag for it. ROS expects boost to contain boost_python (cv_bridge, camera_calibration_parsers for example).