### PR TITLE
rosbridge_suite: 0.10.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4413,7 +4413,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.9.0-0
+      version: 0.10.1-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.10.1-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.9.0-0`

## rosapi

- No changes

## rosbridge_library

```
* Inline cbor library (#377 <https://github.com/RobotWebTools/rosbridge_suite/issues/377>)
  Prefer system version with C speedups, but include pure Python implementation.
* Contributors: Matt Vollrath
```

## rosbridge_server

- No changes

## rosbridge_suite

- No changes
