### PR TITLE
melfa_robot: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6005,6 +6005,27 @@ repositories:
       url: https://github.com/ros/media_export.git
       version: indigo-devel
     status: maintained
+  melfa_robot:
+    doc:
+      type: git
+      url: https://github.com/tork-a/melfa_robot.git
+      version: master
+    release:
+      packages:
+      - melfa_description
+      - melfa_driver
+      - melfa_robot
+      - rv4fl_moveit_config
+      - rv7fl_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/melfa_robot-release.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/tork-a/melfa_robot.git
+      version: master
+    status: developed
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `melfa_robot` to `0.0.3-0`:

- upstream repository: https://github.com/tork-a/melfa_robot.git
- release repository: https://github.com/tork-a/melfa_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `null`
