### PR TITLE
pr2_power_drivers: 1.1.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3576,7 +3576,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
-      version: 1.1.6-0
+      version: 1.1.7-0
     status: unmaintained
   prbt_grippers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_power_drivers` to `1.1.7-0`:

- upstream repository: https://github.com/pr2/pr2_power_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_power_drivers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.1.6-0`

## ocean_battery_driver

```
* Merge pull request #71 <https://github.com/PR2/pr2_power_drivers/issues/71> from Jntzko/last_battery_update
  Initialize last battery update time with 0
* Initialize last battery update time with 0
  in kinetic initializing a ros time with -1 throws the following error:
  "Time is out of dual 32-bit range"
  Change it to time(0) keeps the previous behaviour, but uses time 0 as initial value.
* Contributors: Yannick Jonetzko
```

## power_monitor

- No changes

## pr2_power_board

- No changes

## pr2_power_drivers

- No changes
