### PR TITLE
euslisp: 9.26.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -949,7 +949,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.25.0-0
+      version: 9.26.0-0
     status: developed
   executive_smach:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.26.0-0`:

- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `9.25.0-0`
