### PR TITLE
soem: 1.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5396,6 +5396,22 @@ repositories:
       url: https://github.com/ros-perception/slam_karto.git
       version: melodic-devel
     status: maintained
+  soem:
+    doc:
+      type: git
+      url: https://github.com/mgruhler/soem.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mgruhler/soem-gbp.git
+      version: 1.3.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/mgruhler/soem.git
+      version: master
+    status: maintained
   sophus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.3.0-0`:

- upstream repository: https://github.com/mgruhler/soem.git
- release repository: https://github.com/mgruhler/soem-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
