### PR TITLE
Add python-pyjwt-pip to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1891,6 +1891,11 @@ python-jsonschema-pip:
   ubuntu:
     pip:
       packages: [jsonschema]
+python-jwt:
+  debian: [python-jwt]
+  fedora: [python-jwt]
+  gentoo: [dev-python/python-jwt]
+  ubuntu: [python-jwt]
 python-kdtree:
   debian:
     buster: [python-kdtree]
@@ -2780,11 +2785,6 @@ python-pyinotify:
   fedora: [python-inotify]
   gentoo: [dev-python/pyinotify]
   ubuntu: [python-pyinotify]
-python-jwt:
-  debian: [python-jwt]
-  fedora: [python-jwt]
-  gentoo: [dev-python/python-jwt]
-  ubuntu: [python-jwt]
 python-pykalman:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2781,9 +2781,10 @@ python-pyinotify:
   gentoo: [dev-python/pyinotify]
   ubuntu: [python-pyinotify]
 python-pyjwt-pip:
-  ubuntu:
-    pip:
-      packages: [pyjwt]
+  debian: [python-jwt]
+  fedora: [python-jwt]
+  gentoo: [dev-python/python-jwt]
+  ubuntu: [python-jwt]
 python-pykalman:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2780,7 +2780,7 @@ python-pyinotify:
   fedora: [python-inotify]
   gentoo: [dev-python/pyinotify]
   ubuntu: [python-pyinotify]
-python-pyjwt-pip:
+python-jwt:
   debian: [python-jwt]
   fedora: [python-jwt]
   gentoo: [dev-python/python-jwt]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2780,6 +2780,10 @@ python-pyinotify:
   fedora: [python-inotify]
   gentoo: [dev-python/pyinotify]
   ubuntu: [python-pyinotify]
+python-pyjwt-pip:
+  ubuntu:
+    pip:
+      packages: [pyjwt]
 python-pykalman:
   debian:
     pip:


### PR DESCRIPTION
[PyJWT ](https://pyjwt.readthedocs.io/en/latest/) is commonly used to encode and decode JSON Web Tokens. PyJWT is also required for authentication with Google IoT Core. 