### PR TITLE
pheeno_ros_description: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8305,6 +8305,21 @@ repositories:
       type: git
       url: https://github.com/ACSLaboratory/pheeno_ros.git
       version: kinetic-devel
+  pheeno_ros_description:
+    doc:
+      type: git
+      url: https://github.com/acslaboratory/pheeno_ros_description.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/acslaboratory/pheeno_ros_description-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/acslaboratory/pheeno_ros_description.git
+      version: kinetic-devel
+    status: maintained
   pheeno_ros_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros_description` to `0.1.0-0`:

- upstream repository: https://github.com/acslaboratory/pheeno_ros_description.git
- release repository: https://github.com/acslaboratory/pheeno_ros_description-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## pheeno_ros_description

```
* initial creation of pacakge
```
