### PR TITLE
capabilities: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -332,6 +332,22 @@ repositories:
       url: https://github.com/ros-drivers-gbp/camera_umd-release.git
       version: 0.2.7-0
     status: unmaintained
+  capabilities:
+    doc:
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/capabilities-release.git
+      version: 0.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    status: maintained
   cartesian_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `capabilities` to `0.2.0-0`:

- upstream repository: https://github.com/osrf/capabilities.git
- release repository: https://github.com/ros-gbp/capabilities-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## capabilities

```
* downgrade one of the exceptions to a warning
* fixup tests to reflect changes to client API
* Increase queue_size to 1000 for publishers
* Add queue_size arg for all publishers
* change exception behavior for use/free_capability in client API
* A rosdistro agnostic documentation reference
* conditionally try to stop reverse deps, since other reverse deps may have already stopped it
* make stopping the launch manager more robust to errors
* adds support of namespaces for capability nodelets
* Contributors: Jon Binney, Marcus Liebhardt, Nikolaus Demmel, William Woodall, kentsommer
```
