### PR TITLE
std_capabilities: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5479,6 +5479,22 @@ repositories:
       url: https://github.com/DLu/static_tf.git
       version: master
     status: maintained
+  std_capabilities:
+    doc:
+      type: git
+      url: https://github.com/osrf/std_capabilities.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/std_capabilities-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/std_capabilities.git
+      version: master
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_capabilities` to `0.1.0-0`:

- upstream repository: https://github.com/osrf/std_capabilities.git
- release repository: https://github.com/ros-gbp/std_capabilities-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## std_capabilities

```
* Initial Release
* Contributors: Marcus Liebhardt, William Woodall
```
