### PR TITLE
pilz_industrial_motion: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3337,11 +3337,12 @@ repositories:
       - pilz_industrial_motion
       - pilz_industrial_motion_testutils
       - pilz_msgs
+      - pilz_robot_programming
       - pilz_trajectory_generation
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.2.2-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.0-0`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.2-0`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

```
* Use Eigen::Isometry3d to keep up with the recent changes in moveit
* Contributors: Chris Lalancette
```

## pilz_msgs

- No changes

## pilz_robot_programming

```
* Release Python-API from kinetic version 0.3.1
```

## pilz_trajectory_generation

```
* Use Eigen::Isometry3d to keep up with the recent changes in moveit
* Contributors: Chris Lalancette
```
