### PR TITLE
ipr_extern: 0.8.8-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4593,6 +4593,16 @@ repositories:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git
       version: kinetic-devel
+    release:
+      packages:
+      - ipr_extern
+      - libmodbus
+      - libreflexxestype2
+      - ros_reflexxes
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/KITrobotics/ipr_extern-release.git
+      version: 0.8.8-0
     source:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipr_extern` to `0.8.8-0`:

- upstream repository: https://github.com/KITrobotics/ipr_extern.git
- release repository: https://github.com/KITrobotics/ipr_extern-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## ipr_extern

- No changes

## libmodbus

```
* reintroduiced not so redundant include file
* Contributors: Gilbert Groten
```

## libreflexxestype2

- No changes

## ros_reflexxes

- No changes
