### PR TITLE
force_torque_sensor: 0.8.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2992,7 +2992,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.8.1-0
+      version: 0.8.1-2
     source:
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `force_torque_sensor` to `0.8.1-2`:

- upstream repository: https://github.com/KITrobotics/force_torque_sensor.git
- release repository: https://github.com/KITrobotics/force_torque_sensor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.8.1-0`

## force_torque_sensor

```
* Added joystick and keyboard (#8)
* Scenario update melodic (#7)
  * added scenario parameter
  * fixed wrong variable names
  * Added service for setting offets from outside
  * Moved to Eigen3 from Eigen
  * Update calibrate_tool.py
  * Using WrenchTranform in tf2 instead of manual transform.
  * Corrected error with doTranform for wrenches and corrected package.xml with package meta data.
  * Update .travis.yml
  * Update .travis.rosinstall
* Added Melodic in overview
* Added travis config for melodic
* Update CMakeLists.txt
* Updated INSTALL paths
* Update CMakeLists.txt
* Update CMakeLists.txt
* Update .travis.rosinstall (#3)
  * Update .travis.rosinstall for compiling
* Update CMakeLists.txt
* Update package.xml
* Update .travis.rosinstall
* Merge pull request #2 from KITrobotics/master
  Update README.md
* Update README.md
* Merge pull request #1 from KITrobotics/bugs_clean
  Removed bug setting false static offsets paramters; Commenting out an…
* Create .travis.rosinstall
* Create .travis.yml
* Create README.md
* Removed bug setting false static offsets paramters; Commenting out and deleting some unused code.
* Corrected param names for CoG
* Added corrections to work with schunk_ftc
* Moved class loader to handle
* Added namespaces
* First working version
* Contributors: Denis Štogl, IIROB Praktikum 3, Timo Leitritz
```
