### PR TITLE
ipr_extern: 0.8.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1740,6 +1740,26 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: indigo-devel
     status: maintained
+  ipr_extern:
+    doc:
+      type: git
+      url: https://github.com/KITrobotics/ipr_extern.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ipr_extern
+      - libmodbus
+      - libreflexxestype2
+      - ros_reflexxes
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/KITrobotics/ipr_extern-release.git
+      version: 0.8.8-1
+    source:
+      type: git
+      url: https://github.com/KITrobotics/ipr_extern.git
+      version: kinetic-devel
+    status: developed
   ivcon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipr_extern` to `0.8.8-1`:

- upstream repository: https://github.com/KITrobotics/ipr_extern.git
- release repository: https://github.com/KITrobotics/ipr_extern-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## ipr_extern

- No changes

## libmodbus

```
* reintroduiced not so redundant include file
* Contributors: Gilbert Groten
```

## libreflexxestype2

- No changes

## ros_reflexxes

- No changes
