### PR TITLE
Revert "force_torque_sensor: 0.8.1-3 in 'melodic/distribution.yaml' [bloom]"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1157,21 +1157,6 @@ repositories:
       url: https://github.com/boschresearch/fmi_adapter.git
       version: master
     status: maintained
-  force_torque_sensor:
-    doc:
-      type: git
-      url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: melodic
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.8.1-3
-    source:
-      type: git
-      url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: melodic
-    status: developed
   four_wheel_steering_msgs:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#19767