### PR TITLE
Revert "force_torque_sensor: 0.8.1-3 in 'melodic/distribution.yaml' […

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1172,21 +1172,6 @@ repositories:
       url: https://github.com/boschresearch/fmi_adapter.git
       version: master
     status: maintained
-  force_torque_sensor:
-    doc:
-      type: git
-      url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: melodic
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.8.1-3
-    source:
-      type: git
-      url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: melodic
-    status: developed
   four_wheel_steering_msgs:
     doc:
       type: git


### PR DESCRIPTION
…bloom] (#19767)"

This reverts commit 59552b334244c389ac3d9c1820de9ec9ad80e4cc.