### PR TITLE
Revert "iirob_filters: 0.8.1-2 in 'melodic/distribution.yaml' [bloom]…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1630,7 +1630,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KITrobotics/iirob_filters-release.git
-      version: 0.8.1-2
+      version: 0.8.1-0
     source:
       type: git
       url: https://github.com/KITrobotics/iirob_filters.git


### PR DESCRIPTION
… (#19769)"

This reverts commit 669a37c71dfb2934dc8eedba880018df2cf7959e.