### PR TITLE
flexbe_app: 2.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3642,7 +3642,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.0-0
+      version: 2.1.2-0
     source:
       type: git
       url: https://github.com/FlexBE/flexbe_app.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_app` to `2.1.2-0`:

- upstream repository: https://github.com/FlexBE/flexbe_app.git
- release repository: https://github.com/FlexBE/flexbe_app-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.1.0-0`

## flexbe_app

```
* Merge remote-tracking branch 'origin/develop'
* Switch to curl for nwjs download
* Contributors: Philipp Schillinger
```
