### PR TITLE
Module venv is baked into python3 in fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4779,6 +4779,7 @@ python3-termcolor:
   ubuntu: [python3-termcolor]
 python3-venv:
   debian: [python3-venv]
+  fedora: []
   ubuntu: [python3-venv]
 python3-yaml:
   debian: [python3-yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4779,7 +4779,7 @@ python3-termcolor:
   ubuntu: [python3-termcolor]
 python3-venv:
   debian: [python3-venv]
-  fedora: []
+  fedora: [python3-libs]
   ubuntu: [python3-venv]
 python3-yaml:
   debian: [python3-yaml]


### PR DESCRIPTION
Only ubuntu/debian requires installing separate python3-venv package.