### PR TITLE
flexbe: 1.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2913,6 +2913,31 @@ repositories:
       url: https://github.com/yujinrobot-release/flatbuffers-release.git
       version: 1.1.0-0
     status: maintained
+  flexbe:
+    doc:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    release:
+      packages:
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    status: developed
   flir_boson_usb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.1.1-0`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## flexbe_behavior_engine

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_core

```
* Merge remote-tracking branch 'origin/develop'
* Revise run dependencies
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_input

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_mirror

```
* Merge remote-tracking branch 'origin/develop'
* Merge remote-tracking branch 'origin/master' into develop
* [flexbe_mirror] Fix race condition in mirror restarts
* Contributors: Philipp Schillinger
```

## flexbe_msgs

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_onboard

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_states

```
* Merge remote-tracking branch 'origin/develop'
* Revise run dependencies
* [flexbe_states] Remove deprecated concurrent_state - use Concurrency container instead
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_testing

```
* Merge remote-tracking branch 'origin/develop'
* Revise run dependencies
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_widget

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```
