### PR TITLE
Add virtualenv key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4821,6 +4821,10 @@ tilestache:
   debian: [tilestache]
   fedora: [python-tilestache]
   ubuntu: [tilestache]
+virtualenv:
+  debian: [virtualenv]
+  fedora: [python3-virtualenv]
+  ubuntu: [virtualenv]  
 wxpython:
   arch: [wxpython]
   centos: [wxPython-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4823,8 +4823,8 @@ tilestache:
   ubuntu: [tilestache]
 virtualenv:
   debian: [virtualenv]
-  fedora: [python3-virtualenv]
-  ubuntu: [virtualenv]  
+  fedora: [virtualenv]
+  ubuntu: [virtualenv]
 wxpython:
   arch: [wxpython]
   centos: [wxPython-devel]


### PR DESCRIPTION
ubuntu: https://packages.ubuntu.com/xenial/virtualenv
debian: https://packages.debian.org/stretch/virtualenv

fedora is a weird one: it ships the `/usr/bin/virtualenv` script as part of python3-virtualenv, verified on a clean docker container. Not sure if there's a preferred approach...