### PR TITLE
flexbe_app: 2.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2913,6 +2913,31 @@ repositories:
       url: https://github.com/yujinrobot-release/flatbuffers-release.git
       version: 1.1.0-0
     status: maintained
+  flexbe:
+    doc:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    release:
+      packages:
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    status: developed
   flexbe_app:
     doc:
       type: git
@@ -2922,7 +2947,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.2-0
+      version: 2.1.3-0
     source:
       type: git
       url: https://github.com/FlexBE/flexbe_app.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2913,6 +2913,21 @@ repositories:
       url: https://github.com/yujinrobot-release/flatbuffers-release.git
       version: 1.1.0-0
     status: maintained
+  flexbe_app:
+    doc:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_app-release.git
+      version: 2.1.2-0
+    source:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    status: developed
   flir_boson_usb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_app` to `2.1.2-0`:

- upstream repository: https://github.com/FlexBE/flexbe_app.git
- release repository: https://github.com/FlexBE/flexbe_app-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## flexbe_app

```
* Merge remote-tracking branch 'origin/develop'
* Switch to curl for nwjs download
* Contributors: Philipp Schillinger
```
