### PR TITLE
flexbe_app: 2.1.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -953,6 +953,21 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: lunar-devel
     status: maintained
+  flexbe_app:
+    doc:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_app-release.git
+      version: 2.1.2-0
+    source:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -953,6 +953,31 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: lunar-devel
     status: maintained
+  flexbe:
+    doc:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    release:
+      packages:
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/team-vigir/flexbe_behavior_engine.git
+      version: master
+    status: developed
   flexbe_app:
     doc:
       type: git
@@ -962,7 +987,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.2-0
+      version: 2.1.3-0
     source:
       type: git
       url: https://github.com/FlexBE/flexbe_app.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_app` to `2.1.2-0`:

- upstream repository: https://github.com/FlexBE/flexbe_app.git
- release repository: https://github.com/FlexBE/flexbe_app-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## flexbe_app

```
* Merge remote-tracking branch 'origin/develop'
* Switch to curl for nwjs download
* Contributors: Philipp Schillinger
```
