### PR TITLE
hebi_cpp_api: 2.0.1-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3752,6 +3752,19 @@ repositories:
       url: https://github.com/aws-robotics/health-metrics-collector-ros1.git
       version: master
     status: maintained
+  hebi_cpp_api_ros:
+    doc:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: master
+    release:
+      packages:
+      - hebi_cpp_api
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
+      version: 2.0.1-0
+    status: developed
   hebiros:
     doc:
       type: git


### PR DESCRIPTION
Initial release of hebi_cpp_api package in repository hebi_cpp_api_ros (2.0.1-0):

    upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
    release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
    distro file: kinetic/distribution.yaml
    previous version for package: null

This is a wrapper for the HEBI C++ API, which will allow us to modularize and reduce the complexity of other packages (e.g., hebiros)