### PR TITLE
flexbe_app: 2.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3644,7 +3644,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.2-0
+      version: 2.1.3-0
     source:
       type: git
       url: https://github.com/FlexBE/flexbe_app.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_app` to `2.1.3-0`:

- upstream repository: https://github.com/FlexBE/flexbe_app.git
- release repository: https://github.com/FlexBE/flexbe_app-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.1.2-0`

## flexbe_app

```
* Merge remote-tracking branch 'origin/develop'
* Add cmake dependency on rostest
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```
