### PR TITLE
dataspeed_can: 1.0.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -617,7 +617,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.11-0
+      version: 1.0.12-0
     source:
       type: hg
       url: https://bitbucket.org/dataspeedinc/dataspeed_can


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.12-0`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.11-0`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

- No changes

## dataspeed_can_tools

- No changes

## dataspeed_can_usb

```
* Added tcpNoDelay() for subscribers
* Added firmware version publisher
* Contributors: Kevin Hallenbeck, Lincoln Lorenz
```
