### PR TITLE
pheeno_ros_description: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3349,6 +3349,21 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: melodic-devel
     status: maintained
+  pheeno_ros_description:
+    doc:
+      type: git
+      url: https://github.com/acslaboratory/pheeno_ros_description.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/acslaboratory/pheeno_ros_description-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/acslaboratory/pheeno_ros_description.git
+      version: melodic-devel
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pheeno_ros_description` to `0.1.0-0`:

- upstream repository: https://github.com/acslaboratory/pheeno_ros_description.git
- release repository: https://github.com/acslaboratory/pheeno_ros_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## pheeno_ros_description

```
* initial creation of pacakge
```
