### PR TITLE
hebi_cpp_api_ros: 2.0.1-1 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3788,7 +3788,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
-      version: 2.0.1-0
+      version: 2.0.1-1
     status: developed
   hebiros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository hebi_cpp_api_ros to 2.0.1-1:

    upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
    release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
    distro file: kinetic/distribution.yaml

hebi_cpp_api

* Updated to correctly set aarch64, armhf, and i386 library path on ROS buildfarm
* Contributors: Matthew Tesch