### PR TITLE
rr_openrover_basic: 0.6.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12040,7 +12040,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics/rr_openrover_basic-release.git
-      version: 0.6.0-0
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/RoverRobotics/rr_openrover_basic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_basic` to `0.6.0-1`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_basic.git
- release repository: https://github.com/RoverRobotics/rr_openrover_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.6.0-0`
