### PR TITLE
exotica_val_description: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2737,6 +2737,12 @@ repositories:
       url: https://github.com/ros-visualization/executive_smach_visualization.git
       version: indigo-devel
     status: unmaintained
+  exotica_val_description:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wxmerkt/exotica_val_description-release.git
+      version: 1.0.0-1
   ez_interactive_marker:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica_val_description` to `1.0.0-1`:

- upstream repository: https://github.com/ipab-slmc/exotica_val_description.git
- release repository: https://github.com/wxmerkt/exotica_val_description-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
