### PR TITLE
exotica_val_description: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1001,6 +1001,12 @@ repositories:
       url: https://github.com/jbohren/executive_smach_visualization-release.git
       version: 2.0.2-0
     status: unmaintained
+  exotica_val_description:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wxmerkt/exotica_val_description-release.git
+      version: 1.0.0-1
   fanuc_post_processor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica_val_description` to `1.0.0-1`:

- upstream repository: https://github.com/ipab-slmc/exotica_val_description.git
- release repository: https://github.com/wxmerkt/exotica_val_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
