### PR TITLE
urdf_test: 1.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14139,6 +14139,12 @@ repositories:
       url: https://github.com/ros-controls/urdf_geometry_parser.git
       version: kinetic-devel
     status: developed
+  urdf_test:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/urdf_test-release.git
+      version: 1.0.4-0
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `1.0.4-0`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/pal-gbp/urdf_test-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## urdf_test

```
* Merge branch 'add-test-suffix' into 'master'
  Add test suffix
  See merge request qa/urdf_test!2
* Add test suffix
* Merge branch 'fix-package-dependency' into 'master'
  Fix package dependencies
  See merge request !1
* Fix package dependencies
* Contributors: Victor Lopez, davidfernandez
```
