### PR TITLE
pal_hardware_interfaces: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8123,6 +8123,12 @@ repositories:
       url: https://github.com/astuff/pacmod_game_control.git
       version: release
     status: developed
+  pal_hardware_interfaces:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/pal_hardware_interfaces-release.git
+      version: 0.0.3-0
   panda_moveit_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_hardware_interfaces` to `0.0.3-0`:

- upstream repository: https://github.com/pal-robotics/pal_hardware_interfaces.git
- release repository: https://github.com/pal-gbp/pal_hardware_interfaces-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## pal_hardware_interfaces

```
* added getter to temperature data
* Changed license
* Contributors: Hilario Tome
* added getter to temperature data
* Changed license
* Contributors: Hilario Tome
```
