### PR TITLE
talos_robot: 1.0.44-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13072,12 +13072,7 @@ repositories:
   talos_robot:
     release:
       packages:
-      - talos_bringup
-      - talos_controller_configuration
       - talos_description
-      - talos_description_calibration
-      - talos_description_inertial
-      - talos_robot
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13069,6 +13069,19 @@ repositories:
       url: https://github.com/NicksSimulationsROS/sync_params.git
       version: ros-kinetic
     status: developed
+  talos_robot:
+    release:
+      packages:
+      - talos_bringup
+      - talos_controller_configuration
+      - talos_description
+      - talos_description_calibration
+      - talos_description_inertial
+      - talos_robot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/talos_robot-release.git
+      version: 1.0.44-0
   tango_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_robot` to `1.0.44-0`:

- upstream repository: https://github.com/pal-robotics/talos_robot.git
- release repository: https://github.com/pal-gbp/talos_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## talos_bringup

- No changes

## talos_controller_configuration

```
* Merge branch 'as_safety' into 'erbium-devel'
  Add default_safety_parameters.yaml
  See merge request robots/talos_robot!65
* Drop joint specific safety parameters
* Update default_safety_parameters.yaml
* Add default_safety_parameters.yaml
* Contributors: alexandersherikov
```

## talos_description

- No changes

## talos_description_calibration

- No changes

## talos_description_inertial

- No changes

## talos_robot

- No changes
