### PR TITLE
talos_robot: 1.0.44-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5606,12 +5606,7 @@ repositories:
   talos_robot:
     release:
       packages:
-      - talos_bringup
-      - talos_controller_configuration
       - talos_description
-      - talos_description_calibration
-      - talos_description_inertial
-      - talos_robot
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5603,6 +5603,19 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  talos_robot:
+    release:
+      packages:
+      - talos_bringup
+      - talos_controller_configuration
+      - talos_description
+      - talos_description_calibration
+      - talos_description_inertial
+      - talos_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-gbp/talos_robot-release.git
+      version: 1.0.44-0
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_robot` to `1.0.44-0`:

- upstream repository: https://github.com/pal-robotics/talos_robot.git
- release repository: https://github.com/pal-gbp/talos_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## talos_bringup

- No changes

## talos_controller_configuration

```
* Merge branch 'as_safety' into 'erbium-devel'
  Add default_safety_parameters.yaml
  See merge request robots/talos_robot!65
* Drop joint specific safety parameters
* Update default_safety_parameters.yaml
* Add default_safety_parameters.yaml
* Contributors: alexandersherikov
```

## talos_description

- No changes

## talos_description_calibration

- No changes

## talos_description_inertial

- No changes

## talos_robot

- No changes
