### PR TITLE
neonavigation_msgs: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2867,7 +2867,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_msgs-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_msgs` to `0.3.0-0`:

- upstream repository: https://github.com/at-wat/neonavigation_msgs.git
- release repository: https://github.com/at-wat/neonavigation_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.0-0`

## costmap_cspace_msgs

```
* Fix package dependencies (#5 <https://github.com/at-wat/neonavigation_msgs/issues/5>)
  
    * Fix package dependencies
    * Migrate to manifest format 2
    * Add catkin_lint test
  
* Contributors: Atsushi Watanabe
```

## map_organizer_msgs

```
* Fix package dependencies (#5 <https://github.com/at-wat/neonavigation_msgs/issues/5>)
  
    * Fix package dependencies
    * Migrate to manifest format 2
    * Add catkin_lint test
  
* Contributors: Atsushi Watanabe
```

## neonavigation_msgs

```
* Fix package dependencies (#5 <https://github.com/at-wat/neonavigation_msgs/issues/5>)
  
    * Fix package dependencies
    * Migrate to manifest format 2
    * Add catkin_lint test
  
* Contributors: Atsushi Watanabe
```

## planner_cspace_msgs

```
* Add some more error state number of PlannerStatus (#7 <https://github.com/at-wat/neonavigation_msgs/issues/7>)
* Fix package dependencies (#5 <https://github.com/at-wat/neonavigation_msgs/issues/5>)
  
    * Fix package dependencies
    * Migrate to manifest format 2
    * Add catkin_lint test
  
* Contributors: Atsushi Watanabe
```

## trajectory_tracker_msgs

```
* trajectory_tracker_msgs: add PathWithVelocity message (#9 <https://github.com/at-wat/neonavigation_msgs/issues/9>)
  
    * Add PathWithVelocity
    * Add message converter from Path to PathWithVelocity
    * Add comment of linear_velocity nan value
    * Enable C++11 on test
  
* Fix package dependencies (#5 <https://github.com/at-wat/neonavigation_msgs/issues/5>)
  
    * Fix package dependencies
    * Migrate to manifest format 2
    * Add catkin_lint test
  
* Contributors: Atsushi Watanabe
```
