### PR TITLE
Remove flexbe_app version number from distros

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3635,21 +3635,6 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
-  flexbe_app:
-    doc:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.3-0
-    source:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3635,6 +3635,20 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
+  flexbe_app:
+    doc:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_app-release.git
+    source:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2944,6 +2944,20 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
+  flexbe_app:
+    doc:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_app-release.git
+    source:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2944,21 +2944,6 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
-  flexbe_app:
-    doc:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.3-0
-    source:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -978,6 +978,20 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
+  flexbe_app:
+    doc:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_app-release.git
+    source:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -978,21 +978,6 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
-  flexbe_app:
-    doc:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    release:
-      tags:
-        release: release/lunar/{package}/{version}
-      url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.3-0
-    source:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1149,21 +1149,6 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
-  flexbe_app:
-    doc:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/FlexBE/flexbe_app-release.git
-      version: 2.1.3-0
-    source:
-      type: git
-      url: https://github.com/FlexBE/flexbe_app.git
-      version: master
-    status: developed
   flir_boson_usb:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1149,6 +1149,20 @@ repositories:
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
       version: master
     status: developed
+  flexbe_app:
+    doc:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/FlexBE/flexbe_app-release.git
+    source:
+      type: git
+      url: https://github.com/FlexBE/flexbe_app.git
+      version: master
+    status: developed
   flir_boson_usb:
     doc:
       type: git


### PR DESCRIPTION
Sorry for the back-and-forth! Jenkins is failing for some reason which I cannot really explain, thus the flexbe_app entry should better be removed for now.

Both the prerelease test and my own CI worked without errors and I can also locally create a debian package using `bloom-generate rosdebian --ros-distro melodic` and `fakeroot debian/rules binary` which I then installed and used successfully for several days. So I'm not sure what causes the Jenkins fail...

Thank you!