### PR TITLE
Add python3-lxml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4636,6 +4636,10 @@ python3-lark-parser:
   gentoo: [dev-python/lark]
   ubuntu:
     bionic: [python3-lark-parser]
+python3-lxml:
+  debian: [python3-lxml]
+  fedora: [python3-lxml]
+  ubuntu: [python3-lxml]
 python3-matplotlib:
   arch: [python-matplotlib]
   debian: [python3-matplotlib]


### PR DESCRIPTION
python3-lxml is the packing for lxml XML toolkit is a Pythonic binding for the C libraries libxml2 and libxslt, useful for schema verification and templated stylesheets with XML. The particular use case here would be for ROS security tooling for handling the XML permission and governance files for secure transport. 
 
Context: https://github.com/ros2/sros2/pull/72

Links to original packaging    
* https://packages.ubuntu.com/bionic/python3-lxml
* https://packages.debian.org/stretch/python3-lxml
* https://apps.fedoraproject.org/packages/python3-lxml
 