### PR TITLE
Adding ros_indy to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12741,8 +12741,18 @@ repositories:
     doc:
       type: git
       url: https://github.com/thachdd88/ros_indy.git
-      version: master
+      version: indigo
     release:
+      packages:
+      - indy5_description
+      - indy5_moveit_config
+      - indy7_description
+      - indy7_moveit_config
+      - indy_driver
+      - indyrp2_description
+      - indyrp2_moveit_config
+      - indyrp_description
+      - indyrp_moveit_config
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/thachdd88/ros_indy-release.git
@@ -12750,7 +12760,7 @@ repositories:
     source:
       type: git
       url: https://github.com/thachdd88/ros_indy.git
-      version: master
+      version: indigo
     status: developed
   ros_numpy:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12737,6 +12737,21 @@ repositories:
       type: git
       url: https://github.com/RodBelaFarin/ros_in_hand_scanner.git
       version: master
+  ros_indy:
+    doc:
+      type: git
+      url: https://github.com/thachdd88/ros_indy.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/thachdd88/ros_indy-release.git
+      version: 0.3.4-0
+    source:
+      type: git
+      url: https://github.com/thachdd88/ros_indy.git
+      version: master
+    status: developed
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
I would like ros_indy to be indexed and documented on ros.org.