### PR TITLE
neonavigation_rviz_plugins: 0.3.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8466,6 +8466,24 @@ repositories:
       url: https://github.com/at-wat/neonavigation_msgs.git
       version: master
     status: developed
+  neonavigation_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/at-wat/neonavigation_rviz_plugins.git
+      version: master
+    release:
+      packages:
+      - neonavigation_rviz_plugins
+      - trajectory_tracker_rviz_plugins
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
+      version: 0.3.0-0
+    source:
+      type: git
+      url: https://github.com/at-wat/neonavigation_rviz_plugins.git
+      version: master
+    status: developed
   nerian_sp1:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_rviz_plugins` to `0.3.0-0`:

- upstream repository: https://github.com/at-wat/neonavigation_rviz_plugins.git
- release repository: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## neonavigation_rviz_plugins

```
* Add trajectory_tracker_msgs plugin (#1 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/1>)
  
    * Initial drop
    * Add CI
    * Fix build errors and warnings
    * Disable quaternion validation on indigo
    * Don't validate linear_velocity field
    * Add package README
    * Cleanup code
  
* Contributors: Atsushi Watanabe
```

## trajectory_tracker_rviz_plugins

```
* Add trajectory_tracker_msgs plugin (#1 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/1>)
  
    * Initial drop
    * Add CI
    * Fix build errors and warnings
    * Disable quaternion validation on indigo
    * Don't validate linear_velocity field
    * Add package README
    * Cleanup code
  
* Contributors: Atsushi Watanabe
```
