### PR TITLE
Adding racecar for documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9371,6 +9371,29 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
+  racecar:
+    doc:
+      type: git
+      url: https://github.com/tianbot/tianbot_racecar.git
+      version: master
+    release:
+      packages:
+      - racecar_bringup
+      - racecar_core
+      - racecar_description
+      - racecar_navigation
+      - racecar_rviz
+      - racecar_slam
+      - racecar_teleop
+      - racecar_test
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tianbot/tianbot_racecar-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/tianbot/tianbot_racecar.git
+      version: master
   radar_omnipresense:
     release:
       tags:


### PR DESCRIPTION
I'd like racecar to be indexed and documented on ros.org.