### PR TITLE
nmea_navsat_driver: 0.5.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7307,7 +7307,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git
-      version: jade-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -7316,7 +7316,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git
-      version: jade-devel
+      version: kinetic-devel
     status: maintained
   nodelet_core:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7312,7 +7312,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `0.5.1-0`:

- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.5.0-0`

## nmea_navsat_driver

```
* Add support for IMU aided GPS systems like the Applanix POS/MV, whose NMEA strings typically begin '$IN'. (e.g. $INGGA). Add support for VTG messages, which contain Course Over Ground and Speed Made Good. These are useful when not using RMC messages and you don't have a heading sensor. (#30 <https://github.com/ros-drivers/nmea_navsat_driver/issues/30>/#58 <https://github.com/ros-drivers/nmea_navsat_driver/issues/58>)
* Add a NMEA socket driver node, which is like the existing serial driver node, but instead of attaching to a TTY handle from a serial port, it listens to a UDP port for NMEA sentences. (#32 <https://github.com/ros-drivers/nmea_navsat_driver/issues/32>)
* Add code to handle serial exception to allow node to exit cleanly (#52 <https://github.com/ros-drivers/nmea_navsat_driver/issues/52>)
* Cleanup CMakeLists, package.xml; using package format 2. (#28 <https://github.com/ros-drivers/nmea_navsat_driver/issues/28>)
* Update maintainer to Ed Venator (#38 <https://github.com/ros-drivers/nmea_navsat_driver/issues/38>)
* Add GLONASS support
* Updated driver to accept status of 9 which some novatel recievers report for a WAAS (SBAS) fix.
  See http://www.novatel.com/support/known-solutions/which-novatel-position-types-correspond-to-the-gga-quality-indicator/
* Contributors: Ed Venator, Edward Venator, Eric Perko, Loy, Mike Purvis, Patrick Barone, Timo Röhling, Vikrant Shah
```
