### PR TITLE
vapor_master: 0.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6166,6 +6166,21 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  vapor_master:
+    doc:
+      type: git
+      url: https://github.com/roshub/vapor_master.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/roshub/vapor_master-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/roshub/vapor_master.git
+      version: master
+    status: developed
   variant:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `vapor_master` to `0.1.0-0`:

- upstream repository: https://github.com/roshub/vapor_master.git
- release repository: https://github.com/roshub/vapor_master-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version of package: `null`

### vapor_master
```
* initial release
```