### PR TITLE
ubiquity_motor: 0.8.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14003,7 +14003,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.7.0-0
+      version: 0.8.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.8.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.7.0-0`

## ubiquity_motor

```
* Added firmware loading tool
* Added misc testing scripts
* Don't die when communication not working, only print error
* Use std mutex/atomic instead of boost
* Reduce print level on integral/pid limits
* Contributors: Rohan Agrawal
```
