### PR TITLE
rc_genicam_api: 2.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3985,7 +3985,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.0.0-0
+      version: 2.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.0.2-0`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.0.0-0`

## rc_genicam_api

```
* Fixed bug in rcg::getEnum() function that may lead to a seg fault
* Minor changes in cmake build files
```
