### PR TITLE
libgazebo9 is not packaged for stretch

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -881,15 +881,16 @@ gawk:
 gazebo:
   arch: [gazebo]
   debian:
-    buster: [gazebo7]
+    buster: [gazebo9]
     jessie: [gazebo7]
-    stretch: [gazebo7]
+    stretch: [gazebo9]
   fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   slackware: [gazebo]
   ubuntu:
     artful: [gazebo9]
     bionic: [gazebo9]
+    cosmic: [gazebo9]
     precise: [gazebo]
     quantal: [gazebo]
     raring: [gazebo]
@@ -923,6 +924,7 @@ gazebo9:
   ubuntu:
     artful: [gazebo9]
     bionic: [gazebo9]
+    cosmic: [gazebo9]
 gcc-arm-none-eabi:
   arch: [gcc-arm-none-eabi]
   debian: [gcc-arm-none-eabi]
@@ -1977,6 +1979,7 @@ libgazebo9-dev:
   ubuntu:
     artful: [libgazebo9-dev]
     bionic: [libgazebo9-dev]
+    cosmic: [libgazebo9-dev]
 libgconf2:
   arch: [gconf]
   debian: [libgconf-2-4]


### PR DESCRIPTION
Follow up to #17750

@clalancette  this will effect melodic packages depending on gazebo they have to use the generic gazebo tag not the version specific one.
@j-rivero FYI

Related to this I'm wondering if we really want the gazebo9 tags in the main rosdep database at all. Like any other system dependency we expect to use the system version on all targeted platforms and as such we should just have one key that everyone uses to avoid this issue of packaging things that are uninstallable due to conflicting apt rules.

From: https://packages.debian.org/search?searchon=names&keywords=libgazebo
```
Package libgazebo7
stretch (stable) (libs): Open Source Robotics Simulator - shared library 
7.3.1+dfsg-3: amd64 arm64 armhf i386 mips mips64el mipsel
sid (unstable) (libs): Open Source Robotics Simulator - shared library 
7.8.1+dfsg-4+b1 [debports]: m68k sh4 
7.5.0+dfsg-1 [debports]: hppa
Package libgazebo7-dbgsym
sid (unstable) (debug): debug symbols for libgazebo7 
7.8.1+dfsg-4+b1 [debports]: m68k sh4 
7.5.0+dfsg-1 [debports]: hppa
Package libgazebo7-dev
stretch (stable) (libdevel): Open Source Robotics Simulator - Development Files 
7.3.1+dfsg-3: amd64 arm64 armhf i386 mips mips64el mipsel
sid (unstable) (libdevel): Open Source Robotics Simulator - Development Files 
7.8.1+dfsg-4+b1 [debports]: m68k sh4 
7.5.0+dfsg-1 [debports]: hppa
Package libgazebo9
buster (testing) (libs): Open Source Robotics Simulator - shared library 
9.4.1+dfsg-1+b1: amd64 i386
sid (unstable) (libs): Open Source Robotics Simulator - shared library 
9.4.1+dfsg-1+b1: amd64 i386
Package libgazebo9-dev
buster (testing) (libdevel): Open Source Robotics Simulator - Development Files 
9.4.1+dfsg-1+b1: amd64 i386
sid (unstable) (libdevel): Open Source Robotics Simulator - Development Files 
9.4.1+dfsg-1+b1: amd64 i386
```