### PR TITLE
Adding python3 dependencies for rqt_bag

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4584,6 +4584,17 @@ python3-babeltrace:
   ubuntu:
     wily: [python3-babeltrace]
     xenial: [python3-babeltrace]
+python3-cairo:
+  arch: [python-cairo]
+  debian: [python3-cairo]
+  fedora: [py3cairo]
+  freebsd: [py3-cairo]
+  gentoo: [dev-python/pycairo]
+  opensuse: [python3-cairo]
+  slackware:
+    slackpkg:
+      packages: [py3cairo]
+  ubuntu: [python3-cairo]
 python3-catkin-pkg-modules:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]
@@ -4687,6 +4698,22 @@ python3-pep8:
 python3-pexpect:
   debian: [python3-pexpect]
   ubuntu: [python3-pexpect]
+python3-pil:
+  alpine: [py3-pillow]
+  arch: [python-pillow]
+  debian: [python3-pil]
+  fedora: [python3-pillow, python3-pillow-qt]
+  freebsd: [py3-pillow]
+  gentoo: [dev-python/pillow]
+  opensuse: [python3-pillow]
+  osx:
+    pip:
+      packages: [Pillow]
+  rhel: [python3-pillow]
+  slackware:
+    slackpkg:
+      packages: [python3-pillow]
+  ubuntu: [python3-pil]
 python3-pkg-resources:
   debian: [python3-pkg-resources]
   fedora: [python3-setuptools]


### PR DESCRIPTION
This adds python3 versions of python-cairo and Pillow (the currently maintained fork of PIL). These are dependencies required by rqt_bag.

Links to distro packages
**python3-cairo**
https://www.archlinux.org/packages/extra/x86_64/python-cairo/
https://packages.debian.org/search?keywords=python3-cairo
https://rpmfind.net/linux/rpm2html/search.php?query=pkgconfig(py3cairo)
https://www.freshports.org/graphics/py3-cairo
https://packages.gentoo.org/packages/dev-python/pycairo
https://software.opensuse.org/package/python3-cairo
https://slackbuilds.org/repository/14.1/python/py3cairo/
https://packages.ubuntu.com/search?keywords=python3-cairo

**python3-imaging**
https://pkgs.alpinelinux.org/package/edge/main/x86/py3-pillow
https://www.archlinux.org/packages/community/x86_64/python-pillow/
https://packages.debian.org/jessie/python3-pil
https://rpmfind.net/linux/rpm2html/search.php?query=python3-Pillow
https://fedora.pkgs.org/28/fedora-x86_64/python3-pillow-qt-5.1.0-1.fc28.x86_64.rpm.html
https://www.freshports.org/graphics/py3-pillow
https://software.opensuse.org/package/python3-Pillow
https://slackbuilds.org/repository/14.1/libraries/python3-pillow/
https://packages.ubuntu.com/search?keywords=python3-pil&searchon=names