### PR TITLE
catch_ros: 0.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -470,7 +470,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/AIS-Bonn/catch_ros-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/AIS-Bonn/catch_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros` to `0.3.0-0`:

- upstream repository: https://github.com/AIS-Bonn/catch_ros
- release repository: https://github.com/AIS-Bonn/catch_ros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.0-0`

## catch_ros

```
* cmake: catch_add_rostest() add new target as dependency of 'tests' target
  (issue: #8, PR: #9)
* README.md: add CATCH_CONFIG_MAIN hint (issue: #7)
* README: update link to the catch repo
* updated catch to 2.4.2 (PR: #6)
* ros_junit_reporter: fix warnings
* Contributors: Max Schwarz, Mez Gebre
```
