### PR TITLE
mavros: 0.28.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2206,7 +2206,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.27.0-0
+      version: 0.28.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.28.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.27.0-0`

## libmavconn

```
* libmavconn: add the possibility to set the source component ID through the send_message method
* Contributors: TSC21
```

## mavros

```
* plugin:param: publish new param value
* Merge pull request #1148 <https://github.com/mavlink/mavros/issues/1148> from Kiwa21/pr-param-value
  param plugin : add msg and publisher to catch latest param value
* sys_status: fix build
* sys_state: Small cleanup of #1150 <https://github.com/mavlink/mavros/issues/1150>
* VehicleInfo : add srv into sys_status plugin to request basic info from vehicle
* sys_status: Fix #1151 <https://github.com/mavlink/mavros/issues/1151> bug - incorrect hex print
* plugins:sys_status: Update diag decoder
* frame_tf: mavlink_urt_to_covariance_matrix: make matrix symetrical
* uas_data: add comment on the reverse tf fcu_frd->fcu
* odom: add ODOMETRY handler and publisher
* Handle LOCAL_POSITION_NED_COV messages, add pose_cov, velocity_cov, accel topics
* sys_status : add MAV_TYPE as a parameter
* rc_io: extend handle_servo_output_raw to 16 channels
* param plugin : add msg and publisher to catch latest param value
* plugin:command: Update for C++11, style fix
  Signed-off-by: Vladimir Ermakov <vooon341@gmail.com>
* Fixed NavSatFix bug in mavcmd takeoffcur and landcur
* Fix mavros/param.py to work in python2 and python3, #940 <https://github.com/mavlink/mavros/issues/940>
  Simplify python3 fixes, #940 <https://github.com/mavlink/mavros/issues/940>
  Remove unnecessary functools
* Fix mavros/param.py to work in python2 and python3, #940 <https://github.com/mavlink/mavros/issues/940>
  Simplify python3 fixes, #940 <https://github.com/mavlink/mavros/issues/940>
* Fix mavros/param.py to work in python2 and python3, #940 <https://github.com/mavlink/mavros/issues/940>
* correct the to_string function
* set value back to 30
* add autogenerated to_string function
* style clean up
* Use component_id to determine message sender
* change message name from COMPANION_STATUS to COMPANION_PROCESS_STATUS
* change message to include pid
* Change from specific avoidance status message to a more generic companion status message
* add plugin to receive avoidance status message
* Added RPYrT and uncrustified.
  Pushing version without spaces.
  Version with tabs?
  Fixed all?
  Finally fixed.
  Fixed requestes by @vooon
  Fixed a def.
  Fixed log format.
  Fixed time for log.
* apm_config: enable timesync and system for ardupilot
* Contributors: Dan Nix, Gregoire Linard, Oleg Kalachev, Randy Mackay, TSC21, Vladimir Ermakov, baumanta, fnoop, pedro-roque
```

## mavros_extras

```
* odom: add ODOMETRY handler and publisher
* remove newlines after doxygen
* style clean up
* Use component_id to determine message sender
* send out companion status as heartbeat
* change message name from COMPANION_STATUS to COMPANION_PROCESS_STATUS
* change message to include pid
* Change from specific avoidance status message to a more generic companion status message
* add plugin to receive avoidance status message
* Contributors: TSC21, baumanta
```

## mavros_msgs

```
* plugin:param: publish new param value
* Merge pull request #1148 <https://github.com/mavlink/mavros/issues/1148> from Kiwa21/pr-param-value
  param plugin : add msg and publisher to catch latest param value
* msgs: update Header
* sys_state: Small cleanup of #1150 <https://github.com/mavlink/mavros/issues/1150>
* VehicleInfo : add srv into sys_status plugin to request basic info from vehicle
* mavros_msgs/msg/LogData.msg: Define "offset" field to be of type uint32
* param plugin : add msg and publisher to catch latest param value
* style clean up
* Use component_id to determine message sender
* change message name from COMPANION_STATUS to COMPANION_PROCESS_STATUS
* change message to include pid
* Change from specific avoidance status message to a more generic companion status message
* Add message for avoidance status
* Contributors: Gregoire Linard, Vladimir Ermakov, baumanta, mlvov
```

## test_mavros

- No changes
