### PR TITLE
nonpersistent_voxel_layer: 1.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7347,7 +7347,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
-      version: 1.1.2-0
+      version: 1.1.3-0
     source:
       type: git
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nonpersistent_voxel_layer` to `1.1.3-0`:

- upstream repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
- release repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.1.2-0`
