### PR TITLE
teleop_tools: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5694,7 +5694,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.2.6-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.3.0-0`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.6-0`

## joy_teleop

```
* Fill in the timestamp of outgoing messages, if applicable.
* add service example
* Add option for persistent service, defaulted false
* Contributors: AndyZe, Jeremie Deray, Bence Magyar
```

## key_teleop

- No changes

## mouse_teleop

- No changes

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
