### PR TITLE
spatio_temporal_voxel_layer: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12815,6 +12815,7 @@ repositories:
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
       version: 1.2.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
       version: kinetic-devel

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12813,7 +12813,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
-      version: 1.1.4-2
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spatio_temporal_voxel_layer` to `1.2.0-0`:

- upstream repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
- release repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.1.4-2`
