### PR TITLE
dynamixel_sdk: 3.7.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2393,7 +2393,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.6.2-0
+      version: 3.7.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `3.6.2-0`

## dynamixel_sdk

```
* added clear instruction [#269](https://github.com/ROBOTIS-GIT/DynamixelSDK/issues/269)
* removed busy waiting for rxPacket()
* fixed addStuffing() function (reduced stack memory usage)
* fixed memory issues [#268](https://github.com/ROBOTIS-GIT/DynamixelSDK/issues/268)
* fixed the broadcast ping bug in dxl_monitor
* Contributors: Gilbert, Zerom, Darby Lim, Kurt, Pyo
```
