### PR TITLE
pybind11_catkin: 2.2.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3736,6 +3736,17 @@ repositories:
       url: https://github.com/stonier/py_trees_ros.git
       version: release/0.5-melodic
     status: maintained
+  pybind11_catkin:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wxmerkt/pybind11_catkin-release.git
+      version: 2.2.4-0
+    source:
+      type: git
+      url: https://github.com/ipab-slmc/pybind11_catkin.git
+      version: master
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.2.4-0`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
