### PR TITLE
optpp_catkin: 2.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3176,6 +3176,17 @@ repositories:
       url: https://github.com/tork-a/openrtm_aist_python-release.git
       version: 1.1.0-0
     status: maintained
+  optpp_catkin:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipab-slmc/optpp_catkin-release.git
+      version: 2.4.0-0
+    source:
+      type: git
+      url: https://github.com/ipab-slmc/optpp_catkin.git
+      version: master
+    status: maintained
   orb_slam2_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `optpp_catkin` to `2.4.0-0`:

- upstream repository: https://github.com/ipab-slmc/optpp_catkin.git
- release repository: https://github.com/ipab-slmc/optpp_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
