### PR TITLE
optpp_catkin: 2.4.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7987,6 +7987,17 @@ repositories:
       url: https://github.com/ros-perception/openslam_gmapping.git
       version: master
     status: maintained
+  optpp_catkin:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipab-slmc/optpp_catkin-release.git
+      version: 2.4.0-1
+    source:
+      type: git
+      url: https://github.com/ipab-slmc/optpp_catkin.git
+      version: master
+    status: maintained
   optris_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `optpp_catkin` to `2.4.0-1`:

- upstream repository: https://github.com/ipab-slmc/optpp_catkin.git
- release repository: https://github.com/ipab-slmc/optpp_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
