### PR TITLE
yp-spur: 1.15.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -17776,7 +17776,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.15.2-0
+      version: 1.15.3-0
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.15.3-0`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.15.2-0`
