### PR TITLE
optpp_catkin: 2.4.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8009,7 +8009,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipab-slmc/optpp_catkin-release.git
-      version: 2.4.0-1
+      version: 2.4.0-3
     source:
       type: git
       url: https://github.com/ipab-slmc/optpp_catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `optpp_catkin` to `2.4.0-3`:

- upstream repository: https://github.com/ipab-slmc/optpp_catkin.git
- release repository: https://github.com/ipab-slmc/optpp_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.4.0-1`
