### PR TITLE
optpp_catkin: 2.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3198,7 +3198,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/optpp_catkin-release.git
-      version: 2.4.0-0
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ipab-slmc/optpp_catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `optpp_catkin` to `2.4.0-1`:

- upstream repository: https://github.com/ipab-slmc/optpp_catkin.git
- release repository: https://github.com/ipab-slmc/optpp_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.4.0-0`
