### PR TITLE
exotica: 5.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1001,6 +1001,34 @@ repositories:
       url: https://github.com/jbohren/executive_smach_visualization-release.git
       version: 2.0.2-0
     status: unmaintained
+  exotica:
+    doc:
+      type: git
+      url: https://github.com/ipab-slmc/exotica.git
+      version: master
+    release:
+      packages:
+      - exotica
+      - exotica_aico_solver
+      - exotica_collision_scene_fcl
+      - exotica_collision_scene_fcl_latest
+      - exotica_core
+      - exotica_core_task_maps
+      - exotica_examples
+      - exotica_ik_solver
+      - exotica_levenberg_marquardt_solver
+      - exotica_ompl_solver
+      - exotica_python
+      - exotica_time_indexed_rrt_connect_solver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipab-slmc/exotica-release.git
+      version: 5.0.0-0
+    source:
+      type: git
+      url: https://github.com/ipab-slmc/exotica.git
+      version: master
+    status: developed
   exotica_val_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica` to `5.0.0-0`:

- upstream repository: https://github.com/ipab-slmc/exotica.git
- release repository: https://github.com/ipab-slmc/exotica-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
