### PR TITLE
sick_tim: 0.0.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14915,7 +14915,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.13-0
+      version: 0.0.14-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.14-0`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.13-0`

## sick_tim

```
* Install udev rules during binary package installation
* TiM551/TiM571: Fix HEADER_FIELDS calculation when device name is not set
  Fixes #72 <https://github.com/uos/sick_tim/issues/72>.
* sick_mrs1000: Fix missing cloud time stamp (#69 <https://github.com/uos/sick_tim/issues/69>)
  Fixes #68 <https://github.com/uos/sick_tim/issues/68>.
* Contributors: Martin Günther
```
