### PR TITLE
Adding sciurus17 to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12539,6 +12539,12 @@ repositories:
       url: https://github.com/fzi-forschungszentrum-informatik/schunk_svh_driver.git
       version: master
     status: developed
+  sciurus17:
+    doc:
+      type: git
+      url: https://github.com/rt-net/sciurus17_ros.git
+      version: master
+    status: developed
   scratch4robots:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add sciurus17 for ROS Kinetic to be doc'd and indexed.