### PR TITLE
Revert uuv_simulator to 0.6.2

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14377,7 +14377,6 @@ repositories:
       - uuv_gazebo_plugins
       - uuv_gazebo_ros_plugins
       - uuv_gazebo_ros_plugins_msgs
-      - uuv_gazebo_worlds
       - uuv_sensor_ros_plugins
       - uuv_sensor_ros_plugins_msgs
       - uuv_simulator

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14390,7 +14390,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uuvsimulator/uuv_simulator-release.git
-      version: 0.6.3-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_simulator.git


### PR DESCRIPTION
Reverts #19720

Many of the sourcedebs were not building from this release such as http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__uuv_gazebo_ros_plugins__ubuntu_xenial__source/

It appears that all the tags were not pushed to the release repository: https://github.com/uuvsimulator/uuv_simulator-release
```
00:00:27.279 Invoking 'git clone --branch debian/ros-kinetic-uuv-gazebo-ros-plugins_0.6.3-0_xenial --depth 1 --no-single-branch https://github.com/uuvsimulator/uuv_simulator-release.git /tmp/sourcedeb/source'
00:00:27.285 Cloning into '/tmp/sourcedeb/source'...
00:00:27.570 fatal: Remote branch debian/ros-kinetic-uuv-gazebo-ros-plugins_0.6.3-0_xenial not found in upstream origin
```

@musamarcusso FYI I suspect that there's a dependency that didn't resolve and bloom was told to continue anyway without resolving for all platforms.