### PR TITLE
removing force_torque_sensor and ati_force_torque

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -577,7 +577,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/ati_force_torque-release.git
-      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/KITrobotics/ati_force_torque.git
@@ -3065,7 +3064,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.8.1-2
     source:
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git


### PR DESCRIPTION
There are no appropriate tags in the release repos so they have never successfully built.
https://github.com/KITrobotics/force_torque_sensor-release
This reverts #19710 and #19711

@GDwag FYI