### PR TITLE
Removing talos_robot from the release section as it does not have the…

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13176,7 +13176,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git
-      version: 1.0.44-0
   tango_ros:
     doc:
       type: git


### PR DESCRIPTION
… required tags in the release repo


@v-lopez  this is a partial revert of #19805

From: http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__talos_description__ubuntu_xenial__source/25/console
```
00:04:00.760 Invoking 'git clone --branch debian/ros-kinetic-talos-description_1.0.44-0_xenial --depth 1 --no-single-branch https://github.com/pal-gbp/talos_robot-release.git /tmp/sourcedeb/source'
00:04:00.764 Cloning into '/tmp/sourcedeb/source'...
00:04:01.046 fatal: Remote branch debian/ros-kinetic-talos-description_1.0.44-0_xenial not found in upstream origin
```