### PR TITLE
reintegrate Ardent, Bouncy and Crystal from ros2/rosdistro

### DIFF
--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -34,7 +34,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: master
+      version: ardent
     status: maintained
   ament_cmake_ros:
     release:
@@ -45,7 +45,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: master
+      version: ardent
     status: maintained
   ament_index:
     release:
@@ -59,7 +59,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_index.git
-      version: master
+      version: ardent
     status: maintained
   ament_lint:
     release:
@@ -93,7 +93,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: master
+      version: ardent
     status: maintained
   ament_package:
     release:
@@ -104,7 +104,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_package.git
-      version: master
+      version: ardent
     status: maintained
   ament_tools:
     release:
@@ -115,7 +115,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_tools.git
-      version: master
+      version: ardent
     status: maintained
   cartographer:
     release:
@@ -126,7 +126,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: ardent
     status: maintained
   cartographer_ros:
     release:
@@ -140,7 +140,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/cartographer_ros.git
-      version: ros2
+      version: ardent
     status: maintained
   class_loader:
     release:
@@ -151,7 +151,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/class_loader.git
-      version: ros2
+      version: ardent
     status: maintained
   common_interfaces:
     release:
@@ -175,7 +175,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: master
+      version: ardent
     status: maintained
   console_bridge:
     release:
@@ -212,7 +212,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/demos.git
-      version: master
+      version: ardent
     status: maintained
   depthimage_to_laserscan:
     release:
@@ -223,7 +223,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/depthimage_to_laserscan.git
-      version: ros2
+      version: ardent
     status: maintained
   ecl_tools:
     release:
@@ -245,7 +245,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: master
+      version: ardent
     status: maintained
   examples:
     release:
@@ -268,7 +268,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/examples.git
-      version: master
+      version: ardent
     status: maintained
   fastcdr:
     release:
@@ -307,7 +307,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: ros2
+      version: ardent
     status: maintained
   googletest:
     release:
@@ -321,7 +321,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/googletest.git
-      version: ros2
+      version: ardent
     status: maintained
   joystick_drivers:
     release:
@@ -334,7 +334,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/joystick_drivers.git
-      version: ros2
+      version: ardent
     status: maintained
   kdl_parser:
     release:
@@ -345,7 +345,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/kdl_parser.git
-      version: ros2
+      version: ardent
     status: maintained
   launch:
     release:
@@ -359,7 +359,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/launch.git
-      version: master
+      version: ardent
     status: maintained
   navigation:
     release:
@@ -373,7 +373,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/navigation.git
-      version: ros2
+      version: ardent
     status: maintained
   orocos_kinematics_dynamics:
     release:
@@ -386,7 +386,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: ros2
+      version: ardent
     status: maintained
   osrf_pycommon:
     release:
@@ -408,7 +408,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/pcl_conversions.git
-      version: ros2
+      version: ardent
     status: maintained
   pluginlib:
     doc:
@@ -423,7 +423,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: ros2
+      version: ardent
     status: maintained
   poco_vendor:
     release:
@@ -434,7 +434,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/poco_vendor.git
-      version: master
+      version: ardent
     status: maintained
   rcl:
     release:
@@ -448,7 +448,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: master
+      version: ardent
     status: maintained
   rcl_interfaces:
     release:
@@ -464,7 +464,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: master
+      version: ardent
     status: maintained
   rclcpp:
     release:
@@ -478,7 +478,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: master
+      version: ardent
     status: maintained
   rclpy:
     release:
@@ -489,7 +489,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: master
+      version: ardent
     status: maintained
   rcutils:
     release:
@@ -500,7 +500,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: master
+      version: ardent
     status: maintained
   realtime_support:
     release:
@@ -514,7 +514,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: master
+      version: ardent
     status: maintained
   resource_retriever:
     doc:
@@ -532,7 +532,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: ros2
+      version: ardent
     status: maintained
   rmw:
     release:
@@ -546,7 +546,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: master
+      version: ardent
     status: maintained
   rmw_fastrtps:
     release:
@@ -560,7 +560,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      version: ardent
     status: maintained
   rmw_implementation:
     release:
@@ -571,7 +571,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: master
+      version: ardent
     status: maintained
   rmw_opensplice:
     release:
@@ -587,7 +587,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_opensplice.git
-      version: master
+      version: ardent
     status: maintained
   robot_state_publisher:
     release:
@@ -598,7 +598,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/robot_state_publisher.git
-      version: ros2
+      version: ardent
     status: maintained
   ros1_bridge:
     release:
@@ -609,7 +609,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
-      version: master
+      version: ardent
     status: maintained
   ros2cli:
     release:
@@ -629,7 +629,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: master
+      version: ardent
     status: maintained
   ros_astra_camera:
     release:
@@ -642,7 +642,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros_astra_camera.git
-      version: ros2
+      version: ardent
     status: maintained
   ros_environment:
     release:
@@ -663,8 +663,8 @@ repositories:
       version: 0.4.0-0
     source:
       type: git
-      url: https://github.com/nuclearsandwich/ros_workspace.git
-      version: master
+      url: https://github.com/ros2/ros_workspace.git
+      version: ardent
     status: maintained
   rosidl:
     release:
@@ -685,7 +685,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: master
+      version: ardent
     status: maintained
   rosidl_dds:
     release:
@@ -698,7 +698,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: master
+      version: ardent
     status: maintained
   rosidl_typesupport:
     release:
@@ -714,7 +714,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
+      version: ardent
     status: maintained
   rviz:
     doc:
@@ -737,7 +737,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rviz.git
-      version: ros2
+      version: ardent
     status: maintained
   sros2:
     release:
@@ -748,7 +748,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/sros2.git
-      version: master
+      version: ardent
     status: maintained
   teleop_twist_joy:
     release:
@@ -759,7 +759,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: ros2
+      version: ardent
     status: maintained
   teleop_twist_keyboard:
     release:
@@ -770,7 +770,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/teleop_twist_keyboard.git
-      version: ros2
+      version: ardent
     status: maintained
   tinyxml2_vendor:
     release:
@@ -781,7 +781,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: master
+      version: ardent
     status: maintained
   tinyxml_vendor:
     release:
@@ -792,7 +792,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
-      version: master
+      version: ardent
     status: maintained
   tlsf:
     release:
@@ -803,7 +803,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: master
+      version: ardent
     status: maintained
   turtlebot2_demo:
     doc:
@@ -826,7 +826,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
+      version: ardent
     status: maintained
   uncrustify:
     release:
@@ -837,7 +837,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/uncrustify.git
-      version: master
+      version: ardent
     status: maintained
   urdf:
     release:
@@ -848,7 +848,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: ros2
+      version: ardent
     status: maintained
   urdfdom:
     release:
@@ -917,7 +917,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/vision_opencv.git
-      version: ros2
+      version: ardent
     status: maintained
 type: distribution
 version: 2

--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -867,6 +867,25 @@ repositories:
       url: https://github.com/ros2/urdfdom_headers.git
       version: ros2
     status: maintained
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: ardent
+    release:
+      packages:
+      - desktop
+      - ros_base
+      - ros_core
+      tags:
+        release: release/ardent/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: ardent
+    status: developed
   vision_msgs:
     doc:
       type: git

--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -806,18 +806,23 @@ repositories:
       version: master
     status: maintained
   turtlebot2_demo:
+    doc:
+      type: git
+      url: https://github.com/ros2/turtlebot2_demo.git
+      version: ardent
     release:
       packages:
       - depthimage_to_pointcloud2
       - turtlebot2_amcl
       - turtlebot2_cartographer
+      - turtlebot2_demo
       - turtlebot2_drivers
       - turtlebot2_follower
       - turtlebot2_teleop
       tags:
         release: release/ardent/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/ros2/turtlebot2_demo.git

--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -880,7 +880,7 @@ repositories:
       tags:
         release: release/ardent/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.4.0-0
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros2/variants.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -109,6 +109,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_lint-release.git
       version: 0.5.2-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_lint.git
       version: master

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -996,7 +996,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.5.0-0
+      version: 0.5.2-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1254,7 +1254,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       test_commits: false
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -230,7 +230,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.5.0-0
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros2/common_interfaces.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -307,6 +307,46 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: bouncy
     status: developed
+  ecl_core:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.0-bouncy
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.0-bouncy
+    status: maintained
   ecl_lite:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -485,7 +485,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.5.2-0
+      version: 0.6.0-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -692,7 +692,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -624,7 +624,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1289,11 +1289,14 @@ repositories:
       version: ros2
     release:
       packages:
+      - cv_bridge
       - image_geometry
+      - opencv_tests
+      - vision_opencv
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.0.1-0
+      version: 2.0.3-0
     source:
       test_commits: false
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -860,7 +860,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.5.0-1
+      version: 0.5.1-0
     source:
       test_commits: false
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -386,7 +386,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.9.1-0
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/ros2/geometry2.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1182,13 +1182,14 @@ repositories:
       - depthimage_to_pointcloud2
       - turtlebot2_amcl
       - turtlebot2_cartographer
+      - turtlebot2_demo
       - turtlebot2_drivers
       - turtlebot2_follower
       - turtlebot2_teleop
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot2_demo-release.git
-      version: 0.5.0-2
+      version: 0.5.1-0
     source:
       test_commits: false
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -703,6 +703,21 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: bouncy
     status: developed
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees.git
+      version: release/0.8.x
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/stonier/py_trees-release.git
+      version: 0.8.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees.git
+      version: release/0.8.x
+    status: developed
   py_trees_msgs:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -186,7 +186,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 2.1.1-0
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros2/cartographer.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -10,7 +10,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: master
+      version: bouncy
     release:
       packages:
       - ament_cmake
@@ -38,13 +38,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: master
+      version: bouncy
     status: developed
   ament_cmake_ros:
     doc:
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -53,13 +53,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: master
+      version: bouncy
     status: developed
   ament_index:
     doc:
       type: git
       url: https://github.com/ament/ament_index.git
-      version: master
+      version: bouncy
     release:
       packages:
       - ament_index_cpp
@@ -71,13 +71,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_index.git
-      version: master
+      version: bouncy
     status: developed
   ament_lint:
     doc:
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: master
+      version: bouncy
     release:
       packages:
       - ament_clang_format
@@ -112,13 +112,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: master
+      version: bouncy
     status: developed
   ament_package:
     doc:
       type: git
       url: https://github.com/ament/ament_package.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -127,13 +127,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_package.git
-      version: master
+      version: bouncy
     status: developed
   ament_tools:
     doc:
       type: git
       url: https://github.com/ament/ament_tools.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -142,7 +142,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/ament_tools.git
-      version: master
+      version: bouncy
     status: end-of-life
     status_description: The build tool has been replaced by colcon
   angles:
@@ -164,7 +164,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -173,13 +173,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: bouncy
     status: developed
   cartographer_ros:
     doc:
       type: git
       url: https://github.com/ros2/cartographer_ros.git
-      version: ros2
+      version: bouncy
     release:
       packages:
       - cartographer_ros
@@ -191,13 +191,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/cartographer.git
-      version: ros2
+      version: bouncy
     status: developed
   class_loader:
     doc:
       type: git
       url: https://github.com/ros/class_loader.git
-      version: ros2
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -207,13 +207,13 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/ros/class_loader.git
-      version: ros2
+      version: bouncy
     status: maintained
   common_interfaces:
     doc:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: master
+      version: bouncy
     release:
       packages:
       - actionlib_msgs
@@ -235,7 +235,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: master
+      version: bouncy
     status: developed
   console_bridge:
     doc:
@@ -257,7 +257,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/demos.git
-      version: master
+      version: bouncy
     release:
       packages:
       - composition
@@ -281,13 +281,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/demos.git
-      version: master
+      version: bouncy
     status: maintained
   depthimage_to_laserscan:
     doc:
       type: git
       url: https://github.com/ros2/depthimage_to_laserscan.git
-      version: ros2
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -296,13 +296,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/depthimage_to_laserscan.git
-      version: ros2
+      version: bouncy
     status: developed
   example_interfaces:
     doc:
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -311,13 +311,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: master
+      version: bouncy
     status: developed
   examples:
     doc:
       type: git
       url: https://github.com/ros2/examples.git
-      version: master
+      version: bouncy
     release:
       packages:
       - examples_rclcpp_minimal_client
@@ -338,7 +338,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/examples.git
-      version: master
+      version: bouncy
     status: developed
   fastcdr:
     doc:
@@ -376,7 +376,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: ros2
+      version: bouncy
     release:
       packages:
       - tf2
@@ -391,7 +391,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: ros2
+      version: bouncy
     status: developed
   googletest:
     release:
@@ -433,7 +433,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/kdl_parser.git
-      version: ros2
+      version: bouncy
     status: maintained
   laser_geometry:
     release:
@@ -450,7 +450,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch.git
-      version: master
+      version: bouncy
     release:
       packages:
       - launch
@@ -464,7 +464,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/launch.git
-      version: master
+      version: bouncy
     status: maintained
   libyaml_vendor:
     release:
@@ -475,13 +475,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
-      version: master
+      version: bouncy
     status: maintained
   navigation:
     doc:
       type: git
       url: https://github.com/ros2/navigation.git
-      version: ros2
+      version: bouncy
     release:
       packages:
       - amcl
@@ -493,7 +493,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/navigation.git
-      version: ros2
+      version: bouncy
     status: developed
   navigation_msgs:
     release:
@@ -512,7 +512,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: ros2
+      version: bouncy
     release:
       packages:
       - orocos_kdl
@@ -523,7 +523,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: ros2
+      version: bouncy
     status: developed
   osrf_pycommon:
     release:
@@ -560,13 +560,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/pcl_conversions.git
-      version: ros2
+      version: bouncy
     status: maintained
   pluginlib:
     doc:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: ros2
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -575,13 +575,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: ros2
+      version: bouncy
     status: developed
   poco_vendor:
     doc:
       type: git
       url: https://github.com/ros2/poco_vendor.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -590,13 +590,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/poco_vendor.git
-      version: master
+      version: bouncy
     status: developed
   rcl:
     doc:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rcl
@@ -609,13 +609,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: master
+      version: bouncy
     status: maintained
   rcl_interfaces:
     doc:
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: master
+      version: bouncy
     release:
       packages:
       - builtin_interfaces
@@ -630,13 +630,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: master
+      version: bouncy
     status: maintained
   rclcpp:
     doc:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rclcpp
@@ -648,13 +648,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: master
+      version: bouncy
     status: maintained
   rclpy:
     doc:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -663,7 +663,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: master
+      version: bouncy
     status: maintained
   rcutils:
     release:
@@ -674,13 +674,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: master
+      version: bouncy
     status: maintained
   realtime_support:
     doc:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rttest
@@ -692,7 +692,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: master
+      version: bouncy
     status: maintained
   resource_retriever:
     doc:
@@ -716,7 +716,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rmw
@@ -728,13 +728,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: master
+      version: bouncy
     status: maintained
   rmw_connext:
     doc:
       type: git
       url: https://github.com/ros2/rmw_connext.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rmw_connext_cpp
@@ -746,13 +746,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_connext.git
-      version: master
+      version: bouncy
     status: developed
   rmw_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      version: bouncy
     release:
       packages:
       - fastrtps_cmake_module
@@ -764,13 +764,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      version: bouncy
     status: developed
   rmw_implementation:
     doc:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -779,13 +779,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: master
+      version: bouncy
     status: developed
   rmw_opensplice:
     doc:
       type: git
       url: https://github.com/ros2/rmw_opensplice.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rmw_opensplice_cpp
@@ -796,7 +796,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_opensplice.git
-      version: master
+      version: bouncy
     status: developed
   robot_state_publisher:
     release:
@@ -807,13 +807,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/robot_state_publisher.git
-      version: ros2
+      version: bouncy
     status: maintained
   ros1_bridge:
     doc:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -823,13 +823,13 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/ros2/ros1_bridge.git
-      version: master
+      version: bouncy
     status: developed
   ros2cli:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: master
+      version: bouncy
     release:
       packages:
       - ros2cli
@@ -849,13 +849,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: master
+      version: bouncy
     status: developed
   ros_astra_camera:
     doc:
       type: git
       url: https://github.com/ros2/ros_astra_camera.git
-      version: ros2
+      version: bouncy
     release:
       packages:
       - astra_camera
@@ -866,7 +866,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros_astra_camera.git
-      version: ros2
+      version: bouncy
     status: developed
   ros_environment:
     doc:
@@ -894,7 +894,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rosidl_cmake
@@ -911,13 +911,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: master
+      version: bouncy
     status: developed
   rosidl_dds:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rosidl_generator_dds_idl
@@ -928,13 +928,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: master
+      version: bouncy
     status: developed
   rosidl_defaults:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rosidl_default_generators
@@ -946,13 +946,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: master
+      version: bouncy
     status: developed
   rosidl_python:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: master
+      version: bouncy
     release:
       packages:
       - python_cmake_module
@@ -964,13 +964,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: master
+      version: bouncy
     status: developed
   rosidl_typesupport:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
+      version: bouncy
     release:
       packages:
       - rosidl_typesupport_c
@@ -982,13 +982,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
+      version: bouncy
     status: developed
   rosidl_typesupport_connext:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
-      version: master
+      version: bouncy
     release:
       packages:
       - connext_cmake_module
@@ -1001,13 +1001,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
-      version: master
+      version: bouncy
     status: developed
   rosidl_typesupport_opensplice:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
-      version: master
+      version: bouncy
     release:
       packages:
       - opensplice_cmake_module
@@ -1020,7 +1020,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
-      version: master
+      version: bouncy
     status: developed
   rviz:
     release:
@@ -1041,13 +1041,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rviz.git
-      version: ros2
+      version: bouncy
     status: maintained
   sros2:
     doc:
       type: git
       url: https://github.com/ros2/sros2.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -1056,7 +1056,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/sros2.git
-      version: master
+      version: bouncy
     status: developed
   teleop_twist_joy:
     release:
@@ -1067,13 +1067,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: ros2
+      version: bouncy
     status: maintained
   teleop_twist_keyboard:
     doc:
       type: git
       url: https://github.com/ros2/teleop_twist_keyboard.git
-      version: ros2
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -1082,13 +1082,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/teleop_twist_keyboard.git
-      version: ros2
+      version: bouncy
     status: maintained
   tinyxml2_vendor:
     doc:
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -1097,13 +1097,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: master
+      version: bouncy
     status: maintained
   tinyxml_vendor:
     doc:
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
-      version: master
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -1112,7 +1112,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
-      version: master
+      version: bouncy
     status: maintained
   tlsf:
     release:
@@ -1123,13 +1123,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: master
+      version: bouncy
     status: maintained
   turtlebot2_demo:
     doc:
       type: git
       url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
+      version: bouncy
     release:
       packages:
       - depthimage_to_pointcloud2
@@ -1146,13 +1146,13 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/ros2/turtlebot2_demo.git
-      version: master
+      version: bouncy
     status: developed
   uncrustify:
     doc:
       type: git
       url: https://github.com/ament/uncrustify.git
-      version: master
+      version: bouncy
     release:
       packages:
       - uncrustify_vendor
@@ -1163,13 +1163,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/uncrustify.git
-      version: master
+      version: bouncy
     status: maintained
   urdf:
     doc:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: ros2
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -1178,13 +1178,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: ros2
+      version: bouncy
     status: maintained
   urdfdom:
     doc:
       type: git
       url: https://github.com/ros2/urdfdom.git
-      version: ros2
+      version: bouncy
     release:
       tags:
         release: release/bouncy/{package}/{version}
@@ -1193,7 +1193,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/urdfdom.git
-      version: ros2
+      version: bouncy
     status: maintained
   urdfdom_headers:
     doc:

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -307,6 +307,29 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: bouncy
     status: developed
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.0-bouncy
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.0-bouncy
+    status: maintained
   ecl_tools:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -36,6 +36,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_cmake-release.git
       version: 0.5.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_cmake.git
       version: bouncy
@@ -51,6 +52,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
       version: bouncy
@@ -69,6 +71,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_index-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_index.git
       version: bouncy
@@ -125,6 +128,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_package-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_package.git
       version: bouncy
@@ -140,6 +144,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_tools-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_tools.git
       version: bouncy
@@ -171,6 +176,7 @@ repositories:
       url: https://github.com/ros2-gbp/cartographer-release.git
       version: 2.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/cartographer.git
       version: bouncy
@@ -189,6 +195,7 @@ repositories:
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
       version: 2.1.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/cartographer.git
       version: bouncy
@@ -232,6 +239,7 @@ repositories:
       url: https://github.com/ros2-gbp/common_interfaces-release.git
       version: 0.5.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/common_interfaces.git
       version: bouncy
@@ -278,6 +286,7 @@ repositories:
       url: https://github.com/ros2-gbp/demos-release.git
       version: 0.5.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/demos.git
       version: bouncy
@@ -293,6 +302,7 @@ repositories:
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
       version: 2.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: bouncy
@@ -308,6 +318,7 @@ repositories:
       url: https://github.com/ros2-gbp/example_interfaces-release.git
       version: 0.5.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/example_interfaces.git
       version: bouncy
@@ -335,6 +346,7 @@ repositories:
       url: https://github.com/ros2-gbp/examples-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/examples.git
       version: bouncy
@@ -388,6 +400,7 @@ repositories:
       url: https://github.com/ros2-gbp/geometry2-release.git
       version: 0.9.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/geometry2.git
       version: bouncy
@@ -419,6 +432,7 @@ repositories:
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
       version: 2.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/joystick_drivers.git
       version: bouncy
@@ -430,6 +444,7 @@ repositories:
       url: https://github.com/ros2-gbp/kdl_parser-release.git
       version: 2.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/kdl_parser.git
       version: bouncy
@@ -473,6 +488,7 @@ repositories:
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
       version: 1.0.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
       version: bouncy
@@ -491,6 +507,7 @@ repositories:
       url: https://github.com/ros2-gbp/navigation-release.git
       version: 3.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/navigation.git
       version: bouncy
@@ -521,6 +538,7 @@ repositories:
       url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
       version: 3.0.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
       version: bouncy
@@ -557,6 +575,7 @@ repositories:
       url: https://github.com/ros2-gbp/pcl_conversions-release.git
       version: 2.0.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/pcl_conversions.git
       version: bouncy
@@ -587,6 +606,7 @@ repositories:
       url: https://github.com/ros2-gbp/poco_vendor-release.git
       version: 1.1.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/poco_vendor.git
       version: bouncy
@@ -628,6 +648,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
       version: 0.5.0-3
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
       version: bouncy
@@ -646,6 +667,7 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
       version: bouncy
@@ -673,6 +695,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcutils-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcutils.git
       version: bouncy
@@ -691,6 +714,7 @@ repositories:
       url: https://github.com/ros2-gbp/realtime_support-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/realtime_support.git
       version: bouncy
@@ -727,6 +751,7 @@ repositories:
       url: https://github.com/ros2-gbp/rmw-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw.git
       version: bouncy
@@ -745,6 +770,7 @@ repositories:
       url: https://github.com/ros2-gbp/rmw_connext-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_connext.git
       version: bouncy
@@ -763,6 +789,7 @@ repositories:
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
       version: bouncy
@@ -778,6 +805,7 @@ repositories:
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
       version: 0.5.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_implementation.git
       version: bouncy
@@ -795,6 +823,7 @@ repositories:
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
       version: 0.5.2-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_opensplice.git
       version: bouncy
@@ -806,6 +835,7 @@ repositories:
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
       version: 2.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/robot_state_publisher.git
       version: bouncy
@@ -866,6 +896,7 @@ repositories:
       url: https://github.com/ros2-gbp/ros_astra_camera-release.git
       version: 2.1.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros_astra_camera.git
       version: bouncy
@@ -911,6 +942,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl.git
       version: bouncy
@@ -928,6 +960,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dds.git
       version: bouncy
@@ -946,6 +979,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
       version: bouncy
@@ -983,6 +1017,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
       version: 0.5.0-2
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
       version: bouncy
@@ -1002,6 +1037,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
       version: 0.5.3-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
       version: bouncy
@@ -1021,6 +1057,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: bouncy
@@ -1042,6 +1079,7 @@ repositories:
       url: https://github.com/ros2-gbp/rviz-release.git
       version: 4.0.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rviz.git
       version: bouncy
@@ -1057,6 +1095,7 @@ repositories:
       url: https://github.com/ros2-gbp/sros2-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/sros2.git
       version: bouncy
@@ -1068,6 +1107,7 @@ repositories:
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
       version: 2.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
       version: bouncy
@@ -1083,6 +1123,7 @@ repositories:
       url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
       version: 2.1.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/teleop_twist_keyboard.git
       version: bouncy
@@ -1098,6 +1139,7 @@ repositories:
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
       version: 0.4.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
       version: bouncy
@@ -1113,6 +1155,7 @@ repositories:
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
       version: bouncy
@@ -1124,6 +1167,7 @@ repositories:
       url: https://github.com/ros2-gbp/tlsf-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/tlsf.git
       version: bouncy
@@ -1164,6 +1208,7 @@ repositories:
       url: https://github.com/ros2-gbp/uncrustify-release.git
       version: 0.66.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ament/uncrustify.git
       version: bouncy
@@ -1179,6 +1224,7 @@ repositories:
       url: https://github.com/ros2-gbp/urdf-release.git
       version: 2.1.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/urdf.git
       version: bouncy
@@ -1194,6 +1240,7 @@ repositories:
       url: https://github.com/ros2-gbp/urdfdom-release.git
       version: 2.0.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/urdfdom.git
       version: bouncy

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -532,7 +532,6 @@ repositories:
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
       version: 0.1.5-0
     source:
-      test_commits: false
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
       version: master

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1300,10 +1300,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - cv_bridge
       - image_geometry
-      - opencv_tests
-      - vision_opencv
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -887,7 +887,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.5.3-0
+      version: 0.5.4-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1136,6 +1136,21 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: bouncy
     status: maintained
+  sophus:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.0-bouncy
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.0-bouncy
+    status: maintained
   sros2:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -464,17 +464,6 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: master
     status: developed
-  gazebo_ros_pkgs:
-    doc:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
-    status: developed
   geometry2:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -383,6 +383,17 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: master
     status: developed
+  gazebo_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: ros2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: ros2
+    status: developed
   geometry2:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1300,11 +1300,13 @@ repositories:
       version: ros2
     release:
       packages:
+      - cv_bridge
       - image_geometry
+      - vision_opencv
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.0.3-0
+      version: 2.0.5-0
     source:
       type: git
       url: https://github.com/ros-perception/vision_opencv.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -474,7 +474,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -237,7 +237,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.5.0-1
+      version: 0.5.1-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -501,7 +501,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.0.0-0
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -461,6 +461,7 @@ repositories:
       url: https://github.com/ros2-gbp/launch-release.git
       version: 0.5.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch.git
       version: bouncy
@@ -606,6 +607,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcl-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
       version: bouncy
@@ -660,6 +662,7 @@ repositories:
       url: https://github.com/ros2-gbp/rclpy-release.git
       version: 0.5.2-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
       version: bouncy
@@ -846,6 +849,7 @@ repositories:
       url: https://github.com/ros2-gbp/ros2cli-release.git
       version: 0.5.2-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros2cli.git
       version: bouncy
@@ -961,6 +965,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_python-release.git
       version: 0.5.0-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_python.git
       version: bouncy

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -641,7 +641,6 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.1.0-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -306,7 +306,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.5.0-0
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros2/example_interfaces.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -681,7 +681,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -589,7 +589,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 2.1.0-0
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/ros/pluginlib.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -204,7 +204,6 @@ repositories:
       url: https://github.com/ros2-gbp/class_loader-release.git
       version: 1.1.0-0
     source:
-      test_commits: false
       type: git
       url: https://github.com/ros/class_loader.git
       version: bouncy

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -34,7 +34,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.5.0-1
+      version: 0.5.1-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -307,6 +307,24 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: bouncy
     status: developed
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0-bouncy
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0-bouncy
+    status: maintained
   example_interfaces:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -604,6 +604,50 @@ repositories:
       url: https://github.com/ros2/navigation.git
       version: bouncy
     status: developed
+  navigation2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: master
+    release:
+      packages:
+      - costmap_queue
+      - dwb_controller
+      - dwb_core
+      - dwb_critics
+      - dwb_msgs
+      - dwb_plugins
+      - nav2_amcl
+      - nav2_astar_planner
+      - nav2_bringup
+      - nav2_bt_navigator
+      - nav2_costmap_2d
+      - nav2_costmap_world_model
+      - nav2_dijkstra_planner
+      - nav2_dwb_controller
+      - nav2_dynamic_params
+      - nav2_map_server
+      - nav2_mission_executor
+      - nav2_msgs
+      - nav2_robot
+      - nav2_simple_navigator
+      - nav2_system_tests
+      - nav2_tasks
+      - nav2_util
+      - nav2_voxel_grid
+      - nav_2d_msgs
+      - nav_2d_utils
+      - navigation2
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/SteveMacenski/navigation2-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: master
+    status: maintained
   navigation_msgs:
     release:
       packages:

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -703,6 +703,17 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: bouncy
     status: developed
+  py_trees_msgs:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees_msgs.git
+      version: release/0.4.x
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/stonier/py_trees_msgs-release.git
+      version: 0.4.1-0
+    status: developed
   rcl:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -165,21 +165,6 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
-  apriltag:
-    doc:
-      type: git
-      url: https://github.com/christianrauch/apriltag2.git
-      version: master
-    release:
-      tags:
-        release: release/bouncy/{package}/{version}
-      url: https://github.com/christianrauch/apriltag2-release.git
-      version: 0.9.8-0
-    source:
-      type: git
-      url: https://github.com/christianrauch/apriltag2.git
-      version: master
-    status: maintained
   cartographer:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -276,7 +276,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.5.1-0
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros2/demos.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1040,6 +1040,10 @@ repositories:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
       version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: bouncy
     status: developed
   rosidl:
     doc:

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -376,7 +376,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 1.6.0-4
+      version: 1.6.0-5
     source:
       test_commits: false
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -803,7 +803,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 0.5.0-1
+      version: 0.5.1-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -165,6 +165,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apriltag:
+    doc:
+      type: git
+      url: https://github.com/christianrauch/apriltag2.git
+      version: master
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/christianrauch/apriltag2-release.git
+      version: 0.9.8-0
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag2.git
+      version: master
+    status: maintained
   cartographer:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -126,7 +126,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1088,7 +1088,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 4.0.1-0
+      version: 4.0.2-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -604,49 +604,6 @@ repositories:
       url: https://github.com/ros2/navigation.git
       version: bouncy
     status: developed
-  navigation2:
-    doc:
-      type: git
-      url: https://github.com/ros-planning/navigation2.git
-      version: master
-    release:
-      packages:
-      - costmap_queue
-      - dwb_controller
-      - dwb_core
-      - dwb_critics
-      - dwb_msgs
-      - dwb_plugins
-      - nav2_amcl
-      - nav2_astar_planner
-      - nav2_bringup
-      - nav2_bt_navigator
-      - nav2_costmap_2d
-      - nav2_costmap_world_model
-      - nav2_dijkstra_planner
-      - nav2_dwb_controller
-      - nav2_dynamic_params
-      - nav2_map_server
-      - nav2_mission_executor
-      - nav2_msgs
-      - nav2_robot
-      - nav2_simple_navigator
-      - nav2_system_tests
-      - nav2_tasks
-      - nav2_util
-      - nav2_voxel_grid
-      - nav_2d_msgs
-      - nav_2d_utils
-      - navigation2
-      tags:
-        release: release/bouncy/{package}/{version}
-      url: https://github.com/SteveMacenski/navigation2-release.git
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-planning/navigation2.git
-      version: master
-    status: maintained
   navigation_msgs:
     release:
       packages:

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1261,6 +1261,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: bouncy
+    release:
+      packages:
+      - desktop
+      - ros_base
+      - ros_core
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.5.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: bouncy
+    status: developed
   vision_opencv:
     doc:
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1306,7 +1306,6 @@ repositories:
       url: https://github.com/ros2-gbp/vision_opencv-release.git
       version: 2.0.3-0
     source:
-      test_commits: false
       type: git
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -197,7 +197,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/cartographer.git
+      url: https://github.com/ros2/cartographer_ros.git
       version: bouncy
     status: developed
   class_loader:

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -712,7 +712,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.8.1-0
+      version: 0.8.2-0
     source:
       type: git
       url: https://github.com/stonier/py_trees.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -791,7 +791,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/ros2/rmw_opensplice.git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -1275,7 +1275,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       test_pull_requests: true
       type: git

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -876,7 +876,7 @@ repositories:
       tags:
         release: release/bouncy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.5.2-0
+      version: 0.5.3-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms:
+  ubuntu:
+  - bionic
+repositories:
+type: distribution
+version: 2

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -444,6 +444,25 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: developed
+  rosidl_defaults:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: master
+    release:
+      packages:
+      - rosidl_default_generators
+      - rosidl_default_runtime
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_defaults-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: master
+    status: developed
   rosidl_python:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -305,6 +305,27 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: developed
+  rcl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: master
+    release:
+      packages:
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: master
+    status: developed
   rcl_interfaces:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1166,7 +1166,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.6.1-0
+      version: 0.6.1-1
     source:
       test_commits: false
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -449,6 +449,22 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: developed
+  pcl_conversions:
+    doc:
+      type: git
+      url: https://github.com/ros2/pcl_conversions.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/pcl_conversions-release.git
+      version: 2.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/pcl_conversions.git
+      version: ros2
+    status: developed
   pluginlib:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -221,6 +221,37 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: developed
+  demos:
+    doc:
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    release:
+      packages:
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - topic_monitor
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/demos-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -140,6 +140,18 @@ repositories:
       url: https://github.com/eProsima/Fast-CDR.git
       version: master
     status: developed
+  fastrtps:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/fastrtps-release.git
+      version: 1.6.0-1
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/eProsima/Fast-RTPS.git
+      version: master
+    status: developed
   googletest:
     release:
       packages:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -410,6 +410,26 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: master
     status: developed
+  rosidl_typesupport_opensplice:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+      version: master
+    release:
+      packages:
+      - opensplice_cmake_module
+      - rosidl_typesupport_opensplice_c
+      - rosidl_typesupport_opensplice_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+      version: master
+    status: developed
   tinyxml2_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1306,7 +1306,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       test_commits: false
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -889,7 +889,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -156,7 +156,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/christianrauch/apriltag2-release.git
-      version: 0.9.8-0
+      version: 0.9.8-1
     source:
       type: git
       url: https://github.com/christianrauch/apriltag2.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1365,6 +1365,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_console-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -6,6 +6,24 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  ament_cmake:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: master
+    release:
+      packages:
+      - ament_cmake_core
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake-release.git
+      version: 0.6.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: master
+    status: developed
   ament_package:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,6 +129,21 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/class_loader-release.git
+      version: 1.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
   console_bridge_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,6 +129,17 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
+  fastcdr:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/fastcdr-release.git
+      version: 1.0.8-0
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-CDR.git
+      version: master
+    status: developed
   googletest:
     release:
       packages:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1208,7 +1208,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.0.4-1
+      version: 0.0.5-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -189,6 +189,22 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: developed
+  example_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/example_interfaces-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: bouncy
+    status: developed
   fastcdr:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -154,7 +154,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 2.4.2-0
+      version: 2.4.3-1
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -724,6 +724,21 @@ repositories:
       url: https://github.com/ament/uncrustify_vendor.git
       version: master
     status: developed
+  urdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdfdom.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom-release.git
+      version: 2.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/urdfdom.git
+      version: ros2
+    status: maintained
   urdfdom_headers:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -205,6 +205,34 @@ repositories:
       url: https://github.com/ros2/example_interfaces.git
       version: bouncy
     status: developed
+  examples:
+    doc:
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: master
+    release:
+      packages:
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclpy_executors
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/examples-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: master
+    status: developed
   fastcdr:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -309,7 +309,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.10.0-0
+      version: 0.10.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -396,6 +396,24 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: ros2
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros2/joystick_drivers.git
+      version: ros2
+    release:
+      packages:
+      - joy
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/joystick_drivers-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/joystick_drivers.git
+      version: ros2
+    status: developed
   kdl_parser:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -302,6 +302,47 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  ecl_core:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.0-crystal
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.0-crystal
+    status: maintained
   ecl_lite:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,6 +129,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
+  console_bridge_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
+      version: 1.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: master
+    status: developed
   fastcdr:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -154,7 +154,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 2.4.1-0
+      version: 2.4.2-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -753,7 +753,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -526,13 +526,17 @@ repositories:
       version: master
     status: maintained
   librealsense:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
     release:
       packages:
       - librealsense2
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.16.5-0
+      version: 2.16.5-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -165,6 +165,24 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: developed
+  osrf_testing_tools_cpp:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    release:
+      packages:
+      - osrf_testing_tools_cpp
+      - test_osrf_testing_tools_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    status: developed
   poco_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1414,7 +1414,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -444,6 +444,25 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: developed
+  rosidl_typesupport:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: master
+    release:
+      packages:
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
+      version: 0.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: master
+    status: developed
   rosidl_typesupport_connext:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1124,12 +1124,11 @@ repositories:
       - rviz_default_plugins
       - rviz_ogre_vendor
       - rviz_rendering
-      - rviz_rendering_tests
       - rviz_visual_testing_framework
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 5.0.0-0
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -537,7 +537,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/ros2/launch.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -235,11 +235,13 @@ repositories:
     release:
       packages:
       - launch
+      - launch_ros
       - launch_testing
+      - ros2launch
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.7.1-0
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros2/launch.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -756,6 +756,29 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: crystal-devel
     status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/qt_gui_core-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    status: maintained
   rcl:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1429,7 +1429,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -41,6 +41,22 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: master
     status: developed
+  ament_cmake_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
+      version: 0.5.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: master
+    status: developed
   ament_lint:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -77,7 +77,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1225,11 +1225,12 @@ repositories:
       - rviz_default_plugins
       - rviz_ogre_vendor
       - rviz_rendering
+      - rviz_rendering_tests
       - rviz_visual_testing_framework
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 5.0.0-1
+      version: 5.0.0-2
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1384,7 +1384,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -736,7 +736,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 2.2.0-1
+      version: 2.2.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1395,6 +1395,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: crystal-devel
     status: maintained
+  rqt_msg:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_msg-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -174,7 +174,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/christianrauch/apriltag2_node-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/christianrauch/apriltag2_node.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -230,7 +230,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -411,7 +411,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1480,6 +1480,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: crystal-devel
     status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_srv-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    status: maintained
   rqt_top:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -381,6 +381,22 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: developed
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/pluginlib-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    status: developed
   poco_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1085,7 +1085,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -645,7 +645,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -830,7 +830,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -724,5 +724,20 @@ repositories:
       url: https://github.com/ament/uncrustify_vendor.git
       version: master
     status: developed
+  urdfdom_headers:
+    doc:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_headers-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    status: maintained
 type: distribution
 version: 2

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -395,7 +395,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.7.1-1
+      version: 0.7.2-0
     source:
       type: git
       url: https://github.com/ros2/launch.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,6 +129,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
+  angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/angles-release.git
+      version: 1.12.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    status: maintained
   class_loader:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -503,6 +503,34 @@ repositories:
       url: https://github.com/ros2/rmw_opensplice.git
       version: master
     status: developed
+  ros2cli:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: master
+    release:
+      packages:
+      - ros2cli
+      - ros2lifecycle
+      - ros2msg
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2srv
+      - ros2topic
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: master
+    status: maintained
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1029,7 +1029,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -360,6 +360,22 @@ repositories:
       url: https://github.com/ros2/rcl_interfaces.git
       version: master
     status: developed
+  rclpy:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rclpy-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: master
+    status: developed
   rcutils:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -57,6 +57,24 @@ repositories:
       url: https://github.com/ros2/ament_cmake_ros.git
       version: master
     status: developed
+  ament_index:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: master
+    release:
+      packages:
+      - ament_index_cpp
+      - ament_index_python
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_index-release.git
+      version: 0.5.1-0
+    source:
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: master
+    status: developed
   ament_lint:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -885,11 +885,11 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_object_analytics-release.git
-      version: 0.5.1-0
+      version: 0.5.2-0
     source:
       type: git
       url: https://github.com/intel/ros2_object_analytics.git
-      version: crystal
+      version: master
     status: maintained
   ros2cli:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1151,7 +1151,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -165,6 +165,22 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: developed
+  osrf_pycommon:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_pycommon-release.git
+      version: 0.1.6-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    status: developed
   osrf_testing_tools_cpp:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -287,6 +287,21 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: developed
+  tinyxml_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
+      version: master
+    status: maintained
   uncrustify_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1166,6 +1166,10 @@ repositories:
       version: latest
     status: developed
   rosbag2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
     release:
       packages:
       - ros2bag
@@ -1181,7 +1185,13 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
+    status: developed
   rosidl:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -811,7 +811,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.6.1-1
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -273,6 +273,29 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: master
     status: developed
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: ros2
+    release:
+      packages:
+      - tf2
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_msgs
+      - tf2_ros
+      - tf2_sensor_msgs
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry2-release.git
+      version: 0.10.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: ros2
+    status: maintained
   googletest:
     release:
       packages:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -167,6 +167,24 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: developed
+  launch:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: master
+    release:
+      packages:
+      - launch
+      - launch_testing
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/launch-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: master
+    status: maintained
   libyaml_vendor:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1208,7 +1208,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.0.3-0
+      version: 0.0.4-1
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -769,6 +769,21 @@ repositories:
       url: https://github.com/ros2/robot_state_publisher.git
       version: ros2
     status: developed
+  ros2_object_analytics:
+    release:
+      packages:
+      - object_analytics_msgs
+      - object_analytics_node
+      - object_analytics_rviz
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_analytics-release.git
+      version: 0.5.0-0
+    source:
+      type: git
+      url: https://github.com/intel/ros2_object_analytics.git
+      version: crystal
+    status: maintained
   ros2cli:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -772,7 +772,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1444,7 +1444,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -681,6 +681,22 @@ repositories:
       url: https://github.com/ros2/ros2cli.git
       version: master
     status: maintained
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: crystal
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_environment-release.git
+      version: 2.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: crystal
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -154,6 +154,17 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: developed
+  libyaml_vendor:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/libyaml_vendor-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/libyaml_vendor.git
+      version: master
+    status: developed
   poco_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -373,7 +373,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.0.0-0
+      version: 3.1.0-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -252,6 +252,21 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: master
     status: developed
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros2/depthimage_to_laserscan.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
+      version: 2.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/depthimage_to_laserscan.git
+      version: ros2
+    status: maintained
   example_interfaces:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1071,7 +1071,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -371,6 +371,25 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: developed
+  rosidl_typesupport_connext:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_connext.git
+      version: master
+    release:
+      packages:
+      - connext_cmake_module
+      - rosidl_typesupport_connext_c
+      - rosidl_typesupport_connext_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
+      version: 0.6.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_connext.git
+      version: master
+    status: developed
   tinyxml2_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -278,11 +278,15 @@ repositories:
       version: master
     status: developed
   fastrtps:
+    doc:
+      type: git
+      url: https://github.com/eProsima/Fast-RTPS.git
+      version: master
     release:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 1.6.0-1
+      version: 1.7.0-0
     source:
       test_commits: false
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1380,6 +1380,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: crystal-devel
     status: maintained
+  rqt_image_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_view-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -326,6 +326,21 @@ repositories:
       url: https://github.com/ros2/kdl_parser.git
       version: ros2
     status: developed
+  laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_geometry-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: ros2
+    status: maintained
   launch:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -360,6 +360,25 @@ repositories:
       url: https://github.com/ros2/rcl_interfaces.git
       version: master
     status: developed
+  rclcpp:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: master
+    release:
+      packages:
+      - rclcpp
+      - rclcpp_lifecycle
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rclcpp-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: master
+    status: developed
   rclpy:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1364,6 +1364,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_py_console-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -35,6 +35,20 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.8.0-0
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: ros2
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -772,7 +772,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -963,7 +963,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: master
+      version: crystal
     release:
       packages:
       - rclcpp
@@ -977,7 +977,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: master
+      version: crystal
     status: developed
   rclpy:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -179,7 +179,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.7.0-0
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros2/launch.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -149,7 +149,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: master
+      version: ros2
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -159,7 +159,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: master
+      version: ros2
     status: developed
   class_loader:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -772,7 +772,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.0.2-0
+      version: 1.0.3-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -989,6 +989,31 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: master
     status: developed
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: crystal
+    release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz-release.git
+      version: 5.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: crystal
+    status: maintained
   tinyxml2_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1061,7 +1061,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.6.0-1
+      version: 0.6.1-0
     source:
       test_commits: false
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -783,6 +783,22 @@ repositories:
       url: https://github.com/ros2/tinyxml_vendor.git
       version: master
     status: maintained
+  tlsf:
+    doc:
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/tlsf-release.git
+      version: 0.5.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: master
+    status: maintained
   uncrustify_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -41,6 +41,49 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: master
     status: developed
+  ament_lint:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: master
+    release:
+      packages:
+      - ament_clang_format
+      - ament_cmake_clang_format
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pep8
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_pclint
+      - ament_pep257
+      - ament_pep8
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_lint-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: master
+    status: developed
   ament_package:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -626,7 +626,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1166,6 +1166,21 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: crystal
     status: maintained
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
+      version: 2.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: ros2
+    status: maintained
   teleop_twist_keyboard:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -420,6 +420,25 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: ros2
     status: maintained
+  image_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: ros2
+    release:
+      packages:
+      - depth_image_proc
+      - image_publisher
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/image_pipeline-release.git
+      version: 2.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: ros2
+    status: maintained
   joystick_drivers:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -811,7 +811,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -792,7 +792,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -350,6 +350,22 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: master
     status: developed
+  rmw_implementation:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_implementation-release.git
+      version: 0.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: master
+    status: developed
   rmw_opensplice:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -350,6 +350,24 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: master
     status: developed
+  rmw_opensplice:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_opensplice.git
+      version: master
+    release:
+      packages:
+      - rmw_opensplice_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_opensplice-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_opensplice.git
+      version: master
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1049,5 +1049,25 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 2.1.0-0
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    status: maintained
 type: distribution
 version: 2

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1046,7 +1046,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 0.6.0-1
+      version: 0.6.1-0
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -276,6 +276,29 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: developed
+  rcl_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: master
+    release:
+      packages:
+      - action_msgs
+      - builtin_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - rosgraph_msgs
+      - test_msgs
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_interfaces-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: master
+    status: developed
   rcutils:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1322,6 +1322,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
+      version: 1.0.0-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -162,6 +162,24 @@ repositories:
       url: https://github.com/christianrauch/apriltag2.git
       version: master
     status: maintained
+  apriltag2_node:
+    doc:
+      type: git
+      url: https://github.com/christianrauch/apriltag2_node.git
+      version: master
+    release:
+      packages:
+      - apriltag2_node
+      - apriltag_msgs
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/christianrauch/apriltag2_node-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag2_node.git
+      version: master
+    status: developed
   behaviortree_cpp:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,22 +129,6 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
-  console_bridge:
-    doc:
-      type: git
-      url: https://github.com/ros/console_bridge.git
-      version: master
-    release:
-      tags:
-        release: release/crystal/{package}/{version}
-      url: https://github.com/ros2-gbp/console_bridge-release.git
-      version: 0.4.0-0
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros/console_bridge.git
-      version: master
-    status: maintained
   fastcdr:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1605,7 +1605,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
-      version: 0.4.0-0
+      version: 0.6.0-0
     source:
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -602,7 +602,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1062,7 +1062,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.2-1
+      version: 2.0.3-0
     source:
       type: git
       url: https://github.com/intel/ros2_intel_realsense.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -313,6 +313,24 @@ repositories:
       url: https://github.com/intel/ros2_object_msgs.git
       version: master
     status: maintained
+  orocos_kinematics_dynamics:
+    doc:
+      type: git
+      url: https://github.com/ros2/orocos_kinematics_dynamics.git
+      version: ros2
+    release:
+      packages:
+      - orocos_kdl
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
+      version: 3.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/orocos_kinematics_dynamics.git
+      version: ros2
+    status: developed
   osrf_pycommon:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -780,6 +780,7 @@ repositories:
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
       version: 1.0.2-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/ros/urdfdom_headers.git
       version: master

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1459,7 +1459,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -359,7 +359,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 0.6.0-1
+      version: 0.6.0-2
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1444,7 +1444,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1126,7 +1126,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -955,6 +955,22 @@ repositories:
       url: https://github.com/ros2/robot_state_publisher.git
       version: ros2
     status: developed
+  ros1_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros1_bridge-release.git
+      version: 0.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    status: developed
   ros2_intel_realsense:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -290,6 +290,8 @@ repositories:
       version: master
     release:
       packages:
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
       - examples_rclcpp_minimal_client
       - examples_rclcpp_minimal_composition
       - examples_rclcpp_minimal_publisher
@@ -304,7 +306,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -772,7 +772,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1101,5 +1101,17 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  yaml_cpp_vendor:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+      version: 5.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/yaml_cpp_vendor.git
+      version: master
+    status: maintained
 type: distribution
 version: 2

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -261,6 +261,25 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: master
     status: developed
+  rmw:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: master
+    release:
+      packages:
+      - rmw
+      - rmw_implementation_cmake
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: master
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -35,5 +35,21 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
+  ros_workspace:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 0.6.0-1
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: developed
 type: distribution
 version: 2

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1368,7 +1368,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -334,6 +334,22 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: developed
+  message_filters:
+    doc:
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_message_filters-release.git
+      version: 3.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: master
+    status: maintained
   object_msgs:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -808,7 +808,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 0.6.0-2
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -740,6 +740,22 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: developed
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/python_qt_binding-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    status: maintained
   rcl:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -143,6 +143,21 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: developed
+  poco_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/poco_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/poco_vendor-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/ros2/poco_vendor.git
+      version: master
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1616,6 +1616,17 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: crystal
     status: maintained
+  sophus:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.0-crystal
+    status: maintained
   sros2:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -256,6 +256,17 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: developed
+  object_msgs:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_msgs-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/intel/ros2_object_msgs.git
+      version: master
+    status: maintained
   osrf_pycommon:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1165,6 +1165,23 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  rosbag2:
+    release:
+      packages:
+      - ros2bag
+      - rosbag2
+      - rosbag2_converter_default_plugins
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_test_common
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.0.1-1
   rosidl:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -271,6 +271,22 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: developed
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/kdl_parser-release.git
+      version: 2.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: ros2
+    status: developed
   launch:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -82,5 +82,20 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  uncrustify_vendor:
+    doc:
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: master
+    status: developed
 type: distribution
 version: 2

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -712,7 +712,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.6.1-0
+      version: 0.6.1-1
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1166,6 +1166,21 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: crystal
     status: maintained
+  teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: ros2
+    status: maintained
   tinyxml2_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1395,6 +1395,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: crystal-devel
     status: maintained
+  rqt_shell:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_shell-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -302,6 +302,30 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.0-crystal
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.0-crystal
+    status: maintained
   ecl_tools:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -526,6 +526,25 @@ repositories:
       url: https://github.com/ros2/realtime_support.git
       version: master
     status: developed
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: ros2
+    release:
+      packages:
+      - libcurl_vendor
+      - resource_retriever
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/resource_retriever-release.git
+      version: 2.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: ros2
+    status: developed
   rmw:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -111,7 +111,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1193,8 +1193,10 @@ repositories:
       version: master
     release:
       packages:
+      - ros1_rosbag_storage_vendor
       - ros2bag
       - rosbag2
+      - rosbag2_bag_v2_plugins
       - rosbag2_converter_default_plugins
       - rosbag2_storage
       - rosbag2_storage_default_plugins
@@ -1206,7 +1208,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -326,6 +326,26 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: developed
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_transport
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/image_common-release.git
+      version: 2.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    status: maintained
   kdl_parser:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1146,7 +1146,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 0.6.0-1
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -390,6 +390,26 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_connext.git
       version: master
     status: developed
+  rosidl_typesupport_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: master
+    release:
+      packages:
+      - fastrtps_cmake_module
+      - rosidl_typesupport_fastrtps_c
+      - rosidl_typesupport_fastrtps_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: master
+    status: developed
   tinyxml2_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -17,7 +17,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.6.0-2
+      version: 0.6.0-3
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1410,6 +1410,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_msg.git
       version: crystal-devel
     status: maintained
+  rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_publisher-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -136,6 +136,7 @@ repositories:
       url: https://github.com/ros2-gbp/fastcdr-release.git
       version: 1.0.8-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
       version: master

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1420,6 +1420,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_msg.git
       version: crystal-devel
     status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_plot-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    status: maintained
   rqt_publisher:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -339,6 +339,28 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: master
     status: developed
+  gazebo_ros_pkgs:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: ros2
+    release:
+      packages:
+      - gazebo_dev
+      - gazebo_msgs
+      - gazebo_plugins
+      - gazebo_ros
+      - gazebo_ros_pkgs
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
+      version: 3.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+      version: ros2
+    status: developed
   geometry2:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -174,7 +174,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/christianrauch/apriltag2_node-release.git
-      version: 1.0.0-1
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/christianrauch/apriltag2_node.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1455,6 +1455,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: crystal-devel
     status: maintained
+  rqt_top:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_top-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -851,6 +851,22 @@ repositories:
       url: https://github.com/ament/uncrustify_vendor.git
       version: master
     status: developed
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf-release.git
+      version: 2.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: ros2
+    status: developed
   urdfdom:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -330,6 +330,26 @@ repositories:
       url: https://github.com/ros2/rmw_connext.git
       version: master
     status: developed
+  rmw_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: master
+    release:
+      packages:
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: master
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -664,11 +664,12 @@ repositories:
     release:
       packages:
       - rclcpp
+      - rclcpp_action
       - rclcpp_lifecycle
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -256,6 +256,24 @@ repositories:
       url: https://github.com/ros2/rosidl.git
       version: master
     status: developed
+  rosidl_dds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: master
+    release:
+      packages:
+      - rosidl_generator_dds_idl
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dds-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: master
+    status: developed
   uncrustify_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -806,6 +806,10 @@ repositories:
       version: ros2
     status: developed
   ros2_object_analytics:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_object_analytics.git
+      version: master
     release:
       packages:
       - object_analytics_msgs
@@ -814,7 +818,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_object_analytics-release.git
-      version: 0.5.0-0
+      version: 0.5.1-0
     source:
       type: git
       url: https://github.com/intel/ros2_object_analytics.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -854,6 +854,24 @@ repositories:
       url: https://github.com/ros2/robot_state_publisher.git
       version: ros2
     status: developed
+  ros2_intel_realsense:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: master
+    release:
+      packages:
+      - realsense_camera_msgs
+      - realsense_ros2_camera
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: master
+    status: maintained
   ros2_object_analytics:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -742,6 +742,19 @@ repositories:
       url: https://github.com/ros2/rcl_interfaces.git
       version: master
     status: developed
+  rcl_logging:
+    release:
+      packages:
+      - rcl_logging_noop
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    status: maintained
   rclcpp:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1181,6 +1181,22 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: crystal
     status: maintained
+  sros2:
+    doc:
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/sros2-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    status: developed
   teleop_twist_joy:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -198,7 +198,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -311,6 +311,25 @@ repositories:
       url: https://github.com/ros2/rmw.git
       version: master
     status: developed
+  rmw_connext:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_connext.git
+      version: master
+    release:
+      packages:
+      - rmw_connext_cpp
+      - rmw_connext_shared_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_connext-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_connext.git
+      version: master
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -356,6 +356,21 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: developed
+  tinyxml2_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: master
+    status: maintained
   tinyxml_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,6 +129,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: maintained
+  console_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros/console_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/console_bridge-release.git
+      version: 0.4.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/console_bridge.git
+      version: master
+    status: maintained
   fastcdr:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -280,7 +280,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1307,6 +1307,27 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: master
     status: developed
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -346,6 +346,19 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: master
     status: maintained
+  librealsense:
+    release:
+      packages:
+      - librealsense2
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/librealsense-release.git
+      version: 2.16.5-0
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    status: maintained
   libyaml_vendor:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -145,6 +145,22 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  behaviortree_cpp:
+    doc:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
+      version: 2.4.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    status: developed
   class_loader:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -474,6 +474,27 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: ros2
     status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/image_transport_plugins-release.git
+      version: 2.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    status: maintained
   joystick_drivers:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1444,7 +1444,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1003,7 +1003,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -437,6 +437,50 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: master
     status: maintained
+  navigation2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: master
+    release:
+      packages:
+      - costmap_queue
+      - dwb_controller
+      - dwb_core
+      - dwb_critics
+      - dwb_msgs
+      - dwb_plugins
+      - nav2_amcl
+      - nav2_bringup
+      - nav2_bt_navigator
+      - nav2_costmap_2d
+      - nav2_dwb_controller
+      - nav2_dynamic_params
+      - nav2_map_server
+      - nav2_mission_executor
+      - nav2_motion_primitives
+      - nav2_msgs
+      - nav2_navfn_planner
+      - nav2_robot
+      - nav2_simple_navigator
+      - nav2_system_tests
+      - nav2_tasks
+      - nav2_util
+      - nav2_voxel_grid
+      - nav2_world_model
+      - nav_2d_msgs
+      - nav_2d_utils
+      - navigation2
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/SteveMacenski/navigation2-release.git
+      version: 0.1.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: master
+    status: maintained
   navigation_msgs:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -302,6 +302,25 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0-crystal
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0-crystal
+    status: maintained
   example_interfaces:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -606,7 +606,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -401,6 +401,23 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: master
     status: maintained
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros2
+    release:
+      packages:
+      - map_msgs
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/navigation_msgs-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros2
+    status: maintained
   object_msgs:
     release:
       tags:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -6,5 +6,16 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  ament_package:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_package-release.git
+      version: 0.6.0-0
+    source:
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: master
+    status: maintained
 type: distribution
 version: 2

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -934,6 +934,17 @@ repositories:
       url: https://github.com/ament/uncrustify_vendor.git
       version: master
     status: developed
+  unique_identifier_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: master
+    status: developed
   urdf:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -457,6 +457,25 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: master
     status: developed
+  realtime_support:
+    doc:
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: master
+    release:
+      packages:
+      - rttest
+      - tlsf_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_support-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: master
+    status: developed
   rmw:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -230,6 +230,32 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  rosidl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: master
+    release:
+      packages:
+      - rosidl_actions
+      - rosidl_adapter
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_parser
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: bouncy
+    status: developed
   uncrustify_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -749,7 +749,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -624,7 +624,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -947,7 +947,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1410,6 +1410,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: crystal-devel
     status: maintained
+  rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_service_caller-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: crystal-devel
+    status: maintained
   rqt_shell:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1298,6 +1298,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
       version: 0.6.2-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
       version: master

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -444,6 +444,25 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: developed
+  rosidl_python:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: master
+    release:
+      packages:
+      - python_cmake_module
+      - rosidl_generator_py
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_python-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: master
+    status: developed
   rosidl_typesupport:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -254,7 +254,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: bouncy
+      version: master
     status: developed
   uncrustify_vendor:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1002,7 +1002,7 @@ repositories:
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
       version: 0.6.0-1
     source:
-      test_pull_requests: true
+      test_commits: false
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -939,6 +939,11 @@ repositories:
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
+      version: 2.0.0-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -721,6 +721,22 @@ repositories:
       url: https://github.com/ros2/rmw_opensplice.git
       version: master
     status: developed
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros2/robot_state_publisher.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_state_publisher-release.git
+      version: 2.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/robot_state_publisher.git
+      version: ros2
+    status: developed
   ros2cli:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1404,6 +1404,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    release:
+      packages:
+      - desktop
+      - ros_base
+      - ros_core
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    status: developed
   vision_opencv:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -145,6 +145,23 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apriltag2:
+    doc:
+      type: git
+      url: https://github.com/christianrauch/apriltag2.git
+      version: master
+    release:
+      packages:
+      - apriltag
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/christianrauch/apriltag2-release.git
+      version: 0.9.8-0
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag2.git
+      version: master
+    status: maintained
   behaviortree_cpp:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -245,6 +245,22 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: developed
+  rcutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rcutils-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: master
+    status: developed
   ros_workspace:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -685,7 +685,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -144,6 +144,35 @@ repositories:
       type: git
       url: https://github.com/ros/class_loader.git
       version: ros2
+  common_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: master
+    release:
+      packages:
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/common_interfaces-release.git
+      version: 0.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: master
+    status: developed
   console_bridge_vendor:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -813,7 +813,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcl-release.git
       version: 0.6.3-0
     source:
-      test_pull_requests: true
+      test_commits: false
       type: git
       url: https://github.com/ros2/rcl.git
       version: master

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -13,11 +13,28 @@ repositories:
       version: master
     release:
       packages:
+      - ament_cmake
+      - ament_cmake_auto
       - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_gmock
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_nose
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.6.0-3
+      version: 0.6.0-4
     source:
       test_pull_requests: true
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -867,7 +867,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git

--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -3,6 +3,21 @@
 # see REP 153: http://ros.org/reps/rep-0153.html
 ---
 distributions:
+  ardent:
+    distribution: [ardent/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/ardent-cache.yaml.gz
+    distribution_status: end-of-life
+    distribution_type: ros2
+  bouncy:
+    distribution: [bouncy/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/bouncy-cache.yaml.gz
+    distribution_status: active
+    distribution_type: ros2
+  crystal:
+    distribution: [crystal/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz
+    distribution_status: active
+    distribution_type: ros2
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz

--- a/index.yaml
+++ b/index.yaml
@@ -3,6 +3,15 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 distributions:
+  ardent:
+    distribution: [ardent/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/ardent-cache.yaml.gz
+  bouncy:
+    distribution: [bouncy/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/bouncy-cache.yaml.gz
+  crystal:
+    distribution: [crystal/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz


### PR DESCRIPTION
Related to ros2/rosdistro#492.

Contains all commits from ros2/rosdistro which affect the three ROS 2 distros (using `git-splits`). Each commit message was rewritten to prepend "ros2/rosdistro" to each referenced ticket number (using `git filter-branch --msg-filter ...`). A manual commit at the end adds the three distros to the index files.