### PR TITLE
talos_robot: 1.0.45-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13171,10 +13171,12 @@ repositories:
     release:
       packages:
       - talos_description
+      - talos_description_calibration
+      - talos_description_inertial
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git
-      version: 1.0.44-0
+      version: 1.0.45-1
   tango_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_robot` to `1.0.45-1`:

- upstream repository: https://github.com/pal-robotics/talos_robot.git
- release repository: https://github.com/pal-gbp/talos_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.44-0`

## talos_description

- No changes

## talos_description_calibration

- No changes

## talos_description_inertial

- No changes
