### PR TITLE
talos_robot: 1.0.45-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5710,10 +5710,12 @@ repositories:
     release:
       packages:
       - talos_description
+      - talos_description_calibration
+      - talos_description_inertial
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git
-      version: 1.0.44-0
+      version: 1.0.45-0
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_robot` to `1.0.45-0`:

- upstream repository: https://github.com/pal-robotics/talos_robot.git
- release repository: https://github.com/pal-gbp/talos_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `1.0.44-0`

## talos_description

- No changes

## talos_description_calibration

- No changes

## talos_description_inertial

- No changes
