### PR TITLE
Added pip packages: breathe and exhale

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -49,6 +49,16 @@ azure-iothub-device-client-pip:
   ubuntu:
     pip:
       packages: [azure-iothub-device-client]
+breath-pip:
+  debian:
+    pip:
+      packages: [breath]
+  fedora:
+    pip:
+      packages: [breath]
+  ubuntu:
+    pip:
+      packages: [breath]
 canopen-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -49,16 +49,16 @@ azure-iothub-device-client-pip:
   ubuntu:
     pip:
       packages: [azure-iothub-device-client]
-breath-pip:
+breathe-pip:
   debian:
     pip:
-      packages: [breath]
+      packages: [breathe]
   fedora:
     pip:
-      packages: [breath]
+      packages: [breathe]
   ubuntu:
     pip:
-      packages: [breath]
+      packages: [breathe]
 canopen-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -49,16 +49,6 @@ azure-iothub-device-client-pip:
   ubuntu:
     pip:
       packages: [azure-iothub-device-client]
-breathe-pip:
-  debian:
-    pip:
-      packages: [breathe]
-  fedora:
-    pip:
-      packages: [breathe]
-  ubuntu:
-    pip:
-      packages: [breathe]
 canopen-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -117,6 +117,16 @@ epydoc:
     pip:
       packages: [epydoc]
   ubuntu: [python-epydoc]
+exhale-pip:
+  debian:
+    pip:
+      packages: [exhale]
+  fedora:
+    pip:
+      packages: [exhale]
+  ubuntu:
+    pip:
+      packages: [exhale]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -630,6 +630,10 @@ python-box2d:
   debian: [python-box2d]
   fedora: [pybox2d]
   ubuntu: [python-box2d]
+python-breathe:
+  debian: [python-breathe]
+  fedora: [python-breathe]
+  ubuntu: [python-breathe]
 python-bs4:
   debian: [python-bs4]
   fedora: [python-beautifulsoup4]


### PR DESCRIPTION
Added breathe and exhale: extensions of Sphinx to generate C++ documentation.

### Tests
[X] nosetests

### Breathe
Ubuntu: python-breathe https://packages.ubuntu.com/xenial/python-breathe
Debian: python-breathe https://packages.debian.org/buster/python-breathe
Same for Fedora: https://src.fedoraproject.org/rpms/python-breathe/

### Exhale
* [Pypi](https://pypi.org/project/exhale/)
* [Docs](https://exhale.readthedocs.io/en/latest/)