### PR TITLE
rosdep: add qtmultimedia5-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4441,6 +4441,13 @@ qtmobility-dev:
   fedora: [qt-mobility-devel]
   gentoo: [dev-qt/qt-mobility]
   ubuntu: [qtmobility-dev]
+qtmultimedia5-dev:
+  arch: [qt5-multimedia]
+  debian: [qtmultimedia5-dev]
+  fedora: [qt5-qtmultimedia-devel]
+  freebsd: [qt5-multimedia]
+  gentoo: ['dev-qt/qtmultimedia:5']
+  ubuntu: [qtmultimedia5-dev]
 r-base:
   debian: [r-base]
   fedora: [R]


### PR DESCRIPTION
Useful for playing sounds / media from ROS nodes.