### PR TITLE
backward_ros: 0.1.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -724,7 +724,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pal-gbp/backward_ros-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
   bagger:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `0.1.7-0`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.1.6-0`

## backward_ros

```
* Merge pull request #3 from veimox/bugfix/fix-tests-headers
  modified heders to be included with current cmake configuration
* modified heders to be included with current cmake configuration
* Contributors: Jorge Rodriguez, Victor Lopez
```
