### PR TITLE
backward_ros: 0.1.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -256,6 +256,12 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: developed
+  backward_ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-gbp/backward_ros-release.git
+      version: 0.1.7-0
   bagger:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `0.1.7-0`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## backward_ros

```
* Merge pull request #3 from veimox/bugfix/fix-tests-headers
  modified heders to be included with current cmake configuration
* modified heders to be included with current cmake configuration
* Contributors: Jorge Rodriguez, Victor Lopez
```
