### PR TITLE
rcl: 0.6.4-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -916,7 +916,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.6.3-0
+      version: !!python/unicode '0.6.4-0'
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.6.4-0`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.6.3-0`

## rcl

```
* Added method for accessing rmw_context from rcl_context (#372 <https://github.com/ros2/rcl/issues/372>)
* Added guard against bad allocation when calling rcl_arguments_copy() (#367 <https://github.com/ros2/rcl/issues/367>)
* Updated to ensure that context instance id storage is aligned correctly (#365 <https://github.com/ros2/rcl/issues/365>)
* Fixed error from uncrustify v0.68 (#364 <https://github.com/ros2/rcl/issues/364>)
* Contributors: Jacob Perron, William Woodall, sgvandijk
```

## rcl_action

```
* Added parentheses around use of zerouuid macro (#371 <https://github.com/ros2/rcl/issues/371>)
* Fixed logic that moves goal handles when one expires (#360 <https://github.com/ros2/rcl/issues/360>)
* Updated to avoid timer period being set to 0 (#359 <https://github.com/ros2/rcl/issues/359>)
* Contributors: Jacob Perron, Shane Loretz
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
