### PR TITLE
rosidl_typesupport_fastrtps: 0.6.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1433,7 +1433,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 0.6.0-0
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `0.6.1-0`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.6.0-0`
