### PR TITLE
pybind11_catkin: 2.2.4-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3799,11 +3799,15 @@ repositories:
       version: release/0.5-melodic
     status: maintained
   pybind11_catkin:
+    doc:
+      type: git
+      url: https://github.com/ipab-slmc/pybind11_catkin.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
-      version: 2.2.4-1
+      version: 2.2.4-4
     source:
       type: git
       url: https://github.com/ipab-slmc/pybind11_catkin.git


### PR DESCRIPTION
**This fixes the armhf/arm64 only failures of packages that depend on pybind11_catkin (currently exotica_python).**

Increasing version of package(s) in repository `pybind11_catkin` to `2.2.4-4`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `2.2.4-1`
