### PR TITLE
json_transport: 0.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2024,6 +2024,25 @@ repositories:
       url: https://github.com/tork-a/jskeus-release.git
       version: 1.2.1-0
     status: developed
+  json_transport:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/json_transport.git
+      version: devel
+    release:
+      packages:
+      - json_msgs
+      - json_transport
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/locusrobotics/json_transport-release.git
+      version: 0.0.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/json_transport.git
+      version: devel
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `json_transport` to `0.0.3-0`:

- upstream repository: https://github.com/locusrobotics/json_transport.git
- release repository: https://github.com/locusrobotics/json_transport-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## json_msgs

- No changes

## json_transport

```
* decode as utf 8 (#9 <https://github.com/locusrobotics/json_transport/issues/9>)
* Contributors: Andrew Blakey
```
