### PR TITLE
rviz: 5.1.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1650,7 +1650,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 5.0.0-2
+      version: 5.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `5.1.0-0`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `5.0.0-2`

## rviz2

```
* Update package maintainer for rviz2 (#365 <https://github.com/ros2/rviz/issues/365>)
  Thank you to Deanna for her contributions.
* Contributors: Scott K Logan
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix errors from uncrustify v0.68 (#366 <https://github.com/ros2/rviz/issues/366>)
* Contributors: Jacob Perron, William Woodall
```

## rviz_default_plugins

```
* Migrate scalar displays, i.e. temperature, illuminance, relative humidity, and fluid pressure (#367 <https://github.com/ros2/rviz/issues/367>)
* Fix errors from uncrustify v0.68 (#366 <https://github.com/ros2/rviz/issues/366>)
* Visibility followup for Swatch marker (#297 <https://github.com/ros2/rviz/issues/297>)
* Contributors: GW1708, Jacob Perron, Martin Idel, William Woodall
```

## rviz_ogre_vendor

```
* Skip the system directories when looking for OGRE (#371 <https://github.com/ros2/rviz/issues/371>)
* Contributors: Scott K Logan
```

## rviz_rendering

```
* Handle FindEigen3 module's differing definitions (#370 <https://github.com/ros2/rviz/issues/370>)
* Contributors: Scott K Logan
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Migrate scalar displays, i.e. temperature, illuminance, relative humidity, and fluid pressure (#367 <https://github.com/ros2/rviz/issues/367>)
* Contributors: GW1708
```
