### PR TITLE
Added numpy-quaternion to python.yaml 

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2338,6 +2338,13 @@ python-numpy-stl-pip:
   ubuntu:
     pip:
       packages: [numpy-stl]
+python-numpy-quaternion-pip:
+  osx:
+    pip:
+      packages: [numpy-quaternion]
+  ubuntu:
+    pip:
+      packages: [numpy-quaternion]
 python-numpydoc:
   arch: [python2-numpydoc]
   debian: [python-numpydoc]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2342,6 +2342,12 @@ python-numpy-quaternion-pip:
   osx:
     pip:
       packages: [numpy-quaternion]
+  debian:
+    pip:
+      packages: [numpy-quaternion]
+  fedora:
+    pip:
+      packages: [numpy-quaternion]
   ubuntu:
     pip:
       packages: [numpy-quaternion]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -600,7 +600,7 @@ python-boto3:
   opensuse: [python-boto3]
   ubuntu:
     '*': [python-boto3]
-    trusty:
+    trusty: null
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
@@ -1776,7 +1776,7 @@ python-imaging:
   arch: [python2-pillow]
   debian:
     '*': [python-pil]
-    jessie: [python-imaging]
+    jessie:  [python-imaging]
     stretch: [python-imaging]
   fedora:
     '21': [python-pillow, python-pillow-qt]
@@ -3874,12 +3874,12 @@ python-statsd:
 python-subprocess32:
   debian:
     '*': [python-subprocess32]
-    jessie:
+    jessie: null
   fedora: [python-subprocess32]
   gentoo: [dev-python/subprocess32]
   ubuntu:
     '*': [python-subprocess32]
-    trusty:
+    trusty: null
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -4643,7 +4643,7 @@ python3-gitlab:
 python3-lark-parser:
   fedora:
     '*': [python-lark-parser]
-    '28':
+    '28': null
   gentoo: [dev-python/lark]
   ubuntu:
     bionic: [python3-lark-parser]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -600,7 +600,7 @@ python-boto3:
   opensuse: [python-boto3]
   ubuntu:
     '*': [python-boto3]
-    trusty: null
+    trusty:
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
@@ -1776,7 +1776,7 @@ python-imaging:
   arch: [python2-pillow]
   debian:
     '*': [python-pil]
-    jessie:  [python-imaging]
+    jessie: [python-imaging]
     stretch: [python-imaging]
   fedora:
     '21': [python-pillow, python-pillow-qt]
@@ -2331,6 +2331,19 @@ python-numpy:
     xenial: [python-numpy]
     yakkety: [python-numpy]
     zesty: [python-numpy]
+python-numpy-quaternion-pip:
+  debian:
+    pip:
+      packages: [numpy-quaternion]
+  fedora:
+    pip:
+      packages: [numpy-quaternion]
+  osx:
+    pip:
+      packages: [numpy-quaternion]
+  ubuntu:
+    pip:
+      packages: [numpy-quaternion]
 python-numpy-stl-pip:
   osx:
     pip:
@@ -2338,19 +2351,6 @@ python-numpy-stl-pip:
   ubuntu:
     pip:
       packages: [numpy-stl]
-python-numpy-quaternion-pip:
-  osx:
-    pip:
-      packages: [numpy-quaternion]
-  debian:
-    pip:
-      packages: [numpy-quaternion]
-  fedora:
-    pip:
-      packages: [numpy-quaternion]
-  ubuntu:
-    pip:
-      packages: [numpy-quaternion]
 python-numpydoc:
   arch: [python2-numpydoc]
   debian: [python-numpydoc]
@@ -3874,12 +3874,12 @@ python-statsd:
 python-subprocess32:
   debian:
     '*': [python-subprocess32]
-    jessie: null
+    jessie:
   fedora: [python-subprocess32]
   gentoo: [dev-python/subprocess32]
   ubuntu:
     '*': [python-subprocess32]
-    trusty: null
+    trusty:
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -4643,7 +4643,7 @@ python3-gitlab:
 python3-lark-parser:
   fedora:
     '*': [python-lark-parser]
-    '28': null
+    '28':
   gentoo: [dev-python/lark]
   ubuntu:
     bionic: [python3-lark-parser]


### PR DESCRIPTION
Added pip package to the numpy implementation of quaternions.
numpy-quaternion adds quaterni9on dtype to NumPy (https://github.com/moble/quaternion).

To the best of my knowledge it is only available via Pip.