### PR TITLE
sick_safetyscanners: 1.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5544,6 +5544,21 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: master
     status: maintained
+  sick_safetyscanners:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/SICKAG/sick_safetyscanners-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners.git
+      version: master
+    status: developed
   sick_tim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners` to `1.0.2-0`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners.git
- release repository: https://github.com/SICKAG/sick_safetyscanners-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## sick_safetyscanners

```
* Read the start angle of the field data from the persistent config instead of the current config
* Changed to 0 angle being at the front of the scan
* Allow system to choose the host udp port from the ephemeral range.  Resolve typo -> IPAdress to IPAddress
* Changed default frame_id name to scan
* Change publish_frequency parameter to be skip parameter.
* Add time_offset parameter to adjust scan system timestamps
* Added median reflector bit in message and code
* Added active case number to the service call
* Field data is returned as a vector for all fields
* Added publisher und service server for field data and output paths
* Added Start angle and beam resolution to field data
```
