### PR TITLE
rosdep: add golang-1.10-go specific rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1018,7 +1018,6 @@ gnuplot:
   ubuntu: [gnuplot]
 golang-1.10-go:
   ubuntu: [golang-1.10-go]
-  gentoo: [dev-lang/go]
 golang-go:
   debian: [golang-go]
   gentoo: [dev-lang/go]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1016,6 +1016,9 @@ gnuplot:
   fedora: [gnuplot]
   gentoo: [sci-visualization/gnuplot]
   ubuntu: [gnuplot]
+golang-1.10-go:
+  ubuntu: [golang-1.10-go]
+  gentoo: [dev-lang/go]
 golang-go:
   debian: [golang-go]
   gentoo: [dev-lang/go]


### PR DESCRIPTION
There is no debian package that as 1.10. Gentoo's one seems to be the latest

https://packages.ubuntu.com/cosmic/golang-1.10
https://packages.debian.org/search?keywords=golang-1.&searchon=names&suite=stable&section=all
https://packages.gentoo.org/packages/dev-lang/go