### PR TITLE
pybind11_catkin: 2.2.4-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9141,7 +9141,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
-      version: 2.2.4-2
+      version: 2.2.4-3
     source:
       type: git
       url: https://github.com/ipab-slmc/pybind11_catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.2.4-3`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `2.2.4-2`
