### PR TITLE
pybind11_catkin: 2.2.4-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3826,7 +3826,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
-      version: 2.2.4-4
+      version: 2.2.4-5
     source:
       type: git
       url: https://github.com/ipab-slmc/pybind11_catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.2.4-5`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `2.2.4-4`
