### PR TITLE
demos: 0.6.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -280,7 +280,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.6.2-0`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.6.1-0`

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Added serialized listener demo for python (#287 <https://github.com/ros2/demos/issues/287>)
* Contributors: Joseph Duchesne
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Updated to support OpenCV 2, 3 and 4 (#307 <https://github.com/ros2/demos/issues/307>)
* Updated for OpenCV v4.0 compatibility (#306 <https://github.com/ros2/demos/issues/306>)
* Updated to show freq parameter on help only when necessary (#296 <https://github.com/ros2/demos/issues/296>)
* Contributors: Gonzo, Jacob Perron
```

## intra_process_demo

```
* Updated to support OpenCV 2, 3 and 4 (#307 <https://github.com/ros2/demos/issues/307>)
* Contributors: Jacob Perron
```

## lifecycle

```
* Added readme.rst (#300 <https://github.com/ros2/demos/issues/300>)
* Contributors: Karsten Knese
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## topic_monitor

- No changes
