### PR TITLE
pilz_robots: 0.4.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8544,6 +8544,8 @@ repositories:
       packages:
       - pilz_control
       - pilz_robots
+      - pilz_testutils
+      - prbt_gazebo
       - prbt_hardware_support
       - prbt_ikfast_manipulator_plugin
       - prbt_moveit_config
@@ -8551,7 +8553,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.4.3-0
+      version: 0.4.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.4.4-0`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.4.3-0`

## pilz_control

```
* Increase controller holding mode user feedback from INFO to WARN
```

## pilz_robots

- No changes

## pilz_testutils

```
* Provide class AsyncTest for tests with asynchronous events
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

```
* Provide prbt_gazebo package
* Contributors: Pilz GmbH and Co. KG
```

## prbt_hardware_support

```
* Fix PilzModbusReadClient unittest
```

## prbt_ikfast_manipulator_plugin

```
* Use ikfast plugin template of moveit version 0.10.8
* Fix sign-compare and deprecated warnings
```

## prbt_moveit_config

```
* Set default pipeline to ompl. To run with the specified
  run_depends we cannot default to command_planner.
```

## prbt_support

```
* Fixup of mesh files due to errors in gazebo visualization
```
