### PR TITLE
navigation_experimental: 0.3.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2866,7 +2866,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_experimental-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.3.2-0`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.3.1-0`

## assisted_teleop

```
* Fix some includes
* Contributors: Martin Günther
```

## goal_passer

- No changes

## navigation_experimental

- No changes

## pose_base_controller

- No changes

## pose_follower

```
* max rotation vel in in-place rotation limited (#27 <https://github.com/ros-planning/navigation_experimental/issues/27>)
* pose_follower: Add visualization of global plan (#26 <https://github.com/ros-planning/navigation_experimental/issues/26>)
* Contributors: Martin Günther, Pavel, sumejko92
```

## sbpl_lattice_planner

```
* Reinit on map size, footprint and costmap changes
* Add warning when cost_scaling_factor is too large
  Also see #33 <https://github.com/ros-planning/navigation_experimental/issues/33>.
* Fix example config for TF2 (#30 <https://github.com/ros-planning/navigation_experimental/issues/30>)
* sbpl_lattice_planner: Add missing DEPENDS SBPL
* Contributors: Jonathan Meyer, Martin Günther
```

## sbpl_recovery

```
* Fix some includes
* Contributors: Martin Günther
```

## twist_recovery

- No changes
