### PR TITLE
navigation_experimental: 0.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7120,7 +7120,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_experimental-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.2.1-0`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.2.0-0`

## assisted_teleop

```
* Fix some includes
* Don't link against Eigen_LIBRARIES
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## goal_passer

```
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## navigation_experimental

- No changes

## pose_base_controller

- No changes

## pose_follower

```
* max rotation vel in in-place rotation limited (#27 <https://github.com/ros-planning/navigation_experimental/issues/27>)
* Add visualization of global plan (#26 <https://github.com/ros-planning/navigation_experimental/issues/26>)
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther, Pavel, sumejko92
```

## sbpl_lattice_planner

```
* Reinit on map size, footprint and costmap changes
* Add warning when cost_scaling_factor is too large
  Also see #33 <https://github.com/ros-planning/navigation_experimental/issues/33>.
* Ignore SBPL compile warning (#31 <https://github.com/ros-planning/navigation_experimental/issues/31>)
* Fix example config for TF2 (#30 <https://github.com/ros-planning/navigation_experimental/issues/30>)
* Update to tf2, add dependency
* Contributors: Jonathan Meyer, Martin Günther
```

## sbpl_recovery

```
* Ignore SBPL compile warning
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```

## twist_recovery

```
* Use non deprecated pluginlib macro + headers
* Contributors: Martin Günther
```
