### PR TITLE
add libopencv-contrib-dev to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2428,6 +2428,12 @@ libopenblas-dev:
   debian: [libopenblas-dev]
   fedora: [openblas-devel]
   ubuntu: [libopenblas-dev]
+libopencv-contrib-dev:
+  arch: [opencv-contrib]
+  debian: [libopencv-contrib-dev]
+  fedora: [opencv-contrib]
+  gentoo: [media-libs/opencv]
+  ubuntu: [libopencv-contrib-dev]
 libopencv-dev:
   arch: [opencv]
   debian: [libopencv-dev]
@@ -2443,11 +2449,6 @@ libopencv-dev:
     vivid: [libopencv-dev]
     wily: [libopencv-dev]
     xenial: [libopencv-dev]
-libopencv-contrib-dev:
-  arch: [opencv-contrib]
-  debian: [libopencv-contrib-dev]
-  fedora: [opencv-contrib]
-  ubuntu: [libopencv-contrib-dev]
 libopenexr-dev:
   arch: [openexr]
   debian: [libopenexr-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2443,6 +2443,11 @@ libopencv-dev:
     vivid: [libopencv-dev]
     wily: [libopencv-dev]
     xenial: [libopencv-dev]
+libopencv-contrib-dev:
+  arch: [opencv-contrib]
+  debian: [libopencv-contrib-dev]
+  fedora: [opencv-contrib]
+  ubuntu: [libopencv-contrib-dev]
 libopenexr-dev:
   arch: [openexr]
   debian: [libopenexr-dev]


### PR DESCRIPTION
arch: https://aur-dev.archlinux.org/packages/opencv-contrib/
debian: https://packages.debian.org/sid/libopencv-contrib-dev
fedora: https://apps.fedoraproject.org/packages/opencv-contrib
gentoo: I think this is the same as libopencv-dev key. Should I still add it to the file? https://packages.gentoo.org/packages/media-libs/opencv
macports: could not find anything
ubuntu: https://packages.ubuntu.com/bionic/libopencv-contrib-dev

Not sure if Ubuntu needs all the distributions separate as with libopencv-dev key?