### PR TITLE
gripit: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3638,6 +3638,12 @@ repositories:
       url: https://github.com/anybotics/grid_map.git
       version: master
     status: developed
+  gripit:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Yannick-Oderri/gripit-release.git
+      version: 0.0.1-0
   grizzly:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gripit` to `0.0.1-0`:

- upstream repository: https://github.com/Yannick-Oderri/GripIt.git
- release repository: https://github.com/Yannick-Oderri/gripit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`
