### PR TITLE
ifopt: 2.0.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4311,7 +4311,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 2.0.5-0
+      version: 2.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.0.6-0`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `2.0.5-0`

## ifopt

```
* Enable problems without constraints: Fix issue (#34 <https://github.com/ethz-adrl/ifopt/issues/34> , #35 <https://github.com/ethz-adrl/ifopt/issues/35>)
* Fix/segfaults (#33 <https://github.com/ethz-adrl/ifopt/issues/33>)
* Contributors: Wolfgang Merkt, viviansuzano
```
