### PR TITLE
rospy_message_converter: 0.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4835,6 +4835,22 @@ repositories:
       url: https://github.com/rospilot/rospilot.git
       version: melodic
     status: developed
+  rospy_message_converter:
+    doc:
+      type: git
+      url: https://github.com/uos/rospy_message_converter.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/rospy_message_converter-release.git
+      version: 0.5.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uos/rospy_message_converter.git
+      version: master
+    status: maintained
   rosserial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.0-0`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## rospy_message_converter

```
* Initial release into Lunar and Melodic
* Remove support for Jade (EOL)
* Change maintainer from Brandon Alexander to Martin Günther
* Move repo from baalexander to uos
* Add serialize_deserialize to unit tests, fix incorrect tests caught by this
* Remove dependency on ROS master in tests; all tests are now unit
  tests  (#18 <https://github.com/uos/rospy_message_converter/issues/18>)
* Add service request/response support (#17 <https://github.com/uos/rospy_message_converter/issues/17>)
* Fix fixed-size uint8 array conversion failure (#15 <https://github.com/uos/rospy_message_converter/issues/15>)
* Fix unicode handling in string fields (#13 <https://github.com/uos/rospy_message_converter/issues/13>)
* Enable testing only if CATKIN_ENABLE_TESTING is set (#9 <https://github.com/uos/rospy_message_converter/issues/9>)
* Contributors: Martin Günther, Brandon Alexander, George Laurent, Jean-Baptiste Doyon, Viktor Schlegel, Rein Appeldoorn, Will Baker, neka-nat
```
