### PR TITLE
Add ninja-build rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4021,6 +4021,12 @@ network-manager:
   fedora: [NetworkManager]
   gentoo: [net-misc/networkmanager]
   ubuntu: [network-manager]
+ninja-build:
+  arch: [ninja]
+  debian: [ninja-build]
+  fedora: [ninja-build]
+  gentoo: [dev-util/ninja]
+  ubuntu: [ninja-build]
 nite-dev:
   arch: [primesense-nite]
   debian: [nite-dev]


### PR DESCRIPTION
The Ninja build system is an alternative build system. I need this to release webrtc_ros, since the WebRTC Native API requires Ninja to build.