### PR TITLE
rosjava_bootstrap: 0.3.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11263,7 +11263,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_bootstrap-release.git
-      version: 0.3.2-0
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/rosjava/rosjava_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosjava_bootstrap` to `0.3.3-1`:

- upstream repository: https://github.com/rosjava/rosjava_bootstrap
- release repository: https://github.com/rosjava-release/rosjava_bootstrap-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.3.2-0`

## rosjava_bootstrap

```
* Adding google to repository list in buildscript.gradle.
* Using ChannelBuffers for int8[] data; fixing testInt8List.
* Adding action generation implementation.
* Add tests for byte arrays.
* Add tests for incomplete initialization and string arrays.
* Add tests for fixed sized arrays of floats.
* Add Bazel build for message_generation.
* Minor fixes.
* Contributors: Arne, Ernesto Corbellini, Juan Ignacio Ubeira, Rodrigo Queiro
```
