### PR TITLE
vapor_master: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6294,7 +6294,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roshub/vapor_master-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/roshub/vapor_master.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vapor_master` to `0.2.0-0`:

- upstream repository: https://github.com/roshub/vapor_master.git
- release repository: https://github.com/roshub/vapor_master-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.1.0-0`
