### PR TITLE
pilz_robots: 0.4.6-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8559,7 +8559,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.4.5-0
+      version: 0.4.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.4.6-0`:
- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `kinetic/distribution.yaml`
- previous version for package: `0.4.5-0`

## pilz_control
- No changes 

## pilz_robots
- No changes 

## pilz_testutils
- No changes 

## prbt_gazebo
- No changes 

## prbt_hardware_support
- Update used pipeline in test from command_planner to pilz_command_planner

## prbt_ikfast_manipulator_plugin
- No changes 

## prbt_moveit_config
-  Rename command_planner to pilz_command_planner

## prbt_support
- No changes
