### PR TITLE
webrtc_ros: 59.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14945,6 +14945,16 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  webrtc_ros:
+    release:
+      packages:
+      - webrtc
+      - webrtc_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/webrtc_ros-release.git
+      version: 59.0.0-0
+    status: developed
   webtest:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `webrtc_ros` to `59.0.0-0`:

- upstream repository: https://github.com/RobotWebTools/webrtc_ros.git
- release repository: https://github.com/RobotWebTools-release/webrtc_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## webrtc

```
* Revival release
* Upgrade to WebRTC Native API version 59
```

## webrtc_ros

```
* Upgrade server implementation to support the new API 59
* Remove deprecated browser features from JS code
* Only subscribe once to each ROS image topic, regardless of the number of WebRTC clients
* Various other fixes
* Contributors: Aaron Gokaslan, Mitchell Wills, Robot User, Russell Toris, Timo Röhling
```
