### PR TITLE
pilz_industrial_motion: 0.3.2-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8535,7 +8535,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.3.2-0`:
- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `kinetic/distribution.yaml`
- previous version for package: `0.3.1-0`

## pilz_extensions
- No changes

## pilz_industrial_motion
- No changes

## pilz_industrial_motion_testutils
- No changes

## pilz_msgs
- No changes

## pilz_robot_programming
- No changes

## pilz_trajectory_generation
- use pilz_testutils package for blend test
- use collision-aware ik calculation
