### PR TITLE
robot_recorder: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10148,7 +10148,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa-jfh/robot_recorder-release.git
-      version: 1.0.0-2
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ipa-jfh/robot_recorder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_recorder` to `1.0.1-0`:

- upstream repository: https://github.com/ipa-jfh/robot_recorder.git
- release repository: https://github.com/ipa-jfh/robot_recorder-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `1.0.0-2`

## recordit

```
* invert manual arg to keep default behaviour
* fix manual to auto mode
* install launch file
```

## robot_recorder

- No changes

## rviz_recorder_buttons

- No changes
