### PR TITLE
fmi_adapter_ros2: 0.1.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -464,7 +464,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: 0.1.0
+      version: master
     release:
       packages:
       - fmi_adapter
@@ -476,7 +476,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: 0.1.0
+      version: master
     status: developed
   gazebo_ros_pkgs:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -460,6 +460,24 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: master
     status: developed
+  fmi_adapter_ros2:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: 0.1.0
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: 0.1.0
+    status: developed
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.0-0`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/boschresearch/fmi_adapter_ros2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## fmi_adapter

```
* Initial version for ROS 2, ported from https://github.com/boschresearch/fmi_adapter/
```

## fmi_adapter_examples

```
* Initial version for ROS 2, ported from https://github.com/boschresearch/fmi_adapter/
```
