### PR TITLE
plotjuggler: 2.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3563,7 +3563,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 1.9.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.0.1-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.9.0-0`

## plotjuggler

```
* important bug fix. Removed offset in X axis of PlotXY
* fix minor visualization issue.
* Contributors: Davide Faconti
```
