### PR TITLE
teleop_twist_joy: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13296,7 +13296,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-teleop/teleop_twist_joy-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_twist_joy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `0.1.3-0`:

- upstream repository: https://github.com/ros-teleop/teleop_twist_joy.git
- release repository: https://github.com/ros-teleop/teleop_twist_joy-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.1.2-0`

## teleop_twist_joy

```
* Use industrial ci
* Don't crash with invalid axes.
* Make sure to not crash when the Joy message buttons is too small.
* Don't get the axis twice.
* Add ROS Wiki link (#26 <https://github.com/ros-teleop/teleop_twist_joy/issues/26>)
* Contributors: Chris Lalancette, Julian Gaal, Rousseau Vincent, vincentrou
```
