### PR TITLE
teleop_twist_joy: 0.1.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5835,6 +5835,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_tools.git
       version: melodic-devel
     status: maintained
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_joy.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-teleop/teleop_twist_joy-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_joy.git
+      version: indigo-devel
+    status: maintained
   teleop_twist_keyboard:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `0.1.3-0`:

- upstream repository: https://github.com/ros-teleop/teleop_twist_joy.git
- release repository: https://github.com/ros-teleop/teleop_twist_joy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## teleop_twist_joy

```
* Use industrial ci
* Don't crash with invalid axes.
* Make sure to not crash when the Joy message buttons is too small.
* Don't get the axis twice.
* Add ROS Wiki link (#26 <https://github.com/ros-teleop/teleop_twist_joy/issues/26>)
* Contributors: Chris Lalancette, Julian Gaal, Rousseau Vincent, vincentrou
```
