### PR TITLE
zeroconf_msgs: 0.2.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6655,5 +6655,20 @@ repositories:
       url: https://github.com/openspur/ypspur_ros.git
       version: master
     status: developed
+  zeroconf_msgs:
+    doc:
+      type: git
+      url: https://github.com/stonier/zeroconf_msgs.git
+      version: indigo
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/zeroconf_msgs-release.git
+      version: 0.2.1-0
+    source:
+      type: git
+      url: https://github.com/stonier/zeroconf_msgs.git
+      version: indigo
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_msgs` to `0.2.1-0`:

- upstream repository: https://github.com/stonier/zeroconf_msgs.git
- release repository: https://github.com/yujinrobot-release/zeroconf_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
