### PR TITLE
flir_boson_usb: 1.1.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1007,7 +1007,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/astuff/flir_boson_usb-release.git
-      version: 1.0.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/astuff/flir_boson_usb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_boson_usb` to `1.1.1-0`:

- upstream repository: https://github.com/astuff/flir_boson_usb.git
- release repository: https://github.com/astuff/flir_boson_usb-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.0.0-0`

## flir_boson_usb

```
* Temporarily removing camera_info_manager.
* Contributors: Joshua Whitley
```
