### PR TITLE
py_trees: 1.0.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -881,6 +881,21 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: developed
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/stonier/py_trees.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/stonier/py_trees-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees.git
+      version: release/1.0.x
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `1.0.0-0`:

- upstream repository: https://github.com/stonier/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`
