### PR TITLE
py_trees_msgs: 0.3.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9119,7 +9119,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/py_trees_msgs-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
     source:
       type: git
       url: https://github.com/stonier/py_trees_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.3.6-0`:

- upstream repository: https://github.com/stonier/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.3.5-0`
