### PR TITLE
py_trees_msgs: 0.3.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3806,7 +3806,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stonier/py_trees_msgs-release.git
-      version: 0.3.5-0
+      version: 0.3.6-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees_msgs.git
+      version: release/0.3-melodic
     status: maintained
   py_trees_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.3.6-0`:

- upstream repository: https://github.com/stonier/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.3.5-0`
