### PR TITLE
turtlebot3_simulations: 1.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5990,7 +5990,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `1.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.1.0-0`

## turtlebot3_fake

```
* move out the init() from ROS_ASSERT #68 <https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/68>
* Contributors: Sean Yen, Darby Lim, Pyo
```

## turtlebot3_gazebo

```
* moved <scene> into <world> #65 <https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/65>
* modified ML stage
* delete unused param
* update algorithm and modified variable more clearly
* Contributors: Darby Lim, Gilbert, Louise Poubel, Pyo
```

## turtlebot3_simulations

```
* move out the init() from ROS_ASSERT #68 <https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/68>
* moved <scene> into <world> #65 <https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/65>
* modified ML stage
* delete unused param
* update algorithm and modified variable more clearly
* Contributors: Darby Lim, Gilbert, Louise Poubel, Pyo
```
