### PR TITLE
rosbash_params: 1.0.0-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12985,6 +12985,17 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosbash_params:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/peci1/rosbash_params-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/peci1/rosbash_params.git
+      version: devel
+    status: developed
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbash_params` to `1.0.0-1`:

- upstream repository: https://github.com/peci1/rosbash_params.git
- release repository: https://github.com/peci1/rosbash_params-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## rosbash_params

```
* Initial version.
* Contributors: Martin Pecka
```
