### PR TITLE
Revert rosjava_build_tools request

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11274,7 +11274,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_build_tools-release.git
-      version: 0.3.3-1
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/rosjava/rosjava_build_tools.git


### PR DESCRIPTION
This reverts #19978 which is causing a regression of rosjava_core and others.

@jubeira FYI