### PR TITLE
restore new version of rosjava_build_tools

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11274,7 +11274,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/rosjava_build_tools-release.git
-      version: 0.3.2-0
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/rosjava/rosjava_build_tools.git


### PR DESCRIPTION
Restores #19978 reverted in #20018  that did not fix the broken packages. Ticketed upstream in https://github.com/rosjava/rosjava_core/issues/288