### PR TITLE
vapor_master: 0.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6310,7 +6310,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roshub/vapor_master-release.git
-      version: 0.2.0-0
+      version: 0.3.0-0
     source:
       type: git
       url: https://github.com/roshub/vapor_master.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vapor_master` to `0.3.0-0`:

- upstream repository: https://github.com/roshub/vapor_master.git
- release repository: https://github.com/roshub/vapor_master-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.2.0-0`

## vapor_master

```
* remove dead code
* Allow parameter array and map containers (#26 <https://github.com/roshub/vapor_master/issues/26>)
  * track array items
  * support yaml maps and arrays. ensure single no duplicate param paths and allow updating
* Contributors: 7bit, Nick Zatkovich
```
