### PR TITLE
rosbash_params: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12991,7 +12991,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/peci1/rosbash_params-release.git
-      version: 1.0.0-1
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/peci1/rosbash_params.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbash_params` to `1.0.1-0`:

- upstream repository: https://github.com/peci1/rosbash_params.git
- release repository: https://github.com/peci1/rosbash_params-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.0.0-1`

## rosbash_params

```
* Removed console output in non-verbose mode.
* Contributors: Martin Pecka
```
