### PR TITLE
rosbash_params: 1.0.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12987,11 +12987,15 @@ repositories:
       version: 1.0.0-0
     status: maintained
   rosbash_params:
+    doc:
+      type: git
+      url: https://github.com/peci1/rosbash_params.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/peci1/rosbash_params-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/peci1/rosbash_params.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12999,7 +12999,7 @@ repositories:
     source:
       type: git
       url: https://github.com/peci1/rosbash_params.git
-      version: devel
+      version: master
     status: developed
   rosbridge_suite:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbash_params` to `1.0.1-1`:

- upstream repository: https://github.com/peci1/rosbash_params.git
- release repository: https://github.com/peci1/rosbash_params-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.0.0-1`

## rosbash_params

```
* Removed console output in non-verbose mode.
* Contributors: Martin Pecka
```
