### PR TITLE
zeroconf_jmdns_suite: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15372,7 +15372,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/zeroconf_jmdns_suite-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/rosjava/zeroconf_jmdns_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zeroconf_jmdns_suite` to `0.3.1-0`:

- upstream repository: https://github.com/rosjava/zeroconf_jmdns_suite.git
- release repository: https://github.com/rosjava-release/zeroconf_jmdns_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.3.0-0`

## zeroconf_jmdns_suite

```
* Updating Gradle version to 4.10.2.
* Fixing package name for jmdns package.
* Fix for tutorial links and testing instructions.
* Contributors: Daniel Stonier, Juan Ignacio Ubeira, Julian Cerruti
```
