### PR TITLE
genjava: 0.3.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3334,7 +3334,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosjava-release/genjava-release.git
-      version: 0.3.3-0
+      version: 0.3.4-0
     source:
       type: git
       url: https://github.com/rosjava/genjava.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjava` to `0.3.4-0`:

- upstream repository: https://github.com/rosjava/genjava.git
- release repository: https://github.com/rosjava-release/genjava-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.3.3-0`

## genjava

```
* Updating Gradle version to 4.10.2.
* Minor fixes: cross compilation instruction, typos, dependency warnings.
* Contributors: Arne, Daniel Ingram, Johannes Meyer, Juan Ignacio Ubeira, Julian Cerruti
```
