### PR TITLE
mapviz: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2294,7 +2294,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 0.3.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.0.0-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.3.0-0`

## mapviz

```
* Sharing tf_manager_ between main app and plugins (#555 <https://github.com/swri-robotics/mapviz/issues/555>)
* Contributors: Davide Faconti
```

## mapviz_plugins

```
* Sharing tf_manager_ between main app and plugins (#555 <https://github.com/swri-robotics/mapviz/issues/555>)
* Fix potential segfault in pointcloud plug-in. (#602 <https://github.com/swri-robotics/mapviz/issues/602>)
* Add Measuring Plugin (#598 <https://github.com/swri-robotics/mapviz/issues/598>)
* Contributors: Davide Faconti, Marc Alban, Matthew
```

## multires_image

```
* Sharing tf_manager_ between main app and plugins (#555 <https://github.com/swri-robotics/mapviz/issues/555>)
* Contributors: Davide Faconti
```

## tile_map

```
* Sharing tf_manager_ between main app and plugins (#555 <https://github.com/swri-robotics/mapviz/issues/555>)
* Fix issue with loading Bing map tiles (#599 <https://github.com/swri-robotics/mapviz/issues/599>)
* Contributors: Davide Faconti, P. J. Reed
```
