### PR TITLE
flir_boson_usb: 1.1.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2994,7 +2994,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/flir_boson_usb-release.git
-      version: 1.0.0-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/astuff/flir_boson_usb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_boson_usb` to `1.1.2-0`:

- upstream repository: https://github.com/astuff/flir_boson_usb.git
- release repository: https://github.com/astuff/flir_boson_usb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.0.0-0`

## flir_boson_usb

```
* Found bug in device path parameter.
* Contributors: Joshua Whitley
```
