### PR TITLE
flir_boson_usb: 1.1.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1218,7 +1218,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/flir_boson_usb-release.git
-      version: 1.0.0-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/astuff/flir_boson_usb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_boson_usb` to `1.1.2-0`:

- upstream repository: https://github.com/astuff/flir_boson_usb.git
- release repository: https://github.com/astuff/flir_boson_usb-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.0.0-0`

## flir_boson_usb

```
* Found bug in device path parameter.
* Contributors: Joshua Whitley
```
