### PR TITLE
plotjuggler: 2.0.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3302,7 +3302,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 1.9.0-0
+      version: 2.0.2-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.0.2-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.9.0-0`

## plotjuggler

```
* should solve issue #127 : stop publishers when data reloaded or deleted
* fixing issues whe disabling an already disabled publisher
* solved problem with time slider (issue #125)
* fix issue #126
* StatePublisher improved
* Contributors:  Davide Faconti
```
