### PR TITLE
rosdoc_lite: 0.2.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11202,7 +11202,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rosdoc_lite-release.git
-      version: 0.2.7-0
+      version: 0.2.9-0
     source:
       type: git
       url: https://github.com/ros-infrastructure/rosdoc_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.9-0`:

- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.2.7-0`

## rosdoc_lite

```
* use yaml.safe_load for untrusted yaml input
* Contributors: Dirk Thomas
```
