### PR TITLE
robotnik_msgs: 0.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10407,7 +10407,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
-      version: 0.2.4-0
+      version: 0.2.5-0
     source:
       type: git
       url: https://github.com/RobotnikAutomation/robotnik_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_msgs` to `0.2.5-0`:

- upstream repository: https://github.com/RobotnikAutomation/robotnik_msgs.git
- release repository: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.2.4-0`

## robotnik_msgs

```
* add srv and msg to query alarms
* Create Register msg for Modbus communication
* Add SetNamedDigitalOutput srv
* Adding message for an array of Booleans
* Adding flag lasers_on_standby into SafetyModuleStatus
* Adding BatteryDockingStatus stamped
* setting format of battery status stamped in the correct way
* Adding new messages for battery docking status and battery status stamped
* updated safety msgs
* Added srv ResetFromSubState
* added SubState.msg
* correcting changelog format
* zones msgs are now in their own package
* Added robotnik_navigation_tools msgs
* Removed lasers ok field
* Update LaserStatus.msg
* Update SafetyModuleStatus.msg
* Added new fields to SafetyModuleStatus
* Added new fields to SafetyModuleStatus
```
