### PR TITLE
webrtc_ros: 59.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -17445,7 +17445,11 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/RobotWebTools-release/webrtc_ros-release.git
-      version: 59.0.0-0
+      version: 59.0.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/webrtc_ros.git
+      version: develop
     status: developed
   webtest:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `webrtc_ros` to `59.0.1-0`:

- upstream repository: https://github.com/RobotWebTools/webrtc_ros.git
- release repository: https://github.com/RobotWebTools-release/webrtc_ros-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `59.0.0-0`

## webrtc

```
* Add support for i386 builds
* Forgot dependency on CMake
* Contributors: Timo Röhling
```

## webrtc_ros

```
* No changes
```
