### PR TITLE
webrtc_ros: 59.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14945,6 +14945,20 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  webrtc_ros:
+    release:
+      packages:
+      - webrtc
+      - webrtc_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/webrtc_ros-release.git
+      version: 59.0.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/webrtc_ros.git
+      version: develop
+    status: developed
   webtest:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `webrtc_ros` to `59.0.1-0`:

- upstream repository: https://github.com/RobotWebTools/webrtc_ros.git
- release repository: https://github.com/RobotWebTools-release/webrtc_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## webrtc

```
* Add support for i386 builds
* Forgot dependency on CMake
* Contributors: Timo Röhling
```

## webrtc_ros

```
* No changes
```
