### PR TITLE
webrtc_ros: 59.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6586,6 +6586,20 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  webrtc_ros:
+    release:
+      packages:
+      - webrtc
+      - webrtc_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/webrtc_ros-release.git
+      version: 59.0.1-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/webrtc_ros.git
+      version: develop
+    status: developed
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webrtc_ros` to `59.0.1-0`:

- upstream repository: https://github.com/RobotWebTools/webrtc_ros.git
- release repository: https://github.com/RobotWebTools-release/webrtc_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## webrtc

```
* Add support for i386 builds
* Forgot dependency on CMake
* Contributors: Timo Röhling
```

## webrtc_ros

```
* No changes
```
