### PR TITLE
webrtc_ros: 59.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6594,7 +6594,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/webrtc_ros-release.git
-      version: 59.0.1-0
+      version: 59.0.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/webrtc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webrtc_ros` to `59.0.2-0`:

- upstream repository: https://github.com/RobotWebTools/webrtc_ros.git
- release repository: https://github.com/RobotWebTools-release/webrtc_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `59.0.1-0`

## webrtc

```
* Only require CMake 2.8.12 for Indigo compatibility
* Contributors: Timo Röhling
```

## webrtc_ros

```
* Do not install files outside the package source folder
  I of all people should have caught that.
* Contributors: Timo Röhling
```
