### PR TITLE
flir_boson_usb: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2994,7 +2994,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/flir_boson_usb-release.git
-      version: 1.1.2-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/astuff/flir_boson_usb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_boson_usb` to `1.2.0-0`:

- upstream repository: https://github.com/astuff/flir_boson_usb.git
- release repository: https://github.com/astuff/flir_boson_usb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.1.2-0`

## flir_boson_usb

```
* Merge pull request #2 <https://github.com/astuff/flir_boson_usb/issues/2> from astuff/feat/add_camera_info_manager
  Feat/add camera info manager
* Defaulting to 60 fps everywhere.
* Swapping boost shared pointers for std shared pointers.
* More expressive error messages.
* Adding frame_rate parameter.
* Adding frame_id param and actually making it do something useful.
* Adding launch file with rectification.
* Cleaning up example file and launch file. Added namespace to launch.
* Adding example Boson_640.yaml calibration file.
* Adding camera_info_manager for image rectification.
* Contributors: Joshua Whitley, Rinda Gunjala
```
