### PR TITLE
ros_envelope: 0.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10918,6 +10918,12 @@ repositories:
       url: https://github.com/code-iai/ros_emacs_utils.git
       version: master
     status: maintained
+  ros_envelope:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/craigh92/ros_envelope-release.git
+      version: 0.0.0-0
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_envelope` to `0.0.0-0`:

- upstream repository: https://github.com/craigh92/ros_envelope
- release repository: https://github.com/craigh92/ros_envelope-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
