### PR TITLE
mapviz: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2294,7 +2294,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.0.1-0`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.0.0-0`

## mapviz

- No changes

## mapviz_plugins

```
* Use shared tf manager in measuring_plugin (#604 <https://github.com/swri-robotics/mapviz/issues/604>)
* Contributors: jgassaway
```

## multires_image

- No changes

## tile_map

- No changes
