### PR TITLE
ros_type_introspection: 1.3.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4609,11 +4609,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 1.1.1-0
+      version: 1.3.0-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git
       version: master
+    status: developed
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `1.3.0-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.1.1-0`

## ros_type_introspection

```
* adding new policy
* fix compiler warnings
* added comment
* Contributors: Davide Faconti, Robert Haschke, YiweiHan, janEbert
```
