### PR TITLE
movie_publisher: 1.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7788,11 +7788,6 @@ repositories:
       type: git
       url: https://github.com/peci1/movie_publisher.git
       version: indigo-devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/peci1/movie_publisher-release.git
-      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7783,6 +7783,21 @@ repositories:
       url: https://github.com/davetcoleman/moveit_visual_tools.git
       version: indigo-devel
     status: developed
+  movie_publisher:
+    doc:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/peci1/movie_publisher-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: indigo-devel
+    status: developed
   mrp2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.0.1-0`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## movie_publisher

```
* Fixed install rule.
* Documented all tools in readme.
* Added support for rewriting timestamps from TF messages.
* Fix Python3 compatibility. Added fix_bag_timestamps.
* Added readme.
* Initial commit.
* Contributors: Martin Pecka
```
