### PR TITLE
control_msgs: 2.0.0-0 in 'bouncy/distribution.yaml' [bloom]

### DIFF
--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -260,6 +260,21 @@ repositories:
       url: https://github.com/ros/console_bridge.git
       version: master
     status: maintained
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: bouncy-devel
+    release:
+      tags:
+        release: release/bouncy/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: bouncy-devel
+    status: maintained
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `2.0.0-0`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `bouncy/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## control_msgs

```
* ROS2 Bouncy conversion
* Replace Adolfo with Bence as maintainer
* Contributors: Austin Deric, Bence Magyar, Nestor Gonzalez
```
