### PR TITLE
Create branches from master for future crystal releases.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -939,7 +939,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: master
+      version: crystal
     release:
       packages:
       - rcl
@@ -954,7 +954,7 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/ros2/rcl.git
-      version: master
+      version: crystal
     status: developed
   rcl_interfaces:
     doc:
@@ -1016,7 +1016,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: master
+      version: crystal
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -1026,7 +1026,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: master
+      version: crystal
     status: developed
   rcutils:
     doc:
@@ -1086,7 +1086,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: master
+      version: crystal
     release:
       packages:
       - rmw
@@ -1099,13 +1099,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw.git
-      version: master
+      version: crystal
     status: developed
   rmw_connext:
     doc:
       type: git
       url: https://github.com/ros2/rmw_connext.git
-      version: master
+      version: crystal
     release:
       packages:
       - rmw_connext_cpp
@@ -1118,13 +1118,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_connext.git
-      version: master
+      version: crystal
     status: developed
   rmw_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      version: crystal
     release:
       packages:
       - rmw_fastrtps_cpp
@@ -1138,13 +1138,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: master
+      version: crystal
     status: developed
   rmw_implementation:
     doc:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: master
+      version: crystal
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -1154,13 +1154,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: master
+      version: crystal
     status: developed
   rmw_opensplice:
     doc:
       type: git
       url: https://github.com/ros2/rmw_opensplice.git
-      version: master
+      version: crystal
     release:
       packages:
       - rmw_opensplice_cpp
@@ -1172,7 +1172,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_opensplice.git
-      version: master
+      version: crystal
     status: developed
   robot_state_publisher:
     doc:


### PR DESCRIPTION
The master branches are undergoing development for the next ROS 2
release and are no longer compatibile with Crystal.