### PR TITLE
octomap_mapping: 0.6.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3128,7 +3128,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_mapping-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.2-0`:

- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.1-0`

## octomap_mapping

```
* Update maintainer email (Wolfgang Merkt)
* Contributors: Wolfgang Merkt
```

## octomap_server

```
* Update maintainer email (Wolfgang Merkt)
* Change catkin_package DEPENDS to OCTOMAP to avoid CMake warning
* Update maintainer email (Arming Hornung)
* Update to use non deprecated pluginlib macro
* Fixed memory leak of colors pointer if COLOR_OCTOMAP_SERVER defined
* Contributors: Armin Hornung, Mikael Arguedas, Ronky, Wolfgang Merkt
```
