### PR TITLE
movie_publisher: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7788,6 +7788,11 @@ repositories:
       type: git
       url: https://github.com/peci1/movie_publisher.git
       version: indigo-devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/peci1/movie_publisher-release.git
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.1.0-0`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## movie_publisher

```
* Added checks for exit codes to bash scripts.
* Fixed install targets.
* Added python-opencv alternative backend. This resolves debian packaging issues.
* Contributors: Martin Pecka
```
