### PR TITLE
rosbash_params: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11138,6 +11138,21 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosbash_params:
+    doc:
+      type: git
+      url: https://github.com/peci1/rosbash_params.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/peci1/rosbash_params-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/peci1/rosbash_params.git
+      version: master
+    status: developed
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbash_params` to `1.0.1-0`:

- upstream repository: https://github.com/peci1/rosbash_params.git
- release repository: https://github.com/peci1/rosbash_params-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## rosbash_params

```
* Removed console output in non-verbose mode.
* Contributors: Martin Pecka
```
