### PR TITLE
Add a bunch of RHEL deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -406,6 +406,7 @@ clang-format:
     stretch: [clang-format]
   fedora: [clang]
   gentoo: [sys-devel/clang]
+  rhel: [clang]
   ubuntu: [clang-format]
 clang-tidy:
   debian:
@@ -511,6 +512,7 @@ cppcheck:
   debian: [cppcheck]
   fedora: [cppcheck]
   gentoo: [dev-util/cppcheck]
+  rhel: [cppcheck]
   ubuntu: [cppcheck]
 cppunit:
   arch: [cppunit]
@@ -1588,6 +1590,7 @@ libconsole-bridge-dev:
   freebsd: [ros-console_bridge]
   gentoo: [dev-libs/console_bridge]
   opensuse: [libconsole_bridge0]
+  rhel: [console-bridge-devel]
   slackware: [console_bridge]
   ubuntu: [libconsole-bridge-dev]
 libcpprest-dev:
@@ -1790,11 +1793,13 @@ libfreetype6:
   debian: [libfreetype6]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
+  rhel: [freetype]
   ubuntu: [libfreetype6]
 libfreetype6-dev:
   debian: [libfreetype6-dev]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
+  rhel: [freetype-devel]
   ubuntu: [libfreetype6-dev]
 libftdi-dev:
   arch: [libftdi]
@@ -2440,6 +2445,7 @@ libopencv-dev:
   fedora: [opencv-devel]
   gentoo: [media-libs/opencv]
   macports: [opencv]
+  rhel: [opencv-devel]
   ubuntu:
     artful: [libopencv-dev]
     bionic: [libopencv-dev]
@@ -2652,6 +2658,7 @@ libpoco-dev:
   gentoo: [dev-libs/poco]
   macports: [poco]
   opensuse: [poco-devel]
+  rhel: [poco-devel]
   slackware: [poco]
   ubuntu: [libpoco-dev]
 libpocofoundation9:
@@ -2882,6 +2889,7 @@ libqt5-core:
   freebsd: [qt5-core]
   gentoo: ['dev-qt/qtcore:5']
   opensuse: [libQt5Core5]
+  rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu: [libqt5core5a]
 libqt5-gui:
@@ -2891,6 +2899,7 @@ libqt5-gui:
   freebsd: [qt5-gui]
   gentoo: ['dev-qt/qtgui:5']
   opensuse: [libQt5Gui5]
+  rhel: [qt5-qtbase-gui]
   slackware: [qt5]
   ubuntu: [libqt5gui5]
 libqt5-network:
@@ -2907,6 +2916,7 @@ libqt5-opengl:
   freebsd: [qt5-opengl]
   gentoo: ['dev-qt/qtopengl:5']
   opensuse: [libQt5OpenGL5]
+  rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu: [libqt5opengl5]
 libqt5-opengl-dev:
@@ -2953,6 +2963,7 @@ libqt5-widgets:
   freebsd: [qt5-widgets]
   gentoo: ['dev-qt/qtwidgets:5']
   opensuse: [libQt5Widgets5]
+  rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu: [libqt5widgets5]
 libqt5x11extras5-dev:
@@ -3519,6 +3530,7 @@ libx11-dev:
   debian: [libx11-dev]
   fedora: [libX11-devel]
   gentoo: [x11-libs/libX11]
+  rhel: [libX11-devel]
   ubuntu: [libx11-dev]
 libx264-dev:
   debian: [libx264-dev]
@@ -3598,6 +3610,7 @@ libxml2:
 libxml2-utils:
   debian: [libxml2-utils]
   fedora: [libxml2]
+  rhel: [libxml2]
   ubuntu: [libxml2-utils]
 libxmlrpc-c++:
   arch: [xmlrpc-c]
@@ -4164,6 +4177,7 @@ openssl:
   debian: [openssl]
   fedora: [openssl]
   gentoo: [dev-libs/openssl]
+  rhel: [openssl]
   ubuntu: [openssl]
 optipng:
   debian: [optipng]
@@ -4426,6 +4440,7 @@ qt5-qmake:
   freebsd: [qt5-qmake]
   gentoo: ['dev-qt/qtcore:5']
   opensuse: [libqt5-qtbase-common-devel]
+  rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qt5-qmake]
 qtbase5-dev:
@@ -4435,6 +4450,7 @@ qtbase5-dev:
   freebsd: [qt5-core]
   gentoo: ['dev-qt/qtcore:5', 'dev-qt/qtwidgets:5', 'dev-qt/qttest:5']
   opensuse: [libqt5-qtbase-common-devel, libqt5-qtbase-devel]
+  rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qtbase5-dev]
 qtdeclarative5-dev:
@@ -4841,7 +4857,6 @@ tango-icon-theme:
   macports: [tango-icon-theme]
   mandrake: [tango-icon-theme]
   opensuse: [tango-icon-theme]
-  rhel: [tango-icon-theme]
   slackware: [tango-icon-theme]
   ubuntu: [tango-icon-theme]
 tap-plugins:
@@ -4957,6 +4972,7 @@ tinyxml2:
   freebsd: [tinyxml2]
   gentoo: [dev-libs/tinyxml2]
   opensuse: [tinyxml2-devel]
+  rhel: [tinyxml2-devel]
   ubuntu: [libtinyxml2-dev]
 tix:
   arch: [tix]
@@ -5015,6 +5031,7 @@ uncrustify:
   debian: [uncrustify]
   fedora: [uncrustify]
   gentoo: [uncrustify]
+  rhel: [uncrustify]
   ubuntu: [uncrustify]
 unison:
   arch: [unison]
@@ -5276,6 +5293,7 @@ yaml:
   fedora: [libyaml]
   gentoo: [dev-libs/libyaml]
   macports: [libyaml]
+  rhel: [libyaml-devel]
   ubuntu: [libyaml-dev]
 yaml-cpp:
   alpine: [yaml-cpp-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2107,6 +2107,7 @@ python-mock:
   osx:
     pip:
       packages: [mock]
+  rhel: [python2-mock]
   slackware: [mock]
   ubuntu:
     artful: [python-mock]
@@ -4695,7 +4696,6 @@ python3-matplotlib:
     pip:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
-  rhel: [python3-matplotlib]
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mock:


### PR DESCRIPTION
These packages are available either in the distribution base repository or as part of EPEL (Extra Packages for Enterprise Linux), a curated repository maintained through the Fedora project.

From Base
---------
libfreetype6: http://mirror.centos.org/centos/7/os/x86_64/Packages/freetype-2.8-12.el7.x86_64.rpm
libfreetype6-dev: http://mirror.centos.org/centos/7/os/x86_64/Packages/freetype-devel-2.8-12.el7.x86_64.rpm
libopencv-dev: http://mirror.centos.org/centos/7/os/x86_64/Packages/opencv-devel-2.4.5-3.el7.x86_64.rpm
libqt5-core: http://mirror.centos.org/centos/7/os/x86_64/Packages/qt5-qtbase-5.9.2-3.el7.x86_64.rpm
libqt5-gui: http://mirror.centos.org/centos/7/os/x86_64/Packages/qt5-qtbase-gui-5.9.2-3.el7.x86_64.rpm
libqt5-opengl: http://mirror.centos.org/centos/7/os/x86_64/Packages/qt5-qtbase-5.9.2-3.el7.x86_64.rpm
libqt5-widgets: http://mirror.centos.org/centos/7/os/x86_64/Packages/qt5-qtbase-5.9.2-3.el7.x86_64.rpm
libx11-dev: http://mirror.centos.org/centos/7/os/x86_64/Packages/libX11-devel-1.6.5-2.el7.x86_64.rpm
libxml2-utils: http://mirror.centos.org/centos/7/os/x86_64/Packages/libxml2-2.9.1-6.el7_2.3.x86_64.rpm
openssl: http://mirror.centos.org/centos/7/os/x86_64/Packages/openssl-1.0.2k-16.el7.x86_64.rpm
qt5-qmake: http://mirror.centos.org/centos/7/os/x86_64/Packages/qt5-qtbase-devel-5.9.2-3.el7.x86_64.rpm
qtbase5-dev: http://mirror.centos.org/centos/7/os/x86_64/Packages/qt5-qtbase-devel-5.9.2-3.el7.x86_64.rpm
yaml: http://mirror.centos.org/centos/7/os/x86_64/Packages/libyaml-devel-0.1.4-11.el7_0.x86_64.rpm

From EPEL
---------
clang: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/clang-3.4.2-9.el7.x86_64.rpm
cppcheck: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/cppcheck-1.86-1.el7.x86_64.rpm
console-bridge-devel: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/c/console-bridge-devel-0.2.7-1.el7.x86_64.rpm
libpoco-dev: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/poco-devel-1.6.1-3.el7.x86_64.rpm
python-mock: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/python2-mock-1.0.1-9.el7.noarch.rpm
tinyxml2: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/t/tinyxml2-2.1.0-2.20140406git6ee53e7.el7.x86_64.rpm
uncrustify: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/u/uncrustify-0.64-1.el7.x86_64.rpm

Removals
--------
python3-matplotlib:
- Not in Base: http://mirror.centos.org/centos/7/os/x86_64/Packages/
- Not in EPEL: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/

tango-icon-theme:
- Not in Base: http://mirror.centos.org/centos/7/os/x86_64/Packages/
- Not in EPEL: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/t/