### PR TITLE
hebi_cpp_api: 2.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1599,6 +1599,19 @@ repositories:
       url: https://github.com/ros-drivers-gbp/gscam-release.git
       version: 1.0.1-0
     status: unmaintained
+  hebi_cpp_api_ros:
+    doc:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: master
+    release:
+      packages:
+      - hebi_cpp_api
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
+      version: 2.0.1-0
+    status: developed
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Initial release of hebi_cpp_api package in repository hebi_cpp_api_ros (2.0.1-0):

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
- distro file: melodic/distribution.yaml
- bloom version: 0.7.2
- previous version for package:  null

This is a wrapper for the HEBI C++ API, which will allow us to modularize and reduce the complexity of other packages (e.g., hebiros).  We have already released for `kinetic`; this is just updating the release to include `melodic`.