### PR TITLE
velodyne: 1.5.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6418,7 +6418,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 1.5.1-0
+      version: 1.5.2-0
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.5.2-0`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.5.1-0`

## velodyne

- No changes

## velodyne_driver

```
* Merge pull request #212 <https://github.com/ros-drivers/velodyne/issues/212> from ros-drivers/maint/vdump_as_root
  Modifying vdump script for use as root.
  Tested by @andersfischernielsen.
* Merge pull request #205 <https://github.com/ros-drivers/velodyne/issues/205> from xiesc/master
  support for 64E-S3
* Contributors: Joshua Whitley, Shichao XIE, xiesc
```

## velodyne_laserscan

- No changes

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Merge pull request #205 <https://github.com/ros-drivers/velodyne/issues/205> from xiesc/master
  support for 64E-S3
* add an example yaml file for S3
* Contributors: Joshua Whitley, Shichao XIE, xiesc
```
