### PR TITLE
control_msgs: 2.1.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -256,6 +256,21 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: developed
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 2.1.0-0
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: crystal-devel
+    status: maintained
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `2.1.0-0`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## control_msgs

```
* Fix up dependencies for actionlib and Crystal
* Contributors: Bence Magyar
```
