### PR TITLE
plotjuggler: 2.0.4-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3302,7 +3302,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.0.3-0
+      version: 2.0.4-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.0.4-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `2.0.3-0`

## plotjuggler

```
* add parent to message boxes
* ask confirmation at closeEvent()
* fix problem with selection of second column
* fix issue 132
* simplification
* minor bug fixed in filter of StatePublisher
* Contributors: Davide Facont, Davide Faconti
```
