### PR TITLE
rosdep: added libstdc++6

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3136,6 +3136,11 @@ libstdc++5:
   gentoo: [virtual/libstdc++]
   opensuse: [libstdc++33]
   ubuntu: [libstdc++5]
+libstdc++6:
+  arch: [gcc-libs]
+  debian: [libstdc++6]
+  fedora: [libstdc++]
+  ubuntu: [libstdc++6]
 libsvm-dev:
   debian: [libsvm-dev]
   fedora: [libsvm-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3131,7 +3131,7 @@ libssl-dev:
 libstdc++5:
   arch: [libstdc++5]
   debian: [libstdc++5]
-  fedora: [libstdc++]
+  fedora: [libstdc++5]
   freebsd: [builtin]
   gentoo: [virtual/libstdc++]
   opensuse: [libstdc++33]
@@ -3139,7 +3139,7 @@ libstdc++5:
 libstdc++6:
   arch: [gcc-libs]
   debian: [libstdc++6]
-  fedora: [libstdc++]
+  fedora: [libstdc++6]
   ubuntu: [libstdc++6]
 libsvm-dev:
   debian: [libsvm-dev]


### PR DESCRIPTION
The homer_map_manager package fails to build on arm and arm64 because the libstdc++5 package is missing. So I need to add the libstdc++6 package, since it exists for Ubuntu arm.