### PR TITLE
earth_rover_localization: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2413,6 +2413,12 @@ repositories:
       url: https://github.com/tork-a/dynpick_driver.git
       version: master
     status: maintained
+  earth_rover_localization:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/earthrover/earth_rover_localization-release.git
+      version: 1.0.0-1
   eband_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `earth_rover_localization` to `1.0.0-1`:

- upstream repository: https://github.com/earthrover/earth_rover_localization.git
- release repository: https://github.com/earthrover/earth_rover_localization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## earth_rover_localization

```
* Update CMakeList.txt GeographicLib test
* Update package.xml build depend
* changing package name in launch file
* adding dockerfile and docker-compose
* Fix package name and update Readme
* Contributors: Andres Palomino, Paul Harter
```
