### PR TITLE
hebi_cpp_api_ros: 2.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3845,7 +3845,7 @@ repositories:
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
-      version: 2.0.2
+      version: master
     status: developed
   hebiros:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3841,7 +3841,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
-      version: 2.0.1-1
+      version: 2.0.2-0
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: 2.0.2
     status: developed
   hebiros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository hebi_cpp_api_ros to 2.0.2-0:

    upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
    release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
    distro file: kinetic/distribution.yaml
    bloom version: 0.7.2
    previous version for package: 2.0.1-1

hebi_cpp_api

* Make package installable
* Moved the header files into an include directory
* Removed the Eigen folder; use ROS package instead
* Fixed CMake for installable package
  - Addressed Eigen dependency
  - Installed include files and libraries correctly
* NOTE: this does not correspond with an official 2.0.2
  release of the upstream HEBI C++ API, because these
  changes were all local ROS build system changes. This
  mismatch will be resolved in v2.1.0.
* Contributors: Matthew Tesch, iamtesch