### PR TITLE
web_video_server: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6600,6 +6600,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: jade-devel
     status: maintained
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/web_video_server-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: master
+    status: maintained
   webkit_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.2.0-0`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## web_video_server

```
* Add "default_stream_type" parameter (#84 <https://github.com/RobotWebTools/web_video_server/issues/84>)
  This allows users to specify default stream type in their .launch files. Using a "ros_compressed" stream type sometimes
  results in a much lower resource consumption, and having it set as a default is much nicer for end users.
* Add a workaround for MultipartStream constant busy state (#83 <https://github.com/RobotWebTools/web_video_server/issues/83>)
  * Add a workaround for MultipartStream constant busy state
  * Remove C++11 features
* lax rule for topic name (#77 <https://github.com/RobotWebTools/web_video_server/issues/77>)
* Add PngStreamer (#74 <https://github.com/RobotWebTools/web_video_server/issues/74>)
* fix SteadyTimer check for backported ROS versions (#71 <https://github.com/RobotWebTools/web_video_server/issues/71>)
  i.e. on current kinetic
* Pkg format 2 (#68 <https://github.com/RobotWebTools/web_video_server/issues/68>)
  * use package format 2
  * add missing dependency on sensor_msgs
* fixed undeclared CODEC_FLAG_GLOBAL_HEADER (#65 <https://github.com/RobotWebTools/web_video_server/issues/65>)
* Contributors: Andreas Klintberg, Dirk Thomas, Felix Ruess, Kazuto Murase, Viktor Kunovski, sfalexrog
```
