### PR TITLE
eigenpy: 1.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -942,6 +942,13 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: master
     status: maintained
+  eigenpy:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
+      version: 1.5.0-1
+    status: developed
   ensenso_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `1.5.0-1`:

- upstream repository: https://github.com/ipab-slmc/eigenpy_catkin.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
