### PR TITLE
eigenpy: 1.5.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2634,6 +2634,13 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: master
     status: maintained
+  eigenpy:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
+      version: 1.5.0-0
+    status: developed
   eml:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `1.5.0-0`:

- upstream repository: https://github.com/ipab-slmc/eigenpy_catkin.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
