### PR TITLE
imu_pipeline: 0.2.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4536,7 +4536,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/imu_pipeline-release.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.2.3-0`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros-gbp/imu_pipeline-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.2.2-0`

## imu_pipeline

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## imu_processors

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## imu_transformer

```
* update to use non deprecated pluginlib macro
* Updated maintainers.
* Contributors: Mikael Arguedas, Tony Baltovski
```
