### PR TITLE
imu_pipeline: 0.2.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1592,6 +1592,25 @@ repositories:
       url: https://github.com/swri-robotics/imagezero_transport.git
       version: master
     status: maintained
+  imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: indigo-devel
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/imu_pipeline-release.git
+      version: 0.2.3-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: indigo-devel
+    status: maintained
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.2.3-0`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros-gbp/imu_pipeline-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## imu_pipeline

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## imu_processors

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## imu_transformer

```
* update to use non deprecated pluginlib macro
* Updated maintainers.
* Contributors: Mikael Arguedas, Tony Baltovski
```
