### PR TITLE
heron_desktop: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4010,7 +4010,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_desktop-release.git
-      version: 0.0.2-1
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/heron/heron_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_desktop` to `0.0.3-0`:

- upstream repository: https://github.com/heron/heron_desktop.git
- release repository: https://github.com/clearpath-gbp/heron_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.2-1`

## heron_desktop

- No changes

## heron_viz

```
* Merge pull request #1 <https://github.com/heron/heron_desktop/issues/1> from ssubramaniam-cpr/kinetic-devel
  Changed interactive marker topic update
* Changed interative marker topic update
* Contributors: Shreya Subramaniam, Tony Baltovski
```
