### PR TITLE
control_toolbox: 1.17.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1774,7 +1774,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.16.0-0
+      version: 1.17.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.17.0-0`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.16.0-0`

## control_toolbox

```
* update anti windup clamping
* update negativeIntegrationAntiwindupTest
* Address catkin_lint issues
* Add executable flag
* convert to package xml format 2
* Remove doc header
* Contributors: Bence Magyar, Cong, Gennaro Raiola
```
