### PR TITLE
Add python3-dev rule for Fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4637,6 +4637,7 @@ python3-catkin-pkg-modules:
   ubuntu: [python3-catkin-pkg-modules]
 python3-dev:
   debian: [python3-dev]
+  fedora: [python3-devel]
   gentoo: [=dev-lang/python-3*]
   ubuntu: [python3-dev]
 python3-django:


### PR DESCRIPTION
Listed in the right pane is the `python3-devel` subpackage: https://apps.fedoraproject.org/packages/python3.

Thanks!