### PR TITLE
jsk_roseus: 1.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6028,7 +6028,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.7.1-0
+      version: 1.7.3-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.7.3-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.7.1-0`

## jsk_roseus

- No changes

## roseus

```
* roseus.cpp: when topic is subscribed twice, cleanup previous callback function (#525 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/525> )
  * add test for subscribe object dispose
  * if object is set to gentem symbol, we can not dispose them
  * test/test-subscribe-dispose.test : add test for dispose
* Fix typo in package.xml (#598 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/598> )
* test/add-two-ints-client.l: read request values from argument (#596 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/596> )
* This change enable to call
  ```
  $ rosrun roseus add_two_ints_client.l 4 5
  ```
  Closes #581 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/581>
* roseus: add :last-status-msg method for simple-action-client (#578 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/578> )
* [roseus-util.l] Fixed typo in (one-shot-publish :after-stamp t) :tosec -> :to-sec (#576 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/576> )
* [roseus-util.l] fix comment typo: unction -> function (#583 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/583>)
* roseus: reuse service server/client link on service call if connection is valid (#593 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/593> )
  * roseus.cpp: keep connection to server on persistent service call
  * test-add-two-ints.test: increase timelimit to 120 secs
  * test-service-callback.l: add test for calling unadvertised service
  * test-add-two-ints.l: add test code for persistent service call
* Fix frame-exists method (#592 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/592> )
  * Add code to wait for transform in test-frame-exists by @Affonso-Gui
  * Fix wrong function in the :frame-exists method. (Fix #591 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/591>)
* roseus: setlocale to none (#585 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/585> )
* Contributors: Guilherme Affonso, Yuki Furuta, Kanae Kochigami, Kei Okada, Koga Yuya, Iori Yanokura
```

## roseus_mongo

```
* Merge remote-tracking branch 'origin/master' into last-status-msg
* Contributors: Furushchev
```

## roseus_smach

```
* check why test-smach-action-client-state failing on installed test (#570 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/570> )
* fix make-state-machine docstring (#589 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/589> )
* re-enable test-smach-action-client-state, which is removed in https://github.com/jsk-ros-pkg/jsk_roseus/pull/567#issuecomment-406841511
* Add issue link in make-state-machine docstring (#595 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/595> )
* roseus_smach: change the order of callee args for userdata in pddl2smach (#587 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/587>)
* roseus_smach: pass userdata values unless :arg-keys is set (#586 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/586>)
  * roseus_smach: fix error on exec state machine without *ri*
* Contributors: Guilherme Affonso, Yuki Furuta, Shingo Kitagawa
```

## roseus_tutorials

```
* use ar_pose_alvar instead of ar_pose for kinetic (#582 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/582> )
* Contributors: Yuki Furuta
```
