### PR TITLE
fkie_potree_rviz_plugin: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1170,6 +1170,17 @@ repositories:
       url: https://github.com/fkie/message_filters.git
       version: master
     status: developed
+  fkie_potree_rviz_plugin:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fkie-release/potree_rviz_plugin-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/fkie/potree_rviz_plugin.git
+      version: master
+    status: developed
   flatbuffers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_potree_rviz_plugin` to `1.0.0-0`:

- upstream repository: https://github.com/fkie/potree_rviz_plugin.git
- release repository: https://github.com/fkie-release/potree_rviz_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## fkie_potree_rviz_plugin

```
* Initial release
```
