### PR TITLE
fmi_adapter_ros2: 0.1.3-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -487,7 +487,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.3-0`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/boschresearch/fmi_adapter_ros2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.1.2-0`

## fmi_adapter

```
* Fixed install target location of shared library.
* Improved code snippets on use of FMIAdapter class in README.
```

## fmi_adapter_examples

- No changes
