### PR TITLE
py_trees_ros: 0.5.15-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3912,7 +3912,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 0.5.14-0
+      version: 0.5.15-0
     source:
       type: git
       url: https://github.com/stonier/py_trees_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.15-0`:

- upstream repository: https://github.com/stonier/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.5.14-0`

## py_trees_ros

```
* [programs] blackboard-watcher can operate on the entire blackboard
* [programs] tree-watcher added
```
