### PR TITLE
mavros: 0.29.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2483,7 +2483,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.28.0-0
+      version: 0.29.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.29.0-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.28.0-0`

## libmavconn

```
* Merge branch 'master' into param-timeout
* libmavconn: Fix building without installation. Detect CI environment
* ci:test: temporary disable failed udp bind test
* mavconn:pkg: Move generated files to build tree
* Contributors: Vladimir Ermakov
```

## mavros

```
* Fix broken documentation URLs
* px4_config: set the thrust_scaling to one by default
* local_position: add an aditional topic for velocity on the local frame
* Merge pull request #1136 <https://github.com/mavlink/mavros/issues/1136> from angri/param-timeout
  Request timed up parameters as soon as possible
* Merge branch 'master' into param-timeout
* plugin:param added logging regarding rerequests
* plugin:param fixed second and consequent timeouts in requesting list
* mavros_extras: Wheel odometry plugin updated according to the final mavlink WHEEL_DISTANCE message.
* mavros_extras: Wheel odometry plugin fixes after CR.
* mavros_extras: Wheel odometry plugin added.
* mavsys: add do_message_interval
* sys_status: add set_message_interval service
* lib: fix MAV_COMPONENT to_string
* lib: update sensor orientations
* plugin:param rerequest timed out parameters asap
  Avoid vaiting for the next timeout
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Pavlo Kolomiiets, Randy Mackay, TSC21, Vladimir Ermakov, angri
```

## mavros_extras

```
* obstacle_distance: align comments
* obstacle_distance: fixup items after peer review
  changes include using size_t instead of int for loop variables
  scale_factor calculation ensures argument are floating point
  remove unnecessary n variable
* obstacle_distance: combine sensor distances to fit within outgoing message
* gps_rtk: documentation fixes
* Fix broken documentation URLs
* added tf2_eigen to dependencies, so that building with catkin tools does not fail anymore
* Merge branch 'master' into param-timeout
* mavros_extras: Wheel odometry plugin updated according to the final mavlink WHEEL_DISTANCE message.
* mavros_extras: mavros_plugins.xml fix after bad merge.
* mavros_extras: Wheel odometry plugin, twist covariance matrix non-used diagonal elements zeroed.
* mavros_extras: Wheel odometry plugin, odometry error propagation added respecting kinematics.
* mavros_extras: Wheel odometry plugin travelled distance fixed.
* mavros_extras: Wheel odometry plugin y-speed covariance fixed.
* mavros_extras: Wheel odometry plugin updated to compute accurate speeds from distances using internal timesteps.
* mavros_extras: Wheel odometry plugin fixes after CR.
* mavros_msgs: Float32ArrayStamped replaced by WheelOdomStamped.
* mavros_extras: Wheel odometry plugin added.
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Jan Heitmann, Pavlo Kolomiiets, Randy Mackay, Vladimir Ermakov
```

## mavros_msgs

```
* Fix broken documentation URLs
* Merge branch 'master' into param-timeout
* mavros_extras: Wheel odometry plugin updated according to the final mavlink WHEEL_DISTANCE message.
* mavros_msgs: Float32ArrayStamped replaced by WheelOdomStamped.
* mavros_msgs: Float32ArrayStamped message added.
  For streaming timestamped data from FCU sensors (RPM, WHEEL_DISTANCE, etc.)
* msgs: Fix message id type, mavlink v2 uses 24 bit msg ids
* mavros_msgs: add MessageInterval.srv to CMakeLists
* sys_status: add set_message_interval service
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Pavlo Kolomiiets, Randy Mackay, Vladimir Ermakov
```

## test_mavros

```
* Merge branch 'master' into param-timeout
* Contributors: Vladimir Ermakov
```
