### PR TITLE
py_trees_msgs: 0.4.3-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -911,6 +911,17 @@ repositories:
       url: https://github.com/stonier/py_trees.git
       version: release/1.0.x
     status: developed
+  py_trees_msgs:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/stonier/py_trees_msgs-release.git
+      version: 0.4.3-0
+    source:
+      type: git
+      url: https://github.com/stonier/py_trees_msgs.git
+      version: release/0.4.x
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.4.3-0`:

- upstream repository: https://github.com/stonier/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
