### PR TITLE
e100_bringup-release: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2413,6 +2413,23 @@ repositories:
       url: https://github.com/tork-a/dynpick_driver.git
       version: master
     status: maintained
+  e100_bringup-release:
+    doc:
+      type: git
+      url: https://github.com/BrightenLee/e100_bringup.git
+      version: 0.1.0
+    release:
+      packages:
+      - e100_bringup
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/BrightenLee/e100_bringup-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/BrightenLee/e100_bringup.git
+      version: 0.1.0
+    status: maintained
   earth_rover_localization:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `e100_bringup-release` to `0.1.0-0`:

- upstream repository: https://github.com/BrightenLee/e100_bringup.git
- release repository: https://github.com/BrightenLee/e100_bringup-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## e100_bringup

```
* initial commit
* Contributors: Brighten
```
