### PR TITLE
rqt_tf_tree: 0.6.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12148,7 +12148,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_tf_tree-release.git
-      version: 0.5.8-0
+      version: 0.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `0.6.0-0`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros-gbp/rqt_tf_tree-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.8-0`

## rqt_tf_tree

```
* [capability] add button for clearing the TF buffer #9 <https://github.com/ros-visualization/rqt_tf_tree/issues/9> from christian-rauch/clear_tf_buffer
* [maintenance] Integrate an existing testcase upon build by Catkin. #5 <https://github.com/ros-visualization/rqt_tf_tree/issues/5>
* Contributors: Christian Rauch, Isaac I.Y. Saito, Peter Han
```
