### PR TITLE
rqt_tf_tree: 0.6.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5037,7 +5037,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/rqt_tf_tree-release.git
-      version: 0.5.8-0
+      version: 0.6.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `0.6.0-0`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros-gbp/rqt_tf_tree-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.8-0`

## rqt_tf_tree

```
* [capability] add button for clearing the TF buffer #9 <https://github.com/ros-visualization/rqt_tf_tree/issues/9> from christian-rauch/clear_tf_buffer
* [maintenance] Integrate an existing testcase upon build by Catkin. #5 <https://github.com/ros-visualization/rqt_tf_tree/issues/5>
* Contributors: Christian Rauch, Isaac I.Y. Saito, Peter Han
```
