### PR TITLE
jsk_roseus: 1.7.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6028,7 +6028,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_roseus-release.git
-      version: 1.7.1-0
+      version: 1.7.4-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_roseus` to `1.7.4-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_roseus
- release repository: https://github.com/tork-a/jsk_roseus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.7.1-0`

## jsk_roseus

- No changes

## roseus

```
* .travis.yml: run jsk_pr2eus tests in travis (#599 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/599> )test/simple-client-cancel-test.l: add test to find #567 regression
* Revert "roseus: add :last-status-msg method for simple-action-client" (#578 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/578> )
* Revert "add test for subscribe object dispose" (#525 <https://github.com/jsk-ros-pkg/jsk_roseus/issues/525> )
* Contributors: Kei Okada
```

## roseus_mongo

- No changes

## roseus_smach

- No changes

## roseus_tutorials

- No changes
