### PR TITLE
nerian_stereo: 3.3.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2733,7 +2733,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.2.1-0
+      version: 3.3.0-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `3.3.0-0`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `3.2.1-0`

## nerian_stereo

```
* Updated to Nerian vision software release 6.3.0
* Added functionality to use timestamps from SceneScan for timestamping transmitted messages.
* Contributors: Konstantin Schauwecker
```
