### PR TITLE
nerian_stereo: 3.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7336,7 +7336,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.2.1-0
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `3.3.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `3.2.1-0`

## nerian_stereo

```
* Updated to Nerian vision software release 6.3.0
* Added functionality to use timestamps from SceneScan for timestamping transmitted messages.
* Contributors: Konstantin Schauwecker
```
