### PR TITLE
rc_genicam_api: 2.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3762,7 +3762,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.0.2-0
+      version: 2.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.1.0-0`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.2-0`

## rc_genicam_api

```
* Made System, Interface, Device and Stream objects thread safe
```
