### PR TITLE
rqt_graph: 1.0.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1556,6 +1556,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: crystal-devel
     status: maintained
+  rqt_graph:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_graph-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: crystal-devel
+    status: maintained
   rqt_image_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.0.0-0`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## rqt_graph

```
* copy base rosgraph.impl.graph file (#23 <https://github.com/ros-visualization/rqt_graph/issues/23>)
* port to ROS 2 (#22 <https://github.com/ros-visualization/rqt_graph/issues/22>)
* autopep8 and gitignore (#19 <https://github.com/ros-visualization/rqt_graph/issues/19>)
* replace str() by unicode() (#17 <https://github.com/ros-visualization/rqt_graph/issues/17>)
* edge class is unhashable so cannot put into a set, use a list instead (#16 <https://github.com/ros-visualization/rqt_graph/issues/16>)
```
