### PR TITLE
lgsvl_msgs: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5561,6 +5561,17 @@ repositories:
       url: https://github.com/aws-robotics/lex-ros1.git
       version: master
     status: maintained
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lgsvl/lgsvl_msgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: kinetic-devel
+    status: maintained
   libcreate:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.1-0`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## lgsvl_msgs

```
* add changelog
* update initial version number
* add license
* add Ros package for ground truth messages
* initial commit
* Contributors: David Uhm
```
