### PR TITLE
lgsvl_msgs: 0.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2266,6 +2266,17 @@ repositories:
       version: hydro
     status: developed
     status_description: Slow development
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lgsvl/lgsvl_msgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: melodic-devel
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.1-0`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## lgsvl_msgs

```
* add changelog
* update initial version number
* add license
* add Ros package for ground truth messages
* initial commit
* Contributors: David Uhm
```