### PR TITLE
lgsvl_msgs: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6615,6 +6615,17 @@ repositories:
       url: https://github.com/hiveground-ros-package/leptrino_force_torque.git
       version: master
     status: maintained
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lgsvl/lgsvl_msgs-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: indigo-devel
+    status: maintained
   libccd:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.1-0`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## lgsvl_msgs

```
* add changelog
* update initial version number
* add license
* add Ros package for ground truth messages
* initial commit
* Contributors: David Uhm
```
