### PR TITLE
Added python-ftdi1

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1386,6 +1386,11 @@ python-freezegun-pip:
   ubuntu:
     pip:
       packages: [freezegun]
+python-ftdi1:
+  debian: [python-ftdi1]
+  fedora: [python2-libftdi]
+  gentoo: [dev-embedded/libftdi]
+  ubuntu: [python-ftdi1]
 python-future:
   debian: [python-future]
   fedora: [python-future]


### PR DESCRIPTION
This is a (hidden) dependency of adafruit-gpio-pip when you want to use its FT232 subpackage.

I haven't found any binary packages for Fedora and OSX.