### PR TITLE
pilz_industrial_motion: 0.3.5-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8621,7 +8621,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.3.3-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.3.5-0`:
* upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
* release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
* distro file: `kinetic/distribution.yaml`
* bloom version: `0.7.2`
* previous version for package: `0.3.3-0`

## pilz_extensions
* No changes


## pilz_industrial_motion
* No changes

## pilz_industrial_motion_testutils
```
* Add high level abstraction data classes to represent configuration of robot
* Add high level abstraction data classes to represent different command types
* Add functions to TestdataLoader returning the high level abstraction classes
```

## pilz_msgs
* No changes


## pilz_robot_programming
```
* enable Robot instantiation after a program got killed; add corresponding test
```

## pilz_trajectory_generation
```
* refactor determining the trajectory alignment in the blend implementation
* extend and refactor unittest of blender_transition_window
* add planning group check to blender_transition_window
* Increase line coverage for blending to 100%
```