### PR TITLE
earth_rover_piksi: 1.8.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2446,7 +2446,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/earthrover/earth_rover_piksi.git
-      version: 1.8.2
+      version: master
     status: maintained
   eband_local_planner:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2428,6 +2428,26 @@ repositories:
       url: https://github.com/earthrover/earth_rover_localization.git
       version: master
     status: maintained
+  earth_rover_piksi:
+    doc:
+      type: git
+      url: https://github.com/earthrover/earth_rover_piksi.git
+      version: master
+    release:
+      packages:
+      - earth_rover_piksi
+      - piksi_multi_rtk
+      - piksi_rtk_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/earthrover/earth_rover_piksi-release.git
+      version: 1.8.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/earthrover/earth_rover_piksi.git
+      version: 1.8.2
+    status: maintained
   eband_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `earth_rover_piksi` to `1.8.2-0`:

- upstream repository: https://github.com/earthrover/earth_rover_piksi.git
- release repository: https://github.com/earthrover/earth_rover_piksi-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`
