### PR TITLE
plotjuggler: 2.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8710,7 +8710,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.0.4-0
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.1.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.4-0`

## plotjuggler

```
* fix for dark layout
* fix issue with edited function transforms
* about dialog updated
* added more key shortcuts
* reverted behaviour of Dialog "delete previous curves"?
* fix glitches related to drag and drop
* update timeSlider more often
* play seems to work properly for both sim_time and rewritten timestamps
* play button added
* clock published
* remove timestamp modifier
* Contributors: Davide Faconti
```
