### PR TITLE
marti_common: 2.8.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7049,7 +7049,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.7.2-0
+      version: 2.8.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.8.0-0`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.7.2-0`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Add dynamic parameters (#532 <https://github.com/swri-robotics/marti_common/issues/532>)
* Contributors: Matthew
```

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Reduce the number of local_xy subscribers from 3 per transform manager to 1 (#537 <https://github.com/swri-robotics/marti_common/issues/537>)
* Add dynamic parameters (#532 <https://github.com/swri-robotics/marti_common/issues/532>)
* Contributors: Matthew
```

## swri_yaml_util

- No changes
