### PR TITLE
rc_visard: 2.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4214,7 +4214,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.4.2-0
+      version: 2.5.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.5.0-0`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.4.2-0`

## rc_hand_eye_calibration_client

```
* rename ip parameter to host
* allow hostname as device parameter
```

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

```
* add parameter for max number of reconnections
* fix: enable driver to try to recover even if the very first time no connection worked out
* add diagnostics
* fix reporting of package size
* Fixed hanging image streams after restart of sensor
* Support for rc_visard firmware v1.5.0 additions (require StereoPlus license)
  * quality full
  * advanced smoothing
* improved driver's auto-connect behavior
* also reapply dynamic_reconfigure params after recovery
* fix projection matrix in published right CameraInfo
```
