### PR TITLE
[crystal] Update source and doc branch for demos.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -275,7 +275,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/demos.git
-      version: master
+      version: crystal
     release:
       packages:
       - composition
@@ -300,7 +300,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/demos.git
-      version: master
+      version: crystal
     status: developed
   depthimage_to_laserscan:
     doc:


### PR DESCRIPTION
First reported in https://github.com/ros2/demos/issues/310. The crystal branch has been created and the release track updated in https://github.com/ros2-gbp/demos-release/commit/d7405680fd1682a307c6dca309db619a786364a6