### PR TITLE
rosbash_params: 1.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13021,7 +13021,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/peci1/rosbash_params-release.git
-      version: 1.0.1-1
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/peci1/rosbash_params.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbash_params` to `1.0.2-0`:

- upstream repository: https://github.com/peci1/rosbash_params.git
- release repository: https://github.com/peci1/rosbash_params-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.1-1`

## rosbash_params

```
* Fixed correct handling of whitespace in rosbash_unused_argv.
* Fixed white space in arguments
* Contributors: Martin Pecka
```
