### PR TITLE
rosbash_params: 1.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4715,7 +4715,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/rosbash_params-release.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/peci1/rosbash_params.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbash_params` to `1.0.2-0`:

- upstream repository: https://github.com/peci1/rosbash_params.git
- release repository: https://github.com/peci1/rosbash_params-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.1-0`

## rosbash_params

```
* Fixed correct handling of whitespace in rosbash_unused_argv.
* Fixed white space in arguments
* Contributors: Martin Pecka
```
