### PR TITLE
movie_publisher: 1.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7803,7 +7803,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 1.1.0-0
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.1.1-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.1.0-0`

## movie_publisher

```
* Fixed permissions.
* Moved to python from bc, because it is not installed everywhere.
* More informative error strings.
* Updated to the fixed version rosbash_params==1.0.2.
* Contributors: Martin Pecka
```
