### PR TITLE
movie_publisher: 1.2.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6672,6 +6672,21 @@ repositories:
       url: https://github.com/intel/ros_intel_movidius_ncs.git
       version: master
     status: maintained
+  movie_publisher:
+    doc:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/peci1/movie_publisher-release.git
+      version: 1.2.1-0
+    source:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: kinetic-devel
+    status: developed
   mqtt_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.2.1-0`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## movie_publisher

```
* Fixed permissions.
* Kinetic release.
* Moved to python from bc, because it is not installed everywhere.
* More informative error strings.
* Updated to the fixed version rosbash_params==1.0.2.
* Contributors: Martin Pecka
```
