### PR TITLE
turtlebot3_applications: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6107,6 +6107,28 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: melodic-devel
     status: developed
+  turtlebot3_applications:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: melodic-devel
+    release:
+      packages:
+      - turtlebot3_applications
+      - turtlebot3_automatic_parking
+      - turtlebot3_automatic_parking_vision
+      - turtlebot3_follow_filter
+      - turtlebot3_follower
+      - turtlebot3_panorama
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: melodic-devel
+    status: developed
   turtlebot3_applications_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## turtlebot3_applications

```
* added launch file for automatic_parking node #22 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/22>
* created launch and removed .py
* modified follower
* added follower node runnable from anywhere #25 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/25>
* Contributors: Daniel Ingram, Gilbert, Darby Lim, Pyo
```

## turtlebot3_automatic_parking

```
* added launch file for automatic_parking node #22 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/22>
* created launch and removed .py
* Contributors: Gilbert, Darby Lim, Pyo
```

## turtlebot3_automatic_parking_vision

```
* none
```

## turtlebot3_follow_filter

```
* none
```

## turtlebot3_follower

```
* modified follower
* added follower node runnable from anywhere #25 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/25>
* Contributors: Daniel Ingram, Darby Lim, Gilbert, Pyo
```

## turtlebot3_panorama

```
* none
```
