### PR TITLE
turtlebot3_autorace: 1.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6122,6 +6122,27 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
       version: melodic-devel
     status: developed
+  turtlebot3_autorace:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: melodic-devel
+    release:
+      packages:
+      - turtlebot3_autorace
+      - turtlebot3_autorace_camera
+      - turtlebot3_autorace_control
+      - turtlebot3_autorace_core
+      - turtlebot3_autorace_detect
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: melodic-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_autorace` to `1.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## turtlebot3_autorace

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_camera

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_control

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_core

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_detect

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```
