### PR TITLE
pinocchio: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3656,6 +3656,21 @@ repositories:
       url: https://github.com/PilzDE/pilz_robots.git
       version: kinetic-devel
     status: developed
+  pinocchio:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: devel
+    status: developed
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pinocchio` to `2.0.0-0`:

- upstream repository: https://github.com/ipab-slmc/pinocchio_catkin.git
- release repository: https://github.com/ipab-slmc/pinocchio_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
