### PR TITLE
Switch to crystal branch for realtime_support.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1074,7 +1074,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: master
+      version: crystal
     release:
       packages:
       - rttest
@@ -1087,7 +1087,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: master
+      version: crystal
     status: developed
   resource_retriever:
     doc:


### PR DESCRIPTION
Release track update: https://github.com/ros2-gbp/realtime_support-release/commit/8ada4c9cdc9c3492b54862b529cccb247944f063