### PR TITLE
uuv_simulator: 0.6.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14570,7 +14570,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uuvsimulator/uuv_simulator-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_simulator` to `0.6.5-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.6.4-0`

## uuv_assistants

- No changes

## uuv_auv_control_allocator

- No changes

## uuv_control_cascaded_pid

- No changes

## uuv_control_msgs

- No changes

## uuv_control_utils

- No changes

## uuv_descriptions

- No changes

## uuv_gazebo

- No changes

## uuv_gazebo_plugins

```
* Fix gazebo_dev dependency
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_gazebo_ros_plugins

- No changes

## uuv_gazebo_ros_plugins_msgs

- No changes

## uuv_gazebo_worlds

- No changes

## uuv_sensor_ros_plugins

- No changes

## uuv_sensor_ros_plugins_msgs

- No changes

## uuv_simulator

```
* RM Dependency to uuv_tutorials
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_teleop

- No changes

## uuv_thruster_manager

- No changes

## uuv_trajectory_control

- No changes

## uuv_world_plugins

```
* Fix gazebo_dev dependency
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## uuv_world_ros_plugins

- No changes

## uuv_world_ros_plugins_msgs

- No changes
