### PR TITLE
Fix source branch for example_interfaces.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -415,7 +415,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: bouncy
+      version: master
     status: developed
   examples:
     doc:


### PR DESCRIPTION
This must've snuck in when I was spinning up the Crystal farm and gone unnoticed.