### PR TITLE
robotis_manipulator: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4419,6 +4419,21 @@ repositories:
       url: https://github.com/clearpathrobotics/robot_upstart.git
       version: kinetic-devel
     status: maintained
+  robotis_manipulator:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
+      version: melodic-devel
+    status: developed
   ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_manipulator` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## robotis_manipulator

```
* updated the CHANGELOG and version to release binary packages
* modified the package information for release
* added the manipulation API and functions for controlling the manipulator
* made new ROS package
* Contributors: Hye-Jong KIM, Darby Lim, Yong-Ho Na, Ryan Shim, Guilherme de Campos Affonso, Pyo
```
