### PR TITLE
robotis_manipulator: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10387,6 +10387,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/ROBOTIS-Framework.git
       version: kinetic-devel
     status: developed
+  robotis_manipulator:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
+      version: kinetic-devel
+    status: developed
   robotis_math:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_manipulator` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## robotis_manipulator

```
* updated the CHANGELOG and version to release binary packages
* modified the package information for release
* added the manipulation API and functions for controlling the manipulator
* made new ROS package
* Contributors: Hye-Jong KIM, Darby Lim, Yong-Ho Na, Ryan Shim, Guilherme de Campos Affonso, Pyo
```
