### PR TITLE
dynamixel-workbench-msgs: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2356,7 +2356,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
-      version: 1.0.0-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench-msgs` to `2.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## dynamixel_workbench_msgs

```
* deleted unused msg and srv
* modified for dynamixel-workbench 2.0.0
* Contributors: Darby Lim
```
