### PR TITLE
open_manipulator_msgs: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7909,7 +7909,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator_msgs-release.git
-      version: 0.3.0-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.3.0-0`

## open_manipulator_msgs

```
* added endeffector name
* added params
* added authors
* added path time variable
* deleted unused params
* updated msg and srv
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Yong-Ho Na, Pyo
```
