### PR TITLE
ros_workspace: 0.6.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1322,7 +1322,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 0.6.0-1
+      version: 0.6.1-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `0.6.1-0`:

- upstream repository: https://github.com/ros2/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.0-1`

## ros_workspace

```
* Add COLCON_PREFIX_PATH env hook. (#11 <https://github.com/ros2/ros_workspace/issues/11>)
* Contributors: Dirk Thomas
```
