### PR TITLE
rcutils: 0.6.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1063,7 +1063,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.6.2-0`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.1-0`

## rcutils

```
* Adding an ArrayList and HashMap implementation to rcutils (#131 <https://github.com/ros2/rcutils/issues/131>)
* Change uncrustify max line length to 0 (#133 <https://github.com/ros2/rcutils/issues/133>)
* Contributors: Jacob Perron, Nick Burek
```
