### PR TITLE
rosidl: 0.6.3-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1377,7 +1377,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `0.6.3-0`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.2-0`
