### PR TITLE
open_manipulator_simulations: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3269,6 +3269,24 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  open_manipulator_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
+      version: melodic-devel
+    release:
+      packages:
+      - open_manipulator_gazebo
+      - open_manipulator_simulations
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
+      version: melodic-devel
+    status: developed
   opencv_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_simulations` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## open_manipulator_gazebo

```
* added subscriber for gripper control #3 <https://github.com/ROBOTIS-GIT/open_manipulator_simulations/issues/3>
* added pid gain for gazebo controller
* change gripper name
* change effort to position controllers
* Contributors: Darby Lim, Hye-Jong KIM, Pyo
```

## open_manipulator_simulations

```
* added subscriber for gripper control #3 <https://github.com/ROBOTIS-GIT/open_manipulator_simulations/issues/3>
* added pid gain for gazebo controller
* change gripper name
* change effort to position controllers
* Contributors: Darby Lim, Hye-Jong KIM, Pyo
```
