### PR TITLE
open_manipulator_simulations: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7945,7 +7945,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_simulations` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## open_manipulator_gazebo

```
* added subscriber for gripper control #3 <https://github.com/ROBOTIS-GIT/open_manipulator_simulations/issues/3>
* added pid gain for gazebo controller
* change gripper name
* change effort to position controllers
* Contributors: Darby Lim, Hye-Jong KIM, Pyo
```

## open_manipulator_simulations

```
* added subscriber for gripper control #3 <https://github.com/ROBOTIS-GIT/open_manipulator_simulations/issues/3>
* added pid gain for gazebo controller
* change gripper name
* change effort to position controllers
* Contributors: Darby Lim, Hye-Jong KIM, Pyo
```
