### PR TITLE
turtlebot3_applications: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13903,7 +13903,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_applications-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## turtlebot3_applications

```
* added launch file for automatic_parking node #22 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/22>
* created launch and removed .py
* modified follower
* added follower node runnable from anywhere #25 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/25>
* Contributors: Daniel Ingram, Gilbert, Darby Lim, Pyo
```

## turtlebot3_automatic_parking

```
* added launch file for automatic_parking node #22 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/22>
* created launch and removed .py
* Contributors: Gilbert, Darby Lim, Pyo
```

## turtlebot3_automatic_parking_vision

```
* none
```

## turtlebot3_follow_filter

```
* none
```

## turtlebot3_follower

```
* modified follower
* added follower node runnable from anywhere #25 <https://github.com/ROBOTIS-GIT/turtlebot3_applications/issues/25>
* Contributors: Daniel Ingram, Darby Lim, Gilbert, Pyo
```

## turtlebot3_panorama

```
* none
```
