### PR TITLE
turtlebot3_autorace: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13939,7 +13939,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace-release.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_autorace` to `1.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.1.0-0`

## turtlebot3_autorace

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_camera

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_control

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_core

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```

## turtlebot3_autorace_detect

```
* modified for gazebo mode
* added node_mission
* added travis for ROS Melodic version
* updated the CHANGELOG and version to release binary packages
* Contributors: Gilbert, Pyo
```
