### PR TITLE
open_manipulator_with_tb3_msgs: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7981,7 +7981,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_msgs-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_with_tb3_msgs` to `0.3.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.3.0-0`

## open_manipulator_with_tb3_msgs

```
* updated the CHANGELOG and version to release binary packages
* modified comments of CMakeLists.txt
* added travis option for ROS Melodic
* Contributors: Pyo
```
