### PR TITLE
open_manipulator_with_tb3_msgs: 0.3.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3269,6 +3269,21 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  open_manipulator_with_tb3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_msgs-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
+      version: melodic-devel
+    status: developed
   opencv_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_with_tb3_msgs` to `0.3.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## open_manipulator_with_tb3_msgs

```
* updated the CHANGELOG and version to release binary packages
* modified comments of CMakeLists.txt
* added travis option for ROS Melodic
* Contributors: Pyo
```
