### PR TITLE
open_manipulator_with_tb3_simulations: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3269,6 +3269,24 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  open_manipulator_with_tb3_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations.git
+      version: melodic-devel
+    release:
+      packages:
+      - open_manipulator_with_tb3_gazebo
+      - open_manipulator_with_tb3_simulations
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_simulations-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations.git
+      version: melodic-devel
+    status: developed
   opencv_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_with_tb3_simulations` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_simulations-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## open_manipulator_with_tb3_gazebo

```
* added yaw arguments
* added pid gain for gazebo controller
* added params
* added gripper sub publisher
* added model_5
* updated for sync with new open_manipulator packages #2 <https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations/issues/2>
* updated pid gain
* changed init position
* changed ar_marker model
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_simulations

```
* added yaw arguments
* added pid gain for gazebo controller
* added params
* added gripper sub publisher
* added model_5
* updated for sync with new open_manipulator packages #2 <https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations/issues/2>
* updated pid gain
* changed init position
* changed ar_marker model
* Contributors: Darby Lim, Pyo
```
