### PR TITLE
earth_rover_piksi: 1.8.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2441,7 +2441,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/earthrover/earth_rover_piksi-release.git
-      version: 1.8.2-0
+      version: 1.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `earth_rover_piksi` to `1.8.2-1`:

- upstream repository: https://github.com/earthrover/earth_rover_piksi.git
- release repository: https://github.com/earthrover/earth_rover_piksi-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.8.2-0`
