### PR TITLE
rcl: 0.6.5-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -975,7 +975,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.6.4-0
+      version: 0.6.5-0
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.6.5-0`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.4-0`

## rcl

```
* Changed error to warning when loggers are created for nodes non-unique names.(#385 <https://github.com/ros2/rcl/issues/385>)
  * Backported by #384 <https://github.com/ros2/rcl/issues/384> for Crystal.
* Removed test circumvention now that a bug is fixed in rmw_opensplice. (#386 <https://github.com/ros2/rcl/issues/386>)
  * Backported by #368 <https://github.com/ros2/rcl/issues/368> for Crystal.
* Publish logs to Rosout (#350 <https://github.com/ros2/rcl/issues/350>)
* Contributors: Nick Burek, Steven! Ragnarök
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
