### PR TITLE
rclpy: 0.6.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1047,7 +1047,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.6.2-0`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.1-0`

## rclpy

```
* Added Waitable to callback group (#265 <https://github.com/ros2/rclpy/issues/265>)
* Fixed flake8 error (#263 <https://github.com/ros2/rclpy/issues/263>)
* Added HIDDEN_NODE_PREFIX definition to node.py (#259 <https://github.com/ros2/rclpy/issues/259>)
* Added rclpy raw subscriptions (#242 <https://github.com/ros2/rclpy/issues/242>)
* Added a test for invalid string checks on publishing (#256 <https://github.com/ros2/rclpy/issues/256>)
* Contributors: AAlon, Jacob Perron, Joseph Duchesne, Michel Hidalgo, Shane Loretz
```
