### PR TITLE
sros2: 0.6.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1749,10 +1749,13 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: master
     release:
+      packages:
+      - sros2
+      - sros2_cmake
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.6.2-0`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.1-0`

## sros2

- No changes

## sros2_cmake

```
* Create package for sros2 cmake macros. (#75 <https://github.com/ros2/sros2/issues/75>)
* Contributors: Ross Desmond
```
