### PR TITLE
plotjuggler: 2.1.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3332,7 +3332,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.1.0-0
+      version: 2.1.1-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.1.1-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.0-0`

## plotjuggler

```
* Added filter to function editor
* ask for support
* cleanup
* fix issue with Datetime and cheatsheet dialog
* further stylesheet refinements
* fixing visualization of fucntion editor dialog
* fixing html of cheatsheet
* Contributors: Davide Faconti
```
