### PR TITLE
qt_gui_core: 1.0.4-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -954,7 +954,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.0.4-0`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.3-0`

## qt_dotgraph

```
* skip pydot/pygraphviz tests when unavailable (#161 <https://github.com/ros-visualization/qt_gui_core/issues/161>)
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui

```
* fix dictionary changes size during iteration (#166 <https://github.com/ros-visualization/qt_gui_core/issues/166>)
* fix typo (#164 <https://github.com/ros-visualization/qt_gui_core/issues/164>)
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui_app

```
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui_cpp

```
* support TinyXML2 version 2.2.0 on Xenial (#169 <https://github.com/ros-visualization/qt_gui_core/issues/169>)
* set default C++ standard to 14
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui_py_common

```
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```
