### PR TITLE
bfl: 0.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -294,10 +294,6 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/bfl-release.git
       version: 0.8.0-1
-    source:
-      type: git
-      url: https://github.com/toeklk/orocos-bayesian-filtering.git
-      version: f21791e4d35f7343b06819e0507a21b83edf8f99
     status: unmaintained
   bond_core:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -293,7 +293,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/bfl-release.git
-      version: 0.8.0-0
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/toeklk/orocos-bayesian-filtering.git
+      version: f21791e4d35f7343b06819e0507a21b83edf8f99
     status: unmaintained
   bond_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `bfl` to `0.8.0-1`:

- upstream repository: https://github.com/toeklk/orocos-bayesian-filtering.git
- release repository: https://github.com/ros-gbp/bfl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.8.0-0`
