### PR TITLE
ros_controllers: 0.13.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11026,6 +11026,7 @@ repositories:
       version: kinetic-devel
     release:
       packages:
+      - ackermann_steering_controller
       - diff_drive_controller
       - effort_controllers
       - force_torque_sensor_controller
@@ -11042,7 +11043,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.13.4-0
+      version: 0.13.5-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.13.5-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.13.4-0`

## ackermann_steering_controller

```
* Add ackermann_steering_controller (#356 <https://github.com/ros-controls/ros_controllers/issues/356>)
* Contributors: Mori
* Add ackermann_steering_controller (#356 <https://github.com/ros-controls/ros_controllers/issues/356>)
* Contributors: Mori
```

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

- No changes

## gripper_action_controller

```
* Use a copy of the pointer in update() to avoid crash by cancelCB()
* Contributors: oka
```

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Report errors in updateTrajectoryCommand back though action result error_string
* Remove redundant warning messages
* Return error string when failing to initialize trajectory from message
* don't print warning about dropped first point (#366 <https://github.com/ros-controls/ros_controllers/issues/366>)
* Contributors: Mathias Lüdtke, Miguel Prada, hsl, jschleicher
```

## position_controllers

- No changes

## ros_controllers

```
* Add ackermann_steering_controller (#356 <https://github.com/ros-controls/ros_controllers/issues/356>)
* Contributors: Mori
```

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
