### PR TITLE
ros_controllers: 0.14.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4575,6 +4575,7 @@ repositories:
       version: melodic-devel
     release:
       packages:
+      - ackermann_steering_controller
       - diff_drive_controller
       - effort_controllers
       - force_torque_sensor_controller
@@ -4591,7 +4592,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.14.2-0
+      version: 0.14.3-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.14.3-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.14.2-0`

## ackermann_steering_controller

```
* Sync version number with rest of repo
* migrate to new URDF shared pointer types
* Add ackermann_steering_controller (#356 <https://github.com/ros-controls/ros_controllers/issues/356>)
* Contributors: Bence Magyar, Mathias Lüdtke, Mori
* Sync version number with rest of repo
* migrate to new URDF shared pointer types
* Add ackermann_steering_controller (#356 <https://github.com/ros-controls/ros_controllers/issues/356>)
* Contributors: Bence Magyar, Mathias Lüdtke, Mori
```

## diff_drive_controller

```
* use operators instead of aliases
* Fix typo descripion -> description
* Contributors: Daniel Ingram, James Xu
```

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* Minor change in one of the ROS_INFO_STREAM
* Contributors: Jan-Felix Klein
```

## gripper_action_controller

```
* Use a copy of the pointer in update() to avoid crash by cancelCB()
* Contributors: oka
```

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* use operators instead of aliases
* joint_trajectory_controller: fix minor typo in class doc.
* correctly parse joint trajectory options
* Remove deprecated parameter hold_trajectory_duration (#386 <https://github.com/ros-controls/ros_controllers/issues/386>)
* dont print warning about dropped first point, if it is expected behaviour
* Contributors: AndyZe, G.A. vd. Hoorn, Gennaro Raiola, James Xu, Joachim Schleicher, Karsten Knese
```

## position_controllers

- No changes

## ros_controllers

```
* Add ackermann_steering_controller (#356 <https://github.com/ros-controls/ros_controllers/issues/356>)
* Contributors: Mori
```

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
