### PR TITLE
open_manipulator: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7887,14 +7887,16 @@ repositories:
     release:
       packages:
       - open_manipulator
+      - open_manipulator_control_gui
+      - open_manipulator_controller
       - open_manipulator_description
-      - open_manipulator_dynamixel_ctrl
+      - open_manipulator_libs
       - open_manipulator_moveit
-      - open_manipulator_position_ctrl
+      - open_manipulator_teleop
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
-      version: 1.0.0-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `2.0.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## open_manipulator

```
* updated the CHANGELOG and version to release binary packages
* added new packages (open_manipulator_control_gui, *_controller, *_libs, *_teleop)
* deleted unused packages (open_manipulator_dynamixel_ctrl, open_manipulator_position_ctrl)
* 
  
    * open_manipulator_control_gui -
  
* updated function name, UI
* added group names and gripper args
* added position only client
* modified topic names, end-effector name
* 
  
    * open_manipulator_controller -
  
* added jointspace path serv, moveit params
* added moveit config and controller
* added kinematic pose pub
* added mimic param and end effector point
* added execute permission
* added usb rules
* added cdc rules
* removed warn message
* renamed open_manipulator lib files
* changed math function name, namespace
* changed openManipulatorProcess() to processOpenManipulator()
* updated start_state after execution on MoveIt
* updated thread time, dynamixel profiling control method
* updated drawing line
* updated flexible node
* updated tool control
* updated chain to open_manipulator
* updated new kinematics
* used robot_name on joint_state_publisher's source_list
* 
  
    * open_manipulator_description -
  
* deleted model.launch
* modified gripper origin
* modified end_effector origin
* modified link2 and joint2 position
* updated inertia
* changed calculated inertia param
* changed gripper link name
* changed axis for grip_joint
* 
  
    * open_manipulator_moveit -
  
* added moveit config and controller
* updated moveit rviz
* Updated start_state after execution on Moveit #83 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/83>
* changed control period 40mm to 100mm
* Contributors: Darby Lim, Hye-Jong KIM, Yong-Ho Na, Ryan Shim, Guilherme de Campos Affonso, Pyo
```

## open_manipulator_control_gui

```
* updated the CHANGELOG and version to release binary packages (first relese)
* updated function name, UI
* added group names and gripper args
* added position only client
* modified topic names, end-effector name
* Contributors: Darby Lim, Hye-Jong KIM, Yong-Ho Na, Guilherme de Campos Affonso, Pyo
```

## open_manipulator_controller

```
* added jointspace path serv, moveit params
* added moveit config and controller
* added kinematic pose pub
* added mimic param and end effector point
* added execute permission
* added usb rules
* added cdc rules
* removed warn message
* renamed open_manipulator lib files
* changed math function name, namespace
* changed openManipulatorProcess() to processOpenManipulator()
* updated start_state after execution on MoveIt
* updated thread time, dynamixel profiling control method
* updated drawing line
* updated flexible node
* updated tool control
* updated chain to open_manipulator
* updated new kinematics
* used robot_name on joint_state_publisher's source_list
* Contributors: Darby Lim, Hye-Jong KIM, Yong-Ho Na, Guilherme de Campos Affonso, Pyo
```

## open_manipulator_description

```
* deleted model.launch
* modified gripper origin
* modified end_effector origin
* modified link2 and joint2 position
* updated inertia
* changed calculated inertia param
* changed gripper link name
* changed axis for grip_joint
* Contributors: Darby Lim, Hye-Jong KIM, Yong-Ho Na, Ryan Shim, Guilherme de Campos Affonso, Pyo
```

## open_manipulator_libs

```
* changed open_manipulator_dynamixel_ctrl to open_manipulator_libs
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Hye-Jong KIM, Yong-Ho Na, Ryan Shim, Guilherme de Campos Affonso, Pyo
```

## open_manipulator_moveit

```
* added moveit config and controller
* updated moveit rviz
* Updated start_state after execution on Moveit #83 <https://github.com/ROBOTIS-GIT/open_manipulator/issues/83>
* changed control period 40mm to 100mm
* Contributors: Darby Lim, Yong-Ho Na, Hye-Jong KIM, Guilherme de Campos Affonso, Pyo
```

## open_manipulator_teleop

```
* added new package for teleoperation
* added teleop launch
* updated the CHANGELOG and version to release binary packages
* Contributors: Darby Lim, Hye-Jong KIM, Yong-Ho Na, Guilherme de Campos Affonso, Pyo
```
