### PR TITLE
Deleted the open_manipulator_with_tb3_msgs on ROS Kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7972,21 +7972,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git
       version: kinetic-devel
     status: developed
-  open_manipulator_with_tb3_msgs:
-    doc:
-      type: git
-      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
-      version: kinetic-devel
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3_msgs-release.git
-      version: 0.3.1-0
-    source:
-      type: git
-      url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs.git
-      version: kinetic-devel
-    status: developed
   open_manipulator_with_tb3_simulations:
     doc:
       type: git


### PR DESCRIPTION
We will not use this message in the opinion of @tfoote . We deleted this package on ROS Kinetic and Melodic.
https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs/issues/4
https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_msgs/issues/3