### PR TITLE
open_manipulator_with_tb3: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7966,7 +7966,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3-release.git
-      version: 1.0.1-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_with_tb3` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_with_tb3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.1-0`

## open_manipulator_with_tb3

```
* updated the CHANGELOG and version to release binary packages
* added gazebo and moveit config
* deleted world
* updated to sync for new open_manipulator_package #7 <https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3/issues/7>
* updated inertia params
* added params for ar_marker
* added launch file to run demo
* added gripper controller
* added smach and smach_ros
* added waffle model, ar marker argument, ar tracker, prefix
* added joint control for platform
* added filter
* changed logerr to logwarn
* changed joint trajectory variable
* updated params releated to odom
* added waffle model
* added new moveit configuration
* modified position_only_ik
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_description

```
* added gazebo and moveit config
* deleted world
* updated to sync for new open_manipulator_package #7 <https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3/issues/7>
* updated inertia params
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_tools

```
* updated to sync for new open_manipulator_package
* added params for ar_marker
* added launch file to run demo
* added gripper controller
* added smach and smach_ros
* added waffle model, ar marker argument, ar tracker, prefix
* added joint control for platform
* added filter
* changed logerr to logwarn
* changed joint trajectory variable
* updated params releated to odom
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_waffle_moveit

```
* added waffle model
* added new moveit configuration
* modified position_only_ik
* Contributors: Darby Lim, Pyo
```

## open_manipulator_with_tb3_waffle_pi_moveit

```
* added waffle model
* added new moveit configuration
* modified position_only_ik
* Contributors: Darby Lim, Pyo
```
