### PR TITLE
jsk_pr2eus: 0.3.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5946,7 +5946,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_pr2eus-release.git
-      version: 0.3.13-0
+      version: 0.3.14-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_pr2eus` to `0.3.14-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_pr2eus
- release repository: https://github.com/tork-a/jsk_pr2eus-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.3.13-0`

## jsk_pr2eus

- No changes

## pr2eus

```
* [pr2eus] add :get-grasp-result methody and :wait key to :start-grasp method (#386 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/386> )
* pr2-interface: Make use of return value of :move-gripper method (#364 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/364> )
  
    * pr2-interface: make use of return value for :stop-grasp
    * pr2-interface: fix bug on :start-grasp return value of :joint-angle
    * pr2-interface: make use of return values of :move-gripper
  
* [pr2eus/speak.l] enable speak-jp with wait: t (#369 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/369> )
* add test to reproduce #366 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/366> (play-sound could not play file format) (#371 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/371> )
  
    * fix speak-test-action.py, more test on SAY, PLAY_FILE and buiding files
    * [pr2eus/speak.l] use (namestring) to get string from pathname, Fixed #366 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/366>
    * add test-speak-number / test-ri-speak-number
    * add test to reproduce #366 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/366> (play-sound could not play file format)
  
* pr2-interface.l: Add optional key arguments for :angle-vector-with-constraint (#380 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/380> )
  
    * add :revert-if-fail, :initial-angle-vector, :div optional key for :angle-vector-with-constraint
    * fix minor indent
  
* robot-interface.l: remove old timer-job (#321 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/321> )
* fix speak-test.test to fail on volume==0 (#379 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/379> )
  
    * [pr2eus/speak.l] Fixed volume insertion checking with :volume accessor exists
    * [pr2eus/speak.l] add :volume keyward for play-sound for sound_play >= 0.3.1 (Closes #368 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/368>)
    * fix speak-test.test to fail on volume==0
      pr2eus/test/speak-test.py: check if SoundRequest has volume attribute
  
* .travis.yml : remove hydro/jade, add melodic, fix speak-test for indigo (#385 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/385> )
  
    * test:speak-test.l add (ros::sleep 2) at the end of script, to wait for last message actually send out
    * fix test for indigo
  
* Goal header stamp should be the time message is made  (#358 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/358> )
  
    * fix goal header stamp time
  
* [pr2eus/robot-interface.l] Modified warning message in case of we can not connect to follow joint trajectory server (#381 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/381> )
* fix typo in error message on pr2eus/pr2-interface.l ( #384 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/384> )
* pr2eus: override clear-costmap namespace for pr2 (#343 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/343> )
  
    * pr2eus: override clear-costmap namespace for pr2
    * pr2eus: delegate costmap functions to robot-move-base-interface
    * pr2eus: default value of inflation range: 0.3
  
* add test for pr2/speak.l (#374 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/374> )
  
    * add test for action interface
    * add speak-test.py to check contents of SpeakRequest message
    * run speak-test.l and catch message by hztest
  
* Equalize min-time behavior of end-coords-interpolation to usual angle-vector (#355 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/355> )
  
    * Equalize min-time behavior of end-coords-interpolation to usual angle-vector
    * Add test to catch (#354 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/354>)
    * Add end-coords-interpolation test
  
* pr2eus_moveit: support motion with mobile base (#357 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/357> )
* pr2-ri-test.l : add test to check :wait-interpolation, with timeout (#352 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/352> )
  
    * fix: pr2-ri-test.l: check return value of :wait-ingterpolation as list
    * fix: Calling (load-ros-manifest pr2eus) for the package without msg/srv will be deprecated
    * pr2eus: robot-interface: add :base-controller-joint-names option
    * clean up :interpolatingp of robot-interface, use :interpolatingp in controller-actions class
    * fix :interpolationp of controller-action-client when using real robot
    * pr2-ri-test.l : add test to check return of :wait-interpolation with timeout value
    * fix :wait-interpolation of pr2-interface, do not wait for moving joints when timeout is not equal to 0
    * reduce the retry to 1, 5(retry) x 600 sec exceeds 50min limit of Travis
    * pr2-ri-test.l : add test to check :wait-interpolation, with timeout
  
* euscollada 0.4.0 requires changes in tests (from = to eps=, but seems the output is both 0.0) (#360 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/360> )
  
    * not sure why we do not need this until now, but we need to use eps=
  
* Fix typo. stll -> still (#342 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/342>)
* Fix wrong behaviors in :go-pos-unsafe / :move-trajectory / :move-trajectory (#336 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/336>)
  
    * fix: go-pos-unsafe less than expected if msec < 1000
    * fix: move-trajectory wrong document / implementation
  
* Fix many typos (#337 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/337>)
* run everything within jenkins (#340 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/340>)
  
    * explictly set DISPLAY="" for roseus test
    * re-define :joint-angle to avoid print violate max/min-angle that exceeds 4M log limit
    * test-pr2eus-moveit.l: not sure why, but sometimes utf-8 code is displayed and brakes catkin build
    * set time-limit for pr2-ri-test to 600
    * .travis.yml: run everything within travis
    * install pr2-arm-kinematics for indigo
  
* increase stall_velocity_threshold to pass grasp test (#338 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/338>)
  
    * increase stall_velocity_threshold to pass grasp test
    * add pr2_gazebo and robot_state_publisher to test_depend
    * skip pr2eus_moveit from test
    * set DISPLAY='' when gui is false
    * hydro/indigo run on travis, jade/kinetic run on jenkins
  
* [pr2eus] do not pass :wait-until-update in :state args (#333 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/333> )
  
    * add comment for :state :wait-until-update
    * add :wait-until-update test
    * pass args not including :wait-until-update keys
  
* Fix :end-coords-interpolation problems (#325 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/325> )
  
    * Adapt end-coords-interpolation for over-360 deg turns
    * Add :steps to :end-coords-interpolation
    * Changes to :end-coords-interpolation
  
* pr2eus: partially rever speak function (#332 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/332> )
  
    * sound_play could not run within travis/jenkins, so use hztest a dummy subscriber
    * pr2eus: integrate speak function, add :play-sound :speak-en, :speak-jp method to robot-interface
    * Revert "pr2eus: add text-to-spech method to robot-interface (#318 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/318>)"
      This reverts commit ecb2a1e29d2d56ae16035064c91617f2b0afa786.
  
* pr2eus: add text-to-spech method to robot-interface (#318 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/318>)
  
    * pr2eus: cleanup speak.l
    * pr2eus: robot-interface.l: add text-to-speech methods to robot-interface
    * pr2eus: update test for speak
    * pr2eus: migrate text-to-speech to robot-interface
  
* fix sub-angle-vector when diff is over 640 (#323 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/323> )
  
    * mod 360 to suport rotation over 640
    * add test to chcek sub-angle-vector over 620
    * fix :publish-joint-state after updating angle-vecgtor in robot-interface-simulation-callback, also changed to set av as the keypose
  
* Contributors: Affonso Guilherme, Kei Okada, Shingo Kitagawa, Shun Hasegawa, Yuki Furuta, Hitoshi Kamada, Iori Yanokura
```

## pr2eus_moveit

```
* fix typo and add pr2-init in pr2eus-moveit.l for PR2 + moveit (#382 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/382> )
  
    * add moveit pr2-init in pr2eus-moveit.l
      redefine original pr2-init -> pr2-init-org
    * fix parenthesis close in pr2eus-moveit.l
  
* Fix velocity time scaling (#377 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/377> )
  
    * Fix scaling of multi dof joint trajectory
    * scale accelerations in :trajectory-filter
    * fix velocity time scaling
    * Add test for time scaling of vel and acc in :trajectory-filter
  
* Fix :angle-vector-make-trajectory to ignore start-offset-time (#365 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/365> )
  
    * Remove first point of new traj if it overlaps with existing traj.
      Without this fix, traj points having the same time_from_start appear.
      This may harm joint trajectory action server.
    * Use exact time_from_start to pass test
    * Fix :angle-vector-make-trajectory to ignore start-offset-time
    * Reduce start-offset-time to speed up tests
    * Use init-pose instead of reset-manip-pose to speed up test-angle-vector-sequence-motion-plan
    * Loosen time limit of new test
    * Add test for start-offset-time with avs
  
* Fix time_from_start in motion-planned angle-vector-sequence (#363 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/363> )
  
    * Update robot in *ri* in 1st loop
    * Set time_from_start correctly in :angle-vector-make-trajectory
      Previously, traj points for second av started from zero time_from_start
    * Add equal to sort in test to avoid error
    * Add test for concatenation in :angle-vector-make-trajectory
  
* Fix :trajectory-filter to ignore start-offset-time (#361 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/361> )
  
    * Remove start-offset-time from passing args
    * Fix :trajectory-filter to ignore start-offset-time
    * Add test for start-offset-time
  
* pr2eus_moveit: support motion with mobile base (#357 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/357> )
  
    * reset-total-time is used only when trajectory is short
      See https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/0.3.13/pr2eus_moveit/euslisp/robot-moveit.l#L539-L544
    * Don't skip :trajectory-filter as before
      So far, this has been realized by an odd way
      (https://github.com/jsk-ros-pkg/jsk_pr2eus/commit/ca27e9d8dbe765b1879daf9ccd80e09c81674ab1)
    * pr2eus_moveit: run test only when pr2_gazebo is available
    * pr2eus_moveit: support planning with base movement
  
* run everything within jenkins (#340 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/340>)
  
    * explictly set DISPLAY="" for roseus test
    * re-define :joint-angle to avoid print violate max/min-angle that exceeds 4M log limit
    * test-pr2eus-moveit.l: not sure why, but sometimes utf-8 code is displayed and brakes catkin build
    * set time-limit for pr2-ri-test to 600
    * .travis.yml: run everything within travis
    * install pr2-arm-kinematics for indigo
  
* Use service call for collision-object-publisher (#324 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/324>)
  
    * operate attached_collision_object by service call
    * refactor codes in collision-object-publisher
  
* Contributors: Affonso Guilherme, Kei Okada, Shingo Kitagawa, Shun Hasegawa, Yuki Furuta
```

## pr2eus_tutorials

```
* add jsk_interactive_marker (#349 <https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/349> )
  c.f. https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/348
* Contributors: Kei Okada
```
