### PR TITLE
eigen_stl_containers: 1.0.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -401,6 +401,21 @@ repositories:
       url: https://github.com/stonier/ecl_tools.git
       version: release/1.0-crystal
     status: maintained
+  eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: git@github.com:ros2-gbp/eigen_stl_containers-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    status: maintained
   example_interfaces:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -409,7 +409,7 @@ repositories:
     release:
       tags:
         release: release/crystal/{package}/{version}
-      url: git@github.com:ros2-gbp/eigen_stl_containers-release.git
+      url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
       version: 1.0.0-0
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `1.0.0-0`:

- upstream repository: https://github.com/ros/eigen_stl_containers
- release repository: git@github.com:ros2-gbp/eigen_stl_containers-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## eigen_stl_containers

```
* Port package to ROS 2 (#16 <https://github.com/ros/eigen_stl_containers/issues/16>)
* Switch to package.xml format 2.
* Make sure to include <functional>
* Contributors: Chris Lalancette, Víctor Mayoral Vilches
```
