### PR TITLE
Add ROS2 CI for diagnostics

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -317,6 +317,17 @@ repositories:
       url: https://github.com/ros2/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: ros2-devel
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: ros2-devel
+    status: maintained
   ecl_core:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -321,12 +321,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2-devel
+      version: ros2_devel
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2-devel
+      version: ros2_devel
     status: maintained
   ecl_core:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -321,12 +321,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2_devel
+      version: ros2-devel
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2_devel
+      version: ros2-devel
     status: maintained
   ecl_core:
     doc:


### PR DESCRIPTION
Enable CI for ROS2 on the diagnostics repository, in support of porting diagnostics to ROS2.