### PR TITLE
jsk_model_tools: 0.4.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1812,6 +1812,22 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
       version: master
     status: developed
+  jsk_model_tools:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
+      version: master
+    release:
+      packages:
+      - eus_assimp
+      - euscollada
+      - eusurdf
+      - jsk_model_tools
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/tork-a/jsk_model_tools-release.git
+      version: 0.4.3-0
+    status: maintained
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_model_tools` to `0.4.3-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_model_tools
- release repository: https://github.com/tork-a/jsk_model_tools-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## eus_assimp

- No changes

## euscollada

```
* fix for urdfmodel 1.0.0 (melodic) (#221 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/221>)
* Contributors: Kei Okada
```

## eusurdf

```
* Fix for being deprecated tag: cfmDamping -> implicitSpringDamper (#222 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/222>)
* [eusurdf] add euslisp to INSTALL_DIRS (#220 <https://github.com/jsk-ros-pkg/jsk_model_tools/issues/220>)
* Contributors: Juntaro Tamura, Kentaro Wada
```

## jsk_model_tools

- No changes
