### PR TITLE
fcl_catkin: 0.5.96-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1085,7 +1085,8 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.95-0
+      version: 0.5.96-0
+    status: developed
   fetch_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl_catkin` to `0.5.96-0`:

- upstream repository: https://github.com/wxmerkt/fcl_catkin.git
- release repository: https://github.com/wxmerkt/fcl_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.95-0`
