### PR TITLE
robot_navigation: 0.2.5-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3975,7 +3975,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/locusrobotics/robot_navigation-release.git
-      version: 0.2.2-0
+      version: 0.2.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.2.5-0`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/locusrobotics/robot_navigation-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.2.2-0`
