### PR TITLE
plotjuggler: 2.1.2-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3363,7 +3363,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.1.1-0
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.1.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.1-0`

## plotjuggler

```
* legend button now has three states: left/right/hide
* replace tracker text when position is on the right side
* allow again to use the header.stamp
* fix problem with legend visibility
* Save all tab plots as images in a folder. (#137)
* Make default filename for tab image the tab name (#136)
* Update README.md
* adding instructions to build AppImage
* Contributors: Davide Faconti, d-walsh
```
