### PR TITLE
Fix Fedora's rule for python-opengl

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2403,7 +2403,7 @@ python-opencv:
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]
-  fedora: [PyOpenGL]
+  fedora: [python2-pyopengl]
   freebsd: [py27-PyOpenGL]
   gentoo: [dev-python/pyopengl]
   macports: [py27-opengl]


### PR DESCRIPTION
The virtual package `PyOpenGL` was previously provided by the `python2-pyopengl` package, but that is no longer the case in Fedora 29 and newer. The `python2-pyopengl` package has provided this functionality since (at least) Fedora 24, so the rule change is safe for all currently supported Fedora releases.

https://apps.fedoraproject.org/packages/python2-pyopengl