### PR TITLE
fetch_ros: 0.8.0-0 in melodic [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1120,6 +1120,31 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_open_auto_dock.git
       version: melodic-devel
     status: maintained
+  fetch_ros:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_ros.git
+      version: melodic-devel
+    release:
+      packages:
+      - fetch_calibration
+      - fetch_depth_layer
+      - fetch_description
+      - fetch_ikfast_plugin
+      - fetch_maps
+      - fetch_moveit_config
+      - fetch_navigation
+      - fetch_teleop
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
+      version: 0.8.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/fetchrobotics/fetch_ros.git
+      version: melodic-devel
+    status: maintained
   fetch_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.8.0-0`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## fetch_calibration

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* Merge pull request #100 <https://github.com/fetchrobotics/fetch_ros/issues/100> from aparker-fetch/distro-agnostic-calibration
  removed hardcoded ROS distro from calibrate_robot
* removed hardcoded ROS distro from calibrate_robot
* [Fetch Calibration] fix syntax error (#96 <https://github.com/fetchrobotics/fetch_ros/issues/96>)
  Noticed here https://index.ros.org/stats/errors/
  Failed to parse launchfile launch/capture_manual.launch:
  Missing end tag for 'rosparam' (got "launch")
  Line: 16 Position: 668 Last 80 unconsumed characters:
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* Merge pull request #81 <https://github.com/fetchrobotics/fetch_ros/issues/81> from moriarty/tf2-nav-melodic-devel
  [fetch_depth_layer][tf2] fixes for upstream navigation
  Changes for compatibility with ros-planning/navigation#755 <https://github.com/ros-planning/navigation/issues/755>
* (fetch_calibration) updates for new finders
* Contributors: Alex Moriarty, Andrew Parker, Eric Relson, Michael Ferguson
```

## fetch_depth_layer

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* Merge pull request #81 <https://github.com/fetchrobotics/fetch_ros/issues/81> from moriarty/tf2-nav-melodic-devel
  [fetch_depth_layer][tf2] fixes for upstream navigation
  Changes for compatibility with ros-planning/navigation#755 <https://github.com/ros-planning/navigation/issues/755>
* [fetch_depth_layer][tf2] ros-planning/navigation#755 <https://github.com/ros-planning/navigation/issues/755>
  Don't merge this until ros-planning/navigation#755 <https://github.com/ros-planning/navigation/issues/755>
  Updates fetch_depth_layer for tf2 changes coming upstream.
* Merge pull request #80 <https://github.com/fetchrobotics/fetch_ros/issues/80> from moriarty/opencv3-runtime-symbols-not-found
  [Depth Layer] Fixes OpenCV3 symbol lookup error
  Originally we depended on opencv_candidate which found the OpenCV libs for us.
* Merge pull request #78 <https://github.com/fetchrobotics/fetch_ros/issues/78> from fetchrobotics/build-on-melodic
  fetch_depth_layer is now full OpenCV3 support
* Contributors: Alex Moriarty, Alexander Moriarty, Russell Toris
```

## fetch_description

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* Contributors: Alex Moriarty
```

## fetch_ikfast_plugin

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* Contributors: Alex Moriarty
```

## fetch_maps

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* Contributors: Alex Moriarty
```

## fetch_moveit_config

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* [MoveIt][Melodic]: MoveGroupExecuteService -> MoveGroupExecuteTrajectoryAction (#94 <https://github.com/fetchrobotics/fetch_ros/issues/94>)
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* Contributors: Alex Moriarty, ivandariojr
```

## fetch_navigation

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* Contributors: Alex Moriarty
```

## fetch_teleop

```
* [package.xml] REP-140 package format 2 (#104 <https://github.com/fetchrobotics/fetch_ros/issues/104>)
  closes #83 <https://github.com/fetchrobotics/fetch_ros/issues/83>
* [Docs] Add URL tags to package for wiki.ros.org (#90 <https://github.com/fetchrobotics/fetch_ros/issues/90>)
  The <url> tag is required to automatically fill in at least some info
  on the wiki pages. The extra tags will create links to our docs.
* [teleop] Require primary dead-man for arm motion (#92 <https://github.com/fetchrobotics/fetch_ros/issues/92>)
  * Require primary dead-man for arm teleop, along with with the angular or linear selector button.
* Fixup to add missing variable definition.
* Also require primary deadman for arm teleop
* Contributors: Alex Moriarty, Eric Relson
```
