### PR TITLE
fetch_msgs: 1.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1099,7 +1099,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
-      version: 1.1.0-0
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `1.1.1-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.1.0-0`