### PR TITLE
fetch_robots: 0.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1120,6 +1120,22 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_open_auto_dock.git
       version: melodic-devel
     status: maintained
+  fetch_robots:
+    release:
+      packages:
+      - fetch_bringup
+      - fetch_drivers
+      - freight_bringup
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/fetchrobotics/fetch_robots.git
+      version: melodic-devel
+    status: maintained
   fetch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.8.0-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
