### PR TITLE
Use StringIO from the io module on Python 2

### DIFF
--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -3,10 +3,7 @@
 from __future__ import print_function
 from . import hook_permissions
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 import os
 import subprocess
 import sys


### PR DESCRIPTION
The `cStringIO` module is known to fail given characters which cannot be converted to ASCII.

https://docs.python.org/2/library/stringio.html#cStringIO.StringIO