### PR TITLE
jsk_recognition: 1.2.7-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2122,6 +2122,27 @@ repositories:
       url: https://github.com/tork-a/jsk_model_tools-release.git
       version: 0.4.3-0
     status: developed
+  jsk_recognition:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
+    release:
+      packages:
+      - checkerboard_detector
+      - imagesift
+      - jsk_pcl_ros
+      - jsk_pcl_ros_utils
+      - jsk_perception
+      - jsk_recognition
+      - jsk_recognition_msgs
+      - jsk_recognition_utils
+      - resized_image_transport
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jsk_recognition-release.git
+      version: 1.2.7-2
+    status: maintained
   jsk_roseus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.7-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* add melodic test (#2355 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2355> )
  
    * fix for melodic, use ros::AsyncSpinner
    * revert Reverts #2310 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2310>, kinfu.h uses jsk_rviz_plugins/OverlayText.h, but jsk_recognition should not depends on jsk_visualization, jsk_visualization depends on jsk_recognition
    * moveit API change: Affine3d -> Isometry3d
    * replace tf::MessageFilter by tf2_ros::MessageFilter
  
* OctomapServerContact sample with PR2(#2392 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2392> )
  
    * [jsk_pcl_ros/octomap_server_contact] check wheter tf transformation succeeds.
    * [jsk_pcl_ros/octomap_server_contact] refactor euslisp node for publishing sensor data.
    * [jsk_pcl_ros/octomap_server_contact] use openmp for scan grids.
    * [jsk_pcl_ros/octomap_server_contact] write with one loop for scanning grid.
    * [jsk_pcl_ros/octomap_server_contact] remove unnecessary lines in the case that vertex is not used (= contact surface is not used). change parameter name: use_vetex -> use_contact_surface.
    * [jsk_pcl_ros/octomap_server_contact] clamp min and max points for scanning all leaf.
    * [jsk_pcl_ros/octomap_server_contact] pass timestamp of subscribed message for tf transformation correctly.
    * [jsk_pcl_ros] add launch, scripts, and configs for sample of octomap_server_contact with PR2.
  
* Add method to convert jsk_recognition_msgs/BoundingBox to cube in euslisp (#2384 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2384> )
  
    * add function to convert jsk_recognition_msgs/BoundingBox to cube in euslisp
    * divide single roseus file into node file and library file
    * correct message type
  
* normal_estimation_omp_nodelet.cpp: add line to preserve rgb data of pointcloud (#2388 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2388> )
* [jsk_pcl_ros, jsk_pcl_ros_utils] Use ccache if installed to make it fast to generate object file (#2342 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2342> )
  
    * [jsk_pcl_ros] Use ccache if installed to make it fast to generate object file
  
* Fix cluster point indices decomposer to make bounding box from cloud including nan (#2369 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2369> )
  
    * remove nan only when is_dense is False
    * take over is_dense from input cloud and remove nan for bounding box computation
    * [jsk_pcl_ros] Add test_depend to jsk_perception
    * Add bbox test for cpi decomposer.
  
* [octomap_server_contact] Publish frontier grid (#2344 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2344> )
  
    * add test topics which is passed to test_topic_published.py
    * modify name space in remap
    * add test for octomap_contact
    * install bag file for octomap server contact
    * update sample rviz config for octomap frontier
    * add sample launch file for octomap frontier grid
    * publish frontier grid in octomap_server_contact
  
* Correct md5 of install rosbag file (#2361 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2361> )
* Contributors: Christian Rauch, Kei Okada, Masaki Murooka, Naoya Yamaguchi, Shingo Kitagawa, Shun Hasegawa, Iory Yanokura, Hideaki Ito, Weiqi Yang
```

## jsk_pcl_ros_utils

```
* [jsk_pcl_ros, jsk_pcl_ros_utils] Use ccache if installed to make it fast to generate object file (#2342 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2342> )
* Contributors: Iori Yanokura
```

## jsk_perception

```
* [jsk_perception/ssd_object_detector.py] Add header for publishing result image (#2367 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2367> )
* [jsk_perception] Add deep_sort_tracker_node.py (#2351 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2351> )
  
    * [jsk_perception/deep_sort_net.py] Fixed deep_sort_net import
    * [jsk_perception/test/deep_sort_tracker.test] Disable gpu in test
    * [jsk_perception/sample_deep_sort_tracker.launch] Refactor
    * [jsk_perception/deep_sort_tracker_node.py] Modified import file not to depend on tensorflow
    * Revert "[jsk_perception/deep_sort_tracker] Add dependencies of tensorflow"
      This reverts commit 7dac944cfc9292d81b8bdb90d89e8100eda2bf3a.
    * [jsk_perception/deep_sort_tracker] Add dependencies of tensorflow
    * [jsk_perception/deep_sort_tracker] Install git submodule directory to node_scripts/deep_sort/deep_sort
    * [jsk_perception/deep_sort_tracker_node.py] Add target_labels param to specify input labels/recst
    * [jsk_perception/deep_sort_tracker_node.py] Add test
    * [jsk_perception/deep_sort_tracker_node.py] Renamed publish image topic vis -> viz
    * [jsk_perception/deep_sort_tracker_node.py] Publish labelarray
    * [jsk_perception/sample/deep_sort_tracker] Add pretrained model load
    * [jsk_perception/deep_sort_tracker_noder.py] Add node
    * [jsk_perception/deep_sort_tracker_node.py] Add sample
    * [jsk_perception/install_trained_data.py] Add deepsort trained model
    * [jsk_perception] Add deep_sort by gitsubmodule
  
* [doc] [jsk_perception] Add documentation (#2385 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2385> )
  
    * Rewrite matchtemplate.py with cv2
    * Add test for matchtemplate.py
    * Enable random_forest_server.test only in indigo.
    * Add sample for matchtemplate.py
    * Fix conversion for latest cv_bridge: imgmsg <-> cv2 <-> cv
    * Add test for fisheye_ray.py
    * Add sample for fisheye_ray.py
    * Fix for undefined global variable in fisheye_ray.py
    * Add test for random_forest_server
    * Publish ~output/debug_image in random_forest_client_sample.py
    * Fix for executing RandomForestClassifier
    * Remove unused sklearn module which causes ImportError in sklearn>=0.20
    * Add ~slop param to bof_histogram_extractor
    * Show viewer if gui:=true in sample_background_subtraction
    * Remove unused remapping in sparse_image.test
    * Fix sparse_image_encoder/decoder sample
  
* [jsk_perception] Support fcn8s_atonce model in fcn_object_segmentation.py (#2375 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2375> )
  
    * Fix typo: fcn8s_atonce -> fcn8s_at_once
    * Support fcn8s_atonce model in fcn_object_segmentation.py
  
* [jsk_perception] fix load path for kalmanlib.l (#2377 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2377> )
* [doc] [jsk_perception] [jsk_recognition_utils] Add guide to image recognition with deep learning (#2365 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2365>)
  
    * Add doc for image annotation
    * Add annotate_images_with_labelme to index
    * Add dataset class for semantic segmentation
    * Add install_learning_datasets script
    * Download datasets during catkin build
    * Add .gitignore in learning_datasets/
    * Add train_fcn script
    * Set default learning_rate to valid value
    * Enable plotting from remote host as well
    * Add doc for training FCN
    * Add doc for starting deep learning with image dataset
    * Add how to create dataset, where to store it in documentation
    * Dump param for fcn_object_segmentation.py
    * Add InstanceSegmentationDataset
    * Add train script for Mask-RCNN
    * Fix model_name and outputs in train_fcn.md
    * Add doc for training Mask-RCNN
  
* Contributors: Kei Okada, Yuki Furuta, Yuto Uchimi, Iori Yanokura
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

```
* [jsk_perception] Add deep_sort_tracker_node.py (#2351 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2351> )
  * [jsk_recognition_utils/deep_sort_net.py] Renamed network name DeepSortFeature -> DeepSortFeatureExtractor
  * [jsk_perception/deep_sort/deep_sort_net.py] Moved to jsk_recognition_utils's chainermodels
* [jsk_recognition_utils] Resolve dependency for chainer (#2306 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2306> )
* Support passing Numpy_INCLUDE_DIRS externally (#2389 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2389> )
* [doc] [jsk_perception] [jsk_recognition_utils] Add guide to image recognition with deep learning (#2365 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2365>)
  
    * Add doc for image annotation
    * Add annotate_images_with_labelme to index
    * Add dataset class for semantic segmentation
    * Add install_learning_datasets script
    * Download datasets during catkin build
    * Add .gitignore in learning_datasets/
    * Add train_fcn script
    * Set default learning_rate to valid value
    * Enable plotting from remote host as well
    * Add doc for training FCN
    * Add doc for starting deep learning with image dataset
    * Add how to create dataset, where to store it in documentation
    * Dump param for fcn_object_segmentation.py
    * Add InstanceSegmentationDataset
    * Add train script for Mask-RCNN
    * Fix model_name and outputs in train_fcn.md
    * Add doc for training Mask-RCNN
  
* Contributors: Esteve Fernandez, Yuto Uchimi, Iori Yanokura
```

## resized_image_transport

```
* [resized_image_transport] install resized_image_transport (#2390 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2390> )
* Contributors: Shingo Kitagawa
```
