### PR TITLE
sick_scan: 0.0.16-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5867,6 +5867,17 @@ repositories:
       url: https://github.com/SICKAG/sick_safetyscanners.git
       version: master
     status: developed
+  sick_scan:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/SICKAG/sick_scan-release.git
+      version: 0.0.16-0
+    status: developed
   sick_tim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `0.0.16-0`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## sick_scan

```
* Update README.md
* Improved performance
```
