### PR TITLE
sick_scan: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14958,7 +14958,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 0.0.14-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `0.0.16-0`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.14-0`

## sick_scan

```
* Update README.md
* Improved performance
```
