### PR TITLE
move navigation2 pr builder to crystal-devel

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -755,7 +755,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/navigation2.git
-      version: master
+      version: crystal-devel
     release:
       packages:
       - costmap_queue
@@ -793,7 +793,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-planning/navigation2.git
-      version: master
+      version: crystal-devel
     status: maintained
   navigation_msgs:
     doc:


### PR DESCRIPTION
With an API break in the nightly build targeting dashing we need to move crystal specific developments and builds on the different branch and docs