### PR TITLE
robot_localization: 2.4.7-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10192,7 +10192,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.4.5-0
+      version: 2.4.7-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.4.7-2`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.4.5-0`

## robot_localization

```
* Documentation fixes
* Add broadcast_utm_transform_as_parent_frame
* Enable build optimisations if no build type configured.
* Meridian convergence adjustment added to navsat_transform.
* Contributors: G.A. vd. Hoorn, Pavlo Kolomiiets, diasdm
```
