### PR TITLE
robot_localization: 2.5.6-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3920,7 +3920,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.5.4-0
+      version: 2.5.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.5.6-0`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.5.4-0`

## robot_localization

```
* Documentation changes
* Add broadcast_utm_transform_as_parent_frame
* Enable build optimisations if no build type configured.
* Meridian convergence adjustment added to navsat_transform.
* Contributors: G.A. vd. Hoorn, Pavlo Kolomiiets, diasdm
```
