### PR TITLE
robot_localization: 2.6.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4481,7 +4481,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.6.2-0
+      version: 2.6.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.6.4-0`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.6.2-0`

## robot_localization

```
* Meridian convergence adjustment added to navsat_transform.
* Documentation changes
* Add broadcast_utm_transform_as_parent_frame
* Enable build optimisations if no build type configured.
* Contributors: G.A. vd. Hoorn, Pavlo Kolomiiets, diasdm
```
