### PR TITLE
pilz_robots: 0.4.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8671,7 +8671,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.4.6-0
+      version: 0.4.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.4.7-0`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.4.6-0`

## pilz_control

```
* Fixes for new JointTrajectoryController Interface
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

```
* drop outdated can configurationss
* Contributors: Pilz GmbH and Co. KG
```

## pilz_testutils

```
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

```
* With this change the integrationtest loads the blank.world which
  has no models.
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## prbt_hardware_support

```
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

```
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## prbt_moveit_config

```
* Remove exec_depend on metapackages
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

```
* drop outdated can configuration
* make robot.launch file configurable with args
* Contributors: Pilz GmbH and Co. KG
```
