### PR TITLE
nerian_stereo: 3.3.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3132,7 +3132,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.3.1-0
+      version: 3.3.2-0
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `3.3.2-0`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `3.3.1-0`

## nerian_stereo

```
* Fixed installation permissions
* Contributors: Konstantin Schauwecker
```
