### PR TITLE
fetch_robots: 0.8.1-0 in 'melodic' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1121,6 +1121,10 @@ repositories:
       version: melodic-devel
     status: maintained
   fetch_robots:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_robots.git
+      version: melodic-devel
     release:
       packages:
       - fetch_bringup
@@ -1129,7 +1133,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.8.0-1
+      version: 0.8.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Fix dependencies for build farm with 0.8.1