### PR TITLE
fetch_robots: 0.8.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1133,7 +1133,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.8.2-0
+      version: 0.8.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Sorry for yet another PR.

I've ran the prerelease jobs, and the pass. When trying to run the binary release job locally with 0.8.3, it still seemed to build version 0.8.2, so I think I wasn't setting up rosdistro correctly.
If this doesn't work, I'll ask @jacobperron to give me a tutorial in running the binary release jobs locally when he's home next week.

The source of all these 0.8.0, 0.8.1, 0.8.3 releases is trying to release a pre-combiled binary version of our drivers on the public build farm. https://github.com/fetchrobotics/fetch_robots/pull/27... we knew we were going to get into a bit of a mess at the beginning, hopefully it stabilizes.

Our pre-compiled binary is generated inside of docker and only targets intel / amd64.

So there is another open PR to blacklist the *arm* versions of our packages. https://github.com/ros-infrastructure/ros_buildfarm_config/pull/125