### PR TITLE
rospilot: 1.5.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5156,7 +5156,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.5.2-0
+      version: 1.5.4-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.5.4-0`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.5.2-0`

## rospilot

```
* Update vendored NPM deps
* Remove hard npm dependency
  npm deps must now be vendored
* Remove Highcharts and accelerometer graph page
* Added missing wget dependency to package.xml that was found in first_time_setup.sh.
* Improve cold start H264 streaming to new clients
* Refactor H264 streaming to allow Android app support
* Contributors: Anders Fischer, Christopher Berner
```
