### PR TITLE
open_manipulator: 2.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7900,7 +7900,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
-      version: 2.0.0-0
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `2.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.0-0`

## open_manipulator

```
* added dependency option for open_manipulator_control_gui package
* Contributors: Pyo
```

## open_manipulator_control_gui

```
* added dependency option for open_manipulator_control_gui package
* Contributors: Pyo
```

## open_manipulator_controller

```
* none
```

## open_manipulator_description

```
* none
```

## open_manipulator_libs

```
* none
```

## open_manipulator_moveit

```
* none
```

## open_manipulator_teleop

```
* none
```
