### PR TITLE
open_manipulator: 2.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3373,6 +3373,29 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  open_manipulator:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator.git
+      version: melodic-devel
+    release:
+      packages:
+      - open_manipulator
+      - open_manipulator_control_gui
+      - open_manipulator_controller
+      - open_manipulator_description
+      - open_manipulator_libs
+      - open_manipulator_moveit
+      - open_manipulator_teleop
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator.git
+      version: melodic-devel
+    status: developed
   open_manipulator_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `2.0.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## open_manipulator

```
* added dependency option for open_manipulator_control_gui package
* Contributors: Pyo
```

## open_manipulator_control_gui

```
* added dependency option for open_manipulator_control_gui package
* Contributors: Pyo
```

## open_manipulator_controller

```
* none
```

## open_manipulator_description

```
* none
```

## open_manipulator_libs

```
* none
```

## open_manipulator_moveit

```
* none
```

## open_manipulator_teleop

```
* none
```
