### PR TITLE
jsk_visualization: 2.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6055,7 +6055,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.4-0
+      version: 2.1.5-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.5-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.4-0`

## jsk_interactive

- No changes

## jsk_interactive_marker

- No changes

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

- No changes

## jsk_rviz_plugins

```
* [jsk_rviz_plugins] Add "Align Bottom" option to OverlayText (#723 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/723> )
  
    * Update config for easily understanding the effect of AlignBottom
    * Update overlay_sample.launch
    * Add rosparam to enable/disable reversing lines
    * Add "Align Bottom" option to overlay_text plugin
  
* Contributors: Yuto Uchimi
```

## jsk_visualization

- No changes
