### PR TITLE
jsk_visualization: 2.1.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5187,7 +5187,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.4-0
+      version: 2.1.5-0
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.5-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.4-0`

## jsk_interactive

- No changes

## jsk_interactive_marker

- No changes

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

- No changes

## jsk_rviz_plugins

```
* [jsk_rviz_plugins] Add "Align Bottom" option to OverlayText (#723 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/723> )
  
    * Update config for easily understanding the effect of AlignBottom
    * Update overlay_sample.launch
    * Add rosparam to enable/disable reversing lines
    * Add "Align Bottom" option to overlay_text plugin
  
* Contributors: Yuto Uchimi
```

## jsk_visualization

- No changes
