### PR TITLE
jsk_visualization: 2.1.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2181,6 +2181,24 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_roseus.git
       version: master
     status: developed
+  jsk_visualization:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    release:
+      packages:
+      - jsk_interactive
+      - jsk_interactive_marker
+      - jsk_interactive_test
+      - jsk_rqt_plugins
+      - jsk_rviz_plugins
+      - jsk_visualization
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jsk_visualization-release.git
+      version: 2.1.5-0
+    status: developed
   jskeus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.5-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## jsk_interactive

- No changes

## jsk_interactive_marker

- No changes

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

- No changes

## jsk_rviz_plugins

```
* [jsk_rviz_plugins] Add "Align Bottom" option to OverlayText (#723 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/723> )
  
    * Update config for easily understanding the effect of AlignBottom
    * Update overlay_sample.launch
    * Add rosparam to enable/disable reversing lines
    * Add "Align Bottom" option to overlay_text plugin
  
* Contributors: Yuto Uchimi
```

## jsk_visualization

- No changes
