### PR TITLE
plotjuggler: 2.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9961,7 +9961,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.1.2-1
+      version: 2.1.3-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.1.3-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.2-1`

## plotjuggler

```
* BUG: fixed issue with Customtracker when the plot is zoomed
* new icons
* ULog plugin added
* Allow to build the DataStreamClientSample on Linux (#143)
* Update README.md
* Contributors: Davide Faconti, Romain Reignier
```
