### PR TITLE
robot_navigation: 0.2.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4557,8 +4557,8 @@ repositories:
       - robot_navigation
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/locusrobotics/robot_navigation-release.git
-      version: 0.2.4-0
+      url: https://github.com/DLu/robot_navigation-release.git
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.2.5-1`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/DLu/robot_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.2.4-0`
