### PR TITLE
gripit: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3700,7 +3700,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Yannick-Oderri/gripit-release.git
-      version: 0.0.1-2
+      version: 0.0.3-0
   grizzly:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gripit` to `0.0.3-0`:

- upstream repository: https://github.com/Yannick-Oderri/GripIt.git
- release repository: https://github.com/Yannick-Oderri/gripit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.1-2`
