### PR TITLE
rtmros_hironx: 2.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14317,7 +14317,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/rtmros_hironx-release.git
-      version: 2.1.0-0
+      version: 2.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `2.1.1-0`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.0-0`

## hironx_calibration

- No changes

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* Avoid node clashing when USE_COLLISIONCHECK is true (#528 <https://github.com/start-jsk/rtmros_hironx/issues/528> )
* hironx_ros_bridge/test/test-hironx-ros-bridge.test: increse time-limit from 100 to 200 (#531 <https://github.com/start-jsk/rtmros_hironx/issues/531> )
  
    * increse time-limit from 100 to 200, to solve https://api.travis-ci.org/v3/job/407698809/log.txt
  
* fix python_qt_binding for qt5 (#525 <https://github.com/start-jsk/rtmros_hironx/issues/525> )
* hironx_ros_bridge/src/hironx_ros_bridge/old_api.py: add python file to support old api (#521 <https://github.com/start-jsk/rtmros_hironx/issues/521> )
* Contributors: Guilherme Affonso, Kei Okada, Felix von Drigalski
```

## rtmros_hironx

- No changes
