### PR TITLE
control_msgs: 1.5.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -561,7 +561,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/control_msgs-release.git
-      version: 1.4.0-0
+      version: 1.5.0-0
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.5.0-0`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.4.0-0`

## control_msgs

```
* Adding a JointJog msg
* Replace Adolfo with Bence as maintainer
* Contributors: AndyZe, Bence Magyar
```
