### PR TITLE
removing release version from mynt_eye_ros_wrapper due to FTBFS

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6957,7 +6957,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/harjeb/mynt_eye_ros_wrapper-release.git
-      version: 0.1.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Leaving devel job to hopefully help test a fix for
https://github.com/harjeb/mynt_eye_ros_wrapper/issues/1