### PR TITLE
remove uuv_descriptions and uuv_simulators

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14559,7 +14559,6 @@ repositories:
       - uuv_control_cascaded_pid
       - uuv_control_msgs
       - uuv_control_utils
-      - uuv_descriptions
       - uuv_gazebo
       - uuv_gazebo_plugins
       - uuv_gazebo_ros_plugins
@@ -14567,7 +14566,6 @@ repositories:
       - uuv_gazebo_worlds
       - uuv_sensor_ros_plugins
       - uuv_sensor_ros_plugins_msgs
-      - uuv_simulator
       - uuv_teleop
       - uuv_thruster_manager
       - uuv_trajectory_control


### PR DESCRIPTION
They are failing to bulid due to a missing dependency:
https://github.com/uuvsimulator/uuv_simulator/issues/342

A new release will restore them to the buildfarm. But for now they will not keep trying to rebuild.

FYI @musamarcusso   most recent release was #20311