### PR TITLE
remove pr2_motor_diagnostic_tool from kinetic due to not building

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9115,7 +9115,6 @@ repositories:
       - joint_qualification_controllers
       - pr2_bringup_tests
       - pr2_counterbalance_check
-      - pr2_motor_diagnostic_tool
       - pr2_self_test
       - pr2_self_test_msgs
       tags:


### PR DESCRIPTION
Follow on to: https://github.com/PR2/pr2_self_test/issues/6

It will come back in the next release

FYI @davefeilseifer this was last released in #19146