### PR TITLE
remove mrpt_graphslam_2d from kinetic as it does not build

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6793,7 +6793,6 @@ repositories:
       packages:
       - mrpt_ekf_slam_2d
       - mrpt_ekf_slam_3d
-      - mrpt_graphslam_2d
       - mrpt_icp_slam_2d
       - mrpt_rbpf_slam
       - mrpt_slam


### PR DESCRIPTION
Follow up to: https://github.com/mrpt-ros-pkg/mrpt_slam/issues/54

FYI @jlblancoc Last release appears to have been: #18222