### PR TITLE
Bump twist_mux_msgs to 2.1.0-6

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6575,7 +6575,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/twist_mux_msgs-release.git
-      version: 2.1.0-3
+      version: 2.1.0-6
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux_msgs.git


### PR DESCRIPTION
This should fix this error:

``` bash
Invoking 'git clone --branch debian/ros-melodic-twist-mux-msgs_2.1.0-3_stretch --depth 1 --no-single-branch https://github.com/ros-gbp/twist_mux_msgs-release.git /tmp/sourcedeb/source'
Cloning into '/tmp/sourcedeb/source'...
fatal: Remote branch debian/ros-melodic-twist-mux-msgs_2.1.0-3_stretch not found in upstream origin
# END SUBSECTION
Traceback (most recent call last):
  File "/tmp/ros_buildfarm/scripts/release/get_sources.py", line 50, in <module>
    sys.exit(main())
  File "/tmp/ros_buildfarm/scripts/release/get_sources.py", line 46, in main
    args.os_name, args.os_code_name, args.source_dir, args.debian_repository_urls)
  File "/tmp/ros_buildfarm/ros_buildfarm/sourcedeb_job.py", line 51, in get_sources
    subprocess.check_call(cmd)
  File "/usr/lib/python3.5/subprocess.py", line 271, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', 'clone', '--branch', 'debian/ros-melodic-twist-mux-msgs_2.1.0-3_stretch', '--depth', '1', '--no-single-branch', 'https://github.com/ros-gbp/twist_mux_msgs-release.git', '/tmp/sourcedeb/source']' returned non-zero exit status 128
```

The new branch for `2.1.0-6` is [here](https://github.com/ros-gbp/twist_mux_msgs-release/tree/debian/ros-melodic-twist-mux-msgs_2.1.0-6_stretch)