### PR TITLE
libnabo: 1.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6682,7 +6682,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/ethz-asl/libnabo-release.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       type: git
       url: https://github.com/ethz-asl/libnabo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libnabo` to `1.0.7-0`:
- upstream repository: https://github.com/ethz-asl/libnabo.git
- release repository: https://github.com/ethz-asl/libnabo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.6-0`