### PR TITLE
async_comm: 0.1.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -186,7 +186,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/dpkoch/async_comm-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_comm` to `0.1.1-0`:

- upstream repository: https://github.com/dpkoch/async_comm.git
- release repository: https://github.com/dpkoch/async_comm-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.0-0`

## async_comm

```
* Some cleanup
* Process callbacks on a separate thread
* Made buffer sizes constant, removed faulty mechanism for overriding
* Removed requirement that bulk write length be no greater than write buffer size
* Contributors: Daniel Koch
```
