### PR TITLE
async_comm: 0.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -192,7 +192,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/dpkoch/async_comm-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_comm` to `0.1.1-0`:

- upstream repository: https://github.com/dpkoch/async_comm.git
- release repository: https://github.com/dpkoch/async_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.0-0`

## async_comm

```
* Some cleanup
* Process callbacks on a separate thread
* Made buffer sizes constant, removed faulty mechanism for overriding
* Removed requirement that bulk write length be no greater than write buffer size
* Contributors: Daniel Koch
```
