### PR TITLE
ros_ethercat_eml: 0.3.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11073,6 +11073,17 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: kinetic
     status: maintained
+  ros_ethercat_eml:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/shadow-robot/ros_ethercat_eml-release.git
+      version: 0.3.1-0
+    source:
+      type: git
+      url: https://github.com/shadow-robot/ros_ethercat_eml.git
+      version: kinetic-devel
+    status: maintained
   ros_explorer:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat_eml` to `0.3.1-0`:

- upstream repository: https://github.com/shadow-robot/ros_ethercat_eml.git
- release repository: https://github.com/shadow-robot/ros_ethercat_eml-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ros_ethercat_eml

```
* Moved to new repo
```
