### PR TITLE
jsk_recognition: 1.2.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5144,7 +5144,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.7-0
+      version: 1.2.9-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.9-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.2.7-0`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

- No changes

## jsk_pcl_ros_utils

- No changes

## jsk_perception

- No changes

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

```
* add QT_LIBRARIES Qt5::Widgets to fix 'cannot find -lQt5::Widgets' error on debian stretch (#2398 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2398> )
* Contributors: Kei Okada
```

## resized_image_transport

- No changes
