### PR TITLE
Add qdarkstyle-pip rules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4861,6 +4861,15 @@ python3-yaml:
   fedora: [python3-PyYAML]
   gentoo: [dev-python/pyyaml]
   ubuntu: [python3-yaml]
+qdarkstyle-pip:
+  debian:
+    pip: [qdarkstyle]
+  fedora:
+    pip: [qdarkstyle]
+  osx:
+    pip: [qdarkstyle]
+  ubuntu:
+    pip: [qdarkstyle]
 rosbag-metadata-pip:
   debian:
     pip:


### PR DESCRIPTION
Add rosdep rules for `qdarkstyle`.

**Pypi listing:** https://pypi.org/project/QDarkStyle/
**Repo:** https://github.com/ColinDuquesnoy/QDarkStyleSheet
**Description:** A dark stylesheet for Qt applications