### PR TITLE
py_trees: 0.6.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4124,7 +4124,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.6.1-0
+      version: 0.6.8-0
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4118,8 +4118,8 @@ repositories:
   py_trees:
     doc:
       type: git
-      url: https://github.com/stonier/py_trees.git
-      version: release/0.6-melodic
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/0.6.x
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -4128,8 +4128,8 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/stonier/py_trees.git
-      version: release/0.6-melodic
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/0.6.x
     status: maintained
   py_trees_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.6.8-0`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.1-0`
