### PR TITLE
melfa_robot: 0.0.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6236,7 +6236,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/melfa_robot-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/tork-a/melfa_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `melfa_robot` to `0.0.4-0`:

- upstream repository: https://github.com/tork-a/melfa_robot.git
- release repository: https://github.com/tork-a/melfa_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.0.3-0`

## melfa_description

- No changes

## melfa_driver

```
* Fix wrong install location(#25 <https://github.com/tork-a/melfa_robot/issues/25>)
* Fix minor typo(#20 <https://github.com/tork-a/melfa_robot/issues/20>)
* Contributors: Ryosuke Tajima, Wolf Vollprecht
```

## melfa_robot

- No changes

## rv4fl_moveit_config

- No changes

## rv7fl_moveit_config

- No changes
