### PR TITLE
aws_common: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -676,7 +676,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/aws_common-release.git
-      version: 1.0.0-6
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/aws-robotics/utils-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_common` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/utils-common.git
- release repository: https://github.com/aws-gbp/aws_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-6`

## aws_common

```
* Add ROS2 dependencies to package.xml (#21 <https://github.com/aws-robotics/utils-common/issues/21>)
  * Update package.xml to depend on ament_cmake_gtest and ament_cmake_gmock if building for ROS2.
* Disallow use of non-ParameterPath objects in ParameterReaderInterface (#19 <https://github.com/aws-robotics/utils-common/issues/19>)
* Remove legacy portions of the ParameterReader API (#18 <https://github.com/aws-robotics/utils-common/issues/18>)
  * remove lunar travis builds
  * remove legacy portions of the ParameterReader API
* Update ParameterReader API to support ROS1/ROS2 (#17 <https://github.com/aws-robotics/utils-common/issues/17>)
  * cleanup CMakeFiles
  * refactor using the new ParameterReader API
  * clean up design of ParameterPath object
* Fix tests not running & optimize build time (#13 <https://github.com/aws-robotics/utils-common/issues/13>)
* Merge pull request #9 <https://github.com/aws-robotics/utils-common/issues/9> from xabxx/master
  fixed throttling manager unit test bug
* Update local variable name to class member name
  throttled_function_call_count -> throttled_function_call_count_
* Improve test coverage
* fixed throttling manager unit test bug
* Contributors: AAlon, Abby Xu, M. M, Ross Desmond, hortala
```
