### PR TITLE
py_trees: 0.5.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9228,7 +9228,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.5.10-0
+      version: 0.5.12-0
     source:
       type: git
       url: https://github.com/stonier/py_trees.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9222,8 +9222,8 @@ repositories:
   py_trees:
     doc:
       type: git
-      url: https://github.com/stonier/py_trees.git
-      version: release/0.5-kinetic
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/0.5.x
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -9231,8 +9231,8 @@ repositories:
       version: 0.5.12-0
     source:
       type: git
-      url: https://github.com/stonier/py_trees.git
-      version: release/0.5-kinetic
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/0.5.x
     status: developed
   py_trees_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.5.12-0`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.10-0`

## py_trees

```
[decorators] default option for collapsing decorators (resolves py_trees_ros bug)
```
