### PR TITLE
multimaster_fkie: 0.8.10-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2998,7 +2998,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.8.9-0
+      version: 0.8.10-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.8.10-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.8.9-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

- No changes

## master_sync_fkie

- No changes

## multimaster_fkie

```
* node_manager_fkie: exapand (nodes, topics, services) on filter
* fixed build node_manager_fkie without .git repository issue #91 <https://github.com/fkie/multimaster_fkie/issues/91>
* node_manager_fkie: fixed crash on show critical message dialog
* Contributors: Alexander Tiderko
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* node_manager_fkie: exapand (nodes, topics, services) on filter
* fixed build node_manager_fkie without .git repository issue #91 <https://github.com/fkie/multimaster_fkie/issues/91>
* node_manager_fkie: fixed crash on show critical message dialog
* Contributors: Alexander Tiderko
```
