### PR TITLE
grid_map: 1.6.0-0 added to 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1654,6 +1654,37 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: master
     status: maintained
+  grid_map:
+    doc:
+      type: git
+      url: https://github.com/anybotics/grid_map.git
+      version: master
+    release:
+      packages:
+      - grid_map
+      - grid_map_core
+      - grid_map_costmap_2d
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_octomap
+      - grid_map_pcl
+      - grid_map_ros
+      - grid_map_rviz_plugin
+      - grid_map_sdf
+      - grid_map_visualization
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/anybotics/grid_map-release.git
+      version: 1.6.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/anybotics/grid_map.git
+      version: master
+    status: developed
   grpc:
     doc:
       type: git


### PR DESCRIPTION
Releasing grid_map (previously released for indigo, jade and kinetic) now for melodic.