### PR TITLE
Revert "industrial_core: 0.7.0-0 in 'melodic/distribution.yaml' [bloom]"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1942,30 +1942,6 @@ repositories:
       url: https://github.com/ccny-ros-pkg/imu_tools.git
       version: melodic
     status: developed
-  industrial_core:
-    doc:
-      type: git
-      url: https://github.com/ros-industrial/industrial_core.git
-      version: melodic
-    release:
-      packages:
-      - industrial_core
-      - industrial_deprecated
-      - industrial_msgs
-      - industrial_robot_client
-      - industrial_robot_simulator
-      - industrial_trajectory_filters
-      - industrial_utils
-      - simple_message
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/ros-industrial-release/industrial_core-release.git
-      version: 0.7.0-0
-    source:
-      type: git
-      url: https://github.com/ros-industrial/industrial_core.git
-      version: melodic
-    status: developed
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
As per title, and reverts ros/rosdistro#20289.

I've opened this here, not to directly merge this, but to request some input on a situation we need to resolve in `ros-industrial/industrial_core`.

---

In ros/rosdistro#20289, a Melodic release of `industrial_core` was merged. That release was Bloom-ed from a newly created `melodic` release branch in `ros-industrial/industrial_core`. The release has also been built by the farm, binaries are available in `shadow-fixed`. So far so good.

Only: the release should have been done from the `kinetic` release branch: all changes for Melodic are bw-compatible with Kinetic and there was no need to branch (we purposefully worked towards such a situation).

In order to reduce maintenance overhead, we'd like to update the Melodic release such that it points to the `kinetic` release branch.

The current plan is to:

 1. delete the `kinetic` release branch
 1. rename the current `melodic` release branch to `kinetic` (the only difference between the two is the changelogs for the `0.7.0` release and the tagging commit)
 1. perform a `0.7.0` release into Kinetic reusing the changelogs and tag already present on the (renamed) `kinetic` release branch

Question: should the changes to the `industrial_core` release repository made by Bloom during the Melodic release be reverted? Alternatively, the release track for Melodic in the `industrial_core` release repository could be manually edited to point to the `kinetic` release branch.

I'm not sure what the best / least invasive approach is, so open to suggestions.
