### PR TITLE
uuv_simulator: 0.6.9-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14567,6 +14567,7 @@ repositories:
       - uuv_control_cascaded_pid
       - uuv_control_msgs
       - uuv_control_utils
+      - uuv_descriptions
       - uuv_gazebo
       - uuv_gazebo_plugins
       - uuv_gazebo_ros_plugins
@@ -14574,6 +14575,7 @@ repositories:
       - uuv_gazebo_worlds
       - uuv_sensor_ros_plugins
       - uuv_sensor_ros_plugins_msgs
+      - uuv_simulator
       - uuv_teleop
       - uuv_thruster_manager
       - uuv_trajectory_control
@@ -14583,7 +14585,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uuvsimulator/uuv_simulator-release.git
-      version: 0.6.7-0
+      version: 0.6.9-0
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_simulator` to `0.6.9-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.7-0`

## uuv_assistants

- No changes

## uuv_auv_control_allocator

- No changes

## uuv_control_cascaded_pid

- No changes

## uuv_control_msgs

- No changes

## uuv_control_utils

- No changes

## uuv_descriptions

```
* Replace all gazebo dependencies for gazebo_dev
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_gazebo

- No changes

## uuv_gazebo_plugins

- No changes

## uuv_gazebo_ros_plugins

```
* Replace all gazebo dependencies for gazebo_dev
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_gazebo_ros_plugins_msgs

- No changes

## uuv_gazebo_worlds

```
* Replace all gazebo dependencies for gazebo_dev
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_sensor_ros_plugins

- No changes

## uuv_sensor_ros_plugins_msgs

- No changes

## uuv_simulator

- No changes

## uuv_teleop

- No changes

## uuv_thruster_manager

- No changes

## uuv_trajectory_control

- No changes

## uuv_world_plugins

- No changes

## uuv_world_ros_plugins

```
* Replace all gazebo dependencies for gazebo_dev
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_world_ros_plugins_msgs

- No changes
