### PR TITLE
ml_classifiers: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2723,6 +2723,21 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: melodic-devel
     status: maintained
+  ml_classifiers:
+    doc:
+      type: git
+      url: https://github.com/astuff/ml_classifiers.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/astuff/ml_classifiers-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/astuff/ml_classifiers.git
+      version: master
+    status: maintained
   mongodb_store:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `0.4.0-0`:

- upstream repository: https://github.com/astuff/ml_classifiers.git
- release repository: https://github.com/astuff/ml_classifiers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ml_classifiers

```
* Updating URLs in package.xml.
* Updating README and package.xml with new data.
* Merge pull request #1 <https://github.com/astuff/ml_classifiers/issues/1> from sniekum/master
  Merging from upstream before taking ownership.
* CI: Adding CircleCI tests.
* Replacing createClassInstance with createInstance in pluginlib.
* Merge pull request #7 <https://github.com/astuff/ml_classifiers/issues/7> from astuff/melodic-devel
  Melodic fixes.
* Fixed compilation problems in Melodic.
* Fixing CMakeLists.txt and updating package.xml to version 2.
* Merge pull request #6 <https://github.com/astuff/ml_classifiers/issues/6> from wkentaro/migration-to-jade
  [ml_classifers] eigen -> Eigen3 in CMakeLists.txt
  See: http://wiki.ros.org/jade/Migration#Eigen_CMake_Module_in_cmake_modules
* Merge pull request #3 <https://github.com/astuff/ml_classifiers/issues/3> from jolting/indigo-devel
  Fix build for Indigo
* Contributors: Joshua Whitley, Kentaro Wada, Scott Niekum
```
