### PR TITLE
[melodic] Revert moveit: 1.0.0-0

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2799,7 +2799,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.0.0-0
+      version: 0.10.8-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
- Pointed out https://github.com/ros-planning/moveit/issues/1326#issuecomment-467350195 that it was a premature release.
- Some included packages are [failing to build on buildfarm](http://repositories.ros.org/status_page/ros_melodic_default.html?q=moveit).