### PR TITLE
industrial_core: use Kinetic branches for Melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1946,7 +1946,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git
-      version: melodic
+      version: kinetic
     release:
       packages:
       - industrial_core
@@ -1964,7 +1964,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/industrial_core.git
-      version: melodic
+      version: kinetic
     status: developed
   interactive_markers:
     doc:


### PR DESCRIPTION
As per subject.

Ref: https://github.com/ros/rosdistro/pull/20385.

`kinetic` release branch has been fast-forwarded to `melodic`. `melodic` branch will be removed after this is merged.
