### PR TITLE
fetch_robots: 0.8.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1133,7 +1133,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.8.4-0
+      version: 0.8.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.8.5-0`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.8.4-0`

## fetch_bringup

- No changes

## fetch_drivers

```
* [FIX] missing laser filter plugins (#34 <https://github.com/fetchrobotics/fetch_robots/issues/34>)
  The drivers work without them, but the robot drives reallly slow.
* Contributors: Alex Moriarty
```

## freight_bringup

- No changes
