### PR TITLE
hpp-fcl: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4211,6 +4211,17 @@ repositories:
       url: https://github.com/ros-interactive-manipulation/household_objects_database_msgs.git
       version: hydro-devel
     status: end-of-life
+  hpp-fcl:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipab-slmc/hpp-fcl_catkin-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/humanoid-path-planner/hpp-fcl.git
+      version: devel
+    status: developed
   hr_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpp-fcl` to `1.0.1-0`:

- upstream repository: https://github.com/ipab-slmc/hpp-fcl_catkin.git
- release repository: https://github.com/ipab-slmc/hpp-fcl_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
