### PR TITLE
hpp-fcl: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1747,6 +1747,17 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: melodic-devel
     status: developed
+  hpp-fcl:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipab-slmc/hpp-fcl_catkin-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/humanoid-path-planner/hpp-fcl.git
+      version: devel
+    status: developed
   ibeo_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpp-fcl` to `1.0.1-0`:

- upstream repository: https://github.com/ipab-slmc/hpp-fcl_catkin.git
- release repository: https://github.com/ipab-slmc/hpp-fcl_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
