### PR TITLE
rosbag2: 0.0.6-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1374,7 +1374,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: master
+      version: crystal
     release:
       packages:
       - ros1_rosbag_storage_vendor
@@ -1397,7 +1397,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: master
+      version: crystal
     status: developed
   rosidl:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1392,7 +1392,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.0.6-0`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.0.5-0`

## ros1_rosbag_storage_vendor

- No changes

## ros2bag

```
* Consistent node naming across ros2cli tools (#60 <https://github.com/ros2/rosbag2/issues/60>)
  * Passing CLI_NODE_NAME_PREFIX from ros2cli and using it to start the nodes with appropriate naming.
  * Passing CLI_NODE_NAME_PREFIX from ros2cli and using it to start the nodes with appropriate naming.
  * Fixing linter errors.
  * Renaming CLI_NODE_NAME_PREFIX -> NODE_NAME_PREFIX
* Contributors: AAlon
```

## rosbag2

- No changes

## rosbag2_bag_v2_plugins

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

```
* enforce unique node names (#86 <https://github.com/ros2/rosbag2/issues/86>)
  * enforce unique node names
  * fix cppcheck
* Contributors: Karsten Knese
```

## rosbag2_tests

- No changes

## rosbag2_transport

```
* enforce unique node names (#86 <https://github.com/ros2/rosbag2/issues/86>)
  * enforce unique node names
  * fix cppcheck
* disable cppcheck (#91 <https://github.com/ros2/rosbag2/issues/91>)
* Consistent node naming across ros2cli tools (#60 <https://github.com/ros2/rosbag2/issues/60>)
  * Passing CLI_NODE_NAME_PREFIX from ros2cli and using it to start the nodes with appropriate naming.
  * Passing CLI_NODE_NAME_PREFIX from ros2cli and using it to start the nodes with appropriate naming.
  * Fixing linter errors.
  * Renaming CLI_NODE_NAME_PREFIX -> NODE_NAME_PREFIX
* Contributors: AAlon, Karsten Knese
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
