### PR TITLE
hpp-fcl: 1.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1783,7 +1783,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/hpp-fcl_catkin-release.git
-      version: 1.0.1-0
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpp-fcl` to `1.0.1-2`:

- upstream repository: https://github.com/ipab-slmc/hpp-fcl_catkin.git
- release repository: https://github.com/ipab-slmc/hpp-fcl_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.1-0`
