### PR TITLE
vrx: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7000,6 +7000,26 @@ repositories:
       url: https://github.com/ros-drivers/vrpn_client_ros.git
       version: kinetic-devel
     status: maintained
+  vrx:
+    doc:
+      type: hg
+      url: https://bitbucket.org/osrf/vrx
+      version: default
+    release:
+      packages:
+      - usv_gazebo_plugins
+      - vrx_gazebo
+      - wamv_description
+      - wamv_gazebo
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/vrx-release.git
+      version: 1.0.0-1
+    source:
+      type: hg
+      url: https://bitbucket.org/osrf/vrx
+      version: default
+    status: developed
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.0.0-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## usv_gazebo_plugins

```
* Porting to Gazebo 9
* Rename vmrc to vrx.
* More progress.
* Changed from buoyancy calculation method
* Fixing error where buoyancy force could be applied in the negative direction (downward)
* Add dependency on usv_msgs by usv_gazebo_pinger_plugin.  This forces the message to be built before the plugin is compiled.
* Set the sensor WAM-V as the default model
* Fix the doxygen generation
* Update variable names and comments to be compliant with the Gazebo style guide.
* Add the pinger plugin to the wamv_gazebo package.
  The wamv_gazebo_sensors.urdf file has been modified to add support for the pinger plugin.
* removing static tags so vessel is freee to move
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>
```

## vrx_gazebo

```
* Merge from default.
* tweak the example
* addressing missing documentation and simplifying by removing start_index parameter
* Removing leftovers
* Tweaks
* Style changes.
* Merge from default.
* Merged in symbols_dock_part3 (pull request #66)
  Scan and dock scoring plugin - Part3
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* syncing with default
* Change to use real-time pose for error calculation
* Simplifying by removing some of the timing bits that appear to be specific to the ARIAC Population plugin
* Renaming internal
* Rename part 2 of 2
* Renaming part 1
* Adding scoring and running a quick test
* Functional plugin prototype
* Merge from default.
* Two variants of the scan and dock.
* Remove unused code.
* updating topic names so they match tasks
* tweak
* now publishing waypoints as a latched GeoPath message
* fix function name PublishWaypoints
* only start scoring when in running state
* fixing task names
* Re-basing poplulation plugin to scoring_plugin and adding ROS functionality.  Incomplete, but going home to work from there
* tweak a comment
* tweak
* Granting extra points for docking.
* Tweaks
* PR feedback
* Wrong merges.
* Merge from default.
* Merged in wayfinding-task (pull request #69)
  Wayfinding task
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* remove pointless latch in waypoints topic
* fix timer
* publish at 1 Hz, latch waypoints topic, tweaks
* Merge from default.
* Tweaks.
* Merge from default.
* Prototype of population plugin - only for a single object at a time.  Moves it back to original position when done
* Updates to PopulationPlugin
* Prototype - using PopulationPlugin straight from ARIAC source
* Remove warnings.
* More vrx updates.
* Merge from symbols_dock_part2
* More vrx tweaks.
* Merge from default.
* More updates.
* Porting to Gazebo 9
* Custom tweaks
* Updating the station keeping task.
* More leftovers.
* Rename vmrc to vrx.
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Michael McCarrin <mailto:mrmccarr@nps.edu>, m1chaelm
```

## wamv_description

```
* Rename vmrc to vrx.
* removing static tags so vessel is freee to move
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero
```

## wamv_gazebo

```
* Merge from default.
* Merge from symbols_dock_part2
* Merge from default.
* Merged in vrx (pull request #68)
  Rename vmrc to vrx
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* Custom tweaks
* More leftovers.
* Rename vmrc to vrx.
* assembling pieces for stationkeeping
* Merged in urdf_easy (pull request #62)
  Simplify urdf
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* Simplify urdf files.
* Locking the WAM-V conditionally.
* Playing with locking and releasing.
* Changed from buoyancy calculation method
* Decrease sensor noise to more clearly allow debugging of the simulation.
* Add the pinger plugin to the wamv_gazebo package.
  The wamv_gazebo_sensors.urdf file has been modified to add support for the pinger plugin.
* add missing dependencies
* Create perception.launch and lock the WAM-V.
* removing static tags so vessel is freee to move
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, chapulina <mailto:burajiru.no.chapulina@gmail.com>
```
