### PR TITLE
Revert "pilz_industrial_motion: 0.4.1-0 in melodic (#20398)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3888,7 +3888,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git
-      version: melodic-devel
+      version: kinetic-devel
     release:
       packages:
       - pilz_extensions
@@ -3900,11 +3900,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.1-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git
-      version: melodic-devel
+      version: kinetic-devel
     status: developed
   pilz_robots:
     doc:


### PR DESCRIPTION
This reverts commit 7467c8204377d77e8c505c93968d5d42710bb7c6.

Because we reverted moveit back to 0.10, we also need to revert pilz (see http://build.ros.org/job/Mbin_uB64__pilz_trajectory_generation__ubuntu_bionic_amd64__binary/43/console, where it fails to build because the API to moveit has changed).  @martiniil FYI