### PR TITLE
vrx: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7014,7 +7014,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.0.0-1
+      version: 1.0.1-0
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.0.1-0`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-1`

## usv_gazebo_plugins

- No changes

## vrx_gazebo

- No changes

## wamv_description

```
* Merged in wamv_meshes_meters (pull request #75)
  Fix issue #66
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* Change mesh units to meters.
* Contributors: Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>
```

## wamv_gazebo

```
* changed rviz camera topic
* Contributors: Brian Bingham<mailto:briansbingham@gmail.com>
```
