### PR TITLE
linux_networking: 1.0.12-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2102,6 +2102,34 @@ repositories:
       url: https://github.com/ros-drivers/libuvc_ros.git
       version: master
     status: unmaintained
+  linux_networking:
+    doc:
+      type: git
+      url: https://github.com/PR2/linux_networking.git
+      version: hydro-devel
+    release:
+      packages:
+      - access_point_control
+      - asmach
+      - asmach_tutorials
+      - ddwrt_access_point
+      - hostapd_access_point
+      - ieee80211_channels
+      - linksys_access_point
+      - linux_networking
+      - multi_interface_roam
+      - network_control_tests
+      - network_detector
+      - network_monitor_udp
+      - network_traffic_control
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pr2-gbp/linux_networking-release.git
+      version: 1.0.12-0
+    source:
+      type: git
+      url: https://github.com/pr2/linux_networking.git
+      version: hydro-devel
   log4cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_networking` to `1.0.12-0`:

- upstream repository: https://github.com/PR2/linux_networking.git
- release repository: https://github.com/pr2-gbp/linux_networking-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## access_point_control

- No changes

## asmach

- No changes

## asmach_tutorials

- No changes

## ddwrt_access_point

- No changes

## hostapd_access_point

- No changes

## ieee80211_channels

- No changes

## linksys_access_point

- No changes

## linux_networking

- No changes

## multi_interface_roam

```
* removed roslib declaration
* Contributors: TheDash
```

## network_control_tests

- No changes

## network_detector

```
* changes to cmakelists files to make packages compile in kinetic
* Contributors: David Feil-Seifer
```

## network_monitor_udp

```
* changes to cmakelists files to make packages compile in kinetic
* Contributors: David Feil-Seifer
```

## network_traffic_control

- No changes
