### PR TITLE
darknet_ros: 1.1.4-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1973,7 +1973,6 @@ repositories:
       version: master
     release:
       packages:
-      - darknet_ros
       - darknet_ros_msgs
       tags:
         release: release/kinetic/{package}/{version}

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1973,11 +1973,12 @@ repositories:
       version: master
     release:
       packages:
+      - darknet_ros
       - darknet_ros_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/leggedrobotics/darknet_ros-release.git
-      version: 1.1.3-0
+      version: 1.1.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `darknet_ros` to `1.1.4-0`:

- upstream repository: https://github.com/leggedrobotics/darknet_ros
- release repository: https://github.com/leggedrobotics/darknet_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.1.3-0`

## darknet_ros

```
* Merge pull request #141 <https://github.com/leggedrobotics/darknet_ros/issues/141> from lorenwel/feature/launch_file_arg
  Added arg for launch file parameter files
* Fixed synatx error
* Removed unnecessary args
* Adapted yolo_v3.launch to new launch file
* Added launch file arguments for parameter files
* Merge branch 'Texas-Aerial-Robotics-headerFixForUpsteam'
* Merge branch 'headerFixForUpsteam' of https://github.com/Texas-Aerial-Robotics/darknet_ros into Texas-Aerial-Robotics-headerFixForUpsteam
* Remove unused variable
* Merge branch 'headerFixForUpsteam' of https://github.com/Texas-Aerial-Robotics/darknet_ros into Texas-Aerial-Robotics-headerFixForUpsteam
* Multithreading mismatched image header fix
* Forgot to add image.
* Cropped test image.
* Changed image for test.
* Changed resame image.
* Added new images for test.
* Removed twice loading of weightfile.
* Contributors: Lorenz Wellhausen, Marko Bjelonic, Umer Salman, lorenwel
```

## darknet_ros_msgs

- No changes
