### PR TITLE
mavros: 0.29.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6208,7 +6208,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.29.0-0
+      version: 0.29.1-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.29.1-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.29.0-0`

## libmavconn

```
* All: catkin lint files
* Contributors: Pierre Kancir
```

## mavros

```
* All: catkin lint files
* Update apm_config.yaml
  Setting thrust_scaling in the setpoint_raw message (in my case, to use /mavros/setpoint_raw/attitude)
  Without it, when using Gazebo, get the following problem
  "Recieved thrust, but ignore_thrust is true: the most likely cause of this is a failure to specify the thrust_scaling parameters on px4/apm_config.yaml. Actuation will be ignored." from the function void attitude_cb in setpoint_raw.cpp (http://docs.ros.org/kinetic/api/mavros/html/setpoint__raw_8cpp_source.html)
* cmake: fix #1174 <https://github.com/mavlink/mavros/issues/1174>: add msg deps for package format 2
* Issue #1174 <https://github.com/mavlink/mavros/issues/1174> Added dependency for mavros_msgs and mavros
* Contributors: Adam Watkins, KiloNovemberDelta, Pierre Kancir, Vladimir Ermakov
```

## mavros_extras

```
* All: catkin lint files
* cmake: fix #1174 <https://github.com/mavlink/mavros/issues/1174>: add msg deps for package format 2
* mavros_extras: Convert source files to Unix line endings
* Contributors: Pierre Kancir, Vladimir Ermakov, sfalexrog
```

## mavros_msgs

```
* All: catkin lint files
* mavros_msgs: Fix line endings for OpticalFlowRad message
* Contributors: Pierre Kancir, sfalexrog
```

## test_mavros

```
* All: catkin lint files
* Contributors: Pierre Kancir
```
