### PR TITLE
sick_tim: 0.0.15-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6028,7 +6028,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.15-0`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.14-0`

## sick_tim

```
* Add libusb-1.0-dev to build_export_depend (#75 <https://github.com/uos/sick_tim/issues/75>)
* Contributors: Alex Moriarty
```
