### PR TITLE
indoor_localization: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4650,6 +4650,17 @@ repositories:
       type: git
       url: https://github.com/inomuh/indoor_localization.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/inomuh/indoor_localization-release.git
+      version: 0.1.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/inomuh/indoor_localization.git
+      version: 0.1.0
+    status: developed
   indoor_positioning:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `indoor_localization` to `0.1.0-0`:

- upstream repository: https://github.com/inomuh/indoor_localization.git
- release repository: https://github.com/inomuh/indoor_localization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## indoor_localization

```
* first public release
```
