### PR TITLE
add python-webrtcvad-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4443,6 +4443,19 @@ python-webpy:
   fedora: [python-webpy]
   gentoo: [dev-python/webpy]
   ubuntu: [python-webpy]
+python-webrtcvad-pip:
+  debian:
+    pip:
+      packages: [webrtcvad]
+  fedora:
+    pip:
+      packages: [webrtcvad]
+  osx:
+    pip:
+      packages: [webrtcvad]
+  ubuntu:
+    pip:
+      packages: [webrtcvad]
 python-websocket:
   debian: [python-websocket]
   fedora: [python-websocket-client]


### PR DESCRIPTION
https://pypi.org/project/webrtcvad/
https://github.com/wiseman/py-webrtcvad

This is a python interface to Google's WebRTC Voice Activity Detector (VAD). 