### PR TITLE
catkin: 0.7.15-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -434,7 +434,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.14-0
+      version: 0.7.15-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.15-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.14-0`

## catkin

```
* add local_setup files (#993 <https://github.com/ros/catkin/issues/993>)
* update docs to suggest 'test' path instead of 'tests'. (#990 <https://github.com/ros/catkin/issues/990>)
* generate CTest and dart config to avoid warnings (#987 <https://github.com/ros/catkin/issues/987>)
* fix PYTHONPATH missing in cached environment (#986 <https://github.com/ros/catkin/issues/986>)
* add double quotes around cmake_command to handle spaces (#976 <https://github.com/ros/catkin/issues/976>)
* strip "-l" from "-lpthread" library, to fix a build failure on ros-ros-comm (#975 <https://github.com/ros/catkin/issues/975>)
* correct Python executable in CMake files (#977 <https://github.com/ros/catkin/issues/977>)
* need to sanitize paths before cprint (#969 <https://github.com/ros/catkin/issues/969>)
* add friendly error message for ros/catkin#961 <https://github.com/ros/catkin/issues/961> (#964 <https://github.com/ros/catkin/issues/964>)
* document how to install python subpackages (#962 <https://github.com/ros/catkin/issues/962>)
* add existing catkin logo to README (#959 <https://github.com/ros/catkin/issues/959>)
* fix warnings in docs
* install environment hooks into a package-specific directory (#953 <https://github.com/ros/catkin/issues/953>)
* fix race condition with catkin_tools in parallel builds (#955 <https://github.com/ros/catkin/issues/955>)
* use CATKIN_GLOBAL_ETC_DESTINATION instead of etc (#954 <https://github.com/ros/catkin/issues/954>)
* remove CMAKE_MODULE_PATH from list of "forbidden" variables (#951 <https://github.com/ros/catkin/issues/951>)
* Windows related:
  
    * add win_ros script wrappers to make Python scripts executable (#978 <https://github.com/ros/catkin/issues/978>)
    * fix python_distutils_install.bat.in (#992 <https://github.com/ros/catkin/issues/992>)
    * add script.bat.in template for general use (#981 <https://github.com/ros/catkin/issues/981>)
    * normalize paths in CMAKE_PREFIX_PATH for proper comparison (#979 <https://github.com/ros/catkin/issues/979>)
    * update windows.cmake to fix common build issues on Windows (#984 <https://github.com/ros/catkin/issues/984>)
    * update builder.py to add Windows support (#982 <https://github.com/ros/catkin/issues/982>)
    * ensure desired Python path is added into PATH in setup.bat (#983 <https://github.com/ros/catkin/issues/983>)
    * check both IMPORTED_IMPLIB_ and IMPORTED_LOCATION_ in catkin_libraries.cmake (#980 <https://github.com/ros/catkin/issues/980>)
    * enable catkin build use_nmake on Windows (#949 <https://github.com/ros/catkin/issues/949>)
  
```
