### PR TITLE
genmsg: 0.5.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1450,7 +1450,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.11-0
+      version: 0.5.12-0
     source:
       type: git
       url: https://github.com/ros/genmsg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.12-0`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.11-0`

## genmsg

```
* add missing run_depend on empy (#81 <https://github.com/ros/genmsg/issues/81>)
* use CATKIN_GLOBAL_ETC_DESTINATION for etc (#79 <https://github.com/ros/genmsg/issues/79>)
```
