### PR TITLE
genpy: 0.6.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1480,7 +1480,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.7-0
+      version: 0.6.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.8-0`:

- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.7-0`

## genpy

```
* check size of fixed sized arrays when serializing (#92 <https://github.com/ros/genpy/issues/92>)
* allow returning derived types in overloaded operators (#100 <https://github.com/ros/genpy/issues/100>)
* reload() was move into importlib in Python 3 (#98 <https://github.com/ros/genpy/issues/98>)
* fix _convert_getattr for handling uint8[] message fields in Python 3 (#96 <https://github.com/ros/genpy/issues/96>)
```
