### PR TITLE
rosconsole: 1.13.10-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5087,7 +5087,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole-release.git
-      version: 1.13.9-0
+      version: 1.13.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole` to `1.13.10-0`:

- upstream repository: https://github.com/ros/rosconsole.git
- release repository: https://github.com/ros-gbp/rosconsole-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.13.9-0`

## rosconsole

```
* add missing declaration of deregister_appender in impl namespace (#28 <https://github.com/ros/rosconsole/issues/28>)
* add deregistry declaration and base impl (#23 <https://github.com/ros/rosconsole/issues/23>)
* dll import/export visibility macro update (#26 <https://github.com/ros/rosconsole/issues/26>)
* fix long message causing program exit at exception (#25 <https://github.com/ros/rosconsole/issues/25>)
```
