### PR TITLE
roscpp_core: 0.6.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5125,7 +5125,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.11-0
+      version: 0.6.12-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.12-0`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.11-0`

## cpp_common

```
* update the use of macros in platform.h (#99 <https://github.com/ros/roscpp_core/issues/99>)
* avoid unnecessary memory allocation (std::string) (#95 <https://github.com/ros/roscpp_core/issues/95>)
* fix bug in HAVE_CXXABI_H compiler check (#89 <https://github.com/ros/roscpp_core/issues/89>)
```

## roscpp_serialization

```
* fix GCC8 class-memaccess in VectorSerializer (#102 <https://github.com/ros/roscpp_core/issues/102>)
```

## roscpp_traits

- No changes

## rostime

```
* use std::numeric_limits instead of * _MAX macros for range checking (#103 <https://github.com/ros/roscpp_core/issues/103>)
* use std::this_thread::sleep_for instead of WaitableTimer (#101 <https://github.com/ros/roscpp_core/issues/101>)
* include windows.h in time.cpp (#100 <https://github.com/ros/roscpp_core/issues/100>)
* fix duration bug and add tests. (#98 <https://github.com/ros/roscpp_core/issues/98>)
* fix for Duration::fromSec() which had rounding issues (#93 <https://github.com/ros/roscpp_core/issues/93>)
* fix bug in HAVE_CXXABI_H compiler check (#89 <https://github.com/ros/roscpp_core/issues/89>)
* add ROSTIME_DECL storage-class attribute (#90 <https://github.com/ros/roscpp_core/issues/90>)
```
