### PR TITLE
std_msgs: 0.5.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6203,7 +6203,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/std_msgs-release.git
-      version: 0.5.11-0
+      version: 0.5.12-0
     source:
       type: git
       url: https://github.com/ros/std_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs` to `0.5.12-0`:

- upstream repository: git@github.com:ros/std_msgs.git
- release repository: https://github.com/ros-gbp/std_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.11-0`
