### PR TITLE
mir_robot: 1.0.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2779,6 +2779,31 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: melodic-devel
     status: maintained
+  mir_robot:
+    doc:
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: melodic
+    release:
+      packages:
+      - mir_actions
+      - mir_description
+      - mir_driver
+      - mir_dwb_critics
+      - mir_gazebo
+      - mir_msgs
+      - mir_navigation
+      - mir_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/mir_robot-release.git
+      version: 1.0.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: melodic
+    status: developed
   ml_classifiers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.3-0`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## mir_actions

- No changes

## mir_description

```
* Merge pull request #16 <https://github.com/dfki-ric/mir_robot/issues/16> from niniemann/add-prefix-argument-to-configs
  Add prefix argument to configs
* removed prefix from plugin frameName in sick urdf
  The gazebo plugins automatically use tf_prefix, even if none is set
  (in that case it defaults to the robot namespace). That's why we can
  remove the prefix from the plugins configuration, assuming that the
  robot namespace will be equal to the prefix.
* adds $(arg prefix) to a lot of configs
  This is an important step to be able to re-parameterize move base,
  the diffdrive controller, ekf, amcl and the costmaps for adding a
  tf prefix to the robots links
* workaround eval in xacro for indigo support
* adds tf_prefix argument to imu.gazebo.urdf.xacro
* Add TFs for ultrasound sensors
* Contributors: Martin Günther, Nils Niemann
```

## mir_driver

```
* Make disable_map work with MiR software 2.0
  See #5 <https://github.com/dfki-ric/mir_robot/issues/5>.
* mir_driver: Optionally disable the map topic + TF frame (#6 <https://github.com/dfki-ric/mir_robot/issues/6>)
  This is useful when running one's own SLAM / localization nodes.
  Fixes #5 <https://github.com/dfki-ric/mir_robot/issues/5>.
* Split scan_rep117 topic into two separate topics
  This fixes the problem that the back laser scanner was ignored in the
  navigation costmap in Gazebo (probably because in Gazebo, both laser
  scanners have the exact same timestamp).
* Contributors: Martin Günther
```

## mir_dwb_critics

```
* PathProgressCritic: Add heading score
* Add package: mir_dwb_critics
* Contributors: Martin Günther
```

## mir_gazebo

```
* Add hector_mapping
* fake_localization.launch: Add frame id args
* Merge pull request #16 <https://github.com/dfki-ric/mir_robot/issues/16> from niniemann/add-prefix-argument-to-configs
  Add prefix argument to configs
* adds $(arg prefix) to a lot of configs
  This is an important step to be able to re-parameterize move base,
  the diffdrive controller, ekf, amcl and the costmaps for adding a
  tf prefix to the robots links
* Fix translation error in odom_comb (#12 <https://github.com/dfki-ric/mir_robot/issues/12>)
  Previously, the ekf localization only computed a correct orientation, but the translation still followed the pure odometry data. This led to strange errors where the robot would move sideways (despite only having a diff drive).
  This PR changes the ekf configuration to not use any position information from the odometry, but to integrate the velocities, which fixes this problem.
* Split scan_rep117 topic into two separate topics
  This fixes the problem that the back laser scanner was ignored in the
  navigation costmap in Gazebo (probably because in Gazebo, both laser
  scanners have the exact same timestamp).
* Contributors: Martin Günther, Nils Niemann
```

## mir_msgs

```
* mir_msgs: Compile new msgs + rename mirMsgs -> mir_msgs
* mir_msgs: Add geometry_msgs dependency
  Now that we have an actual msg package dependency, we don't need the std_msgs placeholder any more.
* mir_msgs: Add new messages on kinetic
* Contributors: Martin Günther
```

## mir_navigation

```
* fix frame_id for melodic (#18 <https://github.com/dfki-ric/mir_robot/issues/18>)
* Tune dwb parameters
* PathProgressCritic: Add heading score
* Use dwb_local_planner in move_base config
* Move footprint param to move_base root namespace
  This allows other move_base plugins, such as dwb_local_planner, to
  access this parameter.
* Add hector_mapping
* amcl.launch: Change default, remap service
  This is required if amcl.launch is started within a namespace.
* teb_local_planner: Fix odom topic name
* Merge pull request #16 <https://github.com/dfki-ric/mir_robot/issues/16> from niniemann/add-prefix-argument-to-configs
  Add prefix argument to configs
* adds $(arg prefix) to a lot of configs
  This is an important step to be able to re-parameterize move base,
  the diffdrive controller, ekf, amcl and the costmaps for adding a
  tf prefix to the robots links
* mir_navigation: Adjust helper node topics
* Add amcl launchfile (#11 <https://github.com/dfki-ric/mir_robot/issues/11>)
  * added amcl.launch
  * changed amcl params to default mir amcl parameters
* Merge pull request #13 <https://github.com/dfki-ric/mir_robot/issues/13> from niniemann/fix-virtual-walls
  The previous configuration of the local costmap didn't work for me -- obstacles seen in the laser scans were not added, or were overridden by the virtual_walls_map layer. Reordering the layers and loading the virtual walls before the obstacles fixes this for me.
  Also, I added a with_virtual_walls parameter to start_maps.launch and start_planner.launch.
* added with_virtual_walls parameter to start_maps and start_planner
* reorder local costmap plugins
* Revert "mir_navigation: Disable virtual walls if no map file set"
  This reverts commit 0cfda301b2bb1e8b3458e698efd24a7901e5d132.
  The reason is that the eval keyword was introduced in kinetic, so it
  doesn't work in indigo.
* mir_navigation: Update rviz config
* mir_navigation: Disable virtual walls if no map file set
* mir_navigation: Rename virtual_walls args + files
* mir_navigation: Remove parameter first_map_only
  This parameter must be set to false (the default) when running SLAM
  (otherwise the map updates won't be received), and when running a static
  map_server it doesn't matter; even then, it should be false to allow
  restarting the map_server with a different map. Therefore this commit
  removes it altogether and leaves it at the default of "false".
* split parameter files between mapping/planning (#10 <https://github.com/dfki-ric/mir_robot/issues/10>)
  The differences are simple: When mapping, first_map_only must be
  set to false, and the virtual walls plugin must not be loaded
  (else move_base will wait for a topic that is not going to be
  published).
* Document move_base params, add max_planning_retries
  Setting max_planning_retries to 10 makes the planner fail faster if the
  planning problem is infeasible. By default, there's an infinite number
  of retries, so we had to wait until the planner_patience ran out (5 s).
* Update rviz config
  Make topics relative, so that ROS_NAMESPACE=... works.
* Switch to binary sbpl_lattice_planner dependency
  ... instead of compiling from source.
* Split scan_rep117 topic into two separate topics
  This fixes the problem that the back laser scanner was ignored in the
  navigation costmap in Gazebo (probably because in Gazebo, both laser
  scanners have the exact same timestamp).
* mir_navigation: Add clear_params to move_base launch
* mir_navigation: marking + clearing were switched
  Other than misleading names, this had no effect.
* Contributors: Martin Günther, Nils Niemann, Noël Martignoni
```

## mir_robot

```
* Add package: mir_dwb_critics
* Contributors: Martin Günther
```
