### PR TITLE
Add libclang-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1562,7 +1562,9 @@ libceres-dev:
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   ubuntu: [libceres-dev]
 libclang-dev:
+  arch: [clang]
   debian: [libclang-dev]
+  fedora: [clang-libs]
   ubuntu: [libclang-dev]
 libcoin60-dev:
   arch: [coin]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1561,6 +1561,9 @@ libceres-dev:
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   ubuntu: [libceres-dev]
+libclang-dev:
+  debian: [libclang-dev]
+  ubuntu: [libclang-dev]
 libcoin60-dev:
   arch: [coin]
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1564,7 +1564,7 @@ libceres-dev:
 libclang-dev:
   arch: [clang]
   debian: [libclang-dev]
-  fedora: [clang-libs]
+  fedora: [clang-devel]
   ubuntu: [libclang-dev]
 libcoin60-dev:
   arch: [coin]


### PR DESCRIPTION
As per subject.

 - Debian: [libclang-dev](https://packages.debian.org/jessie/libclang-dev)
 - Ubuntu: [libclang-dev](https://packages.ubuntu.com/xenial/libclang-dev)

I also found some references for [OpenSUSE](https://software.opensuse.org/package/llvm-clang) and [Gentoo](https://packages.gentoo.org/packages/sys-devel/clang), but as I use neither and can't be certain these provide the actual files (`libclang.so` at a minimum) I'm not going to add them.
