### PR TITLE
earth_rover_localization: 1.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2439,7 +2439,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/earthrover/earth_rover_localization-release.git
-      version: 1.0.1-1
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/earthrover/earth_rover_localization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `earth_rover_localization` to `1.2.0-0`:

- upstream repository: https://github.com/earthrover/earth_rover_localization.git
- release repository: https://github.com/earthrover/earth_rover_localization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `1.0.1-1`

## earth_rover_localization

```
* Update readme and install SBP script
* Fixed piksi package in launch and install targets
* Contributors: Andres Palomino
```
