### PR TITLE
rqt_action: 1.0.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1584,6 +1584,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_action-release.git
+      version: 1.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: crystal-devel
+    status: maintained
   rqt_console:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1595,7 +1595,6 @@ repositories:
       url: https://github.com/ros2-gbp/rqt_action-release.git
       version: 1.0.1-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
       version: crystal-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `1.0.1-0`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## rqt_action

```
* updating package.xml to ros2 (#6 <https://github.com/ros-visualization/rqt_action/issues/6>)
* Contributors: Mike Lautman
```
