### PR TITLE
rqt_topic: 1.0.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1761,7 +1761,6 @@ repositories:
       url: https://github.com/ros2-gbp/rqt_topic-release.git
       version: 1.0.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
       version: crystal-devel

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1750,6 +1750,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_top.git
       version: crystal-devel
     status: maintained
+  rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_topic-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.0.0-0`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## rqt_topic

```
* removing the spinner from the ros2 port (#11 <https://github.com/ros-visualization/rqt_topic/issues/11>)
* Merge pull request #9 <https://github.com/ros-visualization/rqt_topic/issues/9> from ros-visualization/ros2_port
* Porting to ROS2
* autopep8 (#6 <https://github.com/ros-visualization/rqt_topic/issues/6>)
* Contributors: Mike Lautman, Stephen, brawner
```
