### PR TITLE
dynamic_robot_state_publisher: 1.1.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -780,6 +780,21 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: master
     status: maintained
+  dynamic_robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/peci1/dynamic_robot_state_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/peci1/dynamic_robot_state_publisher-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/peci1/dynamic_robot_state_publisher.git
+      version: master
+    status: developed
   dynpick_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_robot_state_publisher` to `1.1.1-0`:

- upstream repository: https://github.com/peci1/dynamic_robot_state_publisher.git
- release repository: https://github.com/peci1/dynamic_robot_state_publisher-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## dynamic_robot_state_publisher

```
* Allowed deleting static TF frames that disappeared.
* Fixed deadlock.
* Contributors: Martin Pecka
```
