### PR TITLE
uuv_simulator: 0.6.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14694,7 +14694,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uuvsimulator/uuv_simulator-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_simulator` to `0.6.10-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.6.9-0`

## uuv_assistants

```
* Fix package name to uuv_message_to_tf node
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Fix name of package for uuv_message_to_tf
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Add message_to_tf to package configuration
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Add message_to_tf node
  message_to_tf node is available only until ROS kinetic
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_auv_control_allocator

- No changes

## uuv_control_cascaded_pid

- No changes

## uuv_control_msgs

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_control_utils

- No changes

## uuv_descriptions

```
* Fix dependency for message_to_tf node
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Fix name of package for uuv_message_to_tf
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Fix non-executables
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_gazebo

- No changes

## uuv_gazebo_plugins

```
* Fix dynamic linking for test build
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Replace boost::shared_ptr for std::shared_ptr
  Signed-off-by: Musa Morena Marcusso Manhaes <Musa.Marcusso@de.bosch.com>
* Add boost library dependencies to test build
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_gazebo_ros_plugins

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_gazebo_ros_plugins_msgs

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_gazebo_worlds

```
* Fix non-executables
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_sensor_ros_plugins

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_sensor_ros_plugins_msgs

- No changes

## uuv_simulator

- No changes

## uuv_teleop

- No changes

## uuv_thruster_manager

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_trajectory_control

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Fix non-executables
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_world_plugins

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_world_ros_plugins

```
* Fix errors from catkin_lint
  Signed-off-by: Musa Morena Marcusso Manhaes <mailto:Musa.Marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhaes
```

## uuv_world_ros_plugins_msgs

- No changes
