### PR TITLE
static_transform_mux: 1.1.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5605,6 +5605,21 @@ repositories:
       url: https://github.com/DLu/static_tf.git
       version: master
     status: maintained
+  static_transform_mux:
+    doc:
+      type: git
+      url: https://github.com/tradr-project/static_transform_mux.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/peci1/static_transform_mux-release.git
+      version: 1.1.0-0
+    source:
+      type: git
+      url: https://github.com/tradr-project/static_transform_mux.git
+      version: master
+    status: developed
   std_capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_transform_mux` to `1.1.0-0`:

- upstream repository: https://github.com/tradr-project/static_transform_mux.git
- release repository: https://github.com/peci1/static_transform_mux-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## static_transform_mux

```
* Changed the cache key to allow restructuring the TF tree.
* Contributors: Martin Pecka
```
