### PR TITLE
ouster: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8315,6 +8315,15 @@ repositories:
       type: git
       url: https://bitbucket.org/osrf/gear.git
       version: master
+  ouster:
+    release:
+      packages:
+      - ouster_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/CPFL/ouster-release.git
+      version: 0.1.3-0
+    status: developed
   oxford_gps_eth:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster` to `0.1.3-0`:

- upstream repository: https://github.com/CPFL/ouster.git
- release repository: https://github.com/CPFL/ouster-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ouster_ros

```
* Updated LICENSE
```
