### PR TITLE
Adding teleop_keyboard_omni3 to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13538,7 +13538,7 @@ repositories:
       version: master
     source:
       type: git
-      url: https://github.com/ros-teleop/teleop_twist_keyboard.git
+      url: https://github.com/YugAjmera/teleop_keyboard_omni3.git
       version: master
     status: maintained
   teleop_tools:


### PR DESCRIPTION
Sorry,I made an error while writing the package index. I have corrected that.