### PR TITLE
ouster: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3721,6 +3721,15 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  ouster:
+    release:
+      packages:
+      - ouster_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CPFL/ouster-release.git
+      version: 0.1.3-1
+    status: developed
   oxford_gps_eth:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster` to `0.1.3-1`:

- upstream repository: https://github.com/CPFL/ouster.git
- release repository: https://github.com/CPFL/ouster-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ouster_ros

```
* Updated LICENSE
```
