### PR TITLE
remove smarthome_light_msgs_java from indigo due to not building

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15206,7 +15206,6 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/rosalfred-release/smarthome_light_msgs-release.git
-      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/rosalfred/smarthome_light_msgs.git


### PR DESCRIPTION
partial revert of #11808

It's not building due to a missing install rule:
```
java/opt/ros/indigo/lib/pkgconfig/smarthome_light_msgs_java.pc
00:37:50.475 -- Installing: /tmp/binarydeb/ros-indigo-smarthome-light-msgs-java-0.1.2/debian/ros-indigo-smarthome-light-msgs-java/opt/ros/indigo/share/smarthome_light_msgs_java/cmake/smarthome_light_msgs_javaConfig.cmake
00:37:50.475 -- Installing: /tmp/binarydeb/ros-indigo-smarthome-light-msgs-java-0.1.2/debian/ros-indigo-smarthome-light-msgs-java/opt/ros/indigo/share/smarthome_light_msgs_java/cmake/smarthome_light_msgs_javaConfig-version.cmake
00:37:50.476 -- Installing: /tmp/binarydeb/ros-indigo-smarthome-light-msgs-java-0.1.2/debian/ros-indigo-smarthome-light-msgs-java/opt/ros/indigo/share/smarthome_light_msgs_java/package.xml
00:37:50.477 CMake Error at cmake_install.cmake:51 (FILE):
00:37:50.477   file INSTALL cannot find
00:37:50.477   "/tmp/binarydeb/ros-indigo-smarthome-light-msgs-java-0.1.2/obj-x86_64-linux-gnu/devel/share/maven/org/ros/rosjava_messages".
00:37:50.477 
```

@Theosakamg FYI