### PR TITLE
mavros: 0.29.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6234,7 +6234,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.29.1-0
+      version: 0.29.2-0
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.29.2-0`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.8`
- previous version for package: `0.29.1-0`

## libmavconn

- No changes

## mavros

- No changes

## mavros_extras

```
* extras: odom: update velocity covariance fields from 'twist' to 'velocity_covariance'
* Contributors: TSC21
```

## mavros_msgs

- No changes

## test_mavros

- No changes
