### PR TITLE
[dep] Add imgaug-pip.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -122,6 +122,19 @@ gunicorn:
   fedora: [python-gunicorn]
   gentoo: [www-servers/gunicorn]
   ubuntu: [gunicorn]
+imgaug-pip:
+  debian:
+    pip:
+      packages: [imgaug]
+  fedora:
+    pip:
+      packages: [imgaug]
+  osx:
+    pip:
+      packages: [imgaug]
+  ubuntu:
+    pip:
+      packages: [imgaug]
 intelhex-pip:
   debian:
     pip:


### PR DESCRIPTION
https://pypi.org/project/imgaug/

Not sure where to confirm non-Ubuntu platform (as I'm only on Ubuntu) for `pip` package, but looking at other PRs for pip (e.g. https://github.com/ros/rosdistro/pull/20369/files), is listing pypi page sufficient as a proof?

CC @jonlwowski012