### PR TITLE
Added python-imageio

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1798,51 +1798,29 @@ python-hypothesis:
     zesty: [python-hypothesis]
     zesty_python3: [python3-hypothesis]
 python-imageio:
-  alpine:
-    pip:
-      packages: [imageio]
-  arch:
-    pip:
-      packages: [imageio]
-  cygwin:
-    pip:
-      packages: [imageio]
   debian:
-    '*':
+    '*': [python-imageio]
+    jessie:
       pip:
         packages: [imageio]
-    buster: [python-imageio]
+    stretch:
+      pip:
+        packages: [imageio]
+    wheezy:
+      pip:
+        packages: [imageio]
   fedora:
     pip:
       packages: [imageio]
-  freebsd:
-    pip:
-      packages: [imageio]
   gentoo: [dev-python/imageio]
-  macports:
-    pip:
-      packages: [imageio]
-  opensuse:
-    '*':
-      pip:
-        packages: [imageio]
-    '15.0': [python-imageio]
-  osx:
-    pip:
-      packages: [imageio]
-  rhel:
-    pip:
-      packages: [imageio]
-  slackware:
-    pip:
-      packages: [imageio]
   ubuntu:
-    '*':
+    '*': [python-imageio]
+    trusty:
       pip:
         packages: [imageio]
-    bionic: [python-imageio]
-    cosmic: [python-imageio]
-    disco: [python-imageio]
+    xenial:
+      pip:
+        packages: [imageio]
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1841,11 +1841,8 @@ python-imageio:
       pip:
         packages: [imageio]
     bionic: [python-imageio]
-    bionic_python3: [python3-imageio]
     cosmic: [python-imageio]
-    cosmic_python3: [python3-imageio]
     disco: [python-imageio]
-    disco_python3: [python3-imageio]
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1797,6 +1797,55 @@ python-hypothesis:
     yakkety_python3: [python3-hypothesis]
     zesty: [python-hypothesis]
     zesty_python3: [python3-hypothesis]
+python-imageio:
+  alpine:
+    pip:
+      packages: [imageio]
+  arch:
+    pip:
+      packages: [imageio]
+  cygwin:
+    pip:
+      packages: [imageio]
+  debian:
+    '*':
+      pip:
+        packages: [imageio]
+    buster: [python-imageio]
+  fedora:
+    pip:
+      packages: [imageio]
+  freebsd:
+    pip:
+      packages: [imageio]
+  gentoo: [dev-python/imageio]
+  macports:
+    pip:
+      packages: [imageio]
+  opensuse:
+    '*':
+      pip:
+        packages: [imageio]
+    '15.0': [python-imageio]
+  osx:
+    pip:
+      packages: [imageio]
+  rhel:
+    pip:
+      packages: [imageio]
+  slackware:
+    pip:
+      packages: [imageio]
+  ubuntu:
+    '*':
+      pip:
+        packages: [imageio]
+    bionic: [python-imageio]
+    bionic_python3: [python3-imageio]
+    cosmic: [python-imageio]
+    cosmic_python3: [python3-imageio]
+    disco: [python-imageio]
+    disco_python3: [python3-imageio]
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]


### PR DESCRIPTION
This package has recently been added as a system package to Ubuntu, Debian, Opensuse and Gentoo. On other systems, pip has to be used.

Using it in binary released packages in melodic might be a problem since there's no package manger release for Fedora 28 or Debian Strech. 

https://packages.ubuntu.com/search?keywords=python-imageio
https://packages.ubuntu.com/search?keywords=python3-imageio
https://packages.debian.org/search?keywords=python-imageio
https://software.opensuse.org/package/python2-imageio?search_term=python2-imageio
https://packages.gentoo.org/packages/dev-python/imageio
https://pypi.org/project/imageio/