### PR TITLE
movie_publisher: 1.2.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6784,7 +6784,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 1.2.1-0
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.2.2-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.2.1-0`

## movie_publisher

```
* Made imageio and moviepy mandatory dependencies (they will be removed from package.xml in release repo)
* Contributors: Martin Pecka
```
