### PR TITLE
movie_publisher: 1.1.2-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7804,7 +7804,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.1.2-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.1.1-1`

## movie_publisher

```
* Made imageio and moviepy mandatory dependencies (they will be removed from package.xml in release repo)
* Contributors: Martin Pecka
```
