### PR TITLE
tf_remapper_cpp: 1.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6419,6 +6419,21 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: master
     status: maintained
+  tf_remapper_cpp:
+    doc:
+      type: git
+      url: https://github.com/tradr-project/tf_remapper_cpp.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/tf_remapper_cpp-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/tradr-project/tf_remapper_cpp.git
+      version: master
+    status: developed
   topics_rviz_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_remapper_cpp` to `1.1.1-0`:

- upstream repository: https://github.com/tradr-project/tf_remapper_cpp.git
- release repository: https://github.com/peci1/tf_remapper_cpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
