### PR TITLE
Add python-persist-queue-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2605,6 +2605,19 @@ python-periphery-pip:
   ubuntu:
     pip:
       packages: [python-periphery]
+python-persist-queue-pip:
+  debian:
+    pip:
+      packages: [persist-queue]
+  fedora:
+    pip:
+      packages: [persist-queue]
+  osx:
+    pip:
+      packages: [persist-queue]
+  ubuntu:
+    pip:
+      packages: [persist-queue]
 python-pexpect:
   arch: [python2-pexpect]
   debian: [python-pexpect]


### PR DESCRIPTION
Dependency description: https://pypi.org/project/persist-queue/
Dependency source: https://github.com/peter-wangxu/persist-queue