### PR TITLE
add log4cplus for ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3713,6 +3713,8 @@ lm-sensors:
   fedora: [lm_sensors]
   gentoo: [sys-apps/lm_sensors]
   ubuntu: [lm-sensors]
+log4cplus:
+  ubuntu: [liblog4cplus-dev]
 log4cxx:
   alpine:
     source:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3714,6 +3714,9 @@ lm-sensors:
   gentoo: [sys-apps/lm_sensors]
   ubuntu: [lm-sensors]
 log4cplus:
+  arch: [log4cplus]
+  debian: [liblog4cplus-dev]
+  fedora: [log4cplus-devel]
   ubuntu: [liblog4cplus-dev]
 log4cxx:
   alpine:


### PR DESCRIPTION
Adding an entry for installing the `log4cplus` library on Ubuntu.