### PR TITLE
plotjuggler: 2.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8848,7 +8848,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.1.5-0
+      version: 2.1.6-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.1.6-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.5-0`

## plotjuggler

```
* removed obsolate question
* remember RemoveTimeOffset state
* add clear buffer from data stream
* reject non valid data
* fix sorting in ULog messages
* Fix Ulog window
* ulog plugin improved
* Update .appveyor.yml
* yes, I am sure I want to Quit
* simplifications in RosoutPublisher
* better double click behavior in FunctionEditor
* adding Info and parameters
* big refactoring of ulog parser. Fix issue #151
* download links updated
* Contributors: Davide Faconti
```
