### PR TITLE
system_modes: 0.1.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1805,6 +1805,20 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: crystal
     status: developed
+  system_modes:
+    release:
+      packages:
+      - system_modes
+      - system_modes_examples
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/microROS/system_modes-release.git
+      version: 0.1.1-0
+    source:
+      type: git
+      url: https://github.com/microROS/system_modes.git
+      version: master
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.1.1-0`:

- upstream repository: https://github.com/microROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
