### PR TITLE
acado: 1.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -24,6 +24,12 @@ repositories:
       type: git
       url: https://github.com/Eurecat/abseil-cpp.git
       version: master
+  acado:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tud-cor/acado-release.git
+      version: 1.2.2-1
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.2-1`:

- upstream repository: https://github.com/tud-cor/acado.git
- release repository: https://github.com/tud-cor/acado-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
