### PR TITLE
eml: 1.8.15-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -993,7 +993,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/eml-release.git
-      version: 1.8.15-0
+      version: 1.8.15-2
   ensenso_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eml` to `1.8.15-2`:

- upstream repository: https://www.cse.unr.edu/~dave/eml/eml-r36.tar.gz
- release repository: https://github.com/ros-gbp/eml-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.8.15-0`
