### PR TITLE
pr2_self_test: 1.0.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9223,12 +9223,13 @@ repositories:
       - joint_qualification_controllers
       - pr2_bringup_tests
       - pr2_counterbalance_check
+      - pr2_motor_diagnostic_tool
       - pr2_self_test
       - pr2_self_test_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_self_test-release.git
-      version: 1.0.12-0
+      version: 1.0.12-1
     source:
       type: git
       url: https://github.com/PR2/pr2_self_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.12-1`:

- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/pr2-gbp/pr2_self_test-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.12-0`
