### PR TITLE
rviz: 1.12.17-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12700,7 +12700,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.12.16-0
+      version: 1.12.17-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.12.17-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.12.16-0`

## rviz

```
* [feature] Allowed OGRE_PLUGIN_PATH to be defined at cmake config time (#1274 <https://github.com/ros-visualization/rviz/issues/1274>)
* [feature] EffortDisplay: fixed joint display hierarchy (#1323 <https://github.com/ros-visualization/rviz/issues/1323>)
* [feature] Publicly exposed VisualizationFrame::addPanelByName() (#1303 <https://github.com/ros-visualization/rviz/issues/1303>)
* [feature] Configurable tool button style (#1309 <https://github.com/ros-visualization/rviz/issues/1309>)
* [fix] Consider orientation of poses Path messages (#1246 <https://github.com/ros-visualization/rviz/issues/1246>)
* [fix] Don't hide the toolbar when pressing Esc (#1256 <https://github.com/ros-visualization/rviz/issues/1256>)
* [fix] Gracefully handle invalid DISPLAY variable (#1282 <https://github.com/ros-visualization/rviz/issues/1282>)
* [fix] Panels were sometimes hidden on startup (#1348 <https://github.com/ros-visualization/rviz/issues/1348>)
* [fix] Clear statuses in RobotModelDisplay when (re)loading a model (#1296 <https://github.com/ros-visualization/rviz/issues/1296>)
* [fix] Ensure robot model has loaded before processing JointState msg (#1229 <https://github.com/ros-visualization/rviz/issues/1229>)
* [maintenance] Code cleanup (#1245 <https://github.com/ros-visualization/rviz/issues/1245>)
* [maintenance] Use non-deprecated pluginlib header (#1232 <https://github.com/ros-visualization/rviz/issues/1232>, #1248 <https://github.com/ros-visualization/rviz/issues/1248>)
* Contributors: Alexander Rössler, Chris Ratliff, G.A. vd. Hoorn, Joseph Duchesne, Mikael Arguedas, Rein Appeldoorn, Robert Haschke, Sean Yen [MSFT], W. Nicholas Greene, d-walsh, dhood, ipa-fez
```
