### PR TITLE
ament_cmake: 0.6.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -34,7 +34,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.6.0-4
+      version: 0.6.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `0.6.1-0`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.0-4`
