### PR TITLE
rcl_logging: 0.2.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1051,11 +1051,12 @@ repositories:
   rcl_logging:
     release:
       packages:
+      - rcl_logging_log4cxx
       - rcl_logging_noop
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/ros2/rcl_logging.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `0.2.0-0`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.0-0`

## rcl_logging_log4cxx

```
* First release of rcl_logging_log4cxx (#3 <https://github.com/ros2/rcl_logging/issues/3>)
  * Fixes for building and running on MAC with log4cxx from brew.
  * Fixing the case for finding log4cxx library.
  * Fixing the log4cxx string macro on Windows and the cmake find for windows as well.
  * Fixing the lib generation on windows.
  * Cleanup of formatting.
  * Use static library for windows instead of debug mode
  * Fix "unreferenced local variable" warning
  * Move C incompatible functions out of extern C block
  * Disable ddl-interface warnings
* Contributors: Nick Burek
```

## rcl_logging_noop

- No changes
