### PR TITLE
movie_publisher: 1.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3062,6 +3062,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: melodic-devel
     status: developed
+  movie_publisher:
+    doc:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/movie_publisher-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/peci1/movie_publisher.git
+      version: melodic-devel
+    status: developed
   mrpt1:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `1.3.0-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## movie_publisher

```
* Updated for melodic.
* Contributors: Martin Pecka
```
