### PR TITLE
tf_remapper_cpp: 1.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16143,6 +16143,21 @@ repositories:
       url: https://github.com/davetcoleman/tf_keyboard_cal.git
       version: indigo-devel
     status: developed
+  tf_remapper_cpp:
+    doc:
+      type: git
+      url: https://github.com/tradr-project/tf_remapper_cpp.git
+      version: master
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/peci1/tf_remapper_cpp-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/tradr-project/tf_remapper_cpp.git
+      version: master
+    status: maintained
   thingmagic_rfid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_remapper_cpp` to `1.1.1-0`:

- upstream repository: https://github.com/tradr-project/tf_remapper_cpp.git
- release repository: https://github.com/peci1/tf_remapper_cpp-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
