### PR TITLE
rosbridge_suite: 0.10.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11405,7 +11405,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.10.1-0
+      version: 0.10.2-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.10.2-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.10.1-0`

## rosapi

```
* Use Master.getTopicTypes() in /rosapi/topics to increase performance (#381 <https://github.com/RobotWebTools/rosbridge_suite/issues/381>)
* Contributors: Affonso, Guilherme
```

## rosbridge_library

```
* Fix typo (#379 <https://github.com/RobotWebTools/rosbridge_suite/issues/379>)
* Contributors: David Weis
```

## rosbridge_server

```
* Log Tornado handler exceptions (#386 <https://github.com/RobotWebTools/rosbridge_suite/issues/386>)
  * Decorate most handlers which were previously failing silently.
  * Use a try block in the @coroutine, it refused double decoration.
  * Always raise after logging, so Tornado sees the Exception too.
  * Only warn when racing to write to a closed WebSocket.
* Synchronous websocket write (#385 <https://github.com/RobotWebTools/rosbridge_suite/issues/385>)
  Fixes #212 <https://github.com/RobotWebTools/rosbridge_suite/issues/212>
* Contributors: Matt Vollrath
```

## rosbridge_suite

- No changes
