### PR TITLE
acado: 1.2.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -55,6 +55,20 @@ repositories:
       url: https://github.com/Eurecat/abseil-cpp.git
       version: master
     status: maintained
+  acado:
+    doc:
+      type: git
+      url: https://github.com/tud-cor/acado-release.git
+      version: upstream-patched
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tud-cor/acado-release.git
+      version: 1.2.2-0
+    source:
+      type: git
+      url: https://github.com/tud-cor/acado-release.git
+      version: upstream-patched
   ackermann_controller:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -58,8 +58,8 @@ repositories:
   acado:
     doc:
       type: git
-      url: https://github.com/tud-cor/acado-release.git
-      version: upstream-patched
+      url: https://github.com/tud-cor/acado.git
+      version: tudelft-stable
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -67,8 +67,8 @@ repositories:
       version: 1.2.2-0
     source:
       type: git
-      url: https://github.com/tud-cor/acado-release.git
-      version: upstream-patched
+      url: https://github.com/tud-cor/acado.git
+      version: tudelft-stable
   ackermann_controller:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -25,11 +25,19 @@ repositories:
       url: https://github.com/Eurecat/abseil-cpp.git
       version: master
   acado:
+    doc:
+      type: git
+      url: https://github.com/tud-cor/acado.git
+      version: tudelft-stable
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tud-cor/acado-release.git
       version: 1.2.2-1
+    source:
+      type: git
+      url: https://github.com/tud-cor/acado.git
+      version: tudelft-stable
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.2-0`:

- upstream repository: https://github.com/tud-cor/acado.git
- release repository: https://github.com/tud-cor/acado-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
