### PR TITLE
rosmon: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5335,10 +5335,15 @@ repositories:
       url: https://github.com/xqms/rosmon.git
       version: master
     release:
+      packages:
+      - rosmon
+      - rosmon_core
+      - rosmon_msgs
+      - rqt_rosmon
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.10-0
+      version: 2.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.0.0-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.10-0`

## rosmon

```
* split into separate packages for core, GUI, messages, PR #72
* Contributors: Max Schwarz
```

## rosmon_core

```
* split into separate packages for core, GUI, messages, PR #72
* depend on external rosfmt package, PR #63
* wait for roscore if not already running, issue #61, PR #62
* check for param file errors correctly, issue #66, PR #68
* add --flush-stdout option, PR #69
* Contributors: Max Schwarz, Romain Reignier
```

## rosmon_msgs

```
* split into separate packages for core, GUI, messages, PR #72
* Contributors: Max Schwarz
```

## rqt_rosmon

```
* split into separate packages for core, GUI, messages, PR #72
* Contributors: Max Schwarz
```
