### PR TITLE
rdl: 1.1.0-0 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10062,9 +10062,9 @@ repositories:
       - rdl_benchmark
       - rdl_cmake
       - rdl_dynamics
-      - rdl_urdfreader
       - rdl_msgs
       - rdl_ros_tools
+      - rdl_urdfreader
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/jlack/rdl_release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10063,10 +10063,12 @@ repositories:
       - rdl_cmake
       - rdl_dynamics
       - rdl_urdfreader
+      - rdl_msgs
+      - rdl_ros_tools
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/jlack/rdl_release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://gitlab.com/jlack/rdl.git


### PR DESCRIPTION
Increasing version of package(s) in repository to 1.1.0-0:

upstream repository: https://gitlab.com/jlack/rdl
release repository: https://gitlab.com/jlack/rdl_release
distro file: kinetic/distribution.yaml
bloom version: 0.7.2
previous version for package: 1.0.0-0