### PR TITLE
pr2_ethercat_drivers: 1.8.18-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3609,6 +3609,25 @@ repositories:
       url: https://github.com/pr2-gbp/pr2_controllers-release.git
       version: 1.10.15-0
     status: unmaintained
+  pr2_ethercat_drivers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_ethercat_drivers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ethercat_hardware
+      - fingertip_pressure
+      - pr2_ethercat_drivers
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
+      version: 1.8.18-0
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_ethercat_drivers.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.18-0`:

- upstream repository: https://github.com/pr2/pr2_ethercat_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ethercat_hardware

```
* fix order of Changelog contents
* Merge pull request #75 <https://github.com/pr2/pr2_ethercat_drivers/issues/75> from k-okada/add_travis
  update travis.yml and fix for kinetic/melodic
* fix gcc 8 error narrowing char
  explicitly mark the char array as unsigned.
* add build/run depend to tinyxml
* fixed compile error
* Merge pull request #73 <https://github.com/pr2/pr2_ethercat_drivers/issues/73> from TAMS-Group/pr-kinetic-add-ft-frame
  add frame_id to f/t wrench messages
* add frame_id to f/t wrench messages
  This adds the original frame name to the messages
  from the force torque sensors.
  Fixes #66 <https://github.com/pr2/pr2_ethercat_drivers/issues/66>
* Contributors: David Feil-Seifer, Kei Okada, v4hn
```

## fingertip_pressure

- No changes

## pr2_ethercat_drivers

- No changes
