### PR TITLE
rosmon: 2.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5351,7 +5351,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.0.1-0`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.0-0`

## rosmon

- No changes

## rosmon_core

```
* rosmon_core: remove superfluous pluginlib dependency
  (leftover from the rqt plugin)
* Contributors: Max Schwarz
```

## rosmon_msgs

- No changes

## rqt_rosmon

```
* rqt_rosmon: declare pluginlib dependency in package.xml
* Contributors: Max Schwarz
```
