### PR TITLE
catkin: 0.7.16-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -474,7 +474,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.15-0
+      version: 0.7.16-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.16-0`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.15-0`

## catkin

```
* protection against double -l in pkg-config files (#998 <https://github.com/ros/catkin/issues/998>)
* add error message to the setup.sh if devel space relocation is attempted (#997 <https://github.com/ros/catkin/issues/997>)
```
