### PR TITLE
sros2: 0.6.3-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1831,7 +1831,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.6.2-0
+      version: 0.6.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.6.3-0`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.2-0`

## sros2

```
* [crystal-backport] Backport XML and XSLT functionality (#93 <https://github.com/ros2/sros2/issues/93>)
* Contributors: Mikael Arguedas, Jacob Perron, Ross Desmond, Ruffin White
```

## sros2_cmake

```
* linter invocation fixup (#97 <https://github.com/ros2/sros2/issues/97>)
* command needs to be a list and not a string (#96 <https://github.com/ros2/sros2/issues/96>) (#98 <https://github.com/ros2/sros2/issues/98>)
* [crystal-backport] Backport XML and XSLT functionality (#93 <https://github.com/ros2/sros2/issues/93>)
* Contributors: Mikael Arguedas, Jacob Perron, Ross Desmond, Ruffin White
```
