### PR TITLE
navigation2: 0.1.6-2 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -771,6 +771,7 @@ repositories:
       - nav2_amcl
       - nav2_bringup
       - nav2_bt_navigator
+      - nav2_common
       - nav2_costmap_2d
       - nav2_dwb_controller
       - nav2_dynamic_params
@@ -781,7 +782,6 @@ repositories:
       - nav2_navfn_planner
       - nav2_robot
       - nav2_simple_navigator
-      - nav2_system_tests
       - nav2_tasks
       - nav2_util
       - nav2_voxel_grid
@@ -792,7 +792,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.1.5-0
+      version: 0.1.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.1.6-2`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.5-0`
