### PR TITLE
ouster: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8339,6 +8339,24 @@ repositories:
       type: git
       url: https://bitbucket.org/osrf/gear.git
       version: master
+  ouster-release:
+    doc:
+      type: git
+      url: https://github.com/CPFL/ouster.git
+      version: autoware_branch
+    release:
+      packages:
+      - ouster_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/CPFL/ouster-release.git
+      version: 0.1.6-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CPFL/ouster.git
+      version: autoware_branch
+    status: developed
   oxford_gps_eth:
     doc:
       type: hg

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8339,7 +8339,7 @@ repositories:
       type: git
       url: https://bitbucket.org/osrf/gear.git
       version: master
-  ouster-release:
+  ouster:
     doc:
       type: git
       url: https://github.com/CPFL/ouster.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster-release` to `0.1.6-0`:

- upstream repository: https://github.com/CPFL/ouster.git
- release repository: https://github.com/CPFL/ouster-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ouster_driver

```
* Renamed ouster_ros to ouster_driver
```
