### PR TITLE
ouster: 0.1.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3832,7 +3832,7 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
-  ouster-release:
+  ouster:
     doc:
       type: git
       url: https://github.com/CPFL/ouster.git
@@ -3848,7 +3848,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/CPFL/ouster.git
-      version: autoware_version
+      version: autoware_branch
     status: developed
   oxford_gps_eth:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3832,6 +3832,24 @@ repositories:
       url: https://github.com/orocos/orocos_kinematics_dynamics.git
       version: master
     status: maintained
+  ouster-release:
+    doc:
+      type: git
+      url: https://github.com/CPFL/ouster.git
+      version: autoware_branch
+    release:
+      packages:
+      - ouster_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CPFL/ouster-release.git
+      version: 0.1.6-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CPFL/ouster.git
+      version: autoware_version
+    status: developed
   oxford_gps_eth:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster-release` to `0.1.6-0`:

- upstream repository: https://github.com/CPFL/ouster.git
- release repository: https://github.com/CPFL/ouster-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ouster_driver

```
* Renamed ouster_ros to ouster_driver
```
