### PR TITLE
pilz_industrial_motion: 0.4.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4065,7 +4065,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.1-1
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.2-0`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.4.1-1`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

- No changes

## pilz_msgs

- No changes

## pilz_robot_programming

- No changes

## pilz_trajectory_generation

```
* re-adapt to new RobotState API: remove #attempts
* Contributors: Pilz GmbH and Co. KG
```
