### PR TITLE
navigation2: 0.1.7-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -810,7 +810,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.1.6-2
+      version: 0.1.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.1.7-0`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.6-2`
