### PR TITLE
add rule for python3-lxml for mac os

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4777,6 +4777,9 @@ python3-lark-parser:
 python3-lxml:
   debian: [python3-lxml]
   fedora: [python3-lxml]
+  osx:
+    pip:
+      packages: [lxml]
   ubuntu: [python3-lxml]
 python3-matplotlib:
   arch: [python-matplotlib]


### PR DESCRIPTION
@mjcarroll based on https://github.com/ros2/ros2/issues/656#issuecomment-472614723 it looks like this definition will be needed for users using rosdep on MacOS. Is that right ?

> With macOS: The dependency should be resolved either with rosdep [...]