### PR TITLE
photo: 1.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4052,6 +4052,22 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: melodic
     status: maintained
+  photo:
+    doc:
+      type: git
+      url: https://github.com/bosch-ros-pkg/photo.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/bosch-ros-pkg/photo-release.git
+      version: 1.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/bosch-ros-pkg/photo.git
+      version: melodic-devel
+    status: unmaintained
   pid:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `photo` to `1.0.2-0`:

- upstream repository: https://github.com/bosch-ros-pkg/photo.git
- release repository: https://github.com/bosch-ros-pkg/photo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## photo

```
* update rosdep keys for libgphoto2
* Contributors: root
```
