### PR TITLE
gazebo_ros_pkgs: 3.2.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -556,7 +556,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.1.0-0
+      version: 3.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.2.0-0`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `3.1.0-0`

## gazebo_dev

- No changes

## gazebo_msgs

```
* [ros2] World plugin to get/set entity state services (#839 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/839>)
  remove status_message
* Contributors: chapulina
```

## gazebo_plugins

```
* [ros2] World plugin to get/set entity state services (#839 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/839>)
  remove status_message
* [ros2] Fix diff_drive error message (#882 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/882>)
* Fix Windows conflicting macros and missing usleep (#885 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/885>)
  * Fix conflicting Windows macros and missing usleep
  * fix spacing
  * fix spacing again
  * remove lint
* gazebo_plugins: Port the gazebo_ros_p3d plugin (#845 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/845>)
  * Port the gazebo_ros_p3d plugin
  * Address most of the review feedback. A couple items remain
  * Remove the model_ member variable since it was just and alias for _parent
  * Use OnUpdate instead to get the UpdateInfo through the callback parameter
  * demo, test, and a bit more cleaning up
  * linters
* [ros2] ENABLE_DISPLAY_TESTS, and make camera tests more robust (#854 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/854>)
* Contributors: Jonathan Noyola, Michael Jeronimo, Romain Reignier, chapulina
```

## gazebo_ros

```
* [ros2] Disable test_node to clean CI (#901 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/901>)
  * [ros2] Disable test_node to clean CI
  * uncrustify
* [ros2] Port time commands (pause / reset) (#866 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/866>)
* [ros2] World plugin to get/set entity state services (#839 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/839>)
  remove status_message
* Fix Windows conflicting macros and missing usleep (#885 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/885>)
  * Fix conflicting Windows macros and missing usleep
  * fix spacing
  * fix spacing again
  * remove lint
* Call rclcpp::init() only from gazebo_ros_init (#859 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/859>)
* [ros] Revert sim time test (#853 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/853>)
* Contributors: Jonathan Noyola, Tamaki Nishino, chapulina
```

## gazebo_ros_pkgs

- No changes
