### PR TITLE
cob_common: 0.6.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1386,6 +1386,7 @@ repositories:
       version: indigo_release_candidate
     release:
       packages:
+      - cob_actions
       - cob_common
       - cob_description
       - cob_msgs
@@ -1394,7 +1395,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.10-0`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.9-0`

## cob_actions

```
* Merge pull request #263 <https://github.com/ipa320/cob_common/issues/263> from fmessmer/add_cob_actions
  add cob_actions
* add cob_actions
* Contributors: Felix Messmer, fmessmer
```

## cob_common

```
* Merge pull request #263 <https://github.com/ipa320/cob_common/issues/263> from fmessmer/add_cob_actions
  add cob_actions
* add cob_actions
* Contributors: Felix Messmer, fmessmer
```

## cob_description

```
* Merge pull request #258 <https://github.com/ipa320/cob_common/issues/258> from fmessmer/tricycle_backwards
  allow drive backwards with tricycle
* allow drive backwards with tricycle
* Merge pull request #257 <https://github.com/ipa320/cob_common/issues/257> from fmessmer/introduce_pivot_link
  add base_pivot_link for tricycle mode
* proper tf hierarchy for base_pivot_link
* add base_pivot_link for tricycle mode
* Contributors: Felix Messmer, fmessmer
```

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

- No changes
