### PR TITLE
cob_control: 0.7.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1407,6 +1407,7 @@ repositories:
       version: kinetic_release_candidate
     release:
       packages:
+      - cob_base_controller_utils
       - cob_base_velocity_smoother
       - cob_cartesian_controller
       - cob_collision_velocity_filter
@@ -1419,11 +1420,12 @@ repositories:
       - cob_obstacle_distance
       - cob_omni_drive_controller
       - cob_trajectory_controller
+      - cob_tricycle_controller
       - cob_twist_controller
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.3-0`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.2-0`

## cob_base_controller_utils

```
* Merge pull request #199 <https://github.com/ipa320/cob_control/issues/199> from fmessmer/spin_detector
  Spin detector
* Revert "tmp: add spin_detector to launch"
  This reverts commit d08388aad4e0910f933f8439faff2ce97ba3c1a4.
* tmp: add spin_detector to launch
* allow shutdown vs. halt
* add spin_detector
* Merge pull request #196 <https://github.com/ipa320/cob_control/issues/196> from fmessmer/split_parseWheelTransform
  controller specific parseWheelTransform
* split parseWheelTransform
* Merge pull request #192 <https://github.com/ipa320/cob_control/issues/192> from fmessmer/fix/parseWheelTransform
  fix/parse wheel transform
* fix rotatory direction with proper sign
* fix parseWheelTransform
* debug parseWheelTransform
* Merge pull request #190 <https://github.com/ipa320/cob_control/issues/190> from fmessmer/new_tricycle_controller_kinetic
  new tricycle controller kinetic
* fix launch file
* implement inverse kinematics for control_plugin
* introduce cob_base_controller_utils package
* Contributors: Felix Messmer, fmessmer
```

## cob_base_velocity_smoother

```
* Merge pull request #189 <https://github.com/ipa320/cob_control/issues/189> from JerrelU/kinetic_dev
  Fixed wrong velocity used for linear y
* Fixed wrong velocity used for linear y
* Contributors: Felix Messmer, Jerrel
```

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

```
* Merge pull request #190 <https://github.com/ipa320/cob_control/issues/190> from fmessmer/new_tricycle_controller_kinetic
  new tricycle controller kinetic
* introduce cob_base_controller_utils package
* initial tricycle_controller, fake odom
* Contributors: Felix Messmer, fmessmer, ipa-fxm
```

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

```
* Merge pull request #196 <https://github.com/ipa320/cob_control/issues/196> from fmessmer/split_parseWheelTransform
  controller specific parseWheelTransform
* split parseWheelTransform
* Merge pull request #190 <https://github.com/ipa320/cob_control/issues/190> from fmessmer/new_tricycle_controller_kinetic
  new tricycle controller kinetic
* implement additional config parameter
* introduce cob_base_controller_utils package
* parseWheelTransform from urdf
* missing includes for cob_omni_drive_controller
* Contributors: Felix Messmer, fmessmer, ipa-fxm
```

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

```
* Merge pull request #196 <https://github.com/ipa320/cob_control/issues/196> from fmessmer/split_parseWheelTransform
  controller specific parseWheelTransform
* split parseWheelTransform
* Merge pull request #192 <https://github.com/ipa320/cob_control/issues/192> from fmessmer/fix/parseWheelTransform
  fix/parse wheel transform
* fix rotatory direction with proper sign
* fix rotatory direction
* fix parseWheelTransform
* debug parseWheelTransform
* Merge pull request #191 <https://github.com/ipa320/cob_control/issues/191> from fmessmer/fix_tricycle_odometry
  fix tricycle kinematic formulae
* keep steer pos for zero command
* fix tricycle kinematic formulae
* Merge pull request #190 <https://github.com/ipa320/cob_control/issues/190> from fmessmer/new_tricycle_controller_kinetic
  new tricycle controller kinetic
* fix angular.z direction
* implement additional config parameter
* fix drive velocity factor
* base radius abs value
* fix inverse kinematics, choose solution
* fix forward kinematics
* implement inverse kinematics for control_plugin
* fix forward kinematics in odom_plugin
* use PositionJointInterface for steer_joint
* fake twist_controller
* introduce cob_base_controller_utils package
* parseWheelTransform from urdf
* add fake control_plugin
* initial tricycle_controller, fake odom
* Contributors: Felix Messmer, fmessmer, ipa-fxm, mailto:robot@cob4-21
```

## cob_twist_controller

```
* Merge pull request #197 <https://github.com/ipa320/cob_control/issues/197> from ipa320/fmessmer-patch-1
  add missing install tags
* add missing install tags
* Contributors: Felix Messmer
```
