### PR TITLE
cob_environments: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1477,7 +1477,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_environments-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     source:
       type: git
       url: https://github.com/ipa320/cob_environments.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.6-0`

## cob_default_env_config

```
* Merge pull request #132 <https://github.com/ipa320/cob_environments/issues/132> from fmessmer/nav_command_buttons
  add nav and command buttons to all envs
* add nav and command buttons to all envs
* Contributors: Felix Messmer, fmessmer
```

## cob_environments

- No changes
