### PR TITLE
cob_driver: 0.6.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1456,10 +1456,11 @@ repositories:
       - cob_undercarriage_ctrl
       - cob_utilities
       - cob_voltage_control
+      - laser_scan_densifier
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.12-0
+      version: 0.6.13-0
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.13-0`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.12-0`

## cob_base_drive_chain

- No changes

## cob_bms_driver

```
* Merge pull request #381 <https://github.com/ipa320/cob_driver/issues/381> from pholthau/boost-format
  include boost/format.hpp
* include boost/format.hpp
* Contributors: Felix Messmer, Patrick Holthaus
```

## cob_camera_sensors

- No changes

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

- No changes

## cob_mimic

- No changes

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

```
* Merge pull request #386 <https://github.com/ipa320/cob_driver/issues/386> from benmaidel/fix/check_sensor_value
  [cob_phidgets] srv callback check if digital sensor is already at desired state
* fix indentation
* on srv callback check if digital sensor is already at desired state
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer
```

## cob_relayboard

- No changes

## cob_scan_unifier

```
* Merge pull request #385 <https://github.com/ipa320/cob_driver/issues/385> from fmessmer/scan_unifier_range_initialization
  initialize ranges with max_range rather than zero
* add explanatory comment
* initialize ranges with max_range rather than zero
* Contributors: Felix Messmer, fmessmer
```

## cob_sick_lms1xx

- No changes

## cob_sick_s300

```
* Merge pull request #378 <https://github.com/ipa320/cob_driver/issues/378> from mateuszcierpikowski/feature/auto_reconnect
  add auto reconnect when scanner is disconnected
* add auto reconnect when scanner is disconnected
* Contributors: Felix Messmer, mateuszcierpikowski
```

## cob_sound

```
* Merge pull request #382 <https://github.com/ipa320/cob_driver/issues/382> from fmessmer/install_fix_swift
  fix install tags
* fix install tags
* Contributors: Felix Messmer, fmessmer
```

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

```
* Merge pull request #383 <https://github.com/ipa320/cob_driver/issues/383> from fmessmer/laser_densifier
  add laser scan densifier
* support copy and interpolation mode
* test interpolated densification
* add laser_scan_densifier
* Contributors: Felix Messmer, fmessmer
```
