### PR TITLE
cob_command_tools: 0.6.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1373,7 +1373,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.10-0`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.9-0`

## cob_command_gui

```
* Merge pull request #241 <https://github.com/ipa320/cob_command_tools/issues/241> from fmessmer/add_string_action
  Add string action
* add SetString action interface
* temp_woz
* Contributors: Felix Messmer, fmessmer, ipa-fmw
```

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

```
* Merge pull request #239 <https://github.com/ipa320/cob_command_tools/issues/239> from fmessmer/max_retry_auto_init
  introduce max_retries for auto_init
* introduce max_retries for auto_init
* Merge pull request #231 <https://github.com/ipa320/cob_command_tools/issues/231> from fmessmer/auto_recover_diagnostics_based
  fix typo
* fix typo
* Merge pull request #230 <https://github.com/ipa320/cob_command_tools/issues/230> from fmessmer/auto_recover_diagnostics_based
  do not auto-recover based on diagnostics
* do not auto-recover based on diagnostics
* Merge pull request #229 <https://github.com/ipa320/cob_command_tools/issues/229> from HannesBachter/fix/auto_recover
  case insensitive comparison
* case insensitive comparison
* Contributors: Felix Messmer, fmessmer, hyb
```

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #242 <https://github.com/ipa320/cob_command_tools/issues/242> from fmessmer/diagnostics_based_em_stop_monitor
  diagnostics-based emergency state verbalization
* diagnostics-based emergency state verbalization
* Merge pull request #236 <https://github.com/ipa320/cob_command_tools/issues/236> from fmessmer/missing_dependency_python-requests
  add missing dependency python-requests
* add missing dependency python-requests
* add missing rosdep key ifstat
* Merge pull request #235 <https://github.com/ipa320/cob_command_tools/issues/235> from fmessmer/network_monitor_internal
  network monitor internal
* additional net and statistic keys
* proper timer and STALE handling
* add net_monitor from ethz-asl/ros-system-monitor
* Merge pull request #232 <https://github.com/ipa320/cob_command_tools/issues/232> from Acuda/feature/core_thermal_throttling
  new metrics (thermal throttling, idlejitter) for cpu monitor based on netdata
* use False as default in order to not produce stale/error diagnostics for robots that do not want/have the respective tools setup
* new metrics (thermal throttling, idlejitter) for cpu monitor based on netdata
* Contributors: Björn Eistel, Felix Messmer, fmessmer
```

## cob_script_server

```
* Merge pull request #241 <https://github.com/ipa320/cob_command_tools/issues/241> from fmessmer/add_string_action
  Add string action
* add SetString action interface
* temp_woz
* Merge pull request #237 <https://github.com/ipa320/cob_command_tools/issues/237> from fmessmer/default_value_handling
  fix comments for default values
* fix comments for default values
* Merge pull request #227 <https://github.com/ipa320/cob_command_tools/issues/227> from floweisshardt/feature/new_trajectory
  new trajectory point time calculation
* remove print
* fix syntax
* new trajectory point time calculation
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer, ipa-fmw, mailto:robot@cob4-19
```

## cob_teleop

```
* Merge pull request #238 <https://github.com/ipa320/cob_command_tools/issues/238> from benmaidel/feature/publish_feq
  [cob_teleop] made publish rate configurable
* made publish rate configurable
* Contributors: Benjamin Maidel, Felix Messmer
```

## generic_throttle

- No changes

## service_tools

- No changes
