### PR TITLE
cob_supported_robots: 0.6.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1691,7 +1691,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.9-0
+      version: 0.6.10-0
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.10-0`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.9-0`

## cob_supported_robots

```
* Merge pull request #18 <https://github.com/ipa320/cob_supported_robots/issues/18> from fmessmer/add_cob4-20
  add cob4-20 ipa 340
* add cob4-20 ipa 340
* Contributors: Florian Weisshardt, fmessmer
```
