### PR TITLE
care_o_bot: 0.6.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1093,7 +1093,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/care-o-bot-release.git
-      version: 0.6.6-0
+      version: 0.6.7-0
     status: maintained
   cartesian_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `care_o_bot` to `0.6.7-0`:

- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.6-0`

## care_o_bot

- No changes

## care_o_bot_desktop

- No changes

## care_o_bot_robot

- No changes

## care_o_bot_simulation

- No changes
