### PR TITLE
p2os: 2.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3911,7 +3911,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.1.1-3
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.2.0-0`:

- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.1-3`

## p2os_doc

```
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Hunter L. Allen
```

## p2os_driver

```
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Fix driver license (#56 <https://github.com/allenh1/p2os/issues/56>)
  * Upon further inspection, this p2os_driver is GPL 2
  * Fix kinecalc license line
  * Update p2os_ptz license
  * Fix robot_params license
* Add CI (#54 <https://github.com/allenh1/p2os/issues/54>)
  * Add .travis.yml
  * Add .gitignore
  * Add test script
  * Rename *.h to *.hpp
  * Rename *.cc to *.cpp
  * Apply change to CMakeLists.txt
  * Fix copyright line(s), as well as fix header guard style
  * Default standard to C++14, and bump CMake minimum to 3.9.5
  * Remove unused boost include
  * Make headers pass CI
  * Add build status to the README
* Contributors: Hunter L. Allen
```

## p2os_launch

```
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Hunter L. Allen
```

## p2os_msgs

```
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Hunter L. Allen
```

## p2os_teleop

```
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Hunter L. Allen
```

## p2os_urdf

```
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Fixed color in gazebo with 3at. (#57 <https://github.com/allenh1/p2os/issues/57>)
* Contributors: Alberto, Hunter L. Allen
```
