### PR TITLE
python_qt_binding: 0.3.5-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4494,7 +4494,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.4-0
+      version: 0.3.5-0
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.3.5-0`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.3.4-0`

## python_qt_binding

```
* don't add -l prefix if it already exists (#59 <https://github.com/ros-visualization/python_qt_binding/issues/59>)
* autopep8 (#51 <https://github.com/ros-visualization/python_qt_binding/issues/51>)
* remove :: from shiboken include path (#48 <https://github.com/ros-visualization/python_qt_binding/issues/48>)
```
