### PR TITLE
rqt_plot: 0.4.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5844,7 +5844,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_plot-release.git
-      version: 0.4.8-0
+      version: 0.4.9-0
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `0.4.9-0`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros-gbp/rqt_plot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.4.8-0`

## rqt_plot

```
* avoid crash for unknown message types (#26 <https://github.com/ros-visualization/rqt_plot/issues/26>)
* autopep8 (#15 <https://github.com/ros-visualization/rqt_plot/issues/15>)
* support pyqtgraph < 0.10 (#13 <https://github.com/ros-visualization/rqt_plot/issues/13>)
```
