### PR TITLE
rviz: 1.13.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6163,7 +6163,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.2-0
+      version: 1.13.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.3-0`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.13.2-0`

## rviz

```
* [fix] Fixed build issue on Debian Stretch, using tinyxml2 4.x only (#1354 <https://github.com/ros-visualization/rviz/issues/1354>)
* Contributors: Robert Haschke
```
