### PR TITLE
fetch_gazebo in indigo: enable test_pull_requests

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3445,6 +3445,7 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
       version: 0.7.1-0
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/fetchrobotics/fetch_gazebo.git
       version: gazebo2


### PR DESCRIPTION
Because I broke the **gazebo2** branch and it was the first build triggered since 2016.

It's fixed now:
http://build.ros.org/view/Idev/job/Idev__fetch_gazebo__ubuntu_trusty_amd64/