### PR TITLE
pr2_navigation_apps: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9206,6 +9206,25 @@ repositories:
       url: https://github.com/PR2-prime/pr2_navigation.git
       version: kinetic-devel
     status: unmaintained
+  pr2_navigation_apps:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_navigation_apps.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_2dnav
+      - pr2_2dnav_local
+      - pr2_2dnav_slam
+      - pr2_navigation_apps
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_navigation_apps-release.git
+      version: 1.0.2-0
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_navigation_apps.git
+      version: hydro-devel
   pr2_power_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_navigation_apps` to `1.0.2-0`:

- upstream repository: https://github.com/PR2/pr2_navigation_apps.git
- release repository: https://github.com/pr2-gbp/pr2_navigation_apps-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## pr2_2dnav

```
* Updated pr2_2dnav to install launch files and remove unecessary rosbuild files
* Contributors: TheDash
```

## pr2_2dnav_local

```
* Removed rosbuild files, added install for launch files
* Contributors: TheDash
```

## pr2_2dnav_slam

```
* Removed rosbuild files, added install for launch files
* Contributors: TheDash
```

## pr2_navigation_apps

- No changes
