### PR TITLE
system_modes: 0.1.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1864,7 +1864,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/microROS/system_modes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.1.2-0`:

- upstream repository: https://github.com/microROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.1-0`
