### PR TITLE
Entry for boost-program-options and boost-random

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -310,27 +310,6 @@ boost:
     xenial: [libboost-all-dev]
     yakkety: [libboost-all-dev]
     zesty: [libboost-all-dev]
-boost-program-options:
-  ubuntu:
-    bionic: [libboost-program-options1.65.1]
-    precise: [libboost-program-options1.46.1]
-    trusty: [libboost-program-options1.54.0]
-boost-program-options-dev:
-  ubuntu: [libboost-program-options-dev]
-boost-random:
-  debian:
-    jessie: [libboost-random1.55.0]
-    stretch: [libboost-random1.62.0]
-    wheezy: [libboost-random1.49.0]
-  fedora: [boost-random]
-  ubuntu:
-    bionic: [libboost-random1.65.1]
-    precise: [libboost-random1.46.1]
-    trusty: [libboost-random1.54.0]
-boost-random-dev:
-  debian: [libboost-random-dev]
-  fedora: [boost-devel]
-  ubuntu: [libboost-random-dev]
 box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]
@@ -1517,6 +1496,33 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
+libboost-program-options:
+  debian:
+    jessie: [libboost-program-options1.55.0]
+    stretch: [libboost-program-options1.62.0]
+  fedora: [boost-program-options]
+  ubuntu:
+    bionic: [libboost-program-options1.65.1]
+    trusty: [libboost-program-options1.55.0]
+    xenial: [libboost-program-options1.58.0]
+libboost-program-options-dev:
+  debian: [libboost-program-options-dev]
+  fedora: [boost-program-options]
+  ubuntu: [libboost-program-options-dev]
+libboost-random:
+  debian:
+    jessie: [libboost-random1.55.0]
+    stretch: [libboost-random1.62.0]
+    wheezy: [libboost-random1.49.0]
+  fedora: [boost-random]
+  ubuntu:
+    bionic: [libboost-random1.65.1]
+    precise: [libboost-random1.46.1]
+    trusty: [libboost-random1.54.0]
+libboost-random-dev:
+  debian: [libboost-random-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-random-dev]
 libcairo2-dev:
   arch: [cairo]
   debian: [libcairo2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -310,6 +310,21 @@ boost:
     xenial: [libboost-all-dev]
     yakkety: [libboost-all-dev]
     zesty: [libboost-all-dev]
+boost-program-options:
+  ubuntu: [libboost-program-options]
+boost-program-options-dev:
+  ubuntu: [libboost-program-options-dev]
+boost-random:
+  debian:
+    jessie: [libboost-random1.55.0]
+    stretch: [libboost-random1.62.0]
+    wheezy: [libboost-random1.49.0]
+  fedora: [boost-random]
+  ubuntu: [libboost-random]
+boost-random-dev:
+  debian: [libboost-random-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-random-dev]
 box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]
@@ -1496,21 +1511,6 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
-boost-random:
-  debian:
-    jessie: [libboost-random1.55.0]
-    stretch: [libboost-random1.62.0]
-    wheezy: [libboost-random1.49.0]
-  fedora: [boost-random]
-  ubuntu: [libboost-random]
-boost-random-dev:
-  debian: [libboost-random-dev]
-  fedora: [boost-devel]
-  ubuntu: [libboost-random-dev]
-boost-program-options:
-  ubuntu: [libboost-program-options]
-boost-program-options-dev:
-  ubuntu: [libboost-program-options-dev]
 libcairo2-dev:
   arch: [cairo]
   debian: [libcairo2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1507,6 +1507,10 @@ libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
   ubuntu: [libboost-random-dev]
+libboost-program-options:
+  ubuntu: [libboost-program-options]
+libboost-program-options-dev:
+  ubuntu: [libboost-program-options-dev]
 libcairo2-dev:
   arch: [cairo]
   debian: [libcairo2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -311,7 +311,10 @@ boost:
     yakkety: [libboost-all-dev]
     zesty: [libboost-all-dev]
 boost-program-options:
-  ubuntu: [libboost-program-options]
+  ubuntu:
+    bionic: [libboost-program-options1.65.1]
+    precise: [libboost-program-options1.46.1]
+    trusty: [libboost-program-options1.54.0]
 boost-program-options-dev:
   ubuntu: [libboost-program-options-dev]
 boost-random:
@@ -320,7 +323,10 @@ boost-random:
     stretch: [libboost-random1.62.0]
     wheezy: [libboost-random1.49.0]
   fedora: [boost-random]
-  ubuntu: [libboost-random]
+  ubuntu:
+    bionic: [libboost-random1.65.1]
+    precise: [libboost-random1.46.1]
+    trusty: [libboost-random1.54.0]
 boost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1502,9 +1502,7 @@ libboost-random:
     stretch: [libboost-random1.62.0]
     wheezy: [libboost-random1.49.0]
   fedora: [boost-random]
-  ubuntu:
-    precise: [libboost-random1.46.1]
-    trusty: [libboost-random1.54.0]
+  ubuntu: [libboost-random]
 libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1507,7 +1507,7 @@ libboost-program-options:
     xenial: [libboost-program-options1.58.0]
 libboost-program-options-dev:
   debian: [libboost-program-options-dev]
-  fedora: [boost-program-options]
+  fedora: [boost-devel]
   ubuntu: [libboost-program-options-dev]
 libboost-random:
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1496,20 +1496,20 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
-libboost-random:
+boost-random:
   debian:
     jessie: [libboost-random1.55.0]
     stretch: [libboost-random1.62.0]
     wheezy: [libboost-random1.49.0]
   fedora: [boost-random]
   ubuntu: [libboost-random]
-libboost-random-dev:
+boost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
   ubuntu: [libboost-random-dev]
-libboost-program-options:
+boost-program-options:
   ubuntu: [libboost-program-options]
-libboost-program-options-dev:
+boost-program-options-dev:
   ubuntu: [libboost-program-options-dev]
 libcairo2-dev:
   arch: [cairo]


### PR DESCRIPTION
To not pull in an awful amount of packages via dependency to `boost`, I created an additional resource for `boost-program-options`, similar as it was done for `boost-random`.
nosetests ran without errors.

**Note:** I changed the existing entry for `libboost-random`: I renamed it from `libboost-random` to `boost-random` so that it matches the naming scheme of the rosdep `boost` resource and is placed next to it in the rosdep list. I didn't find any ros package depending boost-random, though.

I am happy to incorporate any feedback or suggestions!
