### PR TITLE
gencpp: 0.6.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1494,7 +1494,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.6.1-0
+      version: 0.6.2-0
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.6.2-0`:

- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.1-0`

## gencpp

```
* add plugins the ability to also generate free functions (#40 <https://github.com/ros/gencpp/issues/40>)
```
