### PR TITLE
catkin_virtualenv: 0.4.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -507,7 +507,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.2.2-0
+      version: 0.4.0-0
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.4.0-0`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.2.2-0`

## catkin_virtualenv

```
* Pin pip to known-working version (#38 <https://github.com/locusrobotics/catkin_virtualenv/issues/38>)
* Fix python3 isolated builds (#37 <https://github.com/locusrobotics/catkin_virtualenv/issues/37>)
  - Pull in an upstream fix to deal with new shebang styles
  - add a new test for isolated py3 virtualenvs
  - switch to using an internal pip module
* venv module doesn't support no-site-packages arg
* Pass arguments to internal venv module if specified (#36 <https://github.com/locusrobotics/catkin_virtualenv/issues/36>)
* Add missing dependency
* Contributors: Paul Bovbel
```
