### PR TITLE
linux_networking: 1.0.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5843,7 +5843,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/linux_networking-release.git
-      version: 1.0.12-0
+      version: 1.0.14-0
     source:
       type: git
       url: https://github.com/pr2/linux_networking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_networking` to `1.0.14-0`:

- upstream repository: https://github.com/PR2/linux_networking.git
- release repository: https://github.com/pr2-gbp/linux_networking-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.12-0`
