### PR TITLE
ur_modern_driver: add Indigo doc entry and update source.

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16793,6 +16793,10 @@ repositories:
       url: https://github.com/uos/uos_tools.git
       version: indigo
   ur_modern_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ur_modern_driver.git
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -16800,7 +16804,7 @@ repositories:
       version: 0.0.3-0
     source:
       type: git
-      url: https://github.com/ThomasTimm/ur_modern_driver.git
+      url: https://github.com/ros-industrial/ur_modern_driver.git
       version: master
     status: maintained
   urdf:


### PR DESCRIPTION
As per subject.

I'd also like to remove the `release` entry, as it's an "unofficial" release Clearpath did in 2016 and is very outdated, but I'll do that in a later PR.
