### PR TITLE
ros_canopen: 0.7.10-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11051,7 +11051,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.9-0
+      version: 0.7.10-0
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.10-0`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.9-0`

## can_msgs

- No changes

## canopen_402

```
* require minimum version of class_loader and pluginlib
* handle invalid supported drive modes object
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

```
* require minimum version of class_loader and pluginlib
* make sync_node return proper error codes
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* require minimum version of class_loader and pluginlib
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

- No changes

## ros_canopen

- No changes

## socketcan_bridge

```
* keep NodeHandle alive in socketcan_bridge tests
* Contributors: Mathias Lüdtke
```

## socketcan_interface

```
* require minimum version of class_loader and pluginlib
* Contributors: Mathias Lüdtke
```
