### PR TITLE
usb_cam_hardware: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14750,6 +14750,25 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  usb_cam_hardware:
+    doc:
+      type: git
+      url: https://github.com/yoshito-n-students/usb_cam_hardware.git
+      version: kinetic-devel
+    release:
+      packages:
+      - usb_cam_controllers
+      - usb_cam_hardware
+      - usb_cam_hardware_interface
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/usb_cam_hardware.git
+      version: kinetic-devel
+    status: developed
   uuv_plume_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam_hardware` to `0.0.2-0`:

- upstream repository: https://github.com/yoshito-n-students/usb_cam_hardware.git
- release repository: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## usb_cam_controllers

```
* Add install commands in CMakeLists.txt
```

## usb_cam_hardware

```
* Add install commands in CMakeLists.txt
```

## usb_cam_hardware_interface

```
* Add install commands in CMakeLists.txt
```
