### PR TITLE
Added librealsense2 and librealsense2-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3038,6 +3038,10 @@ libreadline-java:
   fedora: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
+librealsense2:
+  ubuntu: [librealsense2-dkms, librealsense2-utils]
+librealsense2-dev:
+  ubuntu: [librealsense2-dev, librealsense2-dbg]
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]


### PR DESCRIPTION
Drivers for Intel Realsense depth camera, i.e. Intel Realsense D435.
https://github.com/IntelRealSense/librealsense