### PR TITLE
rosdep: add python-typing

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4349,6 +4349,15 @@ python-twitter:
   fedora: [python-twitter]
   gentoo: [dev-python/python-twitter]
   ubuntu: [python-twitter]
+python-typing:
+  arch: [python2-typing]
+  debian: [python-typing]
+  fedora: [python2-typing]
+  gentoo: [dev-python/typing]
+  ubuntu:
+    '*': [python-typing]
+    trusty: null
+    xenial: null
 python-tz:
   arch: [python2-pytz]
   debian: [python-tz]


### PR DESCRIPTION
typing module allows to add valuable typehints to Python 2 code .

Ubuntu: https://packages.ubuntu.com/bionic/python-typing
Debian: https://packages.debian.org/buster/python-typing
Fedora: https://apps.fedoraproject.org/packages/python2-typing
Arch: https://www.archlinux.org/packages/community/any/python2-typing/
Gentoo: https://packages.gentoo.org/packages/dev-python/typing