### PR TITLE
ros_monitoring_msgs: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5190,6 +5190,21 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: melodic
     status: maintained
+  ros_monitoring_msgs:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/monitoringmessages-ros1.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/monitoringmessages-ros1.git
+      version: master
+    status: maintained
   ros_pytest:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_monitoring_msgs` to `1.0.0-0`:

- upstream repository: https://github.com/aws-robotics/monitoringmessages-ros1.git
- release repository: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
