### PR TITLE
cmake_modules: 0.4.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -565,7 +565,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.4.1-0
+      version: 0.4.2-0
     source:
       type: git
       url: https://github.com/ros/cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.4.2-0`:

- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.4.1-0`

## cmake_modules

```
* Changed FindPoco to use 'd' suffix only when debug libraries are present (#50 <https://github.com/ros/cmake_modules/issues/50>)
  * Recent versions of Debian and Ubuntu (beginning with Stretch and Bionic respectively) do not provide separate debug library versions of Poco.
  * The refactored debug check now actually verifies that a d-suffixed library exists.
  * If not it falls back to using the non-suffixed version of the library which may or may not include debug symbols.
* add note about ROS Lunar and future versioning schemes
* Contributors: Steven! Ragnarök, William Woodall
```
