### PR TITLE
h264_encoder_core: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1825,6 +1825,21 @@ repositories:
       url: https://github.com/ros-drivers-gbp/gscam-release.git
       version: 1.0.1-0
     status: unmaintained
+  h264_encoder_core:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/h264_encoder_core-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
+      version: master
+    status: maintained
   hebi_cpp_api_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_encoder_core` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
- release repository: https://github.com/aws-gbp/h264_encoder_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## h264_encoder_core

```
* Update to use non-legacy ParameterReader API (#9 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/9>)
* Update to use new ParameterReader API (#8 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/8>)
  * fix h264_encoder_test to be compatible with new ParameterReader API
  * increment major version number in package.xml
* Merge pull request #3 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/3> from mm318/bionic_hardware_encoder
  workaround avcodec_find_encoder_by_name() unreliably indicating that h264_omx codec is available
* implementing runtime solution for workaround
* workaround avcodec_find_encoder_by_name() unreliably indicating that h264_omx codec is available
* Contributors: M. M, Miaofei
```
