### PR TITLE
aws_ros1_common: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -705,7 +705,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/aws_ros1_common-release.git
-      version: 1.0.0-0
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/aws-robotics/utils-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_ros1_common` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/utils-ros1.git
- release repository: https://github.com/aws-gbp/aws_ros1_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## aws_ros1_common

```
* Remove legacy portions of the ParameterReader API (#9 <https://github.com/aws-robotics/utils-ros1/issues/9>)
* Update ParameterReader API to support ROS1/ROS2 (#8 <https://github.com/aws-robotics/utils-ros1/issues/8>)
  * Revert "Revert ParameterReader change (#5 <https://github.com/aws-robotics/utils-ros1/issues/5>)"
  * refactor based on new ParameterPath object design
* Revert ParameterReader change (#5 <https://github.com/aws-robotics/utils-ros1/issues/5>)
  * Revert "Parameter Namespacing: Refactoring using the ParameterPath object. (#3 <https://github.com/aws-robotics/utils-ros1/issues/3>)"
  This reverts commit 295f157b32a321e230ef1c7f616ad5abd1bece5e.
  https://github.com/aws-robotics/utils-common/issues/15
* Parameter Namespacing: Refactoring using the ParameterPath object. (#3 <https://github.com/aws-robotics/utils-ros1/issues/3>)
  * Refactoring using the ParameterPath object.
  * Minor test fixes in parameter_reader_test.cpp
  * Adding failure test case for Ros1NodeParameterReader.
  * Bumping major version in package.xml
  * address comments in PR
  * update .travis.yml to build dependencies from latest source
* Contributors: AAlon, M. M
```
