### PR TITLE
cloudwatch_logger: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -544,6 +544,21 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: melodic-devel
     status: maintained
+  cloudwatch_logger:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatchlogs-ros1.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/cloudwatch_logger-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatchlogs-ros1.git
+      version: master
+    status: maintained
   cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_logger` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/cloudwatchlogs-ros1.git
- release repository: https://github.com/aws-gbp/cloudwatch_logger-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## cloudwatch_logger

```
* Add unit tests for cloudwatch_logger node
  - Split log_client.cpp into log_node_param_helper.cpp for
  fetching parameters, and main.cpp for the entry point
  - Setup a static library {PROJECT_NAME}_lib for accessing
  production code from the tests
  - Add tests test_log_node and test_log_node_param_helper,
  resulting in the following overall coverage rate:
  ```
  lines......: 95.5% (362 of 379 lines)
  functions..: 91.1% (92 of 101 functions)
  branches...: 34.9% (626 of 1795 branches)
  ```
  - Also correct typo in README documenting parameter name
  min_log_severity instead of min_log_verbosity
* Update to use non-legacy ParameterReader API (#13 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/13>)
  * Update to use non-legacy ParameterReader API
  * increment package version
* Allow users to configure ROS output location
* Contributors: M. M, Tim Robinson, hortala
```
