### PR TITLE
health_metric_collector: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3932,7 +3932,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/health_metric_collector-release.git
-      version: 1.0.0-1
+      version: 2.0.0-0
     source:
       type: git
       url: https://github.com/aws-robotics/health-metrics-collector-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `health_metric_collector` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/health-metrics-collector-ros1.git
- release repository: https://github.com/aws-gbp/health_metric_collector-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-1`

## health_metric_collector

```
* Update to use non-legacy ParameterReader API (#7 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/7>)
  * Update to use non-legacy ParameterReader API
  * increment package version
* Contributors: M. M
```
