### PR TITLE
health_metric_collector: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1855,6 +1855,21 @@ repositories:
       url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
       version: master
     status: maintained
+  health_metric_collector:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/health-metrics-collector-ros1.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/health_metric_collector-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/health-metrics-collector-ros1.git
+      version: master
+    status: maintained
   hebi_cpp_api_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `health_metric_collector` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/health-metrics-collector-ros1.git
- release repository: https://github.com/aws-gbp/health_metric_collector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## health_metric_collector

```
* Update to use non-legacy ParameterReader API (#7 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/7>)
  * Update to use non-legacy ParameterReader API
  * increment package version
* Contributors: M. M
```
