### PR TITLE
h264_video_encoder: 1.1.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1855,6 +1855,21 @@ repositories:
       url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
       version: master
     status: maintained
+  h264_video_encoder:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/h264_video_encoder-release.git
+      version: 1.1.1-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git
+      version: master
+    status: maintained
   hebi_cpp_api_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_video_encoder` to `1.1.1-0`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git
- release repository: https://github.com/aws-gbp/h264_video_encoder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## h264_video_encoder

```
* Merge pull request #8 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/8> from ryanewel/master
  increases unit test code coverage
* increases unit test code coverage
* Contributors: ryanewel
```
