### PR TITLE
kinesis_video_streamer: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2449,6 +2449,24 @@ repositories:
       url: https://github.com/aws-robotics/kinesisvideo-common.git
       version: master
     status: maintained
+  kinesis_video_streamer:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-ros1.git
+      version: master
+    release:
+      packages:
+      - kinesis_video_msgs
+      - kinesis_video_streamer
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-ros1.git
+      version: master
+    status: maintained
   kobuki:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinesis_video_streamer` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-ros1.git
- release repository: https://github.com/aws-gbp/kinesis_video_streamer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## kinesis_video_msgs

```
* Update package.xml
* Contributors: AAlon
```

## kinesis_video_streamer

```
* Improve GMock dependency resolution in CMakeLists.txt
* Fix gmock dependency in CMakeLists.txt
* Remove extra space from subscription_installer
* Refactor StreamerNode class, add tests
  - Refactor the StreamerNode into its own class without the main()
  function so that it can have its own test suite.
  - Split Initialize function into two to be able to unit tests the initialization
  without mocking out the remote kinesis calls in stream setup.
  - Add more tests to improve code coverage.
* use log4cplus from apt
* Update to use non-legacy ParameterReader API (#11 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/11>)
* Update to use new ParameterReader API (#10 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/10>)
  * adjust usage of the ParameterReader API
  * remove unnecessary dependencies for travis build
  * increment major version number in package.xml
* Use separate node and stream config in example (#5 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/5>)
* Contributors: Avishay Alon, Juan Rodriguez Hortala, M. M, Miaofei, Ross Desmond, Tim Robinson
```
