### PR TITLE
tts: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6757,6 +6757,21 @@ repositories:
       url: https://github.com/bosch-robotics-cr/tracetools.git
       version: devel
     status: developed
+  tts:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/tts-ros1.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/tts-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/tts-ros1.git
+      version: master
+    status: maintained
   turtlebot3:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tts` to `1.0.1-0`:

- upstream repository: https://github.com/aws-robotics/tts-ros1.git
- release repository: https://github.com/aws-gbp/tts-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## tts

```
* Merge pull request #2 <https://github.com/aws-robotics/tts-ros1/issues/2> from yyu/fix
  no assert_called() for older versions of mock
* no assert_called() for older versions of mock
* remove rostest from top level find_package (#1 <https://github.com/aws-robotics/tts-ros1/issues/1>)
  It's conditionally found in the testing section only so it's only a test_depend
* Contributors: Tully Foote, Yuan "Forrest" Yu, y²
```
