### PR TITLE
lex_node: 2.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2601,6 +2601,24 @@ repositories:
       version: hydro
     status: developed
     status_description: Slow development
+  lex_node:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/lex-ros1.git
+      version: master
+    release:
+      packages:
+      - lex_common_msgs
+      - lex_node
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/lex_node-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/lex-ros1.git
+      version: master
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `lex_node` to `2.0.0-0`:

- upstream repository: https://github.com/aws-robotics/lex-ros1.git
- release repository: https://github.com/aws-gbp/lex_node-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## lex_common_msgs

```
* Update package.xml
* Contributors: AAlon
```

## lex_node

```
* Update to use non-legacy ParameterReader API (#12 <https://github.com/aws-robotics/lex-ros1/issues/12>)
* Update to use new ParameterReader API (#10 <https://github.com/aws-robotics/lex-ros1/issues/10>)
  * update lex_node_test to use the new ParameterReader API
  * increment major version number in package.xml
* Revert ParameterReader change (#8 <https://github.com/aws-robotics/lex-ros1/issues/8>)
  * Revert "Updating lex_node_test.cpp to conform to the new ParameterReader API (#6 <https://github.com/aws-robotics/lex-ros1/issues/6>)"
  This reverts commit 98b1fe112bcff0d01cf43620d17e4c956e3e9832.
  https://github.com/aws-robotics/utils-common/issues/15
* Updating lex_node_test.cpp to conform to the new ParameterReader API (#6 <https://github.com/aws-robotics/lex-ros1/issues/6>)
  * update lex_node_test.cpp to conform to the new ParameterReader API
  * update lex_node to be compatible with newer aws sdk
  * use master branch for cloud extension dependencies
* Contributors: AAlon, M. M
```
