### PR TITLE
cloudwatch_common: 1.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1266,7 +1266,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.0.1-0`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## cloudwatch_logs_common

```
* adding unit tests for cloudwatch facade
* Merge pull request #4 <https://github.com/aws-robotics/cloudwatch-common/issues/4> from juanrh/improve-coverage-cloudwatch_logger
  Improve coverage cloudwatch logger
* Make LogManagerFactory mockeable
* Make cloudwatch_logs_common shared lib to use it in other libs
* Merge pull request #1 <https://github.com/aws-robotics/cloudwatch-common/issues/1> from xabxx/master
  [Bug Fix] Resolved false-positive error log messages
* Resolved false-positive error log messages
* Contributors: Abby Xu, Ross Desmond, Ryan Newell, Yuan "Forrest" Yu, hortala
```

## cloudwatch_metrics_common

- No changes
