### PR TITLE
cloudwatch_common: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -544,6 +544,24 @@ repositories:
       url: https://github.com/ros/class_loader.git
       version: melodic-devel
     status: maintained
+  cloudwatch_common:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatch-common.git
+      version: master
+    release:
+      packages:
+      - cloudwatch_logs_common
+      - cloudwatch_metrics_common
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/cloudwatch_common-release.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatch-common.git
+      version: master
+    status: maintained
   cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.0.1-0`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## cloudwatch_logs_common

```
* adding unit tests for cloudwatch facade
* Merge pull request #4 <https://github.com/aws-robotics/cloudwatch-common/issues/4> from juanrh/improve-coverage-cloudwatch_logger
  Improve coverage cloudwatch logger
* Make LogManagerFactory mockeable
* Make cloudwatch_logs_common shared lib to use it in other libs
* Merge pull request #1 <https://github.com/aws-robotics/cloudwatch-common/issues/1> from xabxx/master
  [Bug Fix] Resolved false-positive error log messages
* Resolved false-positive error log messages
* Contributors: Abby Xu, Ross Desmond, Ryan Newell, Yuan "Forrest" Yu, hortala
```

## cloudwatch_metrics_common

- No changes
