### PR TITLE
usb_cam_hardware: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14763,7 +14763,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/yoshito-n-students/usb_cam_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam_hardware` to `0.0.3-0`:

- upstream repository: https://github.com/yoshito-n-students/usb_cam_hardware.git
- release repository: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.2-0`

## usb_cam_controllers

```
* Fix install commands in CMakeLists.txt (install plugins.xml)
```

## usb_cam_hardware

```
* Fix install commands in CMakeLists.txt (install plugins.xml)
```

## usb_cam_hardware_interface

```
* No changes (released along with other packages)
```
