### PR TITLE
e100_base-relase: 0.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2464,7 +2464,7 @@ repositories:
       url: https://github.com/tork-a/dynpick_driver.git
       version: master
     status: maintained
-  e100_base-relase:
+  e100_base:
     doc:
       type: git
       url: https://github.com/gaitech-robotics/e100_base-release.git
@@ -2478,7 +2478,7 @@ repositories:
       version: 0.0.0-0
     source:
       type: git
-      url: https://github.com/gaitech-robotics/e100_base-release.git
+      url: https://github.com/gaitech-robotics/e100_base.git
       version: kinetic-devel
     status: developed
   earth_rover_localization:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2464,6 +2464,23 @@ repositories:
       url: https://github.com/tork-a/dynpick_driver.git
       version: master
     status: maintained
+  e100_base-relase:
+    doc:
+      type: git
+      url: https://github.com/gaitech-robotics/e100_base-release.git
+      version: kinetic-devel
+    release:
+      packages:
+      - e100_base
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gaitech-robotics/e100_base-release.git
+      version: 0.0.0-0
+    source:
+      type: git
+      url: https://github.com/gaitech-robotics/e100_base-release.git
+      version: kinetic-devel
+    status: developed
   earth_rover_localization:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2467,7 +2467,7 @@ repositories:
   e100_base:
     doc:
       type: git
-      url: https://github.com/gaitech-robotics/e100_base-release.git
+      url: https://github.com/gaitech-robotics/e100_base.git
       version: kinetic-devel
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `e100_base-relase` to `0.0.0-0`:

- upstream repository: https://github.com/gaitech-robotics/e100_base.git
- release repository: https://github.com/gaitech-robotics/e100_base-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
