### PR TITLE
ddynamic_reconfigure: 0.1.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2117,6 +2117,12 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
       version: default
     status: developed
+  ddynamic_reconfigure:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure.git
+      version: 0.1.7-0
   ddynamic_reconfigure_python:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure` to `0.1.7-0`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## ddynamic_reconfigure

```
* Merge branch 'fix-gmock-dependency' into 'erbium-devel'
  Rename gmock dependency for public release
  See merge request control/ddynamic_reconfigure!11
* Rename gmock dependency for public release
* Contributors: Victor Lopez
```
