### PR TITLE
roswww: 0.1.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5625,6 +5625,21 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: melodic-devel
     status: maintained
+  roswww:
+    doc:
+      type: git
+      url: https://github.com/tork-a/roswww.git
+      version: develop
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/roswww-release.git
+      version: 0.1.12-0
+    source:
+      type: git
+      url: https://github.com/tork-a/roswww.git
+      version: develop
+    status: developed
   rotors_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.12-0`:

- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/ros-gbp/roswww-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## roswww

```
* [doc] Minor URL update. (#40 <https://github.com/tork-a/roswww/issues/40>)
* fix CDN URL (#45 <https://github.com/tork-a/roswww/issues/45>)
* Contributors: Isaac I.Y. Saito, Makito Ishikura
```
