### PR TITLE
update python-selenium-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3631,6 +3631,9 @@ python-seaborn:
       pip:
         packages: [seaborn]
 python-selenium-pip:
+  debian:
+    pip:
+      packages: [selenium]
   ubuntu:
     pip:
       packages: [selenium]


### PR DESCRIPTION
uppate ~~phntomjs and~~ python-selenium-pip for missing arch (fedora, debian)