### PR TITLE
Modernized libflann ubuntu rule.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1713,11 +1713,15 @@ libfftw3:
   ubuntu: [libfftw3-3, libfftw3-dev]
 libflann:
   arch: [flann]
-  debian: [libflann1.7]
+  debian:
+    '*': [libflann1.9]
+    jessie: [libflann1.8]
+    wheezy: [libflann1.7]
   fedora: [flann]
   gentoo: [sci-libs/flann]
   macports: [flann]
   ubuntu:
+    '*': [libflann1.9]
     precise: [libflann1]
     quantal: [libflann1.7]
     raring: [libflann1.7]


### PR DESCRIPTION
There were no rules for the modern distros, whereas there were plenty of (now) uselsess rules for discontinued ones.

https://packages.ubuntu.com/source/bionic/flann