### PR TITLE
plotjuggler: 2.1.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4313,7 +4313,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.1.6-0
+      version: 2.1.7-0
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.1.7-0`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.1.6-0`

## plotjuggler

```
* Date time visualization on X axis
* fix slow PLAY when rendering takes more than 20 msec
* new way to zoom a single axis (issues #153 and #135)
* Inverted mouse wheel zoom #153
* On MacOS there are several mime formats generated in addition to "curveslist", this fix will keep curves array with names collected instead of resetting it for each new mime format. (#159)
* ulog_parser: fixed parsing of array topics (#157)
  Signed-off-by: Roman <mailto:bapstroman@gmail.com>
* fis issue  #156 : catch expections
* remember if the state of _action_clearBuffer
* QSettings cleanups
* Contributors: Alexey Zaparovanny, Davide Faconti, Roman Bapst
```
