### PR TITLE
rosbag_pandas: 0.5.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11441,6 +11441,17 @@ repositories:
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
       version: 1.0.0-0
     status: maintained
+  rosbag_pandas:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/eurogroep/rosbag_pandas-release.git
+      version: 0.5.3-0
+    source:
+      type: git
+      url: https://github.com/eurogroep/rosbag_pandas.git
+      version: master
+    status: maintained
   rosbash_params:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_pandas` to `0.5.3-0`:

- upstream repository: https://github.com/eurogroep/rosbag_pandas.git
- release repository: https://github.com/eurogroep/rosbag_pandas-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## rosbag_pandas

```
* flatdict dep in package
* Contributors: Rein Appeldoorn
```
