### PR TITLE
ml_classifiers: 0.4.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3127,7 +3127,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/ml_classifiers-release.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/astuff/ml_classifiers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `0.4.1-0`:

- upstream repository: https://github.com/astuff/ml_classifiers.git
- release repository: https://github.com/astuff/ml_classifiers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.4.0-0`

## ml_classifiers

```
* Replacing typedefs with aliases.
* Add run_tests hook for roslint.
* Adding C++11 specifier.
* Contributors: Joshua Whitley
```
