### PR TITLE
md49_base_controller: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3023,6 +3023,26 @@ repositories:
       url: https://github.com/at-wat/mcl_3dl_msgs.git
       version: master
     status: developed
+  md49_base_controller:
+    doc:
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: melodic-devel
+    release:
+      packages:
+      - md49_base_controller
+      - md49_messages
+      - md49_serialport
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Scheik/md49_base_controller-release.git
+      version: 0.1.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Scheik/md49_base_controller.git
+      version: melodic-devel
+    status: developed
   media_export:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `md49_base_controller` to `0.1.4-1`:

- upstream repository: https://github.com/Scheik/md49_base_controller.git
- release repository: https://github.com/Scheik/md49_base_controller-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## md49_base_controller

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```

## md49_messages

```
* No changes, keep release on track with md49_base_controller
* Contributors: Fabian Prinzing
```

## md49_serialport

```
* Update md49_serialport CMakeLists.txt: Marked header files for installation
* Contributors: Fabian Prinzing
```
