### PR TITLE
novatel_gps_driver: 3.7.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3683,7 +3683,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 3.6.0-0
+      version: 3.7.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.7.0-0`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `3.6.0-0`

## novatel_gps_driver

```
* Added IMU: Honeywell HG4930 AN01 (#31 <https://github.com/swri-robotics/novatel_gps_driver/issues/31>)
* Added launch file to test an Ethernet interface. (#33 <https://github.com/swri-robotics/novatel_gps_driver/issues/33>)
* Contributors: Rinda Gunjala, Zach Oakes
```

## novatel_gps_msgs

- No changes
