### PR TITLE
add lark-parser for debian via pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4776,6 +4776,11 @@ python3-gitlab:
       pip:
         packages: [python-gitlab]
 python3-lark-parser:
+  debian:
+    '*': [lark-parser]
+    stretch:
+      pip:
+        packages: [lark-parser]
   fedora:
     '*': [python-lark-parser]
     '28': null


### PR DESCRIPTION
Add pip package `lark-parser` (https://pypi.org/project/lark-parser/) for Debian Stretch.