### PR TITLE
py_trees_ros: 0.5.18-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4638,7 +4638,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 0.5.16-0
+      version: 0.5.18-0
     source:
       type: git
       url: https://github.com/stonier/py_trees_ros.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4637,7 +4637,7 @@ repositories:
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/splintered-reality/py_trees_ros-release.git
+      url: https://github.com/stonier/py_trees_ros-release.git
       version: 0.5.18-0
     source:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4632,17 +4632,17 @@ repositories:
   py_trees_ros:
     doc:
       type: git
-      url: https://github.com/stonier/py_trees_ros.git
-      version: release/0.5-melodic
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/0.5.x
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/stonier/py_trees_ros-release.git
+      url: https://github.com/splintered-reality/py_trees_ros-release.git
       version: 0.5.18-0
     source:
       type: git
-      url: https://github.com/stonier/py_trees_ros.git
-      version: release/0.5-melodic
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/0.5.x
     status: maintained
   pybind11_catkin:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.18-0`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.16-0`

## py_trees_ros

```
* [infra] merge kinetic and melodic release branches
```
