### PR TITLE
Revert "p2os: 2.2.0-1 in 'indigo/distribution.yaml' [bloom]"

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9410,11 +9410,10 @@ repositories:
       - p2os_launch
       - p2os_msgs
       - p2os_teleop
-      - p2os_urdf
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.2.0-1
+      version: 2.0.3-0
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
Reverts ros/rosdistro#20645

This version is still failing http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__p2os_driver__ubuntu_trusty_amd64__binary/25/console

```
01:33:49 if [ -f "/opt/ros/indigo/setup.sh" ]; then . "/opt/ros/indigo/setup.sh"; fi && \
01:33:49 	dh_auto_configure -- \
01:33:49 		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
01:33:49 		-DCMAKE_INSTALL_PREFIX="/opt/ros/indigo" \
01:33:49 		-DCMAKE_PREFIX_PATH="/opt/ros/indigo"
01:33:49 	mkdir -p obj-x86_64-linux-gnu
01:33:49 	cd obj-x86_64-linux-gnu
01:33:49 	cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=None -DCATKIN_BUILD_BINARY_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/opt/ros/indigo -DCMAKE_PREFIX_PATH=/opt/ros/indigo
01:33:50 CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
01:33:50   CMake 3.9.5 or higher is required.  You are running version 2.8.12.2
01:33:50 
01:33:50 
```