### PR TITLE
py_trees_ros: 0.5.18-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9429,7 +9429,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/splintered-reality/py_trees_ros-release.git
+      url: https://github.com/stonier/py_trees_ros-release.git
       version: 0.5.18-0
     source:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9430,7 +9430,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 0.5.17-0
+      version: 0.5.18-0
     source:
       type: git
       url: https://github.com/stonier/py_trees_ros.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9424,17 +9424,17 @@ repositories:
   py_trees_ros:
     doc:
       type: git
-      url: https://github.com/stonier/py_trees_ros.git
-      version: release/0.5-kinetic
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/0.5.x
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/stonier/py_trees_ros-release.git
+      url: https://github.com/splintered-reality/py_trees_ros-release.git
       version: 0.5.18-0
     source:
       type: git
-      url: https://github.com/stonier/py_trees_ros.git
-      version: devel
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/0.5.x
     status: developed
   pybind11_catkin:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.18-0`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.5.17-0`

## py_trees_ros

```
* [infra] merge kinetic and melodic release branches
```
