### PR TITLE
Revert "lex_node: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5668,7 +5668,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/lex_node-release.git
-      version: 2.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-ros1.git


### PR DESCRIPTION
Reverts ros/rosdistro#20634

@AAlon this release has melodic dependencies declared for a kinetic release.

https://github.com/aws-gbp/lex_node-release/blob/9b4f295eb44229b953534fb85d9dc9ab65be7aa1/debian/control#L5

http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__lex_node__ubuntu_xenial_amd64__binary/9/console

It's not going to build. With our standard release pipeline this shouldn't be happening. How are these leaking into your pakages? Are you overriding the rosdep sources locally on your release machine?
