### PR TITLE
Revert "kinesis_video_streamer: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5380,7 +5380,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
-      version: 2.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-ros1.git


### PR DESCRIPTION
Reverts ros/rosdistro#20630

Same problem as #20670 

http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__kinesis_video_streamer__ubuntu_xenial_amd64__binary/7/console