### PR TITLE
Revert "cloudwatch_metrics_collector: 2.0.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1296,7 +1296,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
-      version: 2.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git


### PR DESCRIPTION
Reverts ros/rosdistro#20624

Same problem as #20670 

http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__cloudwatch_metrics_collector__ubuntu_xenial_amd64__binary/11/console