### PR TITLE
codec_image_transport: 0.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1713,6 +1713,21 @@ repositories:
       url: https://github.com/mikeferguson/code_coverage.git
       version: master
     status: developed
+  codec_image_transport:
+    doc:
+      type: git
+      url: https://github.com/yoshito-n-students/codec_image_transport.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/yoshito-n-students/codec_image_transport-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/codec_image_transport.git
+      version: kinetic-devel
+    status: developed
   cog_publisher:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `codec_image_transport` to `0.0.1-0`:

- upstream repository: https://github.com/yoshito-n-students/codec_image_transport.git
- release repository: https://github.com/yoshito-n-students/codec_image_transport-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## codec_image_transport

```
* Initial release
```
