### PR TITLE
py_trees: 1.1.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -947,8 +947,8 @@ repositories:
   py_trees:
     doc:
       type: git
-      url: https://github.com/stonier/py_trees.git
-      version: release/1.0.x
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/1.1.x
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -956,8 +956,8 @@ repositories:
       version: 1.1.0-0
     source:
       type: git
-      url: https://github.com/stonier/py_trees.git
-      version: release/1.0.x
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/1.1.x
     status: developed
   py_trees_msgs:
     release:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -953,7 +953,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/stonier/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `1.1.0-0`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## py_trees

```
**Breaking API**
* [display] print_ascii_tree -> ascii_tree, #178 <https://github.com/splintered-reality/py_trees/pull/178>.
* [display] generate_pydot_graph -> dot_graph, #178 <https://github.com/splintered-reality/py_trees/pull/178>.
* [trees] tick_tock(sleep_ms, ..) -> tick_tock(period_ms, ...),  #182 <https://github.com/splintered-reality/py_trees/pull/182>.
**New Features**
* [trees] add missing add_visitor method
* [trees] flexible setup() for children via kwargs
* [trees] convenience method for ascii tree debugging
* [display] highlight the tip in ascii tree snapshots
**Bugfixes**
* [trees] threaded timers for setup (avoids multiprocessing problems)
* [behaviour|composites] bugfix tip behaviour, add tests
* [display] correct first indent when non-zero in ascii_tree
* [display] apply same formatting to root as children in ascii_tree
```
