### PR TITLE
py_trees_ros_interfaces: 1.1.0-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_interfaces-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -959,22 +959,11 @@ repositories:
       url: https://github.com/stonier/py_trees.git
       version: release/1.0.x
     status: developed
-  py_trees_msgs:
-    release:
-      tags:
-        release: release/crystal/{package}/{version}
-      url: https://github.com/stonier/py_trees_msgs-release.git
-      version: 0.4.3-0
-    source:
-      type: git
-      url: https://github.com/stonier/py_trees_msgs.git
-      version: release/0.4.x
-    status: developed
   py_trees_ros_interfaces:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
-      version: release/1.0.x
+      version: release/1.1.x
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -983,7 +972,7 @@ repositories:
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
-      version: release/1.0.x
+      version: release/1.1.x
     status: developed
   python_qt_binding:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `1.1.0-0`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces.git
- release repository: https://github.com/stonier/py_trees_ros_interfaces-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`
