### PR TITLE
ros_type_introspection: 1.3.1-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4379,7 +4379,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `1.3.1-0`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.3.0-0`

## ros_type_introspection

```
* Merge pull request #32 <https://github.com/facontidavide/ros_type_introspection/issues/32> from aeudes/fix_large_array
* Fix invalid clamp and discard beaviour.
* Contributors: Alexandre Eudes, Davide Faconti
```
