### PR TITLE
Revert "h264_video_encoder: 1.1.1-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3883,7 +3883,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/h264_video_encoder-release.git
-      version: 1.1.1-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git


### PR DESCRIPTION
Reverts ros/rosdistro#20628

Failing to compile due to melodic dependencies similar to #20670