### PR TITLE
Reverting aws_common since the coordinatred releases were not building

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -690,7 +690,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/aws_common-release.git
-      version: 2.0.0-2
+      version: 1.0.0-6
     source:
       type: git
       url: https://github.com/aws-robotics/utils-common.git


### PR DESCRIPTION
There appear to be APIs removed in this release that are breaking the reverted downstream packages. The were reverted re #20670 

Reverts #20614  and the follow up release #20653