### PR TITLE
usb_cam_hardware: 0.0.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7356,6 +7356,25 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  usb_cam_hardware:
+    doc:
+      type: git
+      url: https://github.com/yoshito-n-students/usb_cam_hardware.git
+      version: melodic-devel
+    release:
+      packages:
+      - usb_cam_controllers
+      - usb_cam_hardware
+      - usb_cam_hardware_interface
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
+      version: 0.0.4-0
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/usb_cam_hardware.git
+      version: melodic-devel
+    status: developed
   uuv_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam_hardware` to `0.0.4-0`:

- upstream repository: https://github.com/yoshito-n-students/usb_cam_hardware.git
- release repository: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## usb_cam_controllers

```
* No changes from 0.0.3 (just bump the version number because 0.0.3 for kinetic already released)
```

## usb_cam_hardware

```
* No changes from 0.0.3 (just bump the version number because 0.0.3 for kinetic already released)
```

## usb_cam_hardware_interface

```
* No changes from 0.0.3 (just bump the version number because 0.0.3 for kinetic already released)
```
