### PR TITLE
robosense: 1.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5002,6 +5002,27 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: jade-devel
     status: maintained
+  robosense:
+    doc:
+      type: git
+      url: https://github.com/CPFL/robosense.git
+      version: develop-curves-function
+    release:
+      packages:
+      - rslidar
+      - rslidar_driver
+      - rslidar_msgs
+      - rslidar_pointcloud
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CPFL/robosense-release.git
+      version: 1.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CPFL/robosense.git
+      version: develop-curves-function
+    status: developed
   robot_activity:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robosense` to `1.0.2-0`:

- upstream repository: https://github.com/CPFL/robosense.git
- release repository: https://github.com/CPFL/robosense-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## rslidar

- No changes

## rslidar_driver

```
* Updated maintainer for this fork
* Added license to source files
* Contributors: amc-nu
```

## rslidar_msgs

- No changes

## rslidar_pointcloud

```
* Added license to source files
* Contributors: amc-nu
```
