### PR TITLE
robosense: 1.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10301,6 +10301,27 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_simulator.git
       version: kinetic-devel
     status: maintained
+  robosense:
+    doc:
+      type: git
+      url: https://github.com/CPFL/robosense.git
+      version: develop-curves-function
+    release:
+      packages:
+      - rslidar
+      - rslidar_driver
+      - rslidar_msgs
+      - rslidar_pointcloud
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/CPFL/robosense-release.git
+      version: 1.0.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CPFL/robosense.git
+      version: develop-curves-function
+    status: developed
   robot_activity:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robosense` to `1.0.2-0`:

- upstream repository: https://github.com/CPFL/robosense.git
- release repository: https://github.com/CPFL/robosense-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## rslidar

- No changes

## rslidar_driver

```
* Updated maintainer for this fork
* Added license to source files
* Contributors: amc-nu
```

## rslidar_msgs

- No changes

## rslidar_pointcloud

```
* Added license to source files
* Contributors: amc-nu
```
