### PR TITLE
cloudwatch_metrics_collector: 2.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1296,7 +1296,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
-      version: 1.0.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_metrics_collector` to `2.0.0-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git
- release repository: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-1`

## cloudwatch_metrics_collector

```
* fix broken build when cmake/rostest cannot find the gmock library (#13 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/13>)
* Fix timestamp conversion bug #10 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/10>
* Update CMakeLists.txt
* Update to use non-legacy ParameterReader API (#7 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/7>)
  * Update to use non-legacy ParameterReader API
  * increment package version
  * address comments, remove use of Aws::CloudWatch::Metrics namespace
* Allow users to configure ROS output location
* Contributors: AAlon, Juan Rodriguez Hortala, M. M, Tim Robinson
```
