### PR TITLE
h264_video_encoder: 1.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3883,7 +3883,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/h264_video_encoder-release.git
-      version: 1.0.0-0
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_video_encoder` to `1.1.1-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git
- release repository: https://github.com/aws-gbp/h264_video_encoder-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## h264_video_encoder

```
* Merge pull request #8 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/8> from ryanewel/master
  increases unit test code coverage
* increases unit test code coverage
* Contributors: ryanewel
```
