### PR TITLE
kinesis_video_streamer: 2.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5380,7 +5380,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
-      version: 1.0.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinesis_video_streamer` to `2.0.0-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-ros1.git
- release repository: https://github.com/aws-gbp/kinesis_video_streamer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-1`

## kinesis_video_msgs

```
* Update package.xml
* Contributors: AAlon
```

## kinesis_video_streamer

```
* Improve GMock dependency resolution in CMakeLists.txt
* Fix gmock dependency in CMakeLists.txt
* Remove extra space from subscription_installer
* Refactor StreamerNode class, add tests
  - Refactor the StreamerNode into its own class without the main()
  function so that it can have its own test suite.
  - Split Initialize function into two to be able to unit tests the initialization
  without mocking out the remote kinesis calls in stream setup.
  - Add more tests to improve code coverage.
* use log4cplus from apt
* Update to use non-legacy ParameterReader API (#11 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/11>)
* Update to use new ParameterReader API (#10 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/10>)
  * adjust usage of the ParameterReader API
  * remove unnecessary dependencies for travis build
  * increment major version number in package.xml
* Use separate node and stream config in example (#5 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/5>)
* Contributors: Avishay Alon, Juan Rodriguez Hortala, M. M, Miaofei, Ross Desmond, Tim Robinson
```
