### PR TITLE
husky: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4409,7 +4409,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.3.1-0
+      version: 0.3.2-0
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.3.2-0`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.3.1-0`

## husky_base

- No changes

## husky_bringup

```
* [husky_bringup] Disabled the use of magnetic field msgs in imu_filter_madgwick.
* Contributors: Tony Baltovski
```

## husky_control

- No changes

## husky_description

```
* Added some additional frames on the top plates and an environment variable for diabling the user rails
* Added env var to allow a 7cm forward bumper extension (#92 <https://github.com/husky/husky/issues/92>)
  * Added env var to allow for extendable front bumper
  * Fix weird spacing
  * Uploaded bumper extension meshes
  * Allowed for different lengths of bumper extensions
* Contributors: Dave Niewinski, Guy Stoppi
```

## husky_desktop

- No changes

## husky_gazebo

```
* Added Z to spawn husky launch
* Contributors: Dave Niewinski
```

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
