### PR TITLE
Revert "Reverting aws_common since the coordinatred releases were not building"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -690,7 +690,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/aws_common-release.git
-      version: 1.0.0-6
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/aws-robotics/utils-common.git


### PR DESCRIPTION
Reverts ros/rosdistro#20685

Previous issues have been fixed.