### PR TITLE
Revert "revert aws_ros1_common to match other roll backs"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -705,7 +705,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/aws_ros1_common-release.git
-      version: 1.0.0-0
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/utils-ros1.git


### PR DESCRIPTION
Reverts ros/rosdistro#20688

Previous issues have been fixed.