### PR TITLE
codec_image_transport: 0.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -660,6 +660,21 @@ repositories:
       url: https://github.com/mikeferguson/code_coverage.git
       version: master
     status: developed
+  codec_image_transport:
+    doc:
+      type: git
+      url: https://github.com/yoshito-n-students/codec_image_transport.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yoshito-n-students/codec_image_transport-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/codec_image_transport.git
+      version: melodic-devel
+    status: developed
   collada_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `codec_image_transport` to `0.0.2-0`:

- upstream repository: https://github.com/yoshito-n-students/codec_image_transport.git
- release repository: https://github.com/yoshito-n-students/codec_image_transport-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## codec_image_transport

```
* Initial release
```
