### PR TITLE
ros_controllers: 0.15.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5372,7 +5372,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.14.3-0
+      version: 0.15.0-0
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.15.0-0`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.14.3-0`

## ackermann_steering_controller

```
* Default all controller builds to C++14
* boost::assign -> C++ initializer list
* boost::shared_ptr -> std::shared_ptr
* Contributors: Bence Magyar, Gennaro Raiola
```

## diff_drive_controller

```
* Default all controller builds to C++14
* boost::chrono -> std::chrono
* boost::assign -> C++ initializer list
* boost::shared_ptr -> std::shared_ptr
* Using left/right multiplies for desired vel
* diff-drive publish joint trajectory controller state
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu, Jeremie Deray, Jordan Palacios
```

## effort_controllers

```
* Default all controller builds to C++14
* Use range-based for loops wherever possible
* boost::scoped_ptr -> std::unique_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```

## force_torque_sensor_controller

```
* Default all controller builds to C++14
* boost::shared_ptr -> std::shared_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```

## forward_command_controller

```
* Default all controller builds to C++14
* Contributors: Bence Magyar, Gennaro Raiola
```

## four_wheel_steering_controller

```
* Default all controller builds to C++14
* boost::chrono -> std::chrono
* Adjust missing bsd note
* boost::assign -> C++ initializer list
* boost::shared_ptr -> std::shared_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```

## gripper_action_controller

```
* Default all controller builds to C++14
* Use range-based for loops wherever possible
* boost::shared_ptr -> std::shared_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```

## imu_sensor_controller

```
* Default all controller builds to C++14
* boost::shared_ptr -> std::shared_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```

## joint_state_controller

```
* Default all controller builds to C++14
* Use range-based for loops wherever possible
* boost::shared_ptr -> std::shared_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```

## joint_trajectory_controller

```
* Default all controller builds to C++14
* Use range-based for loops wherever possible
* boost::array -> std::array
* mutex to C++11, boost::scoped_lock -> std::lock_guard
* boost::scoped_ptr -> std::unique_ptr
* boost::shared_ptr -> std::shared_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```

## position_controllers

```
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: James Xu
```

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

```
* Default all controller builds to C++14
* boost::scoped_ptr -> std::unique_ptr
* fix install destination for libraries (#403 <https://github.com/ros-controls/ros_controllers/issues/403>)
* Contributors: Bence Magyar, Gennaro Raiola, James Xu
```
