### PR TITLE
pr2_self_test: 1.0.13-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9306,7 +9306,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_self_test-release.git
-      version: 1.0.12-1
+      version: 1.0.13-0
     source:
       type: git
       url: https://github.com/PR2/pr2_self_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.13-0`:

- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/pr2-gbp/pr2_self_test-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.12-1`

## joint_qualification_controllers

```
* updated maintainer status
* Merge pull request #4 <https://github.com/PR2/pr2_self_test/issues/4> from mikaelarguedas/update_pluginlib_macros
  update to use non deprecated pluginlib macro
* update to use non deprecated pluginlib macro
* Contributors: Austin, David Feil-Seifer, Mikael Arguedas
```

## pr2_bringup_tests

```
* updated maintainer status
* Contributors: David Feil-Seifer
```

## pr2_counterbalance_check

```
* updated maintainer status
* Contributors: David Feil-Seifer
```

## pr2_motor_diagnostic_tool

```
* updated maintainer status
* removed unnecessary dependency on actionlib for pr2_motor_diagnostic_tool package
* Merge pull request #5 <https://github.com/PR2/pr2_self_test/issues/5> from UNR-RoboticsResearchLab/indigo-devel
  added additional package dependencies in order to compile on indigo
* added additional package dependencies in order to compile on indigo
* Contributors: Dave Feil-Seifer, David Feil-Seifer
```

## pr2_self_test

```
* updated maintainer status
* Contributors: David Feil-Seifer
```

## pr2_self_test_msgs

```
* updated maintainer status
* Contributors: David Feil-Seifer
```
