### PR TITLE
fetch_gazebo: 0.7.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3440,10 +3440,12 @@ repositories:
       packages:
       - fetch_gazebo
       - fetch_gazebo_demo
+      - fetch_simulation
+      - fetchit_challenge
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
-      version: 0.7.1-0
+      version: 0.7.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.7.2-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.1-0`

## fetch_gazebo

```
* This release fast-forwarded the gazebo2 branch, and reverted breaking changes from:
  gazebo5, gazebo7 and gazebo9
* [package.xml] adds: license(BSD), author, maintainers (#45) (#55)
  * [package.xml] update maintainers
  * [fetchit_challenge] adds license(BSD), author, maintainers
  * [fetchit_challenge] add <url> tags to package.xml
* [CMake/Catkin] fetch_gazebo install headers (#44)
  catkin_make_isolated --install would fail because we were not installing the header files
  This cherry-picks PR #43
  This fixes #42
* reverts and reverted changes:
  * Revert "update rosdeps for gazebo5"This reverts commit 6ee207e53cc1e8fe3904720c0bfd7cb032997ca5.
  
    * Revert "update changelogs" <0.8.0>
      This reverts commit ab8607adc9b0120c09869fb5c84d320c9c020d3e.
    * Revert "0.8.0"
      This reverts commit 3aa624857adf4142c0ca3708b028a3b05d8737ad.
    * Revert "updates for gazebo7"
      This reverts commit 545769af5fd77aef83e0c182f74e577c983a4ea7.
    * Revert [gazebo9] Merge pull request #24
      "Merge pull request #24 from mikeferguson/gazebo9"
      This reverts commit eecb032ded6f675ded81e477087218a2079944fa, reversing
      changes made to 545769af5fd77aef83e0c182f74e577c983a4ea7.
    * Revert "Merge pull request #25 ... rosdep"
      Merge pull request #25 from stfuchs/fix/melodic-rosdep
      This reverts commit fce68bf44ce2d214edd11f705e61590efbafa1fe, reversing
      changes made to eecb032ded6f675ded81e477087218a2079944fa.
    * Revert PR #29 "[CMake][package] ... REP-140"
      [CMake][package] Clean CMake warnings and REP-140 (#29)"
      This reverts commit 36bf32339acb8763360e63b76b45927c1032ae61.
    * [CMake][package] Clean CMake warnings and REP-140 (#29)
      This cleans up some, but misses one warning- might be coming from gazebo
      itself.
      Also moved to package.xml format 2
    * Merge pull request #25 from stfuchs/fix/melodic-rosdep
      change rosdep from gazebo7 to gazebo9
    * change rosdep from gazebo7 to gazebo9
    * Merge pull request #24 from mikeferguson/gazebo9
      fixes for gazebo9 (melodic)
    * fixes for gazebo9 (melodic)
    * updates for gazebo7
  
* add arg z/yaw for spawning robot
* Contributors: Alexander Moriarty, Michael Ferguson, Russell Toris, Steffen Fuchs, Yuki Furuta
```

## fetch_gazebo_demo

```
* This release fast-forwarded the gazebo2 branch, and reverted breaking changes from:
  gazebo5, gazebo7 and gazebo9
* [package.xml] adds: license(BSD), author, maintainers (#45) (#55)
  * [package.xml] update maintainers
  * [fetchit_challenge] adds license(BSD), author, maintainers
  * [fetchit_challenge] add <url> tags to package.xml
* Reverts and reverted changes:
  * Revert "update changelogs" <0.8.0>This reverts commit ab8607adc9b0120c09869fb5c84d320c9c020d3e.
  
    * Revert "0.8.0"
      This reverts commit 3aa624857adf4142c0ca3708b028a3b05d8737ad.
    * Revert "Corrected Bug for new Melodic MoveIt Version"
      This reverts commit 674f28175ace0c41f6a248abf82cab2b57829d95.
      See PR #26 and PR #32
    * Corrected Bug for new Melodic MoveIt Version
  
* Merge pull request #32 from RDaneelOlivav/gazebo9
  FetchIt Challenge Package addition and minor melodic Moveit Fix
  (partially reverted)
* Added correction suggested in pick and place demo script and new tables
* Add rviz config for pickplace demo
* Contributors: Alexander Moriarty, Kentaro Wada, Miguel Angel Rodríguez
```

## fetch_simulation

```
* [package.xml] sync versions to 0.7.1 for indigo
  - fetch_simulation was backported from 0.8.0
  - fetchit_challenge didn't have a version set
* [fetch_simulation] new meta-package (#52) (#53)
  A meta-package makes installing things easier and they're used with
  wiki.ros.org and index.ros.org to automatically group and link things.
  This is a back-port of #52
* Contributors: Alexander Moriarty
```

## fetchit_challenge

```
* [package.xml] sync versions to 0.7.1 for indigo
  - fetch_simulation was backported from 0.8.0
  - fetchit_challenge didn't have a version set
* [package.xml] adds: license(BSD), author, maintainers (#45) (#55)
  * [package.xml] update maintainers
  * [fetchit_challenge] adds license(BSD), author, maintainers
  * [fetchit_challenge] add <url> tags to package.xml
* Merge pull request #39 from moriarty/gazebo2
  Fast Forward Gazebo2, and revert Gazebo 5,7 & 9
  Not all commits in this branch will compile with Gazebo2 and Indigo.
* Merge pull request #38 from RDaneelOlivav/gazebo9
  Invisible table and gear Fix, creation of simpler simulation environment, creation of different lighting conditions launches
* Merge pull request #32 from RDaneelOlivav/gazebo9
  FetchIt Challenge Package addition and minor melodic Moveit Fix
* Added fetchit Challenge package files
* Contributors: Alexander Moriarty, Miguel Angel Rodríguez
```
