### PR TITLE
fetch_tools: 0.2.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1368,7 +1368,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.2.1-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.2.0-0`

## fetch_tools

```
* Fixups for indigo->melodic; package format (#13 <https://github.com/fetchrobotics/fetch_tools/issues/13>)
  - Updates to debug_snapshot
  - Warning about common failure case when using debug_snapshot
* Contributors: Eric Relson
```
