### PR TITLE
Add python-qt5-bindings-quick

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3267,6 +3267,9 @@ python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
   fedora: [python2-qscintilla-qt5]
   ubuntu: [python-pyqt5.qsci]
+python-qt5-bindings-quick:
+  debian: [python-pyqt5.qtquick]
+  ubuntu: [python-pyqt5.qtquick]
 python-qt5-bindings-webkit:
   arch: [python2-pyqt5]
   debian:


### PR DESCRIPTION
For installing `python-pyqt5.qtquick` from `rosdep install`.