### PR TITLE
jsk_recognition: 1.2.10-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2443,7 +2443,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.9-0
+      version: 1.2.10-0
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+      version: master
     status: maintained
   jsk_roseus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.10-0`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.2.9-0`

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

```
* use (MOVEIT_VERSION_MAJOR == 0 and MOVEIT_VERSION_MINOR < 6), since moveit is upgraded to 1.0 (#2416 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2416>)
* [doc] [jsk_pcl_ros_utils] [jsk_pcl_ros] Add documentation (#2393 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2393>)
  
    * Add test for InteractiveCuboidLikelihood
    * Add dependency on jsk_interactive_marker to jsk_pcl_ros
    * Remove unused nodes in sample_plane_supported_cuboid_estimator.launch
    * Set queue_size explicitly for publisher in sample_simulate_tabletop_cloud.py
    * Add test for EdgebasedCubeFinder
    * Add sample for EdgebasedCubeFinder
    * Add test for FindObjectOnPlane
    * Add sample for FindObjectOnPlane
    * Add test for EnvironmentPlaneModeling
    * Add sample for EnvironmentPlaneModeling
    * Add test for JointStateStaticFilter
    * Add sample for JointStateStaticFilter
    * Install additional rosbag file for move & stop joints
    * Add test for MultiPlaneSACSegmentation
    * Add sample for MultiPlaneSACSegmentation
    * Fix for assertion error (ptr != 0) when subscribing only ~input
    * Add test for HandleEstimator
    * Add sample for HandleEstimator
    * Add test for VoxelGridDownsampleManager/Decoder
    * Add sample for VoxelGridDownsampleManager/Decoder
    * Add test for ColorizeMapRandomForest
    * Add sample for ColorizeMapRandomForest
    * Fix executable name for ColorizeMapRandomForest
    * Fix names in ColorizeMapRandomForest
    * Run test for ColorizeRandomForest only when ml_classifiers is found
    * Add doc for ColorizeRandomForest
    * Add test for ColorizeRandomForest
    * Add sample for ColorizeRandomForest
    * Fix typo in CMakeLists.txt in order to build ColorizeRandomForest
    * Fix names in ColorizeRandomForest
    * Add test for SelectedClusterPublisher
    * Add sample for SelectedClusterPublisher
    * Add test for BilateralFilter
    * Add sample for BilateralFilter
  
* Contributors: Kei Okada, Yuto Uchimi
```

## jsk_pcl_ros_utils

```
* Re-enable pointcloud_to_pcd.test #2402 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2402>)
* [doc] [jsk_pcl_ros_utils] [jsk_pcl_ros] Add documentation (#2393 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2393>)
  
    * Add test for TransformPointcloudInBoundingBox
    * Add sample for TransformPointcloudInBoundingBox
    * Add test for PlaneReasoner
    * Add sample for PlaneReasoner
    * Add test for PlaneRejcetor
    * Add sample for PlaneRejcetor
    * Add test for PolygonAppender
    * Add sample for PolygonAppender
    * Add test for StaticPolygonArrayPublisher
    * Add sample for StaticPolygonArrayPublisher
    * Add test for NormalConcatenater
    * Add sample for NormalConcatenater
  
* Contributors: Yuto Uchimi
```

## jsk_perception

```
* Fix error on setting device number other than 0 on multiple gpu env. (#2412 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2412>)
  
    * face_pose_estimation: support multi gpu env
      mask_rcnn_instance_segmentation.py: support multi gpu env
      people_pose_estimation_2d.py: support multi gpu env
      ssd_object_detector.py: support multi gpu env
  
* Re-enable draw_classification_result.test (#2401 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2401>)
  
    * Re-enable draw_classification_result.test
    * Increase slop for bof_histogram_extractor
  
* Re-enable color_histogram.test( #2400 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2400>)
* Contributors: Yuki Furuta, Yuto Uchimi
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

```
* Add qtbase5-dev as a package.xml dependency for jsk_recognition_utils. (#2417 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2417>)
  Needed since CMakeLists.txt tries to depend on it.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## resized_image_transport

- No changes
