### PR TITLE
fastrtps: 1.7.2-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -515,7 +515,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 1.7.0-0
+      version: 1.7.2-0
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `1.7.2-0`:

- upstream repository: https://github.com/eProsima/Fast-RTPS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.7.0-0`
