### PR TITLE
Add dashing prelease.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 
 bouncy/* @nuclearsandwich
 crystal/* @nuclearsandwich
+dashing/* @nuclearsandwich
 indigo/* @tfoote
 kinetic/* @tfoote
 lunar/* @clalancette

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms:
+  ubuntu:
+  - bionic
+repositories:
+type: distribution
+version: 2

--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -18,6 +18,11 @@ distributions:
     distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz
     distribution_status: active
     distribution_type: ros2
+  dashing:
+    distribution: [dashing/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/dashing-cache.yaml.gz
+    distribution_status: prerelease
+    distribution_type: ros2
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz

--- a/index.yaml
+++ b/index.yaml
@@ -12,6 +12,9 @@ distributions:
   crystal:
     distribution: [crystal/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz
+  dashing:
+    distribution: [dashing/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/dashing-cache.yaml.gz
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz


### PR DESCRIPTION
Adds the release information for Dashing Diademata to both indices.

This is a prerequisite for bringing up the Dashing build farm.