### PR TITLE
pr2_self_test: 1.0.14-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9306,7 +9306,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_self_test-release.git
-      version: 1.0.13-0
+      version: 1.0.14-0
     source:
       type: git
       url: https://github.com/PR2/pr2_self_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.14-0`:

- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/pr2-gbp/pr2_self_test-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.13-0`

## joint_qualification_controllers

- No changes

## pr2_bringup_tests

- No changes

## pr2_counterbalance_check

```
* added some additional python build support
* temporarily removed nosetest due to build interference
* nosetest is now in conditional block (pr2_counterbalance_check)
* Contributors: David Feil-Seifer
```

## pr2_motor_diagnostic_tool

- No changes

## pr2_self_test

- No changes

## pr2_self_test_msgs

- No changes
