### PR TITLE
ouster: 0.1.7-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8408,7 +8408,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/CPFL/ouster-release.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster` to `0.1.7-0`:

- upstream repository: https://github.com/CPFL/ouster.git
- release repository: https://github.com/CPFL/ouster-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.6-0`

## ouster_driver

```
* Sensor model and firmware version validation
* Added sensor model and firmware version validation. The driver currently only works for OS-1-64 and on firmware version 1.10 some configuration parameters disappeared.
* Parameter validation and new pointcloud types
* Added parameter validation to avoid reinitializing the LiDAR. Added new pointcloud types XYZIRF and XYZIRFN. Changed pulse_mode parameter from integer to string for readability. Updated the readme file.
* Contributors: Alexander Carballo, alexandrx
```
