### PR TITLE
Fix libgtkmm install error on Ubuntu/Debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2070,7 +2070,7 @@ libgstreamer1.0-dev:
   ubuntu: [libgstreamer1.0-dev]
 libgtkmm:
   arch: [gtkmm]
-  debian: [libgtkmm-dev]
+  debian: [libgtkmm-2.4-dev]
   fedora: [gtkmm24]
   gentoo: [dev-cpp/gtkmm]
   ubuntu: [libgtkmm-2.4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2073,7 +2073,7 @@ libgtkmm:
   debian: [libgtkmm-dev]
   fedora: [gtkmm24]
   gentoo: [dev-cpp/gtkmm]
-  ubuntu: [libgtkmm-dev]
+  ubuntu: [libgtkmm-2.4-dev]
 libgts:
   arch: [gts]
   debian: [libgts-dev]


### PR DESCRIPTION
Fix libgtkmm install error on Ubuntu on the current rosdep rule.
This PR is related to the issue #20591.