### PR TITLE
Adding dynamixel_control_hw to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2434,6 +2434,11 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
       version: kinetic-devel
     status: developed
+  dynamixel_control_hw:
+    doc:
+      type: git
+      url: https://github.com/resibots/dynamixel_control_hw.git
+      version: kinetic-devel
   dynamixel_motor:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2438,7 +2438,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/resibots/dynamixel_control_hw.git
-      version: kinetic-devel
+      version: master
   dynamixel_motor:
     doc:
       type: git


### PR DESCRIPTION
I would like dynamixel_control_hw to be indexed and documented on ros.org.
Thank you in advance. 