### PR TITLE
acado: 1.2.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -33,11 +33,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tud-cor/acado-release.git
-      version: 1.2.2-1
+      version: 1.2.2-2
     source:
       type: git
       url: https://github.com/tud-cor/acado.git
       version: tudelft-stable
+    status: unmaintained
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.2-2`:

- upstream repository: https://github.com/tud-cor/acado.git
- release repository: https://github.com/tud-cor/acado-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.2.2-1`
