### PR TITLE
acado: 1.2.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -33,7 +33,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tud-cor/acado-release.git
-      version: 1.2.2-1
+      version: 1.2.3-0
     source:
       type: git
       url: https://github.com/tud-cor/acado.git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado` to `1.2.3-0`:

- upstream repository: https://github.com/tud-cor/acado.git
- release repository: https://github.com/tud-cor/acado-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.2.2-1`
