### PR TITLE
navigation_2d: 0.4.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3522,6 +3522,31 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: melodic-devel
     status: maintained
+  navigation_2d:
+    doc:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: melodic
+    release:
+      packages:
+      - nav2d
+      - nav2d_exploration
+      - nav2d_karto
+      - nav2d_localizer
+      - nav2d_msgs
+      - nav2d_navigator
+      - nav2d_operator
+      - nav2d_remote
+      - nav2d_tutorials
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/skasperski/navigation_2d-release.git
+      version: 0.4.2-0
+    source:
+      type: git
+      url: https://github.com/skasperski/navigation_2d.git
+      version: melodic
+    status: maintained
   navigation_experimental:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_2d` to `0.4.2-0`:

- upstream repository: https://github.com/skasperski/navigation_2d.git
- release repository: https://github.com/skasperski/navigation_2d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
