### PR TITLE
fetch_gazebo: 0.7.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3445,7 +3445,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
-      version: 0.7.2-0
+      version: 0.7.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.7.3-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.2-0`

## fetch_gazebo

- No changes

## fetch_gazebo_demo

- No changes

## fetch_simulation

- No changes

## fetchit_challenge

```
* Merge pull request #64 <https://github.com/fetchrobotics/fetch_gazebo/issues/64> from moriarty/indigo-backports
* [FetchIt!] Don't find_package an exec_depend
* [fetchit] catkin depends and installation (#58 <https://github.com/fetchrobotics/fetch_gazebo/issues/58>)
  The models, scripts and launch files were not installed. Fixes #57 <https://github.com/fetchrobotics/fetch_gazebo/issues/57>
* [FetchIt!] fix the stl collision scales (#60 <https://github.com/fetchrobotics/fetch_gazebo/issues/60>)
  Added rescaled stls with corrected origins that generated issue that seems they were no collisions but in fact they were decentered and huge.
  This fixes #56 <https://github.com/fetchrobotics/fetch_gazebo/issues/56>
* [FetchIt!] Model updates for new largeGear (#51 <https://github.com/fetchrobotics/fetch_gazebo/issues/51>)
  * This fixes #50 <https://github.com/fetchrobotics/fetch_gazebo/issues/50> in part, the stl files
  * These changes correspond to fetchrobotics/fetchit#2 <https://github.com/fetchrobotics/fetchit/issues/2>
  * Added updated dae versions with rescaling to correct dimensions and same colours as previous versions
* Contributors: Alexander Moriarty, Carl Saldanha, RDaneelOlivav
```
