### PR TITLE
fetch_gazebo: 0.8.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2983,6 +2983,25 @@ repositories:
       url: https://github.com/stonier/feed_the_troll_msgs-release.git
       version: 0.1.1-0
     status: developed
+  fetch_gazebo:
+    release:
+      packages:
+      - fetch_gazebo
+      - fetch_gazebo_demo
+      - fetch_simulation
+      - fetchit_challenge
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
+      version: 0.8.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/fetchrobotics/fetch_gazebo.git
+      version: gazebo7
+    status: maintained
+    status_description: ' Kinetic only tested in Gazebo use Melodic or Indigo on real
+      Fetch Robots'
   fetch_ros:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_gazebo` to `0.8.2-0`:

- upstream repository: https://github.com/fetchrobotics/fetch_gazebo.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_gazebo-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## fetch_gazebo

- No changes

## fetch_gazebo_demo

- No changes

## fetch_simulation

- No changes

## fetchit_challenge

```
* Merge pull request #65 <https://github.com/fetchrobotics/fetch_gazebo/issues/65> from moriarty/kinetic-backports
* [FetchIt!] Don't find_package an exec_depend
* [fetchit] catkin depends and installation (#58 <https://github.com/fetchrobotics/fetch_gazebo/issues/58>)
  The models, scripts and launch files were not installed. Fixes #57 <https://github.com/fetchrobotics/fetch_gazebo/issues/57>
* [FetchIt!] fix the stl collision scales (#60 <https://github.com/fetchrobotics/fetch_gazebo/issues/60>)
  Added rescaled stls with corrected origins that generated issue that seems they were no collisions but in fact they were decentered and huge.
  This fixes #56 <https://github.com/fetchrobotics/fetch_gazebo/issues/56>
* [FetchIt!] Model updates for new largeGear (#51)
  
  This fixes #50 in part, the stl files
  
  These changes correspond to fetchrobotics/fetchit#2
  
  Added updated dae versions with rescaling to correct dimensions and same colours as previous versions
* Contributors: Alexander Moriarty, Carl Saldanha, Miguel Angel Rodríguez
```
