### PR TITLE
kinesis_video_streamer: 2.0.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5446,7 +5446,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
-      version: 2.0.0-1
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinesis_video_streamer` to `2.0.1-0`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-ros1.git
- release repository: https://github.com/aws-gbp/kinesis_video_streamer-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.0-1`

## kinesis_video_msgs

```
* Setting frame's trackId to the default for compatibility with newer v… (#21 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/21>)
  * Setting frame's trackId to the default for compatibility with newer version of the Kinesis Producer SDK.
  * Update version in package.xml
* Contributors: AAlon
```

## kinesis_video_streamer

```
* Setting frame's trackId to the default for compatibility with newer v… (#21 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/21>)
  * Setting frame's trackId to the default for compatibility with newer version of the Kinesis Producer SDK.
  * Update version in package.xml
* Contributors: AAlon
```
