### PR TITLE
khi_robot: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5419,6 +5419,27 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: kinetic-devel
     status: maintained
+  khi_robot:
+    release:
+      packages:
+      - duaro_description
+      - duaro_gazebo
+      - duaro_ikfast_plugin
+      - duaro_moveit_config
+      - khi_robot
+      - khi_robot_bringup
+      - khi_robot_control
+      - khi_robot_msgs
+      - rs007l_moveit_config
+      - rs007n_moveit_config
+      - rs080n_moveit_config
+      - rs_description
+      - rs_gazebo
+      - rs_ikfast_plugin
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
+      version: 1.0.0-0
   kinesis_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `khi_robot` to `1.0.0-0`:

- upstream repository: https://github.com/Kawasaki-Robotics/khi_robot.git
- release repository: https://github.com/Kawasaki-Robotics/khi_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## duaro_description

```
* Refactoring
* duAro URDF modification
* Contributors: nakamichi_d, matsui_hiro
```

## duaro_gazebo

```
* Refactoring
* Contributors: matsui_hiro, nakamichi_d
```

## duaro_ikfast_plugin

```
* duAro IKfast
* Contributors: nakamichi_d, matsui_hiro
```

## duaro_moveit_config

```
* Refactoring
* duAro URDF modification
* duAro IKfast
* Contributors: matsui_hiro, nakamichi_d
```

## khi_robot

```
* Contributors: nakamichi_d, matsui_hiro
```

## khi_robot_bringup

```
* Refactoring
* duAro IKFast
* Contributors: matsui_hiro, nakamichi_daisuke
```

## khi_robot_control

```
* Refactoring
* Update License
* Modify ERROR/RESTART/QUIT state process
* Modify simulation method
* Add KRNX libraries
* Contributors: nakamichi_d, matsui_hiro
```

## khi_robot_msgs

```
* Refactoring
* Contributors: nakamichi_d, matsui_hiro
```

## rs007l_moveit_config

```
* Refactoring
* Contributors: matsui_hiro, nakamichi_d
```

## rs007n_moveit_config

```
* Refactoring
* Contributors: matsui_hiro, nakamichi_d
```

## rs080n_moveit_config

```
* Refactoring
* Contributors: matsui_hiro, nakamichi_d
```

## rs_description

```
* Refactoring
* Contributors: matsui_hiro, nakamichi_d
```

## rs_gazebo

```
* Refactoring
* Contributors: matsui_hiro, nakamichi_d
```

## rs_ikfast_plugin

```
* Refactoring
* Contributors: matsui_hiro, nakamichi_d
```
