### PR TITLE
Revert "p2os: 2.2.0-0 in 'melodic/distribution.yaml' [bloom] (#20576)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4117,7 +4117,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/allenh1/p2os-release.git
-      version: 2.2.0-0
+      version: 2.1.1-3
     source:
       type: git
       url: https://github.com/allenh1/p2os.git


### PR DESCRIPTION
This reverts commit e6cdad7c78d7b4f3aed16eec3deae60421705f00.

Fixes the errors on the buildfarm so we can unblock the Melodic sync.  @allenh1 FYI.