### PR TITLE
rosbridge_suite: 0.11.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11584,12 +11584,13 @@ repositories:
       packages:
       - rosapi
       - rosbridge_library
+      - rosbridge_msgs
       - rosbridge_server
       - rosbridge_suite
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.10.2-0
+      version: 0.11.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.0-0`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.10.2-0`

## rosapi

- No changes

## rosbridge_library

```
* BSON can send Nan and Inf (#391 <https://github.com/RobotWebTools/rosbridge_suite/issues/391>)
* Contributors: akira_you
```

## rosbridge_msgs

```
* Additional client information websocket (#393 <https://github.com/RobotWebTools/rosbridge_suite/issues/393>)
  * Add package rosbridge_msgs.
  * rosbridge_server: Publish additional information about connected clients.
  * rosbridge_server: Make ClientManager's add_client/remove_client methods thread safe.
  * rosbridge_server: Rm unnecessary publishing.
  * rosbridge_msgs: Cleanup/fix dependencies.
* Contributors: Hans-Joachim Krauch
```

## rosbridge_server

```
* Additional client information websocket (#393 <https://github.com/RobotWebTools/rosbridge_suite/issues/393>)
  * Add package rosbridge_msgs.
  * rosbridge_server: Publish additional information about connected clients.
  * rosbridge_server: Make ClientManager's add_client/remove_client methods thread safe.
  * rosbridge_server: Rm unnecessary publishing.
  * rosbridge_msgs: Cleanup/fix dependencies.
* Handle BadYieldError in Tornado <4.5.0 (#395 <https://github.com/RobotWebTools/rosbridge_suite/issues/395>)
* Contributors: Hans-Joachim Krauch, Matt Vollrath
```

## rosbridge_suite

- No changes
