### PR TITLE
Remove depthimage_to_laserscan.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -320,21 +320,6 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: crystal
     status: developed
-  depthimage_to_laserscan:
-    doc:
-      type: git
-      url: https://github.com/ros2/depthimage_to_laserscan.git
-      version: crystal
-    release:
-      tags:
-        release: release/crystal/{package}/{version}
-      url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.2.0-0
-    source:
-      type: git
-      url: https://github.com/ros2/depthimage_to_laserscan.git
-      version: crystal
-    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
This is in preparation to re-release it from the new source
repository at https://github.com/ros-perception/depthimage_to_laserscan

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>