### PR TITLE
depthimage_to_laserscan: 2.2.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -320,6 +320,21 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: crystal
     status: developed
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
+      version: 2.2.1-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `2.2.1-0`:

- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## depthimage_to_laserscan

```
* Port depthimage_to_laserscan to ROS2.
* Import ROS2 changes from https://github.com/ros2/depthimage_to_laserscan.git to upstream
* Contributors: Chad Rockey, Chris Lalancette, Mikael Arguedas, Shane Loretz, dhood
```
