### PR TITLE
[Crystal patch 4] Bump rclpy 0.6.3-1 -> 0.6.4-0

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1100,7 +1100,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.6.3-1
+      version: 0.6.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Manually creating PR because bloom-release didn't have access needed to fork ros/rosdistro.

Bump `0.6.3-1` to `0.6.4-0` for crystal patch release 4 ros2/ros2#668

Upstream: https://github.com/ros2/rclpy
Release repo: https://github.com/ros2-gbp/rclpy-release

Command I ran

```
bloom-release --rosdistro crystal --track crystal rclpy --override-release-repository-push-url git@github.com:ros2-gbp/rclpy-release.git
```

Doing PR manually because github token I gave to bloom-release does not have fork permissions

```
==> Checking on GitHub for a fork to make the pull request from...
Could not find a fork of ros/rosdistro on the sloretz GitHub account.
Would you like to create one now?
Continue [Y/n]? y
Aborting pull request: HTTP Error 401: Unauthorized (https://api.github.com/repos/ros/rosdistro/forks)
The release of your packages was successful, but the pull request failed.
Please manually open a pull request by editing the file here: 'https://raw.githubusercontent.com/ros/rosdistro/master/crystal/distribution.yaml'
<== No pull request opened.
```
