### PR TITLE
Support python-tilestache on Fedora 28 and newer

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3741,13 +3741,7 @@ python-theano:
     zesty: [python-theano]
 python-tilestache:
   debian: [tilestache]
-  fedora:
-    '21': [python-tilestache]
-    '22': [python-tilestache]
-    '23': [python-tilestache]
-    '24': [python-tilestache]
-    heisenbug: [python-tilestache]
-    schrödinger’s: [python-tilestache]
+  fedora: [python-tilestache]
   ubuntu: [tilestache]
 python-tinydb-pip:
   debian:


### PR DESCRIPTION
https://apps.fedoraproject.org/packages/python-tilestache