### PR TITLE
pr2_metapackages: 1.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9272,6 +9272,24 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: unmaintained
+  pr2_metapackages:
+    doc:
+      type: git
+      url: https://github.com/PR2-prime/pr2_metapackages.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2
+      - pr2_base
+      - pr2_desktop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/PR2-prime/pr2_metapackages-release.git
+      version: 1.1.3-0
+    source:
+      type: git
+      url: https://github.com/PR2-prime/pr2_metapackages.git
+      version: kinetic-devel
   pr2_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_metapackages` to `1.1.3-0`:

- upstream repository: https://github.com/PR2-prime/pr2_metapackages.git
- release repository: https://github.com/PR2-prime/pr2_metapackages-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## pr2

```
* fixed dependencies on two packages (hokuyo_node and geometry_experimental) whose names have changed (urg_node and geometry2)
* Contributors: David Feil-Seifer
```

## pr2_base

```
* removed sql_database package
* fixed dependencies on two packages (hokuyo_node and geometry_experimental) whose names have changed (urg_node and geometry2)
* Contributors: David Feil-Seifer
```

## pr2_desktop

- No changes
