### PR TITLE
Initial OpenEmbedded support for rosdistro

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -97,6 +97,7 @@ asio:
   debian: [libasio-dev]
   fedora: [asio-devel]
   gentoo: [dev-cpp/asio]
+  openembedded: [asio@meta-oe]
   rhel: [asio-devel]
   ubuntu: [libasio-dev]
 assimp:
@@ -105,6 +106,7 @@ assimp:
   fedora: [assimp]
   gentoo: [media-libs/assimp]
   macports: [assimp]
+  openembedded: [assimp@openembedded-core]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
   slackware: [assimp]
@@ -131,6 +133,7 @@ assimp-dev:
   debian: [libassimp-dev]
   fedora: [assimp-devel]
   gentoo: [media-libs/assimp]
+  openembedded: [assimp@openembedded-core]
   opensuse: [libassimp3]
   rhel: [assimp-devel]
   slackware: [assimp]
@@ -287,6 +290,7 @@ boost:
   freebsd: [boost-python-libs]
   gentoo: ['dev-libs/boost[python]']
   macports: [boost]
+  openembedded: [boost@openembedded-core]
   opensuse: [boost-devel]
   rhel: [boost-devel]
   slackware:
@@ -322,6 +326,7 @@ bullet:
   fedora: [bullet-devel]
   gentoo: [sci-physics/bullet]
   macports: [bullet]
+  openembedded: [bullet@meta-ros]
   opensuse: [libbullet]
   ubuntu:
     '*': [libbullet-dev]
@@ -335,6 +340,7 @@ bzip2:
   freebsd: [bzip2]
   gentoo: [app-arch/bzip2]
   macports: [bzip2]
+  openembedded: [bzip2@openembedded-core]
   opensuse: [libbz2-devel]
   rhel: [bzip2-devel]
   slackware:
@@ -399,6 +405,7 @@ clang-format:
     stretch: [clang-format]
   fedora: [clang]
   gentoo: [sys-devel/clang]
+  openembedded: [clang-format@meta-ros]
   rhel: [clang]
   ubuntu: [clang-format]
 clang-tidy:
@@ -416,6 +423,7 @@ cmake:
   freebsd: [cmake]
   gentoo: [dev-util/cmake]
   macports: [cmake]
+  openembedded: [cmake@openembedded-core]
   opensuse: [cmake]
   slackware:
     slackpkg:
@@ -505,6 +513,7 @@ cppcheck:
   debian: [cppcheck]
   fedora: [cppcheck]
   gentoo: [dev-util/cppcheck]
+  openembedded: [cppcheck-native@meta-ros]
   rhel: [cppcheck]
   ubuntu: [cppcheck]
 cppunit:
@@ -514,6 +523,7 @@ cppunit:
   freebsd: [cppunit]
   gentoo: [dev-util/cppunit]
   macports: [cppunit]
+  openembedded: [cppunit@meta-oe]
   opensuse: [libcppunit-devel]
   rhel: [cppunit-devel]
   slackware: [cppunit]
@@ -535,6 +545,7 @@ curl:
   freebsd: [curl]
   gentoo: [net-misc/curl]
   macports: [curl]
+  openembedded: [curl@openembedded-core]
   opensuse: [libcurl-devel, curl]
   rhel: [libcurl-devel, curl]
   slackware:
@@ -596,6 +607,7 @@ dkms:
   debian: [dkms]
   fedora: [dkms]
   gentoo: [sys-kernel/dkms]
+  openembedded: []
   opensuse: [dkms]
   rhel: [dkms]
   ubuntu: [dkms]
@@ -666,6 +678,7 @@ eigen:
   freebsd: [eigen]
   gentoo: [dev-cpp/eigen]
   macports: [eigen3]
+  openembedded: [libeigen@meta-oe]
   opensuse: [libeigen3-devel]
   rhel: [eigen3-devel]
   slackware:
@@ -740,6 +753,7 @@ ffmpeg:
   freebsd: [ffmpeg]
   gentoo: [virtual/ffmpeg]
   macports: [ffmpeg]
+  openembedded: [ffmpeg@openembedded-core]
   opensuse: [ffmpeg]
   slackware: [ffmpeg]
   ubuntu:
@@ -834,6 +848,7 @@ g++-static:
   debian: [g++]
   fedora: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   gentoo: [sys-devel/gcc]
+  openembedded: []
   ubuntu: [g++]
 gamin:
   debian: [gamin]
@@ -888,6 +903,7 @@ gazebo9:
   fedora:
     '30': [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
+  openembedded: []
   ubuntu:
     artful: [gazebo9]
     bionic: [gazebo9]
@@ -991,6 +1007,7 @@ git:
   freebsd: [git]
   gentoo: [dev-vcs/git]
   macports: [git-core]
+  openembedded: [git@openembedded-core]
   opensuse: [git-core]
   rhel: [git]
   ubuntu: [git]
@@ -1012,6 +1029,7 @@ glut:
   fedora: [freeglut-devel]
   gentoo: [media-libs/freeglut]
   macports: [freeglut]
+  openembedded: [freeglut@meta-oe]
   rhel: [freeglut-devel]
   ubuntu: [freeglut3-dev]
 gnuplot:
@@ -1036,6 +1054,7 @@ google-mock:
   fedora: [gmock-devel]
   freebsd: [googlemock]
   gentoo: [dev-cpp/gtest]
+  openembedded: [gtest@meta-oe]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
   ubuntu: [google-mock]
@@ -1183,6 +1202,7 @@ gtest:
   freebsd: [googletest]
   gentoo: [dev-cpp/gtest]
   macports: [ros-gtest]
+  openembedded: [gtest@meta-oe]
   opensuse: [googletest-devel]
   rhel: [gtest-devel]
   slackware: [gtest]
@@ -1213,6 +1233,7 @@ gtk3:
   freebsd: [gtk3]
   gentoo: ['x11-libs/gtk+:3']
   macports: [gtk3]
+  openembedded: [gtk+3@openembedded-core]
   opensuse: [gtk3-devel]
   rhel: [gtk3-devel]
   slackware:
@@ -1548,6 +1569,7 @@ libcairo2-dev:
   debian: [libcairo2-dev]
   fedora: [cairo-devel]
   gentoo: [x11-libs/cairo]
+  openembedded: [cairo@openembedded-core]
   ubuntu: [libcairo2-dev]
 libcap-dev:
   arch: [libcap]
@@ -1579,6 +1601,7 @@ libceres-dev:
     stretch: [libceres-dev]
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
+  openembedded: [ceres-solver@meta-oe]
   ubuntu: [libceres-dev]
 libclang-dev:
   arch: [clang]
@@ -1617,6 +1640,7 @@ libconsole-bridge-dev:
   fedora: [console-bridge-devel]
   freebsd: [ros-console_bridge]
   gentoo: [dev-libs/console_bridge]
+  openembedded: [console-bridge@meta-ros]
   opensuse: [libconsole_bridge0]
   rhel: [console-bridge-devel]
   slackware: [console_bridge]
@@ -1680,6 +1704,7 @@ libdw-dev:
   debian: [libdw-dev]
   fedora: [elfutils-devel]
   gentoo: [dev-libs/elfutils]
+  openembedded: [elfutils@openembedded-core]
   ubuntu: [libdw-dev]
 libdxflib-dev:
   debian: [libdxflib-dev]
@@ -1726,6 +1751,7 @@ libexpat1-dev:
   debian: [libexpat1-dev]
   fedora: [expat-devel]
   gentoo: [dev-libs/expat]
+  openembedded: [expat@openembedded-core]
   ubuntu: [libexpat1-dev]
 libfcl-dev:
   arch: [fcl]
@@ -1825,12 +1851,14 @@ libfreetype6:
   debian: [libfreetype6]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
+  openembedded: [freetype@openembedded-core]
   rhel: [freetype]
   ubuntu: [libfreetype6]
 libfreetype6-dev:
   debian: [libfreetype6-dev]
   fedora: [freetype-devel]
   gentoo: [media-libs/freetype]
+  openembedded: [freetype@openembedded-core]
   rhel: [freetype-devel]
   ubuntu: [libfreetype6-dev]
 libftdi-dev:
@@ -1883,6 +1911,7 @@ libgazebo9-dev:
     buster: [libgazebo9-dev]
     stretch: [libgazebo9-dev]
   gentoo: [sci-electronics/gazebo]
+  openembedded: [libgazebo9@meta-ros]
   ubuntu:
     artful: [libgazebo9-dev]
     bionic: [libgazebo9-dev]
@@ -1919,6 +1948,7 @@ libgflags-dev:
   debian: [libgflags-dev]
   fedora: [gflags-devel]
   gentoo: [dev-cpp/gflags]
+  openembedded: [gflags@meta-oe]
   ubuntu: [libgflags-dev]
 libgfortran3:
   arch: [gcc-libs]
@@ -1955,6 +1985,7 @@ libglfw3-dev:
   debian: [libglfw3-dev]
   fedora: [glfw-devel]
   gentoo: [media-libs/glfw]
+  openembedded: [glfw@meta-intel-realsense]
   rhel: [glfw-devel]
   ubuntu:
     '*': [libglfw3-dev]
@@ -1995,6 +2026,7 @@ libgoogle-glog-dev:
   debian: [libgoogle-glog-dev]
   fedora: [glog-devel]
   gentoo: [dev-cpp/glog]
+  openembedded: [glog@meta-oe]
   ubuntu: [libgoogle-glog-dev]
 libgpgme-dev:
   alpine: [gpgme-dev]
@@ -2006,6 +2038,7 @@ libgpgme-dev:
     wheezy: [libgpgme11-dev]
   fedora: [gpgme-devel]
   gentoo: [app-crypt/gpgme]
+  openembedded: [gpgme@openembedded-core]
   rhel: [gpgme-devel]
   ubuntu:
     artful: [libgpgme-dev]
@@ -2194,6 +2227,7 @@ libjpeg:
   freebsd: [libjpeg-turbo]
   gentoo: [virtual/jpeg]
   macports: [jpeg]
+  openembedded: [libjpeq-turbo@openembedded-core]
   opensuse: [libjpeg62-devel]
   slackware: [libjpeg-turbo]
   ubuntu:
@@ -2419,6 +2453,7 @@ libogg:
   freebsd: [libogg]
   gentoo: [media-libs/libogg]
   macports: [libogg]
+  openembedded: [libogg@openembedded-core]
   opensuse: [libogg-devel]
   rhel: [libogg-devel]
   slackware: [libogg]
@@ -2481,6 +2516,7 @@ libopencv-dev:
   fedora: [opencv-devel]
   gentoo: [media-libs/opencv]
   macports: [opencv]
+  openembedded: [opencv@meta-oe]
   rhel: [opencv-devel]
   ubuntu:
     artful: [libopencv-dev]
@@ -2578,6 +2614,7 @@ libpcap:
   fedora: [libpcap-devel]
   gentoo: [net-libs/libpcap]
   macports: [libpcap]
+  openembedded: [libpcap@openembedded-core]
   ubuntu: [libpcap0.8-dev]
 libpcl-all:
   arch: [pcl]
@@ -2589,6 +2626,7 @@ libpcl-all:
   freebsd: [pcl]
   gentoo: [sci-libs/pcl]
   macports: [libpcl]
+  openembedded: [pcl@meta-ros]
   opensuse: [pcl]
   rhel: [pcl, pcl-tools]
   slackware: [pcl]
@@ -2613,6 +2651,7 @@ libpcl-all-dev:
   freebsd: [pcl]
   gentoo: [sci-libs/pcl]
   macports: [libpcl]
+  openembedded: [pcl@meta-ros]
   opensuse: [pcl]
   rhel: [pcl-devel]
   slackware: [pcl]
@@ -2695,6 +2734,7 @@ libpoco-dev:
   freebsd: [poco-ssl]
   gentoo: [dev-libs/poco]
   macports: [poco]
+  openembedded: [poco@meta-oe]
   opensuse: [poco-devel]
   rhel: [poco-devel]
   slackware: [poco]
@@ -2926,6 +2966,7 @@ libqt5-core:
   fedora: [qt5-qtbase]
   freebsd: [qt5-core]
   gentoo: ['dev-qt/qtcore:5']
+  openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Core5]
   rhel: [qt5-qtbase]
   slackware: [qt5]
@@ -2936,6 +2977,7 @@ libqt5-gui:
   fedora: [qt5-qtbase-gui]
   freebsd: [qt5-gui]
   gentoo: ['dev-qt/qtgui:5']
+  openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Gui5]
   rhel: [qt5-qtbase-gui]
   slackware: [qt5]
@@ -2953,6 +2995,7 @@ libqt5-opengl:
   fedora: [qt5-qtbase]
   freebsd: [qt5-opengl]
   gentoo: ['dev-qt/qtopengl:5']
+  openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5OpenGL5]
   rhel: [qt5-qtbase]
   slackware: [qt5]
@@ -3000,6 +3043,7 @@ libqt5-widgets:
   fedora: [qt5-qtbase]
   freebsd: [qt5-widgets]
   gentoo: ['dev-qt/qtwidgets:5']
+  openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Widgets5]
   rhel: [qt5-qtbase]
   slackware: [qt5]
@@ -3136,6 +3180,7 @@ libsqlite3-dev:
   debian: [libsqlite3-dev]
   fedora: [libsq3-devel]
   gentoo: ['dev-db/sqlite:3']
+  openembedded: [sqlite3@openembedded-core]
   rhel: [libsq3-devel]
   ubuntu: [libsqlite3-dev]
 libsrtp0-dev:
@@ -3166,6 +3211,7 @@ libssl-dev:
   debian: [libssl-dev]
   fedora: [openssl-devel]
   gentoo: [dev-libs/openssl]
+  openembedded: [openssl@openembedded-core]
   rhel: [openssl-devel]
   ubuntu: [libssl-dev]
 libstdc++5:
@@ -3225,6 +3271,7 @@ libtheora:
   freebsd: [libtheora]
   gentoo: [media-libs/libtheora]
   macports: [libtheora]
+  openembedded: [libtheora@openembedded-core]
   opensuse: [libtheora-devel]
   rhel: [libtheora-devel]
   slackware:
@@ -3317,6 +3364,7 @@ libturbojpeg:
   fedora: [turbojpeg-devel]
   freebsd: [libjpeg-turbo]
   gentoo: [media-libs/libjpeg-turbo]
+  openembedded: [libjpeq-turbo@openembedded-core]
   ubuntu:
     '*': [libturbojpeg0-dev]
     precise: [libturbojpeg, libjpeg-turbo8-dev]
@@ -3335,6 +3383,7 @@ libudev-dev:
   debian: [libudev-dev]
   fedora: [libudev-devel]
   gentoo: [virtual/libudev]
+  openembedded: [eudev@openembedded-core]
   ubuntu: [libudev-dev]
 libunittest++:
   arch: [unittestpp]
@@ -3420,6 +3469,7 @@ libusb-1.0-dev:
     beefy: [libusb1-devel]
   gentoo: ['virtual/libusb:1']
   macports: [libusb]
+  openembedded: [libusb1@openembedded-core]
   opensuse: [libusb-1_0-devel]
   rhel: [libusbx-devel]
   ubuntu: [libusb-1.0-0-dev]
@@ -3565,6 +3615,7 @@ libwebp-dev:
   debian: [libwebp-dev]
   fedora: [libwebp-devel]
   gentoo: [media-libs/libwebp]
+  openembedded: [libwebp@openembedded-core]
   ubuntu: [libwebp-dev]
 libwebsocketpp-dev:
   arch: [websocketpp]
@@ -3584,6 +3635,7 @@ libx11-dev:
   debian: [libx11-dev]
   fedora: [libX11-devel]
   gentoo: [x11-libs/libX11]
+  openembedded: [libx11@openembedded-core]
   rhel: [libX11-devel]
   ubuntu: [libx11-dev]
 libx264-dev:
@@ -3598,6 +3650,7 @@ libxaw:
   freebsd: [libXaw]
   gentoo: [x11-libs/libXaw]
   macports: [xorg-libXaw]
+  openembedded: [libxaw@meta-oe]
   opensuse: [xorg-x11-devel]
   rhel: [libXaw-devel]
   ubuntu: [libxaw7-dev]
@@ -3657,6 +3710,7 @@ libxml2:
 libxml2-utils:
   debian: [libxml2-utils]
   fedora: [libxml2]
+  openembedded: [libxml2@openembedded-core]
   rhel: [libxml2]
   ubuntu: [libxml2-utils]
 libxmlrpc-c++:
@@ -3677,6 +3731,7 @@ libxrandr:
   fedora: [libXrandr-devel]
   gentoo: [x11-libs/libXrandr]
   macports: [xorg-libXrandr]
+  openembedded: [libxrandr@openembedded-core]
   rhel: [libXrandr-devel]
   ubuntu: [libxrandr-dev]
 libxslt:
@@ -3717,6 +3772,7 @@ libxxf86vm:
 libzmq3-dev:
   debian: [libzmq3-dev]
   gentoo: [net-libs/cppzmq]
+  openembedded: [zeromq@meta-oe]
   ubuntu: [libzmq3-dev]
 libzmqpp3:
   gentoo: [net-libs/cppzmq]
@@ -3746,6 +3802,7 @@ linux-headers-generic:
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers, kernel-devel]
   gentoo: [sys-kernel/linux-headers]
+  openembedded: [virtual/kernel@openembedded-core]
   rhel: [kernel-headers, kernel-devel]
   ubuntu: [linux-headers-generic]
 linux-kernel-headers:
@@ -3781,6 +3838,7 @@ log4cxx:
   freebsd: [log4cxx]
   gentoo: [dev-libs/log4cxx]
   macports: [ros-log4cxx]
+  openembedded: [log4cxx@meta-ros]
   opensuse: [liblog4cxx-devel]
   rhel: [log4cxx-devel]
   slackware: [apache-log4cxx]
@@ -3832,6 +3890,7 @@ lua5.2-dev:
   debian: [liblua5.2-dev]
   fedora: [lua]
   gentoo: ['dev-lang/lua:5.2']
+  openembedded: [lua@meta-oe]
   ubuntu: [liblua5.2-dev]
 lz4:
   alpine: [lz4-dev]
@@ -4191,6 +4250,7 @@ opengl:
   freebsd: [mesa-libs]
   gentoo: [virtual/opengl]
   macports: [mesa]
+  openembedded: [mesa@openembedded-core]
   opensuse: [Mesa-devel]
   rhel: [mesa-libGL-devel, mesa-libGLU-devel]
   slackware:
@@ -4234,6 +4294,7 @@ openssl:
   debian: [openssl]
   fedora: [openssl]
   gentoo: [dev-libs/openssl]
+  openembedded: [openssl@openembedded-core]
   rhel: [openssl]
   ubuntu: [openssl]
 optipng:
@@ -4260,6 +4321,7 @@ pcre:
   fedora: [pcre-devel]
   gentoo: [dev-libs/libpcre]
   macports: [pcre]
+  openembedded: [libpcre@openembedded-core]
   rhel: [pcre-devel]
   ubuntu: [libpcre3-dev]
 pcre-dev:
@@ -4303,6 +4365,7 @@ pkg-config:
   freebsd: [pkgconf]
   gentoo: [virtual/pkgconfig]
   macports: [pkgconfig]
+  openembedded: [pkgconfig@openembedded-core]
   opensuse: [pkg-config]
   rhel: [pkgconfig]
   slackware:
@@ -4443,6 +4506,7 @@ protobuf-dev:
   freebsd: [protobuf]
   gentoo: [dev-libs/protobuf]
   macports: [protobuf-cpp]
+  openembedded: [protobuf@meta-oe]
   opensuse: [protobuf-devel]
   slackware: [protobuf]
   ubuntu: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]
@@ -4496,6 +4560,7 @@ qt5-qmake:
   fedora: [qt5-qtbase-devel]
   freebsd: [qt5-qmake]
   gentoo: ['dev-qt/qtcore:5']
+  openembedded: [qtbase@meta-qt5]
   opensuse: [libqt5-qtbase-common-devel]
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
@@ -4506,6 +4571,7 @@ qtbase5-dev:
   fedora: [qt5-qtbase-devel]
   freebsd: [qt5-core]
   gentoo: ['dev-qt/qtcore:5', 'dev-qt/qtwidgets:5', 'dev-qt/qttest:5']
+  openembedded: [qtbase@meta-qt5]
   opensuse: [libqt5-qtbase-common-devel, libqt5-qtbase-devel]
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
@@ -4638,6 +4704,7 @@ sdl:
   fedora: [SDL-devel]
   gentoo: [media-libs/libsdl]
   macports: [libsdl]
+  openembedded: [libsdl@openembedded-core]
   ubuntu: [libsdl1.2-dev]
 sdl-gfx:
   arch: [sdl_gfx]
@@ -4652,6 +4719,7 @@ sdl-image:
   freebsd: [sdl_image]
   gentoo: [media-libs/sdl-image]
   macports: [libsdl_image]
+  openembedded: [libsdl-image@meta-oe]
   opensuse: [SDL_image]
   ubuntu: [libsdl-image1.2-dev]
 sdl-mixer:
@@ -4809,6 +4877,7 @@ suitesparse:
   fedora: [suitesparse-devel]
   gentoo: [sci-libs/suitesparse]
   macports: [SuiteSparse]
+  openembedded: [suitesparse@meta-ros]
   ubuntu: [libsuitesparse-dev]
 supervisor:
   arch: [supervisor]
@@ -4918,6 +4987,7 @@ tango-icon-theme:
   gentoo: [x11-themes/tango-icon-theme]
   macports: [tango-icon-theme]
   mandrake: [tango-icon-theme]
+  openembedded: [tango-icon-theme@meta-ros]
   opensuse: [tango-icon-theme]
   slackware: [tango-icon-theme]
   ubuntu: [tango-icon-theme]
@@ -5022,6 +5092,7 @@ tinyxml:
   freebsd: [tinyxml]
   gentoo: [dev-libs/tinyxml]
   macports: [tinyxml]
+  openembedded: [libtinyxml@meta-oe]
   opensuse: [tinyxml-devel]
   rhel: [tinyxml-devel]
   slackware: [tinyxml]
@@ -5033,6 +5104,7 @@ tinyxml2:
   fedora: [tinyxml2-devel]
   freebsd: [tinyxml2]
   gentoo: [dev-libs/tinyxml2]
+  openembedded: [libtinyxml2@meta-oe]
   opensuse: [tinyxml2-devel]
   rhel: [tinyxml2-devel]
   ubuntu: [libtinyxml2-dev]
@@ -5084,6 +5156,7 @@ udev:
   debian: [udev]
   fedora: [systemd-udev]
   gentoo: [sys-fs/udev]
+  openembedded: [eudev@openembedded-core]
   rhel: [systemd]
   ubuntu: [udev]
 udhcpc:
@@ -5094,6 +5167,7 @@ uncrustify:
   debian: [uncrustify]
   fedora: [uncrustify]
   gentoo: [uncrustify]
+  openembedded: []
   rhel: [uncrustify]
   ubuntu: [uncrustify]
 unison:
@@ -5222,6 +5296,7 @@ wx-common:
   debian: [wx-common]
   fedora: [wxGTK-devel]
   gentoo: [x11-libs/wxGTK]
+  openembedded: [wxwidgets@meta-ros]
   ubuntu: [wx-common]
 wxwidgets:
   arch: [wxgtk]
@@ -5234,6 +5309,7 @@ wxwidgets:
   freebsd: [wxgtk2]
   gentoo: [x11-libs/wxGTK]
   macports: [wxWidgets-python]
+  openembedded: [wxwidgets@meta-ros]
   opensuse: [wxGTK-devel]
   rhel: [wxGTK-devel]
   ubuntu:
@@ -5356,6 +5432,7 @@ yaml:
   fedora: [libyaml]
   gentoo: [dev-libs/libyaml]
   macports: [libyaml]
+  openembedded: [libyaml@openembedded-core]
   rhel: [libyaml-devel]
   ubuntu: [libyaml-dev]
 yaml-cpp:
@@ -5374,6 +5451,7 @@ yaml-cpp:
   freebsd: [yaml-cpp]
   gentoo: [dev-cpp/yaml-cpp]
   macports: [yaml-cpp]
+  openembedded: [yaml-cpp@meta-ros]
   opensuse: [yaml-cpp-devel]
   rhel: [yaml-cpp-devel]
   slackware: [yaml-cpp]
@@ -5435,6 +5513,7 @@ zlib:
   freebsd: [builtin]
   gentoo: [sys-libs/zlib]
   macports: [zlib]
+  openembedded: [zlib@openembedded-core]
   opensuse: [zlib-devel]
   rhel: [zlib-devel]
   slackware:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -216,6 +216,7 @@ pydocstyle:
     stretch: [pydocstyle]
   fedora: [python3-pydocstyle]
   gentoo: [dev-python/pydocstyle]
+  openembedded: ['${PYTHON_PN}-pydocstyle@meta-ros']
   ubuntu:
     artful: [pydocstyle]
     bionic: [pydocstyle]
@@ -227,6 +228,7 @@ pyflakes3:
     stretch: [pyflakes3]
   fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]
+  openembedded: ['${PYTHON_PN}-pyflakes@meta-ros']
   rhel: ['python%{python3_pkgversion}-pyflakes']
   ubuntu:
     artful: [pyflakes3]
@@ -393,6 +395,7 @@ python-argparse:
   freebsd: [py27-argparse]
   gentoo: [dev-lang/python]
   macports: [py27-argparse]
+  openembedded: []
   opensuse: [python-argparse]
   osx:
     pip:
@@ -1352,6 +1355,7 @@ python-flake8:
   debian: [python-flake8]
   fedora: [python-flake8]
   gentoo: [dev-python/flake8]
+  openembedded: [python-flake8@meta-ros]
   ubuntu:
     '*': [python-flake8]
     trusty_python3: [python3-flake8]
@@ -2164,6 +2168,7 @@ python-mock:
   fedora: [python-mock]
   freebsd: [py27-mock]
   gentoo: [dev-python/mock]
+  openembedded: [python-mock@meta-python]
   opensuse: [python-mock]
   osx:
     pip:
@@ -3927,6 +3932,7 @@ python-sphinx:
   freebsd: [py27-sphinx]
   gentoo: [dev-python/sphinx]
   macports: [py27-sphinx]
+  openembedded: ['${PYTHON_PN}-sphinx']
   opensuse: [python-Sphinx]
   osx:
     pip:
@@ -4763,11 +4769,13 @@ python3-catkin-pkg-modules:
   debian: [python3-catkin-pkg-modules]
   fedora: [python3-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]
+  openembedded: [python3-catkin-pkg@meta-ros]
   ubuntu: [python3-catkin-pkg-modules]
 python3-dev:
   debian: [python3-dev]
   fedora: [python3-devel]
   gentoo: [=dev-lang/python-3*]
+  openembedded: [python3@openembedded-core]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-django:
@@ -4794,6 +4802,7 @@ python3-empy:
     stretch: [python3-empy]
   fedora: [python3-empy]
   gentoo: [dev-python/empy]
+  openembedded: [python3-empy@meta-ros]
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-flake8:
@@ -4803,6 +4812,7 @@ python3-flake8:
     stretch: [python3-flake8]
   fedora: [python3-flake8]
   gentoo: [dev-python/flake8]
+  openembedded: [python3-flake8@meta-ros]
   ubuntu: [python3-flake8]
 python3-gitlab:
   debian:
@@ -4829,6 +4839,7 @@ python3-lark-parser:
     '*': [python-lark-parser]
     '28': null
   gentoo: [dev-python/lark]
+  openembedded: [python3-lark-parser@meta-ros]
   rhel: ['python%{python3_pkgversion}-lark-parser']
   ubuntu:
     bionic: [python3-lark-parser]
@@ -4836,12 +4847,14 @@ python3-lark-parser:
 python3-lxml:
   debian: [python3-lxml]
   fedora: [python3-lxml]
+  openembedded: [python3-lxml@meta-python]
   ubuntu: [python3-lxml]
 python3-matplotlib:
   arch: [python-matplotlib]
   debian: [python3-matplotlib]
   fedora: [python3-matplotlib]
   gentoo: [dev-python/matplotlib]
+  openembedded: [python3-matplotlib@meta-python]
   opensuse: [python3-matplotlib]
   osx:
     pip:
@@ -4853,26 +4866,31 @@ python3-mock:
   debian: [python3-mock]
   fedora: [python3-mock]
   gentoo: [dev-python/mock]
+  openembedded: [python3-mock@meta-ros]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]
+  openembedded: [python3-nose@openembedded-core]
   rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
 python3-nose-yanc:
   debian: [python3-nose-yanc]
+  openembedded: [python3-nose-yanc@meta-ros]
   ubuntu: [python3-nose-yanc]
 python3-numpy:
   debian: [python3-numpy]
   fedora: [python3-numpy]
   gentoo: [dev-python/numpy]
+  openembedded: [python3-numpy@openembedded-core]
   rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
 python3-opencv:
   debian:
     buster: [python3-opencv]
   fedora: [python3-opencv]
+  openembedded: [opencv@meta-oe]
   ubuntu:
     bionic: [python3-opencv]
 python3-pandas:
@@ -4887,6 +4905,7 @@ python3-pep8:
     stretch: [python3-pep8]
   fedora: [python3-pep8]
   gentoo: [dev-python/pep8]
+  openembedded: [python3-pep8@meta-ros]
   ubuntu: [python3-pep8]
 python3-pexpect:
   debian: [python3-pexpect]
@@ -4915,6 +4934,7 @@ python3-pkg-resources:
   debian: [python3-pkg-resources]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
+  openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
 python3-psutil:
@@ -4923,6 +4943,7 @@ python3-psutil:
   fedora: [python3-psutil]
   gentoo: [dev-python/psutil]
   macports: [py36-psutil]
+  openembedded: [python3-psutil@meta-python]
   opensuse: [python3-psutil]
   osx:
     pip:
@@ -4935,6 +4956,7 @@ python3-pydot:
   debian: [python3-pydot]
   fedora: [python3-pydot]
   gentoo: [dev-python/pydot]
+  openembedded: [python3-pydot@meta-ros]
   ubuntu: [python3-pydot]
 python3-pygraphviz:
   arch: [python2-pygraphviz]
@@ -4942,6 +4964,7 @@ python3-pygraphviz:
   fedora: [python3-pygraphviz]
   freebsd: [py-pygraphviz]
   gentoo: [dev-python/pygraphviz]
+  openembedded: [python3-pygraphviz@meta-ros]
   opensuse: [python-pygraphviz]
   osx:
     pip:
@@ -4954,6 +4977,7 @@ python3-pyparsing:
   debian: [python3-pyparsing]
   fedora: [python3-pyparsing]
   gentoo: [dev-python/pyparsing]
+  openembedded: [python3-pyparsing@meta-python]
   ubuntu: [python3-pyparsing]
 python3-pytest:
   arch: [python-pytest]
@@ -4967,6 +4991,7 @@ python3-qt5-bindings:
   debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, sip]
   gentoo: [dev-python/PyQt5]
+  openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   slackware: [python3-PyQt5]
   ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
@@ -5026,6 +5051,7 @@ python3-setuptools:
   debian: [python3-setuptools]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
+  openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-setuptools]
 python3-sphinx:
@@ -5057,6 +5083,7 @@ python3-yaml:
   debian: [python3-yaml]
   fedora: [python3-PyYAML]
   gentoo: [dev-python/pyyaml]
+  openembedded: [python3-pyyaml@meta-python]
   rhel: ['python%{python3_pkgversion}-PyYAML']
   ubuntu: [python3-yaml]
 qdarkstyle-pip:


### PR DESCRIPTION
  * Requires related changes in rospkg, rosdep
    https://github.com/ros-infrastructure/rospkg/pull/166
    https://github.com/ros-infrastructure/rosdep/pull/673
  * Let us map the generic system dependency name into a recipe name
    available from OE layer index at http://layers.openembedded.org
  * Mapping is based on PACKAGE_ARGUMENT free form format of
    _package_ @  _meta-layer_ , where _package_ resides in the OE _meta-layer_
  * Please see the proposal below:
    https://discourse.ros.org/t/a-proposal-for-a-superflore-oe-recipe-generation-scheme/8401