### PR TITLE
ros_realtime: 1.0.25-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4349,6 +4349,26 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: lunar
     status: maintained
+  ros_realtime:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: hydro-devel
+    release:
+      packages:
+      - allocators
+      - lockfree
+      - ros_realtime
+      - rosatomic
+      - rosrt
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/ros_realtime-release.git
+      version: 1.0.25-0
+    source:
+      type: git
+      url: https://github.com/ros/ros_realtime.git
+      version: hydro-devel
   ros_tutorials:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4369,7 +4369,7 @@ repositories:
       type: git
       url: https://github.com/ros/ros_realtime.git
       version: hydro-devel
-    status: unmaintained 
+    status: unmaintained
   ros_tutorials:
     doc:
       type: git

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4369,6 +4369,7 @@ repositories:
       type: git
       url: https://github.com/ros/ros_realtime.git
       version: hydro-devel
+    status: unmaintained 
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_realtime` to `1.0.25-0`:

- upstream repository: https://github.com/ros/ros_realtime.git
- release repository: https://github.com/ros-gbp/ros_realtime-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ros_realtime

- No changes
