### PR TITLE
wifi_ddwrt: 0.2.0-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -6277,6 +6277,20 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  wifi_ddwrt:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/ros-gbp/wifi_ddwrt-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wifi_ddwrt` to `0.2.0-0`:

- upstream repository: https://github.com/ros-drivers/wifi_ddwrt.git
- release repository: https://github.com/ros-gbp/wifi_ddwrt-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
