### PR TITLE
wifi_ddwrt: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7767,6 +7767,20 @@ repositories:
       url: https://github.com/RobotWebTools/webrtc_ros.git
       version: develop
     status: developed
+  wifi_ddwrt:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/wifi_ddwrt-release.git
+      version: 0.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wifi_ddwrt.git
+      version: hydro-devel
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wifi_ddwrt` to `0.2.0-0`:

- upstream repository: https://github.com/ros-drivers/wifi_ddwrt.git
- release repository: https://github.com/ros-gbp/wifi_ddwrt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
