### PR TITLE
interactive_marker_proxy: 0.1.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2285,6 +2285,21 @@ repositories:
       url: https://github.com/ros-industrial/industrial_core.git
       version: kinetic
     status: developed
+  interactive_marker_proxy:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
+      version: 0.1.2-0
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/interactive_marker_proxy.git
+      version: master
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_proxy` to `0.1.2-0`:

- upstream repository: https://github.com/RobotWebTools/interactive_marker_proxy.git
- release repository: https://github.com/RobotWebTools-release/interactive_marker_proxy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## interactive_marker_proxy

```
* cleanup
* Contributors: Russell Toris
```
