### PR TITLE
depthcloud_encoder: 0.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2232,7 +2232,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
-      version: 0.0.5-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/RobotWebTools/depthcloud_encoder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthcloud_encoder` to `0.1.0-0`:

- upstream repository: https://github.com/RobotWebTools/depthcloud_encoder.git
- release repository: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.5-0`

## depthcloud_encoder

```
* Add ability to latch encoded topic (#12 <https://github.com/RobotWebTools/depthcloud_encoder/issues/12>)
* Make target resolution / crop size a parameter (#11 <https://github.com/RobotWebTools/depthcloud_encoder/issues/11>)
* Add dynamic reconfigure server + fetch focal length from camera info topic (#10 <https://github.com/RobotWebTools/depthcloud_encoder/issues/10>)
  * Add dynamic reconfigure server for some params
  * Fetch focal length from camera info topic
* Parameterize max_depth_per_tile (#8 <https://github.com/RobotWebTools/depthcloud_encoder/issues/8>)
* Update travis config to build for indigo and kinetic (#9 <https://github.com/RobotWebTools/depthcloud_encoder/issues/9>)
* Contributors: Jihoon Lee, Viktor Kunovski
```
