### PR TITLE
rospilot: 1.5.6-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5819,7 +5819,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.5.4-0
+      version: 1.5.6-0
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.5.6-0`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.5.4-0`

## rospilot

```
* Avoid thread exhaustion in h264 server
  Previously, connections didn't timeout, so a badly behaved client
  could exhaust all the threads on the host
* Contributors: Christopher Berner
```
