### PR TITLE
moveit_pr2: 0.7.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6816,7 +6816,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_pr2-release.git
-      version: 0.7.0-2
+      version: 0.7.1-0
     source:
       type: git
       url: https://github.com/ros-planning/moveit_pr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.7.1-0`:

- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.0-2`

## moveit_pr2

- No changes

## pr2_moveit_config

- No changes

## pr2_moveit_plugins

```
* use urdf typedefs to stay compatible with boost vs std ptrs
* Contributors: v4hn
```
