### PR TITLE
behaviotree_cpp_v3: 3.0.7-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -339,7 +339,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
-      version: 3.0.6-0
+      version: 3.0.7-0
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviotree_cpp_v3` to `3.0.7-0`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `3.0.6-0`

## behaviortree_cpp_v3

```
* this should fix issue with tinyXML2 once and for all (maybe...)
* improvement #79
* doc fix
* Deprecating <remap> tag in SubTree
* fix windows compilation
* Update README.md
* back to c++11
* Contributors: Davide Faconti, Ferran Roure
```
