### PR TITLE
roswww: 0.1.12-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11996,7 +11996,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/roswww-release.git
-      version: 0.1.10-0
+      version: 0.1.12-0
     source:
       type: git
       url: https://github.com/tork-a/roswww.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roswww` to `0.1.12-0`:

- upstream repository: https://github.com/tork-a/roswww.git
- release repository: https://github.com/ros-gbp/roswww-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.10-0`

## roswww

```
* [doc] Minor URL update. (#40 <https://github.com/tork-a/roswww/issues/40>)
* fix CDN URL (#45 <https://github.com/tork-a/roswww/issues/45>)
* Contributors: Isaac I.Y. Saito, Makito Ishikura
```
