### PR TITLE
launch: 0.7.4-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -723,7 +723,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.7.3-0
+      version: 0.7.4-0
     source:
       type: git
       url: https://github.com/ros2/launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.7.4-0`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.7.3-0`

## launch

```
* Fixed a bug with the introspector which occurred when the user set the environment in an ExecuteProcess. (#222 <https://github.com/ros2/launch/issues/222>)
* Contributors: Daniel Stonier, Shane Loretz, William Woodall
```

## launch_ros

- No changes

## launch_testing

- No changes

## ros2launch

- No changes
