### PR TITLE
rosdep/python: add python-bitarray

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -549,7 +549,6 @@ python-beautifulsoup:
   gentoo: [dev-python/beautifulsoup]
   ubuntu: [python-beautifulsoup]
 python-bitarray:
-  arch: [python-bitarray]
   debian: [python-bitarray]
   fedora: [python-bitarray]
   gentoo: [dev-python/bitarray]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -548,6 +548,12 @@ python-beautifulsoup:
   fedora: [python-BeautifulSoup]
   gentoo: [dev-python/beautifulsoup]
   ubuntu: [python-beautifulsoup]
+python-bitarray:
+  arch: [python-bitarray]
+  debian: [python-bitarray]
+  fedora: [python-bitarray]
+  gentoo: [dev-python/bitarray]
+  ubuntu: [python-bitarray]
 python-bitstring:
   debian:
     buster: [python-bitstring]


### PR DESCRIPTION
Description: Citing the [pypi doc](https://pypi.org/project/bitarray/):

> This module provides an object type which efficiently represents an array of booleans. Bitarrays are sequence types and behave very much like usual lists. Eight bits are represented by one byte in a contiguous block of memory. The user can select between two representations: little-endian and big-endian. All of the functionality is implemented in C. Methods for accessing the machine representation are provided. This can be useful when bit level access to binary files is required, such as portable bitmap image files (.pbm). Also, when dealing with compressed data which uses variable bit length encoding, you may find this module useful.

Provided as native builds for:

- ~[arch](https://aur.archlinux.org/packages/?O=0&K=python-bitarray)~ (removed as per review)
- [debian](https://packages.debian.org/en/stretch/python-bitarray)
- [fedora](https://apps.fedoraproject.org/packages/python-bitarray)
- [gentoo](https://packages.gentoo.org/packages/dev-python/bitarray)
- [ubuntu](https://packages.ubuntu.com/search?lang=en&keywords=python-bitarray)