### PR TITLE
codec_image_transport: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1722,7 +1722,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yoshito-n-students/codec_image_transport-release.git
-      version: 0.0.1-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/yoshito-n-students/codec_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `codec_image_transport` to `0.0.3-0`:

- upstream repository: https://github.com/yoshito-n-students/codec_image_transport.git
- release repository: https://github.com/yoshito-n-students/codec_image_transport-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.1-0`

## codec_image_transport

```
* Add system dependency to ffmpeg
```
