### PR TITLE
ubiquity_motor: 0.9.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14636,7 +14636,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
-      version: 0.8.0-0
+      version: 0.9.0-0
     source:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.9.0-0`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.8.0-0`

## ubiquity_motor

```
* Allow selecting what firmware version to download
* Adding max motor forward and reverse speeds and max pwm settings all the way from ROS parameters to being pushed to the controller board.
* Analyze information to create diagnostics statuses
* Major update to test_motor_board.py that accepts greatly improved parameter read and set as well as ability to specify com port device to be used
* Adds support for set of hw rev and for pre rev 5.0 estop threshold
* Contributors: Mark Johnston, Rohan Agrawal
```
