### PR TITLE
Adding livox_ros_driver to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5980,6 +5980,25 @@ repositories:
       url: https://github.com/ros-drivers/linux_peripheral_interfaces.git
       version: kinetic
     status: maintained
+  livox_ros_driver:
+    doc:
+      type: git
+      url: https://github.com/Livox-SDK/Livox-SDK-ROS.git
+      version: master
+    release:
+      packages:
+      - display_hub_points
+      - display_lidar_points
+      - linux_ros_driver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Livox-SDK/Livox-SDK-ROS.git
+      version: 2.0.0
+    source:
+      type: git
+      url: https://github.com/Livox-SDK/Livox-SDK-ROS.git
+      version: master
+    status: maintained
   lkh:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5983,20 +5983,11 @@ repositories:
   livox_ros_driver:
     doc:
       type: git
-      url: https://github.com/Livox-SDK/Livox-SDK-ROS.git
+      url: https://github.com/Livox-SDK/livox_ros_driver.git
       version: master
-    release:
-      packages:
-      - display_hub_points
-      - display_lidar_points
-      - linux_ros_driver
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/Livox-SDK/Livox-SDK-ROS.git
-      version: 2.0.0
     source:
       type: git
-      url: https://github.com/Livox-SDK/Livox-SDK-ROS.git
+      url: https://github.com/Livox-SDK/livox_ros_driver.git
       version: master
     status: maintained
   lkh:


### PR DESCRIPTION
Adding livox_ros_driver to documentation index for distro