### PR TITLE
multisense_ros: 4.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3529,6 +3529,28 @@ repositories:
       url: https://github.com/fkie/multimaster_fkie.git
       version: melodic-devel
     status: maintained
+  multisense_ros:
+    doc:
+      type: hg
+      url: https://bitbucket.org/crl/multisense_ros
+      version: default
+    release:
+      packages:
+      - multisense
+      - multisense_bringup
+      - multisense_cal_check
+      - multisense_description
+      - multisense_lib
+      - multisense_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
+      version: 4.0.2-0
+    source:
+      type: hg
+      url: https://bitbucket.org/crl/multisense_ros
+      version: default
+    status: maintained
   mvsim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `4.0.2-0`:

- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## multisense

```
* added C++98 compatibility
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_bringup

```
* added C++98 compatibility
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_cal_check

```
* added C++98 compatibility
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_description

```
* added C++98 compatibility
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_lib

```
* added C++98 compatibility
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_ros

```
* added C++98 compatibility
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```
