### PR TITLE
fetch_ros: 0.8.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1400,11 +1400,12 @@ repositories:
       - fetch_maps
       - fetch_moveit_config
       - fetch_navigation
+      - fetch_ros
       - fetch_teleop
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.8.0-0
+      version: 0.8.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.8.1-0`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.8.0-0`

## fetch_calibration

```
* sync cmake_minimum_required: 2.8.12
* Contributors: Alexander Moriarty
```

## fetch_depth_layer

```
* sync cmake_minimum_required: 2.8.12
* [fetch_depth_layer][OpenCV-4] operator= compile error (#108)
  
  This fixes no match for ‘operator=’ error with OpenCV4 and how the cv::Ptr was being set.
  Fixed by setting the normals_estimator_ pointer similarly to how the plane_estimator_ pointer is being set.
  This closes #82
* [upstream change] pluginlib includes: h -> hpp (#106)
  
  pluginlib provided a script for this change, and it's been backported
  to Indigo, Kinetic- but not Jade.
* Contributors: Alexander Moriarty
```

## fetch_description

```
* sync cmake_minimum_required: 2.8.12
* Added fixed dae models compatible with OpenWebGL (#105 <https://github.com/fetchrobotics/fetch_ros/issues/105>)
* Contributors: Alexander Moriarty, Miguel Angel Rodríguez
```

## fetch_ikfast_plugin

```
* fix Error in latest IK_Fast Plugin #113 (#114)
  
  <string>:3: (INFO/1) Duplicate explicit target name: "#113".
  
  fix Error in latest IK_Fast Plugin #113 with moveit 1.0 interface
  
  Related to the fix for issue #103 PR #107 used the wrong link
* Merge pull request #107 from moriarty/update-ikfast-plugin
  
  [IKFast Plugin] Regenerate fetch_ikfast_plugin
* Contributors: Alexander Moriarty, Carl Saldanha, I-Chen Jwo
```

## fetch_maps

```
* sync cmake_minimum_required: 2.8.12
* Contributors: Alexander Moriarty
```

## fetch_moveit_config

```
* sync cmake_minimum_required: 2.8.12
* Merge pull request #107 <https://github.com/fetchrobotics/fetch_ros/issues/107> from moriarty/update-ikfast-plugin
  [IKFast Plugin] Regenerate fetch_ikfast_plugin
  Fixes #103 <https://github.com/fetchrobotics/fetch_ros/issues/103>
* Contributors: Alexander Moriarty, Carl Saldanha
```

## fetch_navigation

```
* sync cmake_minimum_required: 2.8.12
* Contributors: Alexander Moriarty
```

## fetch_ros

```
* catkin_make only supports cmake 2.8.3 for meta-pkg (#115 <https://github.com/fetchrobotics/fetch_ros/issues/115>)
* sync cmake_minimum_required: 2.8.12
* [fetch_ros] new meta-package (#110 <https://github.com/fetchrobotics/fetch_ros/issues/110>)
* Contributors: Alexander Moriarty
```

## fetch_teleop

```
* sync cmake_minimum_required: 2.8.12
* Contributors: Alexander Moriarty
```
