### PR TITLE
xpp: 1.0.10-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -6373,7 +6373,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/leggedrobotics/xpp-release.git
-      version: 1.0.9-0
+      version: 1.0.10-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.10-0`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.9-0`

## xpp

```
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_examples

```
* Update README.txt
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_hyq

```
* add xacro dependency
* Contributors: Alexander Winkler
```

## xpp_msgs

```
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_quadrotor

```
* add xacro dependency to xpp_hyq and xpp_quadrotor
* Contributors: Alexander Winkler
```

## xpp_states

```
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_vis

```
* checking sum of the contact forces was hiding negative forces. Use norm instead (#10 <https://github.com/leggedrobotics/xpp/issues/10>)
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler, Ruben Grandia
```
