### PR TITLE
cob_command_tools: 0.6.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1373,7 +1373,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.11-0`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.10-0`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #243 <https://github.com/ipa320/cob_command_tools/issues/243> from KITrobotics/cpu_monitor_str_repair
  Repaired call of str object in cpu_monitor
* Merge pull request #244 <https://github.com/ipa320/cob_command_tools/issues/244> from fmessmer/enhance_wlan_monitor
  query all wireless interfaces, fix parsing
* query all wireless interfaces, fix parsing
* Repaired call of str object in cpu_monitor
* Contributors: Felix Messmer, andreeatulbure, fmessmer
```

## cob_script_server

- No changes

## cob_teleop

- No changes

## generic_throttle

- No changes

## service_tools

- No changes
