### PR TITLE
cob_supported_robots: 0.6.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1692,7 +1692,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.11-0`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.10-0`

## cob_supported_robots

```
* Merge pull request #19 <https://github.com/ipa320/cob_supported_robots/issues/19> from fmessmer/add_cob4-25
  add cob4-25
* add cob4-25
* Contributors: Felix Messmer, fmessmer
```
