### PR TITLE
cob_environments: 0.6.8-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -645,6 +645,24 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: indigo_dev
     status: maintained
+  cob_environments:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_default_env_config
+      - cob_environments
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_environments-release.git
+      version: 0.6.8-0
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_environments.git
+      version: indigo_dev
+    status: maintained
   code_coverage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.6.8-0`:

- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## cob_default_env_config

- No changes

## cob_environments

- No changes
