### PR TITLE
cob_calibration_data: 0.6.11-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1347,7 +1347,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.10-0
+      version: 0.6.11-0
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.11-0`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.10-0`

## cob_calibration_data

```
* Merge pull request #150 <https://github.com/ipa320/cob_calibration_data/issues/150> from fmessmer/add_cob4-25
  add cob4-25
* calibrate head_cam cob4-25
* add cob4-25
* Contributors: Felix Messmer, fmessmer
```
