### PR TITLE
universal_robot: 1.2.5-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14745,19 +14745,25 @@ repositories:
     release:
       packages:
       - universal_robot
+      - universal_robots
+      - ur10_e_moveit_config
       - ur10_moveit_config
+      - ur3_e_moveit_config
       - ur3_moveit_config
+      - ur5_e_moveit_config
       - ur5_moveit_config
       - ur_bringup
       - ur_description
       - ur_driver
+      - ur_e_description
+      - ur_e_gazebo
       - ur_gazebo
       - ur_kinematics
       - ur_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.2.1-0
+      version: 1.2.5-0
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.2.5-0`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.2.1-0`

## universal_robot

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* Add new metapackage, first step to rename the repo (#409 <https://github.com/ros-industrial/universal_robot/issues/409>)
* UR-E Series (#380 <https://github.com/ros-industrial/universal_robot/issues/380>)
* Update maintainer and author information.
* Contributors: Dave Niewinski, Nadia Hammoudeh García, gavanderhoorn
```

## universal_robots

```
* First release (of this package)
* Contributors: gavanderhoorn, Nadia Hammoudeh García
```

## ur10_e_moveit_config

```
* First release (of this package)
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* UR-E Series (#380 <https://github.com/ros-industrial/universal_robot/issues/380>)
* Contributors: Dave Niewinski, gavanderhoorn
```

## ur10_moveit_config

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* MoveGroupExecuteService is Deprecated by MoveIt! (#391 <https://github.com/ros-industrial/universal_robot/issues/391>)
* Update maintainer and author information.
* Add roslaunch tests (#362 <https://github.com/ros-industrial/universal_robot/issues/362>)
* Contributors: gavanderhoorn, Nadia Hammoudeh García, 薯片半价
```

## ur3_e_moveit_config

```
* First release (of this package)
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* UR-E Series (#380 <https://github.com/ros-industrial/universal_robot/issues/380>)
* Contributors: Dave Niewinski, gavanderhoorn
```

## ur3_moveit_config

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* MoveGroupExecuteService is Deprecated by MoveIt! (#391 <https://github.com/ros-industrial/universal_robot/issues/391>)
* Update maintainer and author information.
* Add roslaunch tests (#362 <https://github.com/ros-industrial/universal_robot/issues/362>)
* Contributors: gavanderhoorn, Nadia Hammoudeh García, 薯片半价
```

## ur5_e_moveit_config

```
* First release (of this package)
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* UR-E Series (#380 <https://github.com/ros-industrial/universal_robot/issues/380>)
* Contributors: Dave Niewinski, gavanderhoorn
```

## ur5_moveit_config

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* MoveGroupExecuteService is Deprecated by MoveIt! (#391 <https://github.com/ros-industrial/universal_robot/issues/391>)
* Update maintainer and author information.
* Add roslaunch tests (#362 <https://github.com/ros-industrial/universal_robot/issues/362>)
* Contributors: gavanderhoorn, Nadia Hammoudeh García, 薯片半价
```

## ur_bringup

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* update maintainer and author information.
* Add roslaunch tests (#362 <https://github.com/ros-industrial/universal_robot/issues/362>)
* Using the 'doc' attribute on 'arg' elements.
* Contributors: gavanderhoorn, Harsh Deshpande, Nadia Hammoudeh García
```

## ur_description

```
* Add transmission_hw_interface to UR xacro and expose everywhere (#392 <https://github.com/ros-industrial/universal_robot/issues/392>)
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* Updated xacro namespace.
* Update maintainer and author information.
* Updated mesh ambience so the model isn't so dark in Gazebo
* Fix overlapping variable names between robot definition files (#356 <https://github.com/ros-industrial/universal_robot/issues/356>)
* Improve meshes shading (#233 <https://github.com/ros-industrial/universal_robot/issues/233>)
* Added run_depend for xacro
* Using the 'doc' attribute on 'arg' elements.
* Enable self collision in gazebo
* Contributors: Dave Niewinski, Felix von Drigalski, Harsh Deshpande, Joe, Marcel Schnirring, Miguel Prada, MonteroJJ, ipa-fxm
```

## ur_driver

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* update maintainer and author information.
* Contributors: gavanderhoorn
```

## ur_e_description

```
* First release (of this package)
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* UR-E Series (#380 <https://github.com/ros-industrial/universal_robot/issues/380>)
* Contributors: Dave Niewinski, gavanderhoorn
```

## ur_e_gazebo

```
* First release (of this package)
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* UR-E Series (#380 <https://github.com/ros-industrial/universal_robot/issues/380>)
* Contributors: Dave Niewinski, gavanderhoorn
```

## ur_gazebo

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* UR-E Series (#380 <https://github.com/ros-industrial/universal_robot/issues/380>)
* Update maintainer and author information.
* Add roslaunch tests (#362 <https://github.com/ros-industrial/universal_robot/issues/362>)
* Using the 'doc' attribute on 'arg' elements.
* Contributors: Dave Niewinski, gavanderhoorn, Harsh Deshpande, Nadia Hammoudeh García
```

## ur_kinematics

```
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* Removed non-existent moveit KDL libraries from ur_kinematics includes
* Update maintainer and author information.
* Missed python module definition and setup.py script (#364 <https://github.com/ros-industrial/universal_robot/issues/364>)
* Use the new proposed API to query params from correct namespaces (#334 <https://github.com/ros-industrial/universal_robot/issues/334>)
* Setting default ik_weights to 1.0 (#346 <https://github.com/ros-industrial/universal_robot/issues/346>)
* ur_moveit_plugin: fix compile error with GCC6
* Contributors: Alexander Rössler, gavanderhoorn, Henning Kayser, Mike Lautman, Nadia Hammoudeh García, jwhendy
```

## ur_msgs

```
* Correct width and type of 'digital_*_bits'. (#416 <https://github.com/ros-industrial/universal_robot/issues/416>)
* Clarify use of fields in SetIO svc. (#415 <https://github.com/ros-industrial/universal_robot/issues/415>)
* Update maintainer listing: add Miguel (#410 <https://github.com/ros-industrial/universal_robot/issues/410>)
* Add RobotModeDataMsg (#395 <https://github.com/ros-industrial/universal_robot/issues/395>)
* Update maintainer and author information.
* Contributors: Felix von Drigalski, gavanderhoorn
```
