### PR TITLE
industrial_robot_status_controller: 0.1.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4841,7 +4841,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/gavanderhoorn/industrial_robot_status_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_robot_status_controller` to `0.1.1-0`:

- upstream repository: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
- release repository: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.0-0`

## industrial_robot_status_controller

```
* Don't export build deps. (#3 <https://github.com/gavanderhoorn/industrial_robot_status_controller/issues/3>)
```

## industrial_robot_status_interface

- No changes
