### PR TITLE
towr: 1.4.1-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14170,7 +14170,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ethz-adrl/towr-release.git
-      version: 1.4.0-0
+      version: 1.4.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `towr` to `1.4.1-0`:

- upstream repository: https://github.com/ethz-adrl/towr.git
- release repository: https://github.com/ethz-adrl/towr-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.4.0-0`

## towr

```
* Merge pull request (#56 <https://github.com/ethz-adrl/towr/issues/56>) from ethz-adrl/expose-params
* add explanation for assert in phase_durations
* Merge branch 'sweetie-bot-project-feat/access-optimization-parameteres' into expose-params
* Optimize GetPhaseDurations(). Remove unnecessary GetNormalizedPhaseDurations().
* Make GaitGenerator::SetGaits() method public.
* Move default parameter values to header.
* Use pair<double,double> instead of array<double,2> to store bounds.
* Expose contstraints and costs field to user. Remove unnecessary private functions.
* Add missing underscore postfix for bounds_final variables.
* Take into account weights of the costs. (#51 <https://github.com/ethz-adrl/towr/issues/51>)
* Contributors: Alexander Winkler, Mathieu Geisert, awinkler, disRecord
```

## towr_ros

```
* Merge pull request (#56 <https://github.com/ethz-adrl/towr/issues/56>) from ethz-adrl/expose-params
* Contributors: Alexander Winkler, awinkler
```
