### PR TITLE
rexrov2: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10314,6 +10314,22 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
     status: maintained
+  rexrov2:
+    release:
+      packages:
+      - rexrov2_control
+      - rexrov2_description
+      - rexrov2_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uuvsimulator/rexrov2-release.git
+      version: 0.1.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uuvsimulator/rexrov2.git
+      version: 0.1.3
+    status: developed
   rfsm:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10328,7 +10328,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/uuvsimulator/rexrov2.git
-      version: 0.1.3
+      version: master
     status: developed
   rfsm:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rexrov2` to `0.1.3-0`:

- upstream repository: https://github.com/uuvsimulator/rexrov2.git
- release repository: https://github.com/uuvsimulator/rexrov2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## rexrov2_control

- No changes

## rexrov2_description

```
* Fix path to rexrov2_description
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## rexrov2_gazebo

- No changes
