### PR TITLE
codec_image_transport: 0.0.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -687,7 +687,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yoshito-n-students/codec_image_transport-release.git
-      version: 0.0.2-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/yoshito-n-students/codec_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `codec_image_transport` to `0.0.4-0`:

- upstream repository: https://github.com/yoshito-n-students/codec_image_transport.git
- release repository: https://github.com/yoshito-n-students/codec_image_transport-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.2-0`

## codec_image_transport

```
* Add system dependency to ffmpeg
```
