### PR TITLE
rosbag2: 0.0.7-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1404,7 +1404,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.0.7-0`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.6-0`

## ros1_rosbag_storage_vendor

```
* [backport] ros1 dependency handling (#98 <https://github.com/ros2/rosbag2/issues/98>)
  * removed dependency to ros1_bridge package (#90 <https://github.com/ros2/rosbag2/issues/90>)
  * removed dependency to ros1_bridge package:
  * checking if package is available
  * if not skipping (with warnings)
  * now rosbag2_tests builds on systems without ros1
  * check ros1 deps correctly on all packages
  * add ros1_bridge to test package
  * silently try to find the bridge
  * correct missing linter errors (#96 <https://github.com/ros2/rosbag2/issues/96>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* Contributors: Karsten Knese
```

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_bag_v2_plugins

```
* [backport] ros1 dependency handling (#98 <https://github.com/ros2/rosbag2/issues/98>)
  * removed dependency to ros1_bridge package (#90 <https://github.com/ros2/rosbag2/issues/90>)
  * removed dependency to ros1_bridge package:
  * checking if package is available
  * if not skipping (with warnings)
  * now rosbag2_tests builds on systems without ros1
  * check ros1 deps correctly on all packages
  * add ros1_bridge to test package
  * silently try to find the bridge
  * correct missing linter errors (#96 <https://github.com/ros2/rosbag2/issues/96>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* Contributors: Karsten Knese
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* [backport] ros1 dependency handling (#98 <https://github.com/ros2/rosbag2/issues/98>)
  * removed dependency to ros1_bridge package (#90 <https://github.com/ros2/rosbag2/issues/90>)
  * removed dependency to ros1_bridge package:
  * checking if package is available
  * if not skipping (with warnings)
  * now rosbag2_tests builds on systems without ros1
  * check ros1 deps correctly on all packages
  * add ros1_bridge to test package
  * silently try to find the bridge
  * correct missing linter errors (#96 <https://github.com/ros2/rosbag2/issues/96>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* Contributors: Karsten Knese
```

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
