### PR TITLE
ament_package: 0.7.0-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -6,5 +6,20 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  ament_package:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_package-release.git
+      version: 0.7.0-0
+    source:
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.7.0-0`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev0`
- previous version for package: `null`
