### PR TITLE
Remove source entry for ubiquity_motor

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16630,10 +16630,10 @@ repositories:
       url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
       version: 0.5.0-0
     source:
+      test_commits: false
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git
       version: indigo-devel
-      test_commits: false
     status: developed
   ublox:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16633,6 +16633,7 @@ repositories:
       type: git
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git
       version: indigo-devel
+      test_commits: false
     status: developed
   ublox:
     doc:


### PR DESCRIPTION
The buildfarm CI is redundant for us so the emails are a little annoying