### PR TITLE
ament_cmake: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -6,6 +6,23 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  ament_cmake:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: master
+    release:
+      packages:
+      - ament_cmake_core
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: master
+    status: developed
   ament_package:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `0.7.0-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev0`
- previous version for package: `null`
