### PR TITLE
flexbe: 1.1.2-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1016,7 +1016,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.1.1-0
+      version: 1.1.2-0
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.1.2-0`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.1.1-0`

## flexbe_behavior_engine

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_core

```
* Merge remote-tracking branch 'origin/develop'
* Merge pull request #66 <https://github.com/team-vigir/flexbe_behavior_engine/issues/66> from ksm0709/add_remove_result
  add remove_result function to proxy action client
* add remove_result function to proxy action client
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger, taehokang
```

## flexbe_input

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_mirror

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_msgs

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_onboard

```
* Merge remote-tracking branch 'origin/develop'
* [flexbe_onboard] Change input parsing warning to debug level
* Merge pull request #70 <https://github.com/team-vigir/flexbe_behavior_engine/issues/70> from henroth/bugfix/fix_incorrect_warning_format
  Fix formatting error that crashes behavior construction
* In certain cases if an input key has a weird value (such as 0_degrees) it can cause an exception that prevents the behavior from being built. This is due to incorrect formatting in a warning message. This fixes the warning message formatting
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Henry Roth, Philipp Schillinger
```

## flexbe_states

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_testing

```
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```

## flexbe_widget

```
* Merge remote-tracking branch 'origin/develop'
* [flexbe_widget] Robustify action server when spammed with failing behaviors
* Merge remote-tracking branch 'origin/master' into develop
* Contributors: Philipp Schillinger
```
