### PR TITLE
ros_workspace: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -38,5 +38,16 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  ros_workspace:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `0.7.0-1`:

- upstream repository: https://github.com/nuclearsandwich/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev0`
- previous version for package: `null`

## ros_workspace

```
* Add LICENSE file containing full Apache 2.0 license text. (#13 <https://github.com/ros2/ros_workspace/issues/13>)
* Contributors: Steven! Ragnarök
```
