### PR TITLE
ml_classifiers: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3241,7 +3241,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/ml_classifiers-release.git
-      version: 0.4.1-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/astuff/ml_classifiers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `1.0.0-0`:

- upstream repository: https://github.com/astuff/ml_classifiers.git
- release repository: https://github.com/astuff/ml_classifiers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.4.1-0`

## ml_classifiers

```
* Merge pull request #2 <https://github.com/astuff/ml_classifiers/issues/2> from astuff/ros-transition
  ROS2 Hybrid Package - now builds in ROS Kinetic/Melodic and ROS2 Crystal
* ROS2: Making classifier_server a class.
* Creating separate ros1/ros2 xml files.
* ROS1: Removing roslint in favor of ROS2 linting.
* ROS2: Disabling boost in pluginlib.
* ROS2: Updating copyrights to conform to ament_copyright.
* ROS2: Fixing cmake exports.
* Contributors: Joshua Whitley
```
