### PR TITLE
Add several Python3 rules for RHEL/CentOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -227,6 +227,7 @@ pyflakes3:
     stretch: [pyflakes3]
   fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]
+  rhel: ['python%{python3_pkgversion}-pyflakes']
   ubuntu:
     artful: [pyflakes3]
     bionic: [pyflakes3]
@@ -4763,6 +4764,7 @@ python3-dev:
   debian: [python3-dev]
   fedora: [python3-devel]
   gentoo: [=dev-lang/python-3*]
+  rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-django:
   debian: [python3-django]
@@ -4788,6 +4790,7 @@ python3-empy:
     stretch: [python3-empy]
   fedora: [python3-empy]
   gentoo: [dev-python/empy]
+  rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-flake8:
   debian:
@@ -4822,6 +4825,7 @@ python3-lark-parser:
     '*': [python-lark-parser]
     '28': null
   gentoo: [dev-python/lark]
+  rhel: ['python%{python3_pkgversion}-lark-parser']
   ubuntu:
     bionic: [python3-lark-parser]
     xenial: [python3-lark-parser]
@@ -4845,6 +4849,7 @@ python3-mock:
   debian: [python3-mock]
   fedora: [python3-mock]
   gentoo: [dev-python/mock]
+  rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-nose:
   debian: [python3-nose]
@@ -4857,6 +4862,7 @@ python3-numpy:
   debian: [python3-numpy]
   fedora: [python3-numpy]
   gentoo: [dev-python/numpy]
+  rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
 python3-opencv:
   debian:
@@ -4904,6 +4910,7 @@ python3-pkg-resources:
   debian: [python3-pkg-resources]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
+  rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
 python3-psutil:
   arch: [python-psutil]
@@ -4915,6 +4922,7 @@ python3-psutil:
   osx:
     pip:
       packages: [psutil]
+  rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
 python3-pydot:
@@ -4933,6 +4941,7 @@ python3-pygraphviz:
   osx:
     pip:
       packages: [pygraphviz]
+  rhel: ['python%{python3_pkgversion}-pygraphviz']
   slackware: [pygraphviz]
   ubuntu: [python3-pygraphviz]
 python3-pyparsing:
@@ -4946,6 +4955,7 @@ python3-pytest:
   debian: [python3-pytest]
   fedora: [python3-pytest]
   gentoo: [dev-python/pytest]
+  rhel: ['python%{python3_pkgversion}-pytest']
   ubuntu: [python3-pytest]
 python3-qt5-bindings:
   arch: [python-pyqt5]
@@ -4974,6 +4984,7 @@ python3-setuptools:
   debian: [python3-setuptools]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
+  rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-setuptools]
 python3-sphinx:
   debian: [python3-sphinx]
@@ -5000,6 +5011,7 @@ python3-yaml:
   debian: [python3-yaml]
   fedora: [python3-PyYAML]
   gentoo: [dev-python/pyyaml]
+  rhel: ['python%{python3_pkgversion}-PyYAML']
   ubuntu: [python3-yaml]
 qdarkstyle-pip:
   debian:


### PR DESCRIPTION
These packages are all part of Fedora EPEL 7.

The RPM macro `python3_pkgversion` resolves to the package version number of the primary Python 3 version in each distribution. This is true in Fedora and EPEL. Currently, `python3_pkgversion` resolves to `3` on Fedora and `36` in EPEL 7. It is likely that RHEL 8 will use a different Python 3 version, and since it will ship with the base OS, `python3_pkgversion` will likely resolve to `3` for that release.

By using the macro, we can ensure that we're always getting packages for the default version of python 3, which has changed in the past, and also avoiding creating separate rules for EPEL 7 and 8.

The Fedora packages site doesn't do well for Python 3 EPEL packages, but here is the result of listing the resolved keys on CentOS 7, demonstrating that each package is available from the `epel` repository.
```
$ yum list available --show-duplicates python36-devel python36-empy python36-lark-parser python36-mock python36-numpy python36-setuptools python36-psutil python36-pyflakes python36-pygraphviz python36-pytest
Available Packages
python36-setuptools python36-PyYAML
python36-PyYAML.x86_64       3.11-4.el7       epel
python36-devel.x86_64        3.6.6-5.el7      epel
python36-empy.noarch         3.3.3-2.el7      epel
python36-lark-parser.noarch  0.6.4-6.el7      epel
python36-mock.noarch         2.0.0-2.el7      epel
python36-numpy.x86_64        1.10.4-7.el7     epel
python36-psutil.x86_64       2.2.1-5.el7      epel
python36-pyflakes.noarch     1.6.0-4.el7      epel
python36-pygraphviz.x86_64   1.3-2.rc2.el7.2  epel
python36-pytest.noarch       2.9.2-3.el7      epel
python36-setuptools.noarch   39.2.0-3.el7     epel
```