### PR TITLE
mrpt2: 1.9.9-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -773,12 +773,6 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: crystal
     status: maintained
-  mrpt2:
-    release:
-      tags:
-        release: release/crystal/{package}/{version}
-      url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
-      version: 1.9.9-0
   ml_classifiers:
     doc:
       type: git
@@ -794,6 +788,12 @@ repositories:
       url: https://github.com/astuff/ml_classifiers.git
       version: master
     status: maintained
+  mrpt2:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
+      version: 1.9.9-0
   navigation2:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -773,6 +773,12 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: crystal
     status: maintained
+  mrpt2:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
+      version: 1.9.9-0
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `1.9.9-0`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
