### PR TITLE
rosparam_shortcuts: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5977,7 +5977,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
-      version: 0.2.1-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rosparam_shortcuts.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.3.0-1`:

- upstream repository: https://github.com/PickNikRobotics/rosparam_shortcuts.git
- release repository: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.2.1-0`

## rosparam_shortcuts

```
* Deprecate Affine3d transforms and support Isometry3d (#7 <https://github.com/picknikrobotics/rosparam_shortcuts/issues/7>)
* Merge pull request #4 <https://github.com/picknikrobotics/rosparam_shortcuts/issues/4> from PickNikRobotics/kinetic-devel-eigen-additions
  adding support for loading trajectories and loading quaternions
* removing EigenSTL
* adding support for loading trajectories and loading quaternions
* Merge pull request #3 <https://github.com/picknikrobotics/rosparam_shortcuts/issues/3> from gavanderhoorn/patch-1
  Fix minor typo in API doc link.
* Fix minor typo in API doc link.
* Contributors: Dave Coleman, G.A. vd. Hoorn, Henning Kayser, mike
```
