### PR TITLE
Revert "ml_classifiers: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6650,7 +6650,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/ml_classifiers-release.git
-      version: 1.0.0-0
+      version: 0.4.1-0
     source:
       type: git
       url: https://github.com/astuff/ml_classifiers.git


### PR DESCRIPTION
Reverts ros/rosdistro#20839 see https://github.com/ros/rosdistro/pull/20841#issuecomment-481860668 for details