### PR TITLE
khi_robot: 1.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5444,26 +5444,30 @@ repositories:
       version: kinetic-devel
     status: maintained
   khi_robot:
+    doc:
+      type: git
+      url: https://github.com/Kawasaki-Robotics/khi_robot.git
+      version: master
     release:
       packages:
-      - duaro_description
-      - duaro_gazebo
-      - duaro_ikfast_plugin
-      - duaro_moveit_config
+      - khi_duaro_description
+      - khi_duaro_gazebo
+      - khi_duaro_ikfast_plugin
+      - khi_duaro_moveit_config
       - khi_robot
       - khi_robot_bringup
       - khi_robot_control
       - khi_robot_msgs
-      - rs007l_moveit_config
-      - rs007n_moveit_config
-      - rs080n_moveit_config
-      - rs_description
-      - rs_gazebo
-      - rs_ikfast_plugin
+      - khi_rs007l_moveit_config
+      - khi_rs007n_moveit_config
+      - khi_rs080n_moveit_config
+      - khi_rs_description
+      - khi_rs_gazebo
+      - khi_rs_ikfast_plugin
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
-      version: 1.0.0-0
+      version: 1.1.0-1
   kinesis_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `khi_robot` to `1.1.0-1`:

- upstream repository: https://github.com/Kawasaki-Robotics/khi_robot.git
- release repository: https://github.com/Kawasaki-Robotics/khi_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## khi_duaro_description

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert duaro_* to khi_duaro_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_duaro_gazebo

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert duaro_* to khi_duaro_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_duaro_ikfast_plugin

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert duaro_* to khi_duaro_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_duaro_moveit_config

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert duaro_* to khi_duaro_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_robot

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs080n_* to khi_rs080n_*
* Convert rs007l_* to khi_rs007l_*
* Convert rs007n_* to khi_rs007n_*
* Convert rs_* to khi_rs_*
* Convert duaro_* to khi_duaro_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_robot_bringup

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs_* to khi_rs_*
* Convert duaro_* to khi_duaro_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_robot_control

```
* robot_control: fix msg deps of main. (#9 <https://github.com/Kawasaki-Robotics/khi_robot/issues/9>)
  Seems to have been remove in #6 <https://github.com/Kawasaki-Robotics/khi_robot/issues/6>.
* update travis.yml (#6 <https://github.com/Kawasaki-Robotics/khi_robot/issues/6>)
  * update travis.yml
  * rs_desc: add missing install targets.
  * duaro_desc: add missing install targets.
  * rs_gazebo: add missing install targets.
  * duaro_gazebo: add missing install targets.
  * description: pkgs do not run depend on urdf.
  * duaro_desc: add roslaunch testing.
  Tries to load xacro as parameter.
  * rs_desc: add roslaunch testing.
  Tries to load xacros as parameters.
  * robot_control: use imported target for KRNX binary blob.
  Avoid setting link directories.
  * robot_control: warn user if CPU arch could not be detected.
  * robot_control: remove redundant dep declaration.
  'khi_robot_msgs' is already a build_depend and is another package, so build ordering will already take the dependencies into account.
  * robot_control: don't install headers.
  The main library is not exported (by catkin_package(..)), so the headers also don't need to be installed.
  This also resolves an installation issue: the install(..) statement expects a sub dir called 'khi_robot_control' in the 'include' directory, but that doesn't exist.
  * robot_control: sort components alphabetically.
  Make catkin_lint happ(ier).
  * robot_control: fix realtime_tools unconfigured build dep.
  * robot_control: sort source files for robot_client target.
  Make catkin_lint happ(ier).
  * moveit_cfgs: install scripts dir.
  * rs080n_moveit_config does not have script directory
  * set indigo as allow_failures
  * add test for khi_robot_control/main and libkrnx
  * robot_control: work-around for KRNX lib blob linking issues.
  Based on suggestion from @k-okada.
  Not sure whether this is an actual proper solution, or just a work-around.
  Systems with stricter ld library path security might not like this.
* Updates to build scripts and manifests (packaging) (#5 <https://github.com/Kawasaki-Robotics/khi_robot/issues/5>)
  * rs_desc: add missing install targets.
  * duaro_desc: add missing install targets.
  * rs_gazebo: add missing install targets.
  * duaro_gazebo: add missing install targets.
  * description: pkgs do not run depend on urdf.
  * duaro_desc: add roslaunch testing.
  Tries to load xacro as parameter.
  * rs_desc: add roslaunch testing.
  Tries to load xacros as parameters.
  * robot_control: use imported target for KRNX binary blob.
  Avoid setting link directories.
  * robot_control: warn user if CPU arch could not be detected.
  * robot_control: don't install headers.
  The main library is not exported (by catkin_package()), so the headers also don't need to be installed.
  This also resolves an installation issue: the install(..) statement expects a sub dir called 'khi_robot_control' in the 'include' directory, but that doesn't exist.
  * robot_control: sort components alphabetically.
  Make catkin_lint happ(ier).
  * robot_control: fix realtime_tools unconfigured build dep.
  * robot_control: sort source files for robot_client target.
  Make catkin_lint happ(ier).
  * moveit_cfgs: install scripts dir.
  Except RS080N.
  * robot_control: work-around for KRNX lib blob linking issues.
  Based on suggestion from @k-okada.
  Not sure whether this is an actual proper solution, or just a work-around.
  Systems with stricter ld library path security might not like this.
* Contributors: G.A. vd. Hoorn, Kei Okada
```

## khi_robot_msgs

- No changes

## khi_rs007l_moveit_config

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs007l_* to khi_rs007l_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_rs007n_moveit_config

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs007n_* to khi_rs007n_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_rs080n_moveit_config

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs080n_* to khi_rs080n_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_rs_description

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs_* to khi_rs_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_rs_gazebo

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs_* to khi_rs_*
* Contributors: Hiroki Matsui, nakamichi_d
```

## khi_rs_ikfast_plugin

```
* Merge pull request #10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10> from d-nakamichi/khi_prefix
  Prefix all pkgs with 'khi_'
* Convert rs_* to khi_rs_*
* Contributors: Hiroki Matsui, nakamichi_d
```
