### PR TITLE
googletest: 1.8.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -38,6 +38,20 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.8.0-1
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: ros2
+    status: maintained
   ros_workspace:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.8.0-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
