### PR TITLE
ament_cmake: 0.7.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -13,11 +13,28 @@ repositories:
       version: master
     release:
       packages:
+      - ament_cmake
+      - ament_cmake_auto
       - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_gmock
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_nose
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.7.0-1
+      version: 0.7.0-2
     source:
       type: git
       url: https://github.com/ament/ament_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `0.7.0-2`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `0.7.0-1`
