### PR TITLE
uncrustify_vendor: 1.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -63,5 +63,16 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  uncrustify_vendor:
+    doc:
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
+      version: 1.2.0-1
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `uncrustify_vendor` to `1.2.0-1`:

- upstream repository: https://github.com/ament/uncrustify_vendor.git
- release repository: https://github.com/ros2-gbp/uncrustify_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
