### PR TITLE
ament_lint: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -40,6 +40,49 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: master
     status: developed
+  ament_lint:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: master
+    release:
+      packages:
+      - ament_clang_format
+      - ament_cmake_clang_format
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pep8
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_pclint
+      - ament_pep257
+      - ament_pep8
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_lint-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: master
+    status: developed
   ament_package:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.7.0-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
