### PR TITLE
tinyxml_vendor: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -123,6 +123,17 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  tinyxml_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
+      version: master
+    status: maintained
   uncrustify_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml_vendor` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/tinyxml_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
