### PR TITLE
libyaml_vendor: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -112,6 +112,17 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  libyaml_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/libyaml_vendor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/libyaml_vendor.git
+      version: master
+    status: maintained
   poco_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
