### PR TITLE
ament_cmake_ros: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -40,6 +40,22 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: master
     status: developed
+  ament_cmake_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: master
+    status: developed
   ament_lint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
