### PR TITLE
console_bridge_vendor: 1.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -133,6 +133,17 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  console_bridge_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: master
+    status: maintained
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge_vendor` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/console_bridge_vendor.git
- release repository: https://github.com/ros2-gbp/console_bridge_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
