### PR TITLE
tinyxml2_vendor: 0.6.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -196,6 +196,17 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  tinyxml2_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
+      version: 0.6.1-1
+    source:
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: master
+    status: maintained
   tinyxml_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml2_vendor` to `0.6.1-1`:

- upstream repository: https://github.com/ros2/tinyxml2_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
