### PR TITLE
yaml_cpp_vendor: 6.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -244,5 +244,16 @@ repositories:
       url: https://github.com/ament/uncrustify_vendor.git
       version: master
     status: maintained
+  yaml_cpp_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+      version: 6.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/yaml_cpp_vendor.git
+      version: master
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`

## yaml_cpp_vendor

```
* Pass through compiler and c++ flags (#4 <https://github.com/ros2/yaml_cpp_vendor/issues/4>)
* Contributors: Emerson Knapp
```
