### PR TITLE
urdfdom_headers: 1.0.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -244,5 +244,20 @@ repositories:
       url: https://github.com/ament/uncrustify_vendor.git
       version: master
     status: maintained
+  urdfdom_headers:
+    doc:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_headers-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `1.0.3-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
