### PR TITLE
osrf_testing_tools_cpp: 1.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -184,6 +184,25 @@ repositories:
       url: https://github.com/osrf/osrf_pycommon.git
       version: master
     status: maintained
+  osrf_testing_tools_cpp:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    release:
+      packages:
+      - osrf_testing_tools_cpp
+      - test_osrf_testing_tools_cpp
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
+      version: 1.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    status: developed
   poco_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.2.0-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
