### PR TITLE
mrpt_navigation: 0.1.24-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3520,7 +3520,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.22-0
+      version: 0.1.24-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.24-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.22-0`

## mrpt_local_obstacles

```
* Fix build against MRPT 1.9.9
* Contributors: Julian Lopez Velasquez
```

## mrpt_localization

```
* Fix build against MRPT 1.9.9
* Contributors: Inounx, Jose Luis Blanco-Claraco, Julian Lopez Velasquez, Markus Bader
```

## mrpt_map

```
* fix build against mrpt-1.5
* Fix build against MRPT 1.9.9
* Contributors: Inounx, Jose Luis Blanco-Claraco, Julian Lopez Velasquez
```

## mrpt_navigation

- No changes

## mrpt_rawlog

```
* Fix build against mrpt-1.5
* Fix build against MRPT 1.9.9
* fix regression introduced in last refactor of mrpt_rawlog
* rawlog_record: Explain error if cannot write .rawlog
* Contributors: Jose Luis Blanco Claraco, Julian Lopez Velasquez
```

## mrpt_reactivenav2d

```
* Fix build against MRPT 1.9.9
* Contributors: Julian Lopez Velasquez
```

## mrpt_tutorials

- No changes
