### PR TITLE
visp: 3.2.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15278,7 +15278,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.1.0-2
+      version: 3.2.0-3
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.2.0-3`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `3.1.0-2`
