### PR TITLE
fastcdr: 1.0.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -144,6 +144,17 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: maintained
+  fastcdr:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/fastcdr-release.git
+      version: 1.0.8-1
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-CDR.git
+      version: ba94e149b4a5e61f0618065a3fcf5f48b57e775f
+    status: developed
   googletest:
     release:
       packages:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -151,6 +151,8 @@ repositories:
       url: https://github.com/ros2-gbp/fastcdr-release.git
       version: 1.0.8-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
       version: ba94e149b4a5e61f0618065a3fcf5f48b57e775f


### PR DESCRIPTION
Increasing version of package(s) in repository `fastcdr` to `1.0.8-1`:

- upstream repository: https://github.com/eProsima/Fast-CDR.git
- release repository: https://github.com/ros2-gbp/fastcdr-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
