### PR TITLE
fastrtps: 1.7.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -164,6 +164,8 @@ repositories:
       url: https://github.com/ros2-gbp/fastrtps-release.git
       version: 1.7.2-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-RTPS.git
       version: c776f0f0964e697f93b51590688569567a7056f3

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -157,6 +157,17 @@ repositories:
       url: https://github.com/eProsima/Fast-CDR.git
       version: ba94e149b4a5e61f0618065a3fcf5f48b57e775f
     status: developed
+  fastrtps:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/fastrtps-release.git
+      version: 1.7.2-1
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-RTPS.git
+      version: c776f0f0964e697f93b51590688569567a7056f3
+    status: developed
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `1.7.2-1`:

- upstream repository: https://github.com/eProsima/Fast-RTPS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0.dev2`
- previous version for package: `null`
