### PR TITLE
rosidl_dds: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -288,6 +288,24 @@ repositories:
       url: https://github.com/ros2/rosidl.git
       version: master
     status: developed
+  rosidl_dds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: master
+    release:
+      packages:
+      - rosidl_generator_dds_idl
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dds-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: master
+    status: developed
   tinyxml2_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dds` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rosidl_dds.git
- release repository: https://github.com/ros2-gbp/rosidl_dds-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
