### PR TITLE
class_loader: 1.3.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -133,6 +133,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/class_loader-release.git
+      version: 1.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
+    status: developed
   console_bridge_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `1.3.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## class_loader

```
* Updated test configuration to check copyright of files where possible. (#123 <https://github.com/ros/class_loader/issues/123>)
* Updated to use ament_target_dependencies where possible. (#121 <https://github.com/ros/class_loader/issues/121>)
* Contributors: ivanpauno, jpsamper2009
```
