### PR TITLE
astyx_client: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -557,6 +557,15 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: release
     status: developed
+  astyx_client:
+    release:
+      packages:
+      - astyx_client
+      - astyx_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/qiaoyuzhang/plusai_astyx.git
+      version: 0.1.0-1
   async_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astyx_client` to `0.1.0-1`:

- upstream repository: https://github.com/PlusAI/plusai_astyx.git
- release repository: https://github.com/qiaoyuzhang/plusai_astyx.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
