### PR TITLE
rosparam_shortcuts: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5977,7 +5977,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rosparam_shortcuts.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.3.1-1`:

- upstream repository: https://github.com/PickNikRobotics/rosparam_shortcuts.git
- release repository: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.3.0-1`

## rosparam_shortcuts

```
* removing deprecated functions because catkin can't tell the difference between affine3d and isometry3d (#9 <https://github.com/picknikrobotics/rosparam_shortcuts/issues/9>)
* Travis badge fixup (#8 <https://github.com/picknikrobotics/rosparam_shortcuts/issues/8>)
  * fixing travis and build tags
  * updating install instructions
  * adding melodic ci
* Contributors: Mike Lautman
```
