### PR TITLE
Add stomp_ros repository.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13050,6 +13050,16 @@ repositories:
       url: https://github.com/stdr-simulator-ros-pkg/stdr_simulator.git
       version: indigo-devel
     status: developed
+  stomp_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/stomp_ros.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/ros-industrial/stomp_ros.git
+      version: melodic-devel
+    status: maintained
   summit_x_common:
     doc:
       type: git


### PR DESCRIPTION
As per subject.

Note: `melodic-devel` is not a typo, the branch is bw-compatible.
