### PR TITLE
rcutils: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -276,6 +276,22 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
+  rcutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rcutils-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: master
+    status: developed
   ros_environment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rcutils

```
* Fix ASAN failure in test_string_map.cpp (#147 <https://github.com/ros2/rcutils/issues/147>)
* Add tests for stdatomic_helper.h and fix bugs (#150 <https://github.com/ros2/rcutils/issues/150>)
* Windows messages when atomic type is unsupported (#145 <https://github.com/ros2/rcutils/issues/145>)
* Use CMake property to determine when to use memory_tools. (#139 <https://github.com/ros2/rcutils/issues/139>)
* Add section about DCO to CONTRIBUTING.md
* Use ament_target_dependencies where possible. (#137 <https://github.com/ros2/rcutils/issues/137>)
* Fix doc typo in string_map.h. (#138 <https://github.com/ros2/rcutils/issues/138>)
* Add launch along with launch_testing as test dependencies. (#136 <https://github.com/ros2/rcutils/issues/136>)
* Drops legacy launch API usage. (#134 <https://github.com/ros2/rcutils/issues/134>)
* Contributors: Dirk Thomas, Jacob Perron, Michel Hidalgo, Shane Loretz, Steven! Ragnarök, Thomas Moulard, ivanpauno
```
