### PR TITLE
rmw: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -294,6 +294,25 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
+  rmw:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: master
+    release:
+      packages:
+      - rmw
+      - rmw_implementation_cmake
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: master
+    status: developed
   ros_environment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
