### PR TITLE
rosidl_typesupport_opensplice: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -452,6 +452,25 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: master
     status: developed
+  rosidl_typesupport_opensplice:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+      version: master
+    release:
+      packages:
+      - opensplice_cmake_module
+      - rosidl_typesupport_opensplice_c
+      - rosidl_typesupport_opensplice_cpp
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+      version: master
+    status: developed
   tinyxml2_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_opensplice` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_opensplice.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
