### PR TITLE
rmw_opensplice: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -348,6 +348,24 @@ repositories:
       url: https://github.com/ros2/rmw_connext.git
       version: master
     status: developed
+  rmw_opensplice:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_opensplice.git
+      version: master
+    release:
+      packages:
+      - rmw_opensplice_cpp
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_opensplice-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_opensplice.git
+      version: master
+    status: developed
   ros_environment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_opensplice` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rmw_opensplice.git
- release repository: https://github.com/ros2-gbp/rmw_opensplice-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
