### PR TITLE
multi_object_tracking_lidar: 1.0.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7950,6 +7950,22 @@ repositories:
       url: https://github.com/lukscasanova/mtig_driver.git
       version: master
     status: developed
+  multi_object_tracking_lidar:
+    doc:
+      type: git
+      url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
+      version: v1.0.0
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
+      version: v1.0.0
+    status: maintained
   multikey_teleop:
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7964,7 +7964,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
-      version: v1.0.0
+      version: master
     status: maintained
   multikey_teleop:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_object_tracking_lidar` to `1.0.0-0`:

- upstream repository: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
- release repository: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## multi_object_tracking_lidar

```
* Updated README with usage instructions
* Renamed node name to kf_tracker to match bin name
* Changed package name to multi_object_tracking_lidar
* Updated package info & version num
* Updated with a short demo on sample AV LIDAR scans
* Added README with a short summary of the code
* Working state of Multiple object stable tracking using Lidar scans with an extended Kalman Filter (rosrun kf_tracker tracker). A naive tracker is implemented in main_naive.cpp for comparison (rosrun kf_tracker naive_tracker).
* v2. Unsupervised clustering is incorporated into the same node (tracker).
* v1. Object ID/data association works. In this version PCL based unsupervised clustering is done separately.
* Contributors: Praveen Palanisamy
```
