### PR TITLE
rmw_implementation: 0.7.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -384,6 +384,22 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: master
     status: developed
+  rmw_implementation:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_implementation-release.git
+      version: 0.7.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: master
+    status: developed
   rmw_opensplice:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `0.7.0-2`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
