### PR TITLE
Re-add mrpt_graphslam_2d

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7052,6 +7052,7 @@ repositories:
       packages:
       - mrpt_ekf_slam_2d
       - mrpt_ekf_slam_3d
+      - mrpt_graphslam_2d
       - mrpt_icp_slam_2d
       - mrpt_rbpf_slam
       - mrpt_slam


### PR DESCRIPTION
Undo of https://github.com/ros/rosdistro/commit/8f164df5dafd459692593f2644c7edf8269253a8
Since we identified the problem to be a bug, already fixed in v1.7.0,
which was forgotten to be released for Kinetic.

Will be released just after this PR.