### PR TITLE
mrpt_slam: 0.1.9-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3552,7 +3552,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.9-0`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.8-0`

## mrpt_ekf_slam_2d

```
* Fix build against MRPT 1.9.9
* Switch header guards to pragma once
* Contributors: Jose Luis Blanco-Claraco, Julian Lopez Velasquez, Vladislav Tananaev
```

## mrpt_ekf_slam_3d

```
* Fix build against MRPT 1.9.9
* Switch header guards to pragma once
* Contributors: Jose Luis Blanco-Claraco, Julian Lopez Velasquez, Vladislav Tananaev
```

## mrpt_graphslam_2d

```
* Fix build against MRPT 1.9.9
* Switch header guards to pragma once
* Contributors: Jose Luis Blanco-Claraco, Julian Lopez Velasquez, Vladislav Tananaev
```

## mrpt_icp_slam_2d

```
* Fix build againt MRPT 1.9.9
* Switch header guards to pragma once
* Contributors: Jose Luis Blanco-Claraco, Julian Lopez Velasquez, Vladislav Tananaev
```

## mrpt_rbpf_slam

```
* fix build against mrpt-1.5 & 1.9.9
* Feature/refactor mrpt rbpf slam
* Add option to specify simplemap save path
* Add some non zero default noise values for thrun's motion model
* Small documentation fixes
* Rename example file
* Switch header guards to pragma once
* Add launch file for turtlebot3
* Switch default log level to INFO
* Contributors: Jose Luis Blanco-Claraco, Julian Lopez Velasquez, Vladislav Tananaev
```

## mrpt_slam

- No changes
