### PR TITLE
rosidl_defaults: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -483,6 +483,25 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: developed
+  rosidl_defaults:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: master
+    release:
+      packages:
+      - rosidl_default_generators
+      - rosidl_default_runtime
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_defaults-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: master
+    status: developed
   rosidl_typesupport:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
