### PR TITLE
rcl_logging: 0.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -294,25 +294,6 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
-  rcl_logging:
-    doc:
-      type: git
-      url: https://github.com/ros2/rcl_logging.git
-      version: master
-    release:
-      packages:
-      - rcl_logging_log4cxx
-      - rcl_logging_noop
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 0.2.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros2/rcl_logging.git
-      version: master
-    status: developed
   rcl_interfaces:
     doc:
       type: git
@@ -335,6 +316,25 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
+      version: master
+    status: developed
+  rcl_logging:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    release:
+      packages:
+      - rcl_logging_log4cxx
+      - rcl_logging_noop
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
       version: master
     status: developed
   rcpputils:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -294,6 +294,25 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
+  rcl_logging:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    release:
+      packages:
+      - rcl_logging_log4cxx
+      - rcl_logging_noop
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    status: developed
   rcpputils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rcl_logging_log4cxx

```
* First release of rcl_logging_log4cxx (#3 <https://github.com/ros2/rcl_logging/issues/3>)
  * Fixes for building and running on MAC with log4cxx from brew.
  * Fixing the case for finding log4cxx library.
  * Fixing the log4cxx string macro on Windows and the cmake find for windows as well.
  * Fixing the lib generation on windows.
  * Cleanup of formatting.
  * Use static library for windows instead of debug mode
  * Fix "unreferenced local variable" warning
  * Move C incompatible functions out of extern C block
  * Disable ddl-interface warnings
* Contributors: Nick Burek
```

## rcl_logging_noop

- No changes
