### PR TITLE
pluginlib: 2.3.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -282,6 +282,22 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: developed
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/pluginlib-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    status: maintained
   poco_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `2.3.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## pluginlib

```
* Updated build to choose the appropriate library for experimental filesystem, based on the compiler and standard library. (#146 <https://github.com/ros/pluginlib/issues/146>)
* Added stdc++fs as a target link library for clang compiler on linux. (#144 <https://github.com/ros/pluginlib/issues/144>)
* Added Michael as maintainer (for build e-mails). (#137 <https://github.com/ros/pluginlib/issues/137>)
* Contributors: Emerson Knapp, Michael Carroll, bhatsach
```
