### PR TITLE
urdfdom: 2.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -694,6 +694,22 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: master
     status: developed
+  urdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdfdom.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/urdfdom.git
+      version: ros2
+    status: maintained
   urdfdom_headers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
