### PR TITLE
tinydir_vendor: 1.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -657,6 +657,22 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: master
     status: developed
+  tinydir_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/tinydir_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/tinydir_vendor-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinydir_vendor.git
+      version: master
+    status: maintained
   tinyxml2_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `tinydir_vendor` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/tinydir_vendor.git
- release repository: https://github.com/ros2-gbp/tinydir_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
