### PR TITLE
rclcpp: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -374,6 +374,27 @@ repositories:
       url: https://github.com/ros2/rcl_logging.git
       version: master
     status: developed
+  rclcpp:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: master
+    release:
+      packages:
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rclcpp-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: master
+    status: developed
   rclpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rclcpp

```
* Added Options-struct interfaces for creating publishers/subscribers (pre-QoS, standalone). (#673 <https://github.com/ros2/rclcpp/issues/673>)
* Replaced strncpy with memcpy. (#684 <https://github.com/ros2/rclcpp/issues/684>)
* Replaced const char * with a std::array<char, TOPIC_NAME_LENGTH> as the key of IPM IDTopicMap. (#671 <https://github.com/ros2/rclcpp/issues/671>)
* Refactored SignalHandler logger to avoid race during destruction. (#682 <https://github.com/ros2/rclcpp/issues/682>)
* Introduce rclcpp_components to implement composition. (#665 <https://github.com/ros2/rclcpp/issues/665>)
* Added QoS policy check when configuring intraprocess, skip interprocess publish when possible. (#674 <https://github.com/ros2/rclcpp/issues/674>)
* Updated to use do { .. } while(0) around content of logging macros. (#681 <https://github.com/ros2/rclcpp/issues/681>)
* Added function to get publisher's actual QoS settings. (#667 <https://github.com/ros2/rclcpp/issues/667>)
* Updated to avoid race that triggers timer too often. (#621 <https://github.com/ros2/rclcpp/issues/621>)
* Exposed get_fully_qualified_name in NodeBase API. (#662 <https://github.com/ros2/rclcpp/issues/662>)
* Updated to use ament_target_dependencies where possible. (#659 <https://github.com/ros2/rclcpp/issues/659>)
* Fixed wait for service memory leak bug. (#656 <https://github.com/ros2/rclcpp/issues/656>)
* Fixed test_time_source test. (#639 <https://github.com/ros2/rclcpp/issues/639>)
* Fixed hard-coded duration type representation so int64_t isn't assumed. (#648 <https://github.com/ros2/rclcpp/issues/648>)
* Fixed cppcheck warning. (#646 <https://github.com/ros2/rclcpp/issues/646>)
* Added count matching api and intra-process subscriber count. (#628 <https://github.com/ros2/rclcpp/issues/628>)
* Added Sub Node alternative. (#581 <https://github.com/ros2/rclcpp/issues/581>)
* Replaced 'auto' with 'const auto &'. (#630 <https://github.com/ros2/rclcpp/issues/630>)
* Set Parameter Event Publisher settings. #591 <https://github.com/ros2/rclcpp/issues/591> (#614 <https://github.com/ros2/rclcpp/issues/614>)
* Replaced node constructor arguments with NodeOptions. (#622 <https://github.com/ros2/rclcpp/issues/622>)
* Updated to pass context to wait set (#617 <https://github.com/ros2/rclcpp/issues/617>)
* Added API to get parameters in a map. (#575 <https://github.com/ros2/rclcpp/issues/575>)
* Updated Bind usage since it is is no longer in std::__1. (#618 <https://github.com/ros2/rclcpp/issues/618>)
* Fixed errors from uncrustify v0.68. (#613 <https://github.com/ros2/rclcpp/issues/613>)
* Added new constructors for SyncParameterClient. (#612 <https://github.com/ros2/rclcpp/issues/612>)
* Contributors: Alberto Soragna, Chris Lalancette, Dirk Thomas, Emerson Knapp, Francisco Martín Rico, Jacob Perron, Marko Durkovic, Michael Carroll, Peter Baughman, Shane Loretz, Wei Liu, William Woodall, Yutaka Kondo, ivanpauno, kuzai, rarvolt
```

## rclcpp_action

```
* Fixed hard-coded duration type representation so int64_t isn't assumed. (#648 <https://github.com/ros2/rclcpp/issues/648>)
* Added documentation to rclcpp_action. (#650 <https://github.com/ros2/rclcpp/pull/650>)
* Updated to use separated action types. (#601 <https://github.com/ros2/rclcpp/issues/601>)
* Updated to wait for action server before sending goal. (#637 <https://github.com/ros2/rclcpp/issues/637>)
* Refactored server goal handle's try_canceling() function. (#603 <https://github.com/ros2/rclcpp/issues/603>)
* Contributors: Emerson Knapp, Jacob Perron, Michel Hidalgo, Shane Loretz
```

## rclcpp_components

```
* Introduce rclcpp_components to implement composition (#665 <https://github.com/ros2/rclcpp/issues/665>)
* Contributors: Michael Carroll
```

## rclcpp_lifecycle

```
* Fixed linter errors in rclcpp_lifecycle. (#672 <https://github.com/ros2/rclcpp/issues/672>)
* Added parameter-related templates to LifecycleNode. (#645 <https://github.com/ros2/rclcpp/issues/645>)
* Fixed use_sim_time issue on LifeCycleNode. (#651 <https://github.com/ros2/rclcpp/issues/651>)
* Updated to use ament_target_dependencies where possible. (#659 <https://github.com/ros2/rclcpp/issues/659>)
* Fixed hard-coded duration type representation so int64_t isn't assumed. (#648 <https://github.com/ros2/rclcpp/issues/648>)
* Added a method to the LifecycleNode class to get the logging interface. (#652 <https://github.com/ros2/rclcpp/issues/652>)
* Set Parameter Event Publisher settings #591 <https://github.com/ros2/rclcpp/issues/591> (#614 <https://github.com/ros2/rclcpp/issues/614>)
* Replaced node constructor arguments with NodeOptions. (#622 <https://github.com/ros2/rclcpp/issues/622>)
* Removed dependency on rclpy. (#626 <https://github.com/ros2/rclcpp/issues/626>)
* Contributors: Emerson Knapp, Karsten Knese, Michael Carroll, Michael Jeronimo, Vinnam Kim, William Woodall, ivanpauno, rarvolt
```
