### PR TITLE
examples: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -205,6 +205,38 @@ repositories:
       url: https://github.com/ros2/example_interfaces.git
       version: master
     status: developed
+  examples:
+    doc:
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: master
+    release:
+      packages:
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclpy_executors
+      - examples_rclpy_minimal_action_client
+      - examples_rclpy_minimal_action_server
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/examples-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: master
+    status: developed
   fastcdr:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `examples` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/examples.git
- release repository: https://github.com/ros2-gbp/examples-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## examples_rclcpp_minimal_action_client

```
* Updated to use separated action types. (#227 <https://github.com/ros2/examples/issues/227>)
* Contributors: Dirk Thomas
```

## examples_rclcpp_minimal_action_server

```
* Updated to use separated action types. (#227 <https://github.com/ros2/examples/issues/227>)
* Contributors: Dirk Thomas
```

## examples_rclcpp_minimal_client

- No changes

## examples_rclcpp_minimal_composition

```
* Updated minimal_composition example for rclcpp_components. (#232 <https://github.com/ros2/examples/issues/232>)
* Contributors: Michael Carroll
```

## examples_rclcpp_minimal_publisher

- No changes

## examples_rclcpp_minimal_service

- No changes

## examples_rclcpp_minimal_subscriber

- No changes

## examples_rclcpp_minimal_timer

- No changes

## examples_rclpy_executors

- No changes

## examples_rclpy_minimal_action_client

```
* Added rclpy action examples. (#222 <https://github.com/ros2/examples/issues/222>)
* Contributors: Jacob Perron
```

## examples_rclpy_minimal_action_server

```
* Added rclpy action examples (#222 <https://github.com/ros2/examples/issues/222>)
* Contributors: Jacob Perron
```

## examples_rclpy_minimal_publisher

- No changes

## examples_rclpy_minimal_service

- No changes

## examples_rclpy_minimal_subscriber

- No changes
