### PR TITLE
message_filters: 3.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -307,6 +307,22 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: maintained
+  message_filters:
+    doc:
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_message_filters-release.git
+      version: 3.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: master
+    status: developed
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## message_filters

```
* Added direct dependency on python_cmake_module. (#19 <https://github.com/ros2/message_filters/issues/19>)
* Updated to use Python debug interpreter on Windows. (#18 <https://github.com/ros2/message_filters/issues/18>)
* Contributors: Dirk Thomas, Steven! Ragnarök
```
