### PR TITLE
geometry2: 0.11.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -263,6 +263,29 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: c776f0f0964e697f93b51590688569567a7056f3
     status: developed
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: ros2
+    release:
+      packages:
+      - tf2
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_msgs
+      - tf2_ros
+      - tf2_sensor_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry2-release.git
+      version: 0.11.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: ros2
+    status: maintained
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## tf2

- No changes

## tf2_eigen

```
* Updated to use ament_target_dependencies where possible. (#98 <https://github.com/ros2/geometry2/issues/98>)
* Contributors: ivanpauno
```

## tf2_geometry_msgs

```
* Updated to use ament_target_dependencies where possible. (#98 <https://github.com/ros2/geometry2/issues/98>)
```

## tf2_msgs

- No changes

## tf2_ros

```
* Updated to use node inteface pointers in the MessageFilter class. (#96 <https://github.com/ros2/geometry2/pull/96>)
* Updated message_filter.h. (#91 <https://github.com/ros2/geometry2/issues/91>)
* Contributors: Michael Jeronimo, Sagnik Basu
```

## tf2_sensor_msgs

- No changes
