### PR TITLE
multi_object_tracking_lidar: 1.0.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3558,6 +3558,22 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
       version: master
     status: maintained
+  multi_object_tracking_lidar:
+    doc:
+      type: git
+      url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
+      version: 1.0.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
+      version: master
+    status: maintained
   multimaster_fkie:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_object_tracking_lidar` to `1.0.0-0`:

- upstream repository: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
- release repository: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `null`

## multi_object_tracking_lidar

```
* Updated README with usage instructions
* Renamed node name to kf_tracker to match bin name
* Changed package name to multi_object_tracking_lidar
* Updated package info & version num
* Updated with a short demo on sample AV LIDAR scans
* Added README with a short summary of the code
* Working state of Multiple object stable tracking using Lidar scans with an extended Kalman Filter (rosrun kf_tracker tracker). A naive tracker is implemented in main_naive.cpp for comparison (rosrun kf_tracker naive_tracker).
* v2. Unsupervised clustering is incorporated into the same node (tracker).
* v1. Object ID/data association works. In this version PCL based unsupervised clustering is done separately.
* Contributors: Praveen Palanisamy
```
