### PR TITLE
robot_state_publisher: 2.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -667,6 +667,22 @@ repositories:
       url: https://github.com/ros2/rmw_opensplice.git
       version: master
     status: developed
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros2/robot_state_publisher.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_state_publisher-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/robot_state_publisher.git
+      version: ros2
+    status: maintained
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## robot_state_publisher

```
* Set urdf content as parameter. (#15 <https://github.com/ros2/robot_state_publisher/issues/15>)
* Contributors: Karsten Knese
```
