### PR TITLE
launch_ros: 0.8.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -335,6 +335,25 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: master
     status: developed
+  launch_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: master
+    release:
+      packages:
+      - launch_ros
+      - ros2launch
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_ros-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: master
+    status: developed
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## launch_ros

```
* Make 'ros2 launch' work again. (#201 <https://github.com/ros2/launch_ros/issues/201>)
* Added LaunchLogger class (#145 <https://github.com/ros2/launch/issues/145>)
* Changed logger.warn (deprecated) to logger.warning. (#199 <https://github.com/ros2/launch/issues/199>)
* Added Plumb rclpy.init context to get_default_launch_description. (#193 <https://github.com/ros2/launch/issues/193>)
* Added normalize_parameters and evaluate_paramters. (#192 <https://github.com/ros2/launch/issues/192>)
* Added normalize_remap_rule and types. (#173 <https://github.com/ros2/launch/issues/173>)
* Contributors: Chris Lalancette, Dirk Thomas, Jacob Perron, Peter Baughman, Shane Loretz
```

## ros2launch

```
* Added --show-all-subprocesses-output command line option. (#10 <https://github.com/ros2/launch/issues/10>)
* Make 'ros2 launch' work again. (#201 <https://github.com/ros2/launch/issues/201>)
* Added plumb rclpy.init context to get_default_launch_description. (#193 <https://github.com/ros2/launch/issues/193>)
* Refactored arg print functions (#172 <https://github.com/ros2/launch/issues/172>)
* Contributors: Chris Lalancette, Michel Hidalgo, Peter Baughman
```
