### PR TITLE
demos: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -189,6 +189,37 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: maintained
+  demos:
+    doc:
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    release:
+      packages:
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - topic_monitor
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/demos-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## composition

```
* Updated for new rclcpp_components package. (#319 <https://github.com/ros2/demos/issues/319>)
* Added launch along with launch_testing as test dependencies. (#313 <https://github.com/ros2/demos/issues/313>)
* Dropped legacy launch API usage. (#311 <https://github.com/ros2/demos/issues/311>)
* Contributors: Michael Carroll, Michel Hidalgo
```

## demo_nodes_cpp

```
* Moved away from deprecated rclcpp APIs. (#321 <https://github.com/ros2/demos/issues/321>)
* Added launch along with launch_testing as test dependencies. (#313 <https://github.com/ros2/demos/issues/313>)
* Updated for NodeOptions Node constructor. (#308 <https://github.com/ros2/demos/issues/308>)
* Contributors: Emerson Knapp, Michael Carroll, Michel Hidalgo
```

## demo_nodes_cpp_native

```
* Added launch along with launch_testing as test dependencies. (#313 <https://github.com/ros2/demos/issues/313>)
* Contributors: Michel Hidalgo
```

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Added launch along with launch_testing as test dependencies. (#313 <https://github.com/ros2/demos/issues/313>)
* Contributors: Michel Hidalgo
```

## intra_process_demo

```
* Added launch along with launch_testing as test dependencies. (#313 <https://github.com/ros2/demos/issues/313>)
* Updated for NodeOptions Node constructor. (#308 <https://github.com/ros2/demos/issues/308>)
* Contributors: Michael Carroll, Michel Hidalgo
```

## lifecycle

```
* Updated for NodeOptions Node constructor. (#308 <https://github.com/ros2/demos/issues/308>)
* Contributors: Michael Carroll
```

## logging_demo

```
* Updated for new rclcpp_components package. (#319 <https://github.com/ros2/demos/issues/319>)
* Added launch along with launch_testing as test dependencies. (#313 <https://github.com/ros2/demos/issues/313>)
* Dropped legacy launch API usage. (#311 <https://github.com/ros2/demos/issues/311>)
* Contributors: Michael Carroll, Michel Hidalgo
```

## pendulum_control

```
* Removed unused lambda capture. (#315 <https://github.com/ros2/demos/issues/315>)
* Added launch along with launch_testing as test dependencies. (#313 <https://github.com/ros2/demos/issues/313>)
* Dropped legacy launch API usage. (#311 <https://github.com/ros2/demos/issues/311>)
* Contributors: Emerson Knapp, Michel Hidalgo
```

## pendulum_msgs

- No changes

## topic_monitor

- No changes
