### PR TITLE
rcl: 0.7.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -475,7 +475,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.7.0-1
+      version: 0.7.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.7.0-2`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`

## rcl

```
* Added more test cases for graph API + fix bug. (#404 <https://github.com/ros2/rcl/issues/404>)
* Fixed missing include. (#413 <https://github.com/ros2/rcl/issues/413>)
* Updated to use pedantic. (#412 <https://github.com/ros2/rcl/issues/412>)
* Added function to get publisher actual qos settings. (#406 <https://github.com/ros2/rcl/issues/406>)
* Refactored graph API docs. (#401 <https://github.com/ros2/rcl/issues/401>)
* Updated to use ament_target_dependencies where possible. (#400 <https://github.com/ros2/rcl/issues/400>)
* Fixed regression around fully qualified node name. (#402 <https://github.com/ros2/rcl/issues/402>)
* Added function rcl_names_and_types_init. (#403 <https://github.com/ros2/rcl/issues/403>)
* Fixed uninitialize sequence number of client. (#395 <https://github.com/ros2/rcl/issues/395>)
* Added launch along with launch_testing as test dependencies. (#393 <https://github.com/ros2/rcl/issues/393>)
* Set symbol visibility to hidden for rcl. (#391 <https://github.com/ros2/rcl/issues/391>)
* Updated to split test_token to avoid compiler note. (#392 <https://github.com/ros2/rcl/issues/392>)
* Dropped legacy launch API usage. (#387 <https://github.com/ros2/rcl/issues/387>)
* Improved security directory lookup. (#332 <https://github.com/ros2/rcl/issues/332>)
* Enforce non-null argv values on rcl_init(). (#388 <https://github.com/ros2/rcl/issues/388>)
* Removed incorrect argument documentation. (#361 <https://github.com/ros2/rcl/issues/361>)
* Changed error to warning for multiple loggers. (#384 <https://github.com/ros2/rcl/issues/384>)
* Added rcl_node_get_fully_qualified_name. (#255 <https://github.com/ros2/rcl/issues/255>)
* Updated rcl_remap_t to use the PIMPL pattern. (#377 <https://github.com/ros2/rcl/issues/377>)
* Fixed documentation typo. (#376 <https://github.com/ros2/rcl/issues/376>)
* Removed test circumvention now that a bug is fixed in rmw_opensplice. (#368 <https://github.com/ros2/rcl/issues/368>)
* Updated to pass context to wait set, and fini rmw context. (#373 <https://github.com/ros2/rcl/issues/373>)
* Updated to publish logs to Rosout. (#350 <https://github.com/ros2/rcl/issues/350>)
* Contributors: AAlon, Dirk Thomas, Jacob Perron, M. M, Michael Carroll, Michel Hidalgo, Mikael Arguedas, Nick Burek, RARvolt, Ross Desmond, Sachin Suresh Bhat, Shane Loretz, William Woodall, ivanpauno
```

## rcl_action

```
* Added Action graph API (#411 <https://github.com/ros2/rcl/issues/411>)
* Updated to use ament_target_dependencies where possible. (#400 <https://github.com/ros2/rcl/issues/400>)
* Fixed typo in Doxyfile. (#398 <https://github.com/ros2/rcl/issues/398>)
* Updated tests to use separated action types. (#340 <https://github.com/ros2/rcl/issues/340>)
* Fixed minor documentation issues. (#397 <https://github.com/ros2/rcl/issues/397>)
* Set symbol visibility to hidden for rcl. (#391 <https://github.com/ros2/rcl/issues/391>)
* Fixed rcl_action documentation. (#380 <https://github.com/ros2/rcl/issues/380>)
* Removed now unused test executable . (#382 <https://github.com/ros2/rcl/issues/382>)
* Removed unused action server option 'clock_type'. (#382 <https://github.com/ros2/rcl/issues/382>)
* Set error message when there is an invalid goal transition. (#382 <https://github.com/ros2/rcl/issues/382>)
* Updated to pass context to wait set, and fini rmw context (#373 <https://github.com/ros2/rcl/issues/373>)
* Contributors: Dirk Thomas, Jacob Perron, Sachin Suresh Bhat, William Woodall, ivanpauno
```

## rcl_lifecycle

```
* Updated to use ament_target_dependencies where possible. (#400 <https://github.com/ros2/rcl/issues/400>)
* Set symbol visibility to hidden for rcl. (#391 <https://github.com/ros2/rcl/issues/391>)
* Contributors: Sachin Suresh Bhat, ivanpauno
```

## rcl_yaml_param_parser

```
* Corrected bool reading from yaml files. (#415 <https://github.com/ros2/rcl/issues/415>)
* Added launch along with launch_testing as test dependencies. (#393 <https://github.com/ros2/rcl/issues/393>)
* Set symbol visibility to hidden for rcl. (#391 <https://github.com/ros2/rcl/issues/391>)
* Contributors: Michel Hidalgo, Sachin Suresh Bhat, ivanpauno
```
