### PR TITLE
ml_classifiers: 1.0.0-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -782,7 +782,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/astuff/ml_classifiers-release.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/astuff/ml_classifiers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `1.0.0-1`:

- upstream repository: https://github.com/astuff/ml_classifiers.git
- release repository: https://github.com/astuff/ml_classifiers-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-0`

## ml_classifiers

```
* Merge pull request #2 <https://github.com/astuff/ml_classifiers/issues/2> from astuff/ros-transition
  ROS2 Hybrid Package - now builds in ROS Kinetic/Melodic and ROS2 Crystal
* ROS2: Making classifier_server a class.
* Creating separate ros1/ros2 xml files.
* ROS1: Removing roslint in favor of ROS2 linting.
* ROS2: Disabling boost in pluginlib.
* ROS2: Updating copyrights to conform to ament_copyright.
* ROS2: Fixing cmake exports.
* Contributors: Joshua Whitley
```
