### PR TITLE
ml_classifiers: 1.0.1-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -782,7 +782,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/astuff/ml_classifiers-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/astuff/ml_classifiers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `1.0.1-1`:

- upstream repository: https://github.com/astuff/ml_classifiers.git
- release repository: https://github.com/astuff/ml_classifiers-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-1`

## ml_classifiers

```
* Merge pull request #3 <https://github.com/astuff/ml_classifiers/issues/3> from dirk-thomas/patch-1
* add build dep on ros_environment to ensure the env variable ROS_VERSION is defined
* Contributors: Dirk Thomas, Joshua Whitley
```
