### PR TITLE
Added fping to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -792,6 +792,13 @@ fluid:
   macports: [fltk]
   opensuse: [fltk-devel]
   ubuntu: [fluid]
+fping:
+  arch: [fping]
+  debian: [fping]
+  fedora: [fping]
+  gentoo: [net-analyzer/fping]
+  macports: [fping]
+  ubuntu: [fping]
 freeimage:
   arch: [freeimage]
   debian: [libfreeimage-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -797,7 +797,6 @@ fping:
   debian: [fping]
   fedora: [fping]
   gentoo: [net-analyzer/fping]
-  macports: [fping]
   ubuntu: [fping]
 freeimage:
   arch: [freeimage]


### PR DESCRIPTION
We use [fping](https://www.fping.org/) in one of our projects. Nice way to ping multiple hosts very fast.

Package sources (I only tested ubuntu) but i think they should be correct.
[arch](https://www.archlinux.de/packages?search=fping)
[debian](https://packages.debian.org/search?keywords=fping)
[fedora](https://rpms.remirepo.net/rpmphp/zoom.php?rpm=fping)
[gentoo](https://packages.gentoo.org/packages/net-analyzer/fping)
[macports](https://www.macports.org/ports.php?by=library&substr=fping)
[ubuntu](https://packages.ubuntu.com/xenial/net/fping)
