### PR TITLE
make python-tk more symmetric on fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4251,7 +4251,7 @@ python-tinydb-pip:
 python-tk:
   arch: [python2, tk]
   debian: [python-tk]
-  fedora: [blt, tcl, tix, tk]
+  fedora: [python-tkinter]
   ubuntu:
     '*': [python-tk]
     bionic_python3: [python3-tk]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4251,7 +4251,7 @@ python-tinydb-pip:
 python-tk:
   arch: [python2, tk]
   debian: [python-tk]
-  fedora: [python-tkinter]
+  fedora: [python2-tkinter]
   ubuntu:
     '*': [python-tk]
     bionic_python3: [python3-tk]


### PR DESCRIPTION
Following up #20944