### PR TITLE
toposens: 0.9.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7193,6 +7193,28 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
       version: melodic
     status: maintained
+  toposens:
+    doc:
+      type: git
+      url: 'https://gitlab.com/toposens/ros-projects/ts-ros.git '
+      version: master
+    release:
+      packages:
+      - toposens
+      - toposens_driver
+      - toposens_markers
+      - toposens_msgs
+      - toposens_pointcloud
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.com/toposens/ros-projects/toposens-release.git
+      version: 0.9.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: 'https://gitlab.com/toposens/ros-projects/ts-ros.git '
+      version: master
+    status: developed
   towr:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `0.9.2-1`:

- upstream repository: https://gitlab.com/toposens/ros-projects/ts-ros.git
- release repository: https://gitlab.com/toposens/ros-projects/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## toposens

```
* Fixed package versions
* Contributors: Adi Singh
```

## toposens_driver

```
* Fixed package versions
* Contributors: Adi Singh
```

## toposens_markers

```
* Fixed package versions
* Contributors: Adi Singh
```

## toposens_msgs

```
* Fixed package versions
* Contributors: Adi Singh
```

## toposens_pointcloud

```
* Fixed package versions
* Contributors: Adi Singh
```
