### PR TITLE
Lots of RHEL/CentOS deps needed for ROS 2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -97,6 +97,7 @@ asio:
   debian: [libasio-dev]
   fedora: [asio-devel]
   gentoo: [dev-cpp/asio]
+  rhel: [asio-devel]
   ubuntu: [libasio-dev]
 assimp:
   arch: [assimp]
@@ -596,6 +597,7 @@ dkms:
   fedora: [dkms]
   gentoo: [sys-kernel/dkms]
   opensuse: [dkms]
+  rhel: [dkms]
   ubuntu: [dkms]
 dnsmasq:
   debian: [dnsmasq]
@@ -990,6 +992,7 @@ git:
   gentoo: [dev-vcs/git]
   macports: [git-core]
   opensuse: [git-core]
+  rhel: [git]
   ubuntu: [git]
 gitg:
   debian: [gitg]
@@ -1952,6 +1955,7 @@ libglfw3-dev:
   debian: [libglfw3-dev]
   fedora: [glfw-devel]
   gentoo: [media-libs/glfw]
+  rhel: [glfw-devel]
   ubuntu:
     '*': [libglfw3-dev]
     trusty: null
@@ -2002,6 +2006,7 @@ libgpgme-dev:
     wheezy: [libgpgme11-dev]
   fedora: [gpgme-devel]
   gentoo: [app-crypt/gpgme]
+  rhel: [gpgme-devel]
   ubuntu:
     artful: [libgpgme-dev]
     bionic: [libgpgme-dev]
@@ -2415,6 +2420,7 @@ libogg:
   gentoo: [media-libs/libogg]
   macports: [libogg]
   opensuse: [libogg-devel]
+  rhel: [libogg-devel]
   slackware: [libogg]
   ubuntu: [libogg-dev]
 libogre-dev:
@@ -2584,6 +2590,7 @@ libpcl-all:
   gentoo: [sci-libs/pcl]
   macports: [libpcl]
   opensuse: [pcl]
+  rhel: [pcl, pcl-tools]
   slackware: [pcl]
   ubuntu:
     artful: [libpcl-apps1.8, libpcl-common1.8, libpcl-features1.8, libpcl-filters1.8, libpcl-io1.8, libpcl-kdtree1.8, libpcl-keypoints1.8, libpcl-ml1.8, libpcl-octree1.8, libpcl-outofcore1.8, libpcl-people1.8, libpcl-recognition1.8, libpcl-registration1.8, libpcl-sample-consensus1.8, libpcl-search1.8, libpcl-segmentation1.8, libpcl-stereo1.8, libpcl-surface1.8, libpcl-tracking1.8, libpcl-visualization1.8]
@@ -2607,6 +2614,7 @@ libpcl-all-dev:
   gentoo: [sci-libs/pcl]
   macports: [libpcl]
   opensuse: [pcl]
+  rhel: [pcl-devel]
   slackware: [pcl]
   ubuntu:
     artful: [libpcl-dev]
@@ -3128,6 +3136,7 @@ libsqlite3-dev:
   debian: [libsqlite3-dev]
   fedora: [libsq3-devel]
   gentoo: ['dev-db/sqlite:3']
+  rhel: [libsq3-devel]
   ubuntu: [libsqlite3-dev]
 libsrtp0-dev:
   debian: [libsrtp0-dev]
@@ -3157,6 +3166,7 @@ libssl-dev:
   debian: [libssl-dev]
   fedora: [openssl-devel]
   gentoo: [dev-libs/openssl]
+  rhel: [openssl-devel]
   ubuntu: [libssl-dev]
 libstdc++5:
   arch: [libstdc++5]
@@ -3216,6 +3226,7 @@ libtheora:
   gentoo: [media-libs/libtheora]
   macports: [libtheora]
   opensuse: [libtheora-devel]
+  rhel: [libtheora-devel]
   slackware:
     slackpkg:
       packages: [libtheora]
@@ -3410,6 +3421,7 @@ libusb-1.0-dev:
   gentoo: ['virtual/libusb:1']
   macports: [libusb]
   opensuse: [libusb-1_0-devel]
+  rhel: [libusbx-devel]
   ubuntu: [libusb-1.0-0-dev]
 libusb-dev:
   arch: [libusb-compat]
@@ -3734,6 +3746,7 @@ linux-headers-generic:
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers, kernel-devel]
   gentoo: [sys-kernel/linux-headers]
+  rhel: [kernel-headers, kernel-devel]
   ubuntu: [linux-headers-generic]
 linux-kernel-headers:
   arch: [linux-api-headers]
@@ -5071,6 +5084,7 @@ udev:
   debian: [udev]
   fedora: [systemd-udev]
   gentoo: [sys-fs/udev]
+  rhel: [systemd]
   ubuntu: [udev]
 udhcpc:
   arch: [udhcp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4858,6 +4858,7 @@ python3-mock:
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]
+  rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
 python3-nose-yanc:
   debian: [python3-nose-yanc]


### PR DESCRIPTION
All of these are available in either `base`, `updates` or `epel`:
```
$ yum list available --show-duplicates --quiet asio-devel dkms git glfw-devel gpgme-devel kernel-devel kernel-headers libogg-devel libsq3-devel libtheora-devel libusbx-devel openssl-devel pcl pcl-devel pcl-tools python36-nose systemd
Available Packages
asio-devel.x86_64                     1.10.8-1.el7                       epel
dkms.noarch                           2.6.1-1.el7                        epel
git.x86_64                            1.8.3.1-20.el7                     updates
glfw-devel.x86_64                     1:3.2.1-2.el7                      epel
gpgme-devel.x86_64                    1.3.2-5.el7                        base
kernel-devel.x86_64                   3.10.0-957.10.1.el7                updates
kernel-headers.x86_64                 3.10.0-957.10.1.el7                updates
libogg-devel.x86_64                   2:1.3.0-7.el7                      base
libsq3-devel.x86_64                   20071018-20.el7                    epel
libtheora-devel.x86_64                1:1.1.1-8.el7                      base
libusbx-devel.x86_64                  1.0.21-1.el7                       base
openssl-devel.x86_64                  1:1.0.2k-16.el7_6.1                updates
pcl.x86_64                            1.7.2-1.el7                        epel
pcl-devel.x86_64                      1.7.2-1.el7                        epel
pcl-tools.x86_64                      1.7.2-1.el7                        epel
python36-nose.noarch                  1.3.7-4.el7                        epel
systemd.x86_64                        219-62.el7_6.5                     updates
```