### PR TITLE
keystroke: 0.1.1-5 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -694,6 +694,13 @@ repositories:
       url: https://github.com/ros2/kdl_parser.git
       version: crystal
     status: developed
+  keystroke:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/RoverRobotics/ros2-keystroke-release.git
+      version: 0.1.1-5
+    status: developed
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keystroke` to `0.1.1-5`:

- upstream repository: https://github.com/RoverRobotics/ros2-keystroke.git
- release repository: https://github.com/RoverRobotics/ros2-keystroke-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## keystroke

```
* Pull setup info from package.xml
* Add a ROS2 launch file
* Add node that listens for keystrokes
* Initial commit
```
