### PR TITLE
odva_ethernetip: 0.1.4-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4003,7 +4003,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/ros-drivers/odva_ethernetip.git


### PR DESCRIPTION
Increasing version of package(s) in repository `odva_ethernetip` to `0.1.4-0`:

- upstream repository: https://github.com/ros-drivers/odva_ethernetip.git
- release repository: https://github.com/ros-drivers-gbp/odva_ethernetip-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.3-0`

## odva_ethernetip

```
* Update .travis.yml to use industrial CI to test against Xenial
* Logging using console_bridge (#15 <https://github.com/ros-drivers/odva_ethernetip/issues/15>)
  - cout replaced by logInform
  - cerr with 'Warning: ' string replaced by logWarn
  - cerr without 'Warning: ' string replaced by logErr
* Contributors: Rein Appeldoorn
```
