### PR TITLE
Revert "linux_networking: 1.0.15-0 in 'melodic/distribution.yaml' [bl…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2924,12 +2924,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/linux_networking-release.git
-      version: 1.0.15-0
+      version: 1.0.13-2
     source:
       type: git
       url: https://github.com/pr2/linux_networking.git
       version: melodic-devel
-    status: maintained
   lusb:
     doc:
       type: hg


### PR DESCRIPTION
…oom] (#20762)"

This reverts commit 0343264ba7b1a0f4b5ddeb0cdf35f110ed87b1e7.

@davefeilseifer FYI, so I can unstick melodic