### PR TITLE
omron_os32c_driver: 0.1.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8129,11 +8129,19 @@ repositories:
       version: 1.2.3-1
     status: maintained
   omron_os32c_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/omron.git
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/omron-release.git
-      version: 0.1.2-0
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/omron.git
+      version: kinetic-devel
     status: maintained
   omronsentech_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `omron_os32c_driver` to `0.1.3-0`:

- upstream repository: https://github.com/ros-drivers/omron.git
- release repository: https://github.com/ros-drivers-gbp/omron-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.2-0`

## omron_os32c_driver

```
* Merge pull request #23 <https://github.com/ros-drivers/omron/issues/23> from ros-drivers/ci/kinetic_melodic
  Industrial CI Kinetic + Melodic
* fix: test narrow conversion from char to uint8_t
* Merge pull request #21 <https://github.com/ros-drivers/omron/issues/21> from ros-drivers/rosconsole_bridge
  Enabled rosconsole_bridge for odva_ethernetip
* Contributors: Rein Appeldoorn
```
