### PR TITLE
omron_os32c_driver: 0.1.3-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4023,6 +4023,21 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.4.2-0
+  omron_os32c_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/omron.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/omron-release.git
+      version: 0.1.3-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/omron.git
+      version: kinetic-devel
+    status: maintained
   open_karto:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `omron_os32c_driver` to `0.1.3-0`:

- upstream repository: https://github.com/ros-drivers/omron.git
- release repository: https://github.com/ros-drivers-gbp/omron-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## omron_os32c_driver

```
* Merge pull request #23 <https://github.com/ros-drivers/omron/issues/23> from ros-drivers/ci/kinetic_melodic
  Industrial CI Kinetic + Melodic
* fix: test narrow conversion from char to uint8_t
* Merge pull request #21 <https://github.com/ros-drivers/omron/issues/21> from ros-drivers/rosconsole_bridge
  Enabled rosconsole_bridge for odva_ethernetip
* Contributors: Rein Appeldoorn
```
