### PR TITLE
swri_profiler: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -15936,7 +15936,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
-      version: 0.0.3-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.2.0-0`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.3-0`

## swri_profiler

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Install Python scripts & HTML files
* Contributors: P. J. Reed
```

## swri_profiler_msgs

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Contributors: P. J. Reed
```

## swri_profiler_tools

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Fix deps, cmakelist and localPos() to get working on indigo
* Contributors: Matthew Bries, P. J. Reed
```
