### PR TITLE
swri_profiler: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13751,7 +13751,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
-      version: 0.1.0-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13742,7 +13742,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git
-      version: kinetic-devel
+      version: master
     release:
       packages:
       - swri_profiler
@@ -13755,7 +13755,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git
-      version: kinetic-devel
+      version: master
     status: developed
   sync_params:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.2.0-0`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.0-0`

## swri_profiler

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Install Python scripts & HTML files
* Contributors: P. J. Reed
```

## swri_profiler_msgs

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Contributors: P. J. Reed
```

## swri_profiler_tools

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Fix deps, cmakelist and localPos() to get working on indigo
* Contributors: Matthew Bries, P. J. Reed
```
