### PR TITLE
ariles_ros: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -170,6 +170,13 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros.git
       version: indigo-devel
     status: maintained
+  ariles_ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/asherikov/ariles-release.git
+      version: 1.1.1-1
+    status: developed
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ariles_ros` to `1.1.1-1`:

- upstream repository: https://github.com/asherikov/ariles.git
- release repository: https://github.com/asherikov/ariles-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ariles_ros

```
* Sync to 1.1.1, added README.md
* Initial ROS release.
```
