### PR TITLE
teleop_twist_keyboard: 2.3.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1014,6 +1014,22 @@ repositories:
       url: https://github.com/ros2/teleop_twist_joy.git
       version: dashing
     status: maintained
+  teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    status: maintained
   tinydir_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `2.3.0-1`:

- upstream repository: https://github.com/ros2/teleop_twist_keyboard.git
- release repository: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## teleop_twist_keyboard

```
* changing QoS to default (#18 <https://github.com/ros2/teleop_twist_keyboard/issues/18>)
* Contributors: thorstink
```
