### PR TITLE
angles: 1.12.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -133,6 +133,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/angles-release.git
+      version: 1.12.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.12.1-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## angles

```
* Adding export lines to CMakeLists.txt (#14 <https://github.com/ros/angles/issues/14>)
  * Adding export lines to CMakeLists.txt
  This is needed for dependent packages to pick up the include
  directory
* Contributors: Carl Delsey
```
