### PR TITLE
laser_geometry: 2.0.0-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -363,6 +363,17 @@ repositories:
       url: https://github.com/ros2/kdl_parser.git
       version: ros2
     status: maintained
+  laser_geometry:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_geometry-release.git
+      version: 2.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: ros2
+    status: maintained
   launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.0.0-0`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## laser_geometry

```
* Removed the ``angle`` dependency as no longer necessary.
* Updated to build statically but use position independent code.
* Updated to compile, and to remove PointCloud support, and remove boost.
* Added visibility headers modified from ``rclcpp``.
* Updated ``laser_geometry`` to build for ros2 (and on Windows 10).
* Improved use of numpy. (#14 <https://github.com/ros-perception/laser_geometry/issues/14>)
* Contributors: Alessandro Bottero, Andreas Greimel, Brian Fjeldstad, Eric Wieser, Jon Binney, Jonathan Binney, Martin Idel, Mikael Arguedas, Vincent Rabaud, William Woodall
```
