### PR TITLE
navigation_msgs: 2.0.1-0 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -860,7 +860,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `2.0.1-0`:

- upstream repository: https://github.com/ros-planning/navigation_msgs
- release repository: https://github.com/ros2-gbp/navigation_msgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.0-0`

## map_msgs

```
* Changed cmake code to use ``add_compile_options`` instead of setting only cxx flags.
* Contributors: Mikael Arguedas
```
