### PR TITLE
navigation_msgs: 2.0.1-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -428,6 +428,23 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: master
     status: developed
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros2
+    release:
+      packages:
+      - map_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/navigation_msgs-release.git
+      version: 2.0.1-0
+    source:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros2
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `2.0.1-0`:

- upstream repository: https://github.com/ros-planning/navigation_msgs
- release repository: https://github.com/ros2-gbp/navigation_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## map_msgs

```
* Changed cmake code to use ``add_compile_options`` instead of setting only cxx flags.
* Contributors: Mikael Arguedas
```
