### PR TITLE
keystroke: 0.2.1-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -699,7 +699,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/RoverRobotics/ros2-keystroke-release.git
-      version: 0.2.0-2
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/RoverRobotics/ros2-keystroke.git


### PR DESCRIPTION
Increasing version of package(s) in repository `keystroke` to `0.2.1-1`:

- upstream repository: https://github.com/RoverRobotics/ros2-keystroke.git
- release repository: https://github.com/RoverRobotics/ros2-keystroke-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-2`

## keystroke

```
* Explicitly document python version
  Add setuptools minimum version 40.5 (need for [options.data_files])
```
