### PR TITLE
doosan_robot: 0.9.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2333,6 +2333,25 @@ repositories:
       type: git
       url: https://github.com/doosan-robotics/doosan-robot.git
       version: master
+    release:
+      packages:
+      - doosan_robot
+      - doosan_robotics
+      - dsr_control
+      - dsr_description
+      - dsr_example_cpp
+      - dsr_example_py
+      - dsr_gazebo
+      - dsr_launcher
+      - dsr_msgs
+      - moveit_config_m0609
+      - moveit_config_m0617
+      - moveit_config_m1013
+      - moveit_config_m1509
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/doosan-robotics/doosan-robot-release.git
+      version: 0.9.6-1
     source:
       type: git
       url: https://github.com/doosan-robotics/doosan-robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `doosan_robot` to `0.9.6-1`:

- upstream repository: https://github.com/doosan-robotics/doosan-robot.git
- release repository: https://github.com/doosan-robotics/doosan-robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
