### PR TITLE
opencv_apps: 2.0.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3190,7 +3190,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-perception/opencv_apps-release.git
-      version: 2.0.0-0
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-perception/opencv_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opencv_apps` to `2.0.1-1`:

- upstream repository: https://github.com/ros-perception/opencv_apps.git
- release repository: https://github.com/ros-perception/opencv_apps-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-0`

## opencv_apps

```
* support catkin_lint and clang-format tests in travis.yml (#93 <https://github.com/ros-perception/opencv_apps/issues/93>)
  
    * override is not supported gcc4.6 (12.04), remove this fix and add NOLINT
    * clang-tidy code need c++11
    * fix code by run-clang-tidy -fix
    * fix format by clang-format
    * fix CMakeLists.txt and package.xml for catkin_lint
    * support catkin_lint and clang-format tests
  
* add queue_size parameter to all nodes, see #83 <https://github.com/ros-perception/opencv_apps/issues/83> (#92 <https://github.com/ros-perception/opencv_apps/issues/92>)
  
    * add queue_size arg to launch files
    * sometimes simple_example_test fails with 'average rate (36.121Hz) exceeded maximum (35.000Hz)'
  
* add queue_size parameter to all nodes, see #83 <https://github.com/ros-perception/opencv_apps/issues/83>
* add melodic badge
* Contributors: Furushchev, Hironori Fujimoto, Kei Okada, higashide, iory, moju zhao
* add melodic badge
* Add lk flow params trackbar (#78 <https://github.com/ros-perception/opencv_apps/issues/78>)
* Remove duplication of add_library for simple_flow (#88)
  
  ${_opencv_apps_nodelet_cppfiles} adds simple_flow to library but also
  ${${PROJECT_NAME}_EXTRA_FILES} does same thing
* Do not pefrom face recognition process without the trained data (#91 <https://github.com/ros-perception/opencv_apps/issues/91>)
  
    * Add warning logger to prompt face data tranining
    * Add a check to decide whether to perform the face recognition in callback function, according to the content of th
  
* fback_flow: add option to set 'queue_size' (#83 <https://github.com/ros-perception/opencv_apps/issues/83>)
* travis.yml: add melodic and remove jade (#84 <https://github.com/ros-perception/opencv_apps/issues/84>)
* [face_detection.launch] Fixed path of haarcascade xml for OpenCV-3.3.1 (#79 <https://github.com/ros-perception/opencv_apps/issues/79>)
* Contributors: Yuki Furuta, Hironori Fujimoto, Kei Okada, Taichi Higashide, Iory Yanokura, Moju Zhao
```
