### PR TITLE
rexrov2: 0.1.3-0 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -4043,6 +4043,26 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
     status: maintained
+  rexrov2:
+    doc:
+      type: git
+      url: https://github.com/uuvsimulator/rexrov2.git
+      version: 0.1.3
+    release:
+      packages:
+      - rexrov2_control
+      - rexrov2_description
+      - rexrov2_gazebo
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/uuvsimulator/rexrov2-release.git
+      version: 0.1.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uuvsimulator/rexrov2.git
+      version: master
+    status: developed
   rfsm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rexrov2` to `0.1.3-0`:

- upstream repository: https://github.com/uuvsimulator/rexrov2.git
- release repository: https://github.com/uuvsimulator/rexrov2-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## rexrov2_control

- No changes

## rexrov2_description

```
* Fix path to rexrov2_description
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## rexrov2_gazebo

- No changes
