### PR TITLE
eca_a9: 0.1.6-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2559,6 +2559,26 @@ repositories:
       url: https://github.com/utexas-bwi/eband_local_planner.git
       version: master
     status: maintained
+  eca_a9:
+    doc:
+      type: git
+      url: https://github.com/uuvsimulator/eca_a9.git
+      version: 0.1.6
+    release:
+      packages:
+      - eca_a9_control
+      - eca_a9_description
+      - eca_a9_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uuvsimulator/eca_a9-release.git
+      version: 0.1.6-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uuvsimulator/eca_a9.git
+      version: master
+    status: developed
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eca_a9` to `0.1.6-0`:

- upstream repository: https://github.com/uuvsimulator/eca_a9.git
- release repository: https://github.com/uuvsimulator/eca_a9-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## eca_a9_control

- No changes

## eca_a9_description

```
* Fix class call for rosunit
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Fix name of the package
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Fix URDF test with correct package
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Add documentation to input arguments
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## eca_a9_gazebo

- No changes
