### PR TITLE
desistek_saga: 0.3.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2253,6 +2253,26 @@ repositories:
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
       version: indigo-devel
     status: maintained
+  desistek_saga:
+    doc:
+      type: git
+      url: https://github.com/uuvsimulator/desistek_saga.git
+      version: master
+    release:
+      packages:
+      - desistek_saga_control
+      - desistek_saga_description
+      - desistek_saga_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uuvsimulator/desistek_saga-release.git
+      version: 0.3.2-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uuvsimulator/desistek_saga.git
+      version: master
+    status: developed
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `desistek_saga` to `0.3.2-0`:

- upstream repository: https://github.com/uuvsimulator/desistek_saga.git
- release repository: https://github.com/uuvsimulator/desistek_saga-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## desistek_saga_control

```
* Set package format to 2
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## desistek_saga_description

```
* Set package format to 2
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Fix description dependencies
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Fix package name for URDF tests
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```

## desistek_saga_gazebo

```
* Set package format to 2
  Signed-off-by: Musa Morena Marcusso Manhães <mailto:musa.marcusso@de.bosch.com>
* Contributors: Musa Morena Marcusso Manhães
```
