### PR TITLE
Added UC Berkeley AUTOLAB dependencies to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,6 +29,14 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+autolab-core-pip:
+  ubuntu:
+    pip: 
+      packages: [autolab-core]
+autolab-perception-pip:
+  ubuntu:
+    pip: 
+      packages: [autolab_perception]
 awsiotpythonsdk-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -31,11 +31,11 @@ adafruit-pca9685-pip:
       packages: [adafruit-pca9685]
 autolab-core-pip:
   ubuntu:
-    pip: 
+    pip:
       packages: [autolab-core]
 autolab-perception-pip:
   ubuntu:
-    pip: 
+    pip:
       packages: [autolab_perception]
 awsiotpythonsdk-pip:
   debian:


### PR DESCRIPTION
We have a few core libraries that we use here at the [UC Berkeley AUTOLAB](http://autolab.berkeley.edu/) for common robotics motion and vision applications. We also have a lot of research collaborators using them, so it would be great it we could include them here!

[autolab-core](https://pypi.org/project/autolab-core/)
[autolab_perception](https://pypi.org/project/autolab_perception/)

Thanks!

