### PR TITLE
Added UC Berkeley AUTOLAB visualization dependency to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -37,6 +37,10 @@ autolab-perception-pip:
   ubuntu:
     pip:
       packages: [autolab_perception]
+autolab-visualization-pip:
+  ubuntu:
+    pip:
+      packages: [visualization]
 awsiotpythonsdk-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,6 +29,14 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+autolab-core-pip:
+  ubuntu:
+    pip: 
+      packages: [autolab-core]
+autolab-perception-pip:
+  ubuntu:
+    pip: 
+      packages: [autolab_perception]
 awsiotpythonsdk-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -31,11 +31,11 @@ adafruit-pca9685-pip:
       packages: [adafruit-pca9685]
 autolab-core-pip:
   ubuntu:
-    pip: 
+    pip:
       packages: [autolab-core]
 autolab-perception-pip:
   ubuntu:
-    pip: 
+    pip:
       packages: [autolab_perception]
 awsiotpythonsdk-pip:
   debian:


### PR DESCRIPTION
Sorry, in the last PR I missed a dependency and it would be great if it could also be included!

[visualization](https://pypi.org/project/visualization/)

Thanks!