### PR TITLE
Revert "swri_profiler: 0.2.0-0 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13775,7 +13775,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git
-      version: kinetic-devel
+      version: master
     release:
       packages:
       - swri_profiler
@@ -13788,7 +13788,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git
-      version: kinetic-devel
+      version: master
     status: developed
   sync_params:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13775,7 +13775,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git
-      version: master
+      version: kinetic-devel
     release:
       packages:
       - swri_profiler
@@ -13784,11 +13784,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
-      version: 0.2.0-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git
-      version: master
+      version: kinetic-devel
     status: developed
   sync_params:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#20963

@pjreed swri_profiler_tools appears to be failing to build on all platforms.

It looks to be an issue with the availability of Qt. Maybe there's a dependency missing.
http://build.ros.org/job/Kbin_uX64__swri_profiler_tools__ubuntu_xenial_amd64__binary/12/console
```
23:35:56 -- Detecting CXX compile features - done
23:35:56 qmake: could not find a Qt installation of ''
23:35:56 CMake Error at /usr/share/cmake-3.5/Modules/FindQt4.cmake:1326 (message):
23:35:56   Found unsuitable Qt version "" from NOTFOUND, this code requires Qt 4.x
23:35:56 Call Stack (most recent call first):
23:35:56   CMakeLists.txt:18 (find_package)
23:35:56 
23:35:56 
23:35:56 -- Configuring incomplete, errors occurred!
23:35:56 See also "/tmp/binarydeb/ros-kinetic-swri-profiler-tools-0.2.0/obj-x86_64-linux-gnu/CMakeFiles/CMakeOutput.log".
23:35:56 	cd /tmp/binarydeb/ros-kinetic-swri-profiler-tools-0.2.0
23:35:56 	cd obj-x86_64-linux-gnu
23:35:56 	"tail -v -n +0 CMakeCache.txt"
```