### PR TITLE
pr2_simulator: 2.0.13-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3806,6 +3806,26 @@ repositories:
       url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
       version: 1.1.7-0
     status: unmaintained
+  pr2_simulator:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pr2_controller_configuration_gazebo
+      - pr2_gazebo
+      - pr2_gazebo_plugins
+      - pr2_simulator
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_simulator-release.git
+      version: 2.0.13-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_simulator.git
+      version: kinetic-devel
+    status: unmaintained
   pyros_config:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.13-1`:

- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## pr2_controller_configuration_gazebo

- No changes

## pr2_gazebo

```
* enable test code in pr2_simulator (#145 <https://github.com/PR2/pr2_simulator/issues/145>)
* pr2_no_controllers.launch: remove deprecated --ros_namespace /gazebo. This is not used long time, but using argparse cache this error. https://github.com/ros-simulation/gazebo_ros_pkgs/commit/46ac000ea34d006d9f37a2392c2146bbd9e6d1be
* package.xml: add more run_depend and test_depend, also export gazebo_model_path
* Contributors: Kei Okada
```

## pr2_gazebo_plugins

- No changes

## pr2_simulator

- No changes
