### PR TITLE
prbt_grippers: 0.0.3-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9579,7 +9579,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/prbt_grippers-release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/PilzDE/prbt_grippers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `prbt_grippers` to `0.0.3-0`:

- upstream repository: https://github.com/PilzDE/prbt_grippers.git
- release repository: https://github.com/PilzDE/prbt_grippers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.2-0`

## prbt_grippers

- No changes

## prbt_pg70_support

```
* Move the include of gripper brackets to prbt_support
* Omit definition of gripper brackets in pg70.urdf.xacro
* Contributors: Pilz GmbH and Co. KG
```
