### PR TITLE
prbt_grippers: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4837,7 +4837,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/prbt_grippers-release.git
-      version: 0.0.2-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/PilzDE/prbt_grippers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `prbt_grippers` to `0.0.3-1`:

- upstream repository: https://github.com/PilzDE/prbt_grippers.git
- release repository: https://github.com/PilzDE/prbt_grippers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.2-0`

## prbt_grippers

- No changes

## prbt_pg70_support

```
* Move the include of gripper brackets to prbt_support
* Omit definition of gripper brackets in pg70.urdf.xacro
* Contributors: Pilz GmbH and Co. KG
```
