### PR TITLE
pr2_self_test: 1.0.15-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10525,15 +10525,22 @@ repositories:
       version: hydro-devel
     status: maintained
   pr2_self_test:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_self_test.git
+      version: hydro-devel
     release:
       packages:
       - joint_qualification_controllers
+      - pr2_bringup_tests
       - pr2_counterbalance_check
+      - pr2_motor_diagnostic_tool
+      - pr2_self_test
       - pr2_self_test_msgs
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/TheDash/pr2_self_test-release.git
-      version: 1.0.12-0
+      url: https://github.com/pr2-gbp/pr2_self_test-release.git
+      version: 1.0.15-1
     source:
       type: git
       url: https://github.com/PR2/pr2_self_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_self_test` to `1.0.15-1`:

- upstream repository: https://github.com/PR2/pr2_self_test.git
- release repository: https://github.com/pr2-gbp/pr2_self_test-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.12-0`

## joint_qualification_controllers

```
* Merge pull request #8 <https://github.com/PR2/pr2_self_test/issues/8> from knorth55/indigo-fix
  Fixed bugs to run PR2 couter balance adjustment on Indigo
* add message_generation and message_runtime
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2_bringup_tests

- No changes

## pr2_counterbalance_check

```
* Merge pull request #8 <https://github.com/PR2/pr2_self_test/issues/8> from knorth55/indigo-fix
  Fixed bugs to run PR2 couter balance adjustment on Indigo
* Merge pull request #1 <https://github.com/PR2/pr2_self_test/issues/1> from k-okada/indigo-fix
  remove duplicated -catkin_python_setup
* to import functions, need to import pr2_counterbalance_check.counterbalance_analysis
* remove ROSPACK_MAKEDIST and wrong catkin_python_setup placement
* add install to CMakeLists.txt in pr2_counterbalance_check
* add python setup in pr2_counterbalance_check
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2_motor_diagnostic_tool

- No changes

## pr2_self_test

- No changes

## pr2_self_test_msgs

```
* Merge pull request #8 <https://github.com/PR2/pr2_self_test/issues/8> from knorth55/indigo-fix
  Fixed bugs to run PR2 couter balance adjustment on Indigo
* add srvs in pr2_self_test_msgs
* Contributors: Kei Okada, Shingo Kitagawa
```
