### PR TITLE
pr2_common: 1.12.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4775,7 +4775,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_common-release.git
-      version: 1.12.3-0
+      version: 1.12.4-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: melodic-devel
     status: unmaintained
   pr2_common_actions:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.12.4-1`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.12.3-0`

## pr2_common

- No changes

## pr2_dashboard_aggregator

- No changes

## pr2_description

```
* Merge pull request #274 <https://github.com/PR2/pr2_common/issues/274> from knorth55/fix-gripper
  Revert #255 <https://github.com/PR2/pr2_common/issues/255>
* Revert "[pr2_description] fix: gripper reduction 3141.6 -> 314.16"
  This reverts commit d5c8f476c6882b74a03bdc39eccf36823da3ad97.
* Contributors: Kei Okada, Shingo Kitagawa
```

## pr2_machine

- No changes

## pr2_msgs

- No changes
