### PR TITLE
joystick_drivers: 2.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -347,6 +347,24 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros2/joystick_drivers.git
+      version: dashing
+    release:
+      packages:
+      - joy
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/joystick_drivers-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/joystick_drivers.git
+      version: dashing
+    status: maintained
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
