### PR TITLE
prosilica_gige_sdk: 1.26.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4942,6 +4942,20 @@ repositories:
       url: https://github.com/PilzDE/prbt_grippers.git
       version: kinetic-devel
     status: developed
+  prosilica_gige_sdk:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
+      version: 1.26.3-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_gige_sdk` to `1.26.3-1`:

- upstream repository: https://github.com/ros-drivers/prosilica_gige_sdk.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
