### PR TITLE
Added python dependency to oyaml pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2503,6 +2503,13 @@ python-openssl:
   debian: [python-openssl]
   gentoo: [dev-python/pyopenssl]
   ubuntu: [python-openssl]
+python-oyaml-pip:
+  debian:
+    pip:
+      packages: [oyaml]
+  ubuntu:
+    pip:
+      packages: [oyaml]
 python-packaging:
   debian: [python-packaging]
   fedora: [python-packaging]


### PR DESCRIPTION
Pip has been chosen as there is no official Debian package for that python
package.