### PR TITLE
pilz_robots: 0.5.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4646,7 +4646,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.2-0
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.3-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.2-0`

## pilz_control

```
* Fixes for new JointTrajectoryController Interface
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

```
* drop outdated can configurationss
* Contributors: Pilz GmbH and Co. KG
```

## pilz_testutils

```
* Make docu compabtible with both kinetic and melodic
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

```
* Remove rosparam block no longer needed
* Add world_name argument to gazebo launch file.
* Install launch and config folder of prbt_gazebo
* Contributors: Pilz GmbH and Co. KG
```

## prbt_hardware_support

```
* cleanup CMakeLists of prbt_hardware_support
* update the documentation
* more precise error output when failing to read modbus register
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

```
* Remove unused testfile
* drop outdated can configuration
* Contributors: Pilz GmbH and Co. KG
```

## prbt_moveit_config

```
* Set interactive marker size in RViz config
* Remove unnecessary file test_context.launch
* Add missing dependency on joint_state_controller
* update the documentation
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

```
* Add acceptance test for joint position limits
* Relax joint limits.
* Replace the radian values for the position limits (they have been rounded too roughly).
* Added support for force-/torque sensors in gazebo
* allow gripper_name as outside property instead of passing it explicitly
* Add gripper brackets definition to prbt.xacro
* Remove unnecessary file test_context.launch
  This file is moved to pilz_trajectory_generation, where it is mainly used.
  The test urdf_tests can use the original file planning_context.launch.
* Add missing dependency on joint_state_controller
* Relax joint limits (recompute radian values and round up 5th decimal)
* Contributors: Pilz GmbH and Co. KG
```
