### PR TITLE
quaternion_operation: 0.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5152,7 +5152,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OUXT-Polaris/quaternion_operation-release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `quaternion_operation` to `0.0.1-2`:

- upstream repository: https://github.com/OUXT-Polaris/quaternion_operation.git
- release repository: https://github.com/OUXT-Polaris/quaternion_operation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-1`

## quaternion_operation

```
* add mainpage
* add documents for All functions
* update .gitignore
* add rosdoc
* add getRotation test
* add getRoataion function
* add slerp function
* add eigen to the depends
* add test
* update package.xml
* update .travis.yml
* add test
* initial commit
* Contributors: Masaya Kataoka, MasayaKataoka
```
