### PR TITLE
Add python-pycurl python rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2861,6 +2861,7 @@ python-pyaudio:
   ubuntu: [python-pyaudio]
 python-pycurl:
   debian: [python-pycurl]
+  fedora: [python2-pycurl]
   ubuntu: [python-pycurl]
 python-pydbus:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2859,6 +2859,9 @@ python-pyaudio:
   fedora: [pyaudio]
   gentoo: [dev-python/pyaudio]
   ubuntu: [python-pyaudio]
+python-pycurl:
+  debian: [python-pycurl]
+  ubuntu: [python-pycurl]
 python-pydbus:
   ubuntu:
     artful: [python-pydbus]


### PR DESCRIPTION
You can find here the package for debian:
https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=python-pycurl

and for Ubuntu:
https://packages.ubuntu.com/search?keywords=python-pycurl&searchon=names&suite=all&section=all