### PR TITLE
khi_robot: 1.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5529,7 +5529,13 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Kawasaki-Robotics/khi_robot.git
+      version: master
+    status: developed
   kinesis_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `khi_robot` to `1.1.1-1`:

- upstream repository: https://github.com/Kawasaki-Robotics/khi_robot.git
- release repository: https://github.com/Kawasaki-Robotics/khi_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-1`

## khi_duaro_description

- No changes

## khi_duaro_gazebo

- No changes

## khi_duaro_ikfast_plugin

- No changes

## khi_duaro_moveit_config

- No changes

## khi_robot

- No changes

## khi_robot_bringup

- No changes

## khi_robot_control

```
* Update a document and error messages (#15 <https://github.com/Kawasaki-Robotics/khi_robot/issues/15>)
  * Modify error messages
  * fixup! Modify error messages
  * fixup! Modify error messages
  * fixup! Modify error messages
  * fixup! Modify error messages
* set HOME position separately (#16 <https://github.com/Kawasaki-Robotics/khi_robot/issues/16>)
* Split command string in two (#14 <https://github.com/Kawasaki-Robotics/khi_robot/issues/14>)
* Merge pull request #13 <https://github.com/Kawasaki-Robotics/khi_robot/issues/13> from d-nakamichi/load_rtc_param
  Load a temporary RTC param file
* fixup! Load temporary RTC param file
* Merge pull request #12 <https://github.com/Kawasaki-Robotics/khi_robot/issues/12> from d-nakamichi/control_axes_bug_fix
  Limit AS control axes to ROS driver's control axes
* Load temporary RTC param file
* Limit AS control axes to ROS driver's control axes
* Merge pull request #11 <https://github.com/Kawasaki-Robotics/khi_robot/issues/11> from d-nakamichi/buildfarm_fix
  Add test_depend
* Add test_depend
* Contributors: Daisuke NAKAMICHI, Hiroki Matsui, nakamichi_d
```

## khi_robot_msgs

- No changes

## khi_rs007l_moveit_config

```
* minor fix (#10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10>)
  rs007l -> khi_rs007l
* Contributors: Daisuke NAKAMICHI
```

## khi_rs007n_moveit_config

- No changes

## khi_rs080n_moveit_config

- No changes

## khi_rs_description

- No changes

## khi_rs_gazebo

- No changes

## khi_rs_ikfast_plugin

- No changes
