### PR TITLE
multi_object_tracking_lidar: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7192,7 +7192,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
-      version: 1.0.0-0
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_object_tracking_lidar` to `1.0.1-1`:

- upstream repository: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
- release repository: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-0`

## multi_object_tracking_lidar

```
* Fixed cv_bridge build depend
* Removed indirection op to be compatible with OpenCV 3+
* Added visualization_msgs & cv_bridge build & run dependencies
* Contributors: Praveen Palanisamy
```
