### PR TITLE
multi_object_tracking_lidar: 1.0.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2738,6 +2738,22 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
       version: compat-mrpt-1.3
     status: maintained
+  multi_object_tracking_lidar:
+    doc:
+      type: git
+      url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
+      version: master
+    release:
+      tags:
+        release: release/lunar/{package}/{version}
+      url: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
+      version: master
+    status: maintained
   multisense_ros:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_object_tracking_lidar` to `1.0.1-1`:

- upstream repository: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
- release repository: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## multi_object_tracking_lidar

```
* Fixed cv_bridge build depend
* Removed indirection op to be compatible with OpenCV 3+
* Added visualization_msgs & cv_bridge build & run dependencies
* Contributors: Praveen Palanisamy
```
