### PR TITLE
rostate_machine: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12160,6 +12160,21 @@ repositories:
       url: https://github.com/clearpathrobotics/rosserial_leonardo_cmake.git
       version: hydro-devel
     status: maintained
+  rostate_machine:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/rostate_machine.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/rostate_machine-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/rostate_machine.git
+      version: master
+    status: developed
   rostful:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rostate_machine` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/rostate_machine.git
- release repository: https://github.com/OUXT-Polaris/rostate_machine-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
