### PR TITLE
rostate_machine: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6275,6 +6275,21 @@ repositories:
       url: https://github.com/ros-drivers/rosserial.git
       version: melodic-devel
     status: maintained
+  rostate_machine:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/rostate_machine.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/rostate_machine-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/rostate_machine.git
+      version: master
+    status: developed
   roswww:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rostate_machine` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/rostate_machine.git
- release repository: https://github.com/OUXT-Polaris/rostate_machine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
