### PR TITLE
vision_opencv: 2.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1224,6 +1224,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: developed
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 2.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.1.1-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cv_bridge

```
* Replace ament commands with colcon (#263 <https://github.com/ros-perception/vision_opencv/issues/263>)
  Latest ros2 repo does not include ament_tools. Executing ament command results in error.
* Contributors: Lalit Begani
```

## image_geometry

```
* [image_geometry] Enable python package installation (#257 <https://github.com/ros-perception/vision_opencv/issues/257>)
  * [image_geometry] Install python package.
* Contributors: Michael Carroll
```

## vision_opencv

- No changes
