### PR TITLE
robot_state_publisher: 2.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -842,7 +842,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.2.1-1`:

- upstream repository: https://github.com/ros2/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.2.0-1`

## robot_state_publisher

```
* Updated to avoid deprecated API. (#18 <https://github.com/ros2/robot_state_publisher/issues/18>)
* Contributors: William Woodall
```
