### PR TITLE
demos: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -229,7 +229,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`

## composition

```
* Renamed launch file, updated to avoid redundant default actions, and set output to screen. (#326 <https://github.com/ros2/demos/issues/326>)
* Updated constructor to const ref to NodeOptions. (#323 <https://github.com/ros2/demos/issues/323>)
* Added basic composition launch demo. (#324 <https://github.com/ros2/demos/issues/324>)
* Contributors: Michael Carroll, William Woodall
```

## demo_nodes_cpp

```
* Updated to declare parameters. (#241 <https://github.com/ros2/demos/issues/241>)
* Contributors: Shane Loretz
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Removed support for OpenCV 2. (#322 <https://github.com/ros2/demos/issues/322>)
* Contributors: Jacob Perron
```

## intra_process_demo

- No changes

## lifecycle

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## topic_monitor

- No changes
