### PR TITLE
prosilica_driver: 1.9.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4942,6 +4942,22 @@ repositories:
       url: https://github.com/PilzDE/prbt_grippers.git
       version: kinetic-devel
     status: developed
+  prosilica_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
+    release:
+      packages:
+      - prosilica_camera
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
+      version: 1.9.4-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: hydro-devel
   prosilica_gige_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_driver` to `1.9.4-1`:

- upstream repository: https://github.com/ros-drivers/prosilica_driver.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
