### PR TITLE
rostate_machine: 0.0.2-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6300,7 +6300,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OUXT-Polaris/rostate_machine-release.git
-      version: 0.0.2-1
+      version: 0.0.2-3
     source:
       type: git
       url: https://github.com/OUXT-Polaris/rostate_machine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rostate_machine` to `0.0.2-3`:

- upstream repository: https://github.com/OUXT-Polaris/rostate_machine.git
- release repository: https://github.com/OUXT-Polaris/rostate_machine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.2-1`
