### PR TITLE
py_trees: 1.2.0-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1013,7 +1013,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
-      version: release/1.1.x
+      version: release/1.2.x
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -1022,7 +1022,7 @@ repositories:
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
-      version: release/1.1.x
+      version: release/1.2.x
     status: developed
   py_trees_ros_interfaces:
     doc:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1018,7 +1018,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 1.1.0-0
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `1.2.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-0`

## py_trees

```
**Breaking API**
* [trees] removes the curious looking and unused ``destroy()`` method, #193 <https://github.com/splintered-reality/py_trees/pull/193>
* [display] ``ascii_tree`` -> ``ascii_tree``/``unicode_tree()``, no longer subverts the choice depending on your stdout, #192 <https://github.com/splintered-reality/py_trees/pull/192>
* [display] ``dot_graph`` -> ``dot_tree`` for consistency with the text tree methods, #192 <https://github.com/splintered-reality/py_trees/pull/192>
**New Features**
* [behaviour] ``shutdown()`` method to compliment ``setup()``, #193 <https://github.com/splintered-reality/py_trees/pull/193>
* [display] ``xhtml_tree`` provides an xhtml compatible equivalent to the ``ascii_tree`` representation, #192 <https://github.com/splintered-reality/py_trees/pull/192>
* [trees] walks the tree calling ``shutdown()`` on each node in it's own ``shutdown()`` method, #193 <https://github.com/splintered-reality/py_trees/pull/193>
* [visitors] get a ``finalise()`` method called immediately prior to post tick handlers, #191 <https://github.com/splintered-reality/py_trees/pull/191>
```
