### PR TITLE
py_trees_ros_interfaces: 1.1.1-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1033,7 +1033,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_interfaces-release.git
-      version: 1.1.0-0
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `1.1.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces.git
- release repository: https://github.com/stonier/py_trees_ros_interfaces-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-0`
