### PR TITLE
pr2_simulator: 2.0.14-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4918,7 +4918,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_simulator-release.git
-      version: 2.0.13-1
+      version: 2.0.14-0
     source:
       type: git
       url: https://github.com/PR2/pr2_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_simulator` to `2.0.14-0`:

- upstream repository: https://github.com/pr2/pr2_simulator.git
- release repository: https://github.com/pr2-gbp/pr2_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.13-1`

## pr2_controller_configuration_gazebo

- No changes

## pr2_gazebo

```
* Merge pull request #146 <https://github.com/PR2/pr2_simulator/issues/146> from k-okada/fix_stretch
  remove gazebo depends
* use custom empty.world which does not require downloading models
* Contributors: Kei Okada
```

## pr2_gazebo_plugins

```
* Merge pull request #146 <https://github.com/PR2/pr2_simulator/issues/146> from k-okada/fix_stretch
  remove gazebo depends
* remove gazebo depends
  since gazebo_plugins already depend on gazebo via gazebo_dev and this solves build farm error on stretch http://build.ros.org/job/Mbin_dsv8_dSv8__pr2_gazebo_plugins__debian_stretch_arm64__binary/
* Contributors: Kei Okada
```

## pr2_simulator

- No changes
