### PR TITLE
volksbot_driver: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8124,6 +8124,21 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: kinetic-devel
     status: maintained
+  volksbot_driver:
+    doc:
+      type: git
+      url: https://github.com/uos/volksbot_driver.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/volksbot_driver-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/uos/volksbot_driver.git
+      version: master
+    status: maintained
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `volksbot_driver` to `1.0.0-1`:

- upstream repository: https://github.com/uos/volksbot_driver.git
- release repository: https://github.com/uos-gbp/volksbot_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## volksbot_driver

```
* Release version 1.0.0
* Contributors: Jochen Sprickerhof, Marc-André Aßbrock, Martin Günther, Michael Görner, Michael Stypa, Sebastian Pütz, Tristan Igelbrink, ma-assbrock, v4hn
```
