### PR TITLE
cartographer: 1.0.0-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -214,6 +214,21 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/cartographer.git
- release repository: https://github.com/ros2-gbp/cartographer-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
