### PR TITLE
ros_workspace: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -910,7 +910,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `0.7.1-1`:

- upstream repository: https://github.com/nuclearsandwich/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`

## ros_workspace

```
* Reverted adding the COLCON_PREFIX_PATH env var. (#14 <https://github.com/ros2/ros_workspace/issues/14>)
* Contributors: Dirk Thomas
```
