### PR TITLE
rcl: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -599,7 +599,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.7.0-3
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-3`

## rcl

```
* Replaced reinterperet_cast with static_cast. (#410 <https://github.com/ros2/rcl/issues/410>)
* Fixed leak in __wait_set_clean_up. (#418 <https://github.com/ros2/rcl/issues/418>)
* Updated initialization of rmw_qos_profile_t struct instances. (#416 <https://github.com/ros2/rcl/issues/416>)
* Contributors: Dirk Thomas, M. M, jhdcs
```

## rcl_action

```
* Renamed action state transitions (#409 <https://github.com/ros2/rcl/issues/409>)
* Updated initialization of rmw_qos_profile_t struct instances. (#416 <https://github.com/ros2/rcl/issues/416>)
* Contributors: Jacob Perron, M. M
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
