### PR TITLE
multimaster_fkie: 0.8.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3680,7 +3680,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 0.8.10-0
+      version: 0.8.12-0
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multimaster_fkie` to `0.8.12-0`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.8.10-0`

## default_cfg_fkie

- No changes

## master_discovery_fkie

```
* Merge pull request #100 <https://github.com/fkie/multimaster_fkie/issues/100> from stertingen/patch-1
  zeroconf.py: Detect IPv6 usage from environment
* zeroconf.py: Detect IPv6 usage from environment
  Set environment ROS_IPV6=on to enable the IPv6 RPC server.
* master_discovery_fkie: zeroconf: added fqdn-parameter, see issue #99 <https://github.com/fkie/multimaster_fkie/issues/99>
* master_discovery_fkie: fixed some format warning
* master_discovery_fkie: zeroconf use for monitoruri the same hostname from masteruri
* Contributors: Alexander Tiderko, Hermann von Kleist
```

## master_sync_fkie

- No changes

## multimaster_fkie

```
* node_manager_fkie: fixed lost nodes while grouping
* Merge pull request #100 <https://github.com/fkie/multimaster_fkie/issues/100> from stertingen/patch-1
  zeroconf.py: Detect IPv6 usage from environment
  Set environment ROS_IPV6=on to enable the IPv6 RPC server.
* master_discovery_fkie: zeroconf: added fqdn-parameter, see issue #99 <https://github.com/fkie/multimaster_fkie/issues/99>
* master_discovery_fkie: zeroconf use for monitoruri the same hostname from masteruri
* Contributors: Alexander Tiderko, Hermann von Kleist
```

## multimaster_msgs_fkie

- No changes

## node_manager_fkie

```
* fixed lost nodes while grouping
* Contributors: Alexander Tiderko
```
