### PR TITLE
rc_common_msgs: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5272,6 +5272,21 @@ repositories:
       url: https://github.com/roboception/rc_cloud_accumulator.git
       version: master
     status: developed
+  rc_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_common_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_common_msgs-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/roboception/rc_common_msgs.git
+      version: master
+    status: developed
   rc_dynamics_api:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_common_msgs` to `0.2.1-1`:

- upstream repository: https://github.com/roboception/rc_common_msgs.git
- release repository: https://github.com/roboception-gbp/rc_common_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rc_common_msgs

```
* add KeyValue msg
```
