### PR TITLE
eigenpy: 1.5.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1261,7 +1261,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 1.5.0-1
+      version: 1.5.1-2
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
     status: developed
   eml:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `1.5.1-2`:

- upstream repository: https://github.com/ipab-slmc/eigenpy_catkin.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.5.0-1`
