### PR TITLE
eigenpy: 1.5.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2827,7 +2827,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 1.5.0-0
+      version: 1.5.1-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
     status: developed
   eml:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `1.5.1-1`:

- upstream repository: https://github.com/ipab-slmc/eigenpy_catkin.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.5.0-0`
