### PR TITLE
ros1_bridge: 0.6.2-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1358,7 +1358,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.6.2-0
+      version: 0.6.2-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.6.2-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.2-0`
