### PR TITLE
Update debian roskeys for libgphoto2-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2037,7 +2037,7 @@ libgpgme-dev:
     zesty: [libgpgme-dev]
 libgphoto-dev:
   arch: [libgphoto2]
-  debian: [libgphoto2-2-dev]
+  debian: [libgphoto2-dev]
   fedora: [libgphoto2-devel]
   gentoo: [media-gfx/gphoto2]
   ubuntu:


### PR DESCRIPTION
The package in debian stretch is renamed to `libgphoto2-dev`:
https://packages.debian.org/stretch/libgphoto2-dev

Looking at [this](https://packages.debian.org/search?keywords=libgphoto2-dev&searchon=names&suite=all&section=all) the new key is generally available in older debian versions as well.