### PR TITLE
Revert "mrpt1: 1.5.7-7 in 'melodic/distribution.yaml' [bloom] (#21041)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3555,7 +3555,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt1-release.git
-      version: 1.5.7-7
+      version: 1.5.7-6
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git


### PR DESCRIPTION
This reverts commit 28cb92d739da371f382c025281f38213ff222e24 from https://github.com/ros/rosdistro/pull/21041