### PR TITLE
wge100_driver: 1.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8268,6 +8268,24 @@ repositories:
       url: https://github.com/RobotWebTools/webrtc_ros.git
       version: develop
     status: developed
+  wge100_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: kinetic-devel
+    release:
+      packages:
+      - wge100_camera
+      - wge100_camera_firmware
+      - wge100_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/wge100_driver-release.git
+      version: 1.8.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: kinetic-devel
   wifi_ddwrt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wge100_driver` to `1.8.2-1`:

- upstream repository: https://github.com/ros-drivers/wge100_driver.git
- release repository: https://github.com/ros-drivers-gbp/wge100_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
