### PR TITLE
alpine: use packaged gmock over source

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1050,9 +1050,7 @@ golang-go:
   gentoo: [dev-lang/go]
   ubuntu: [golang-go]
 google-mock:
-  alpine:
-    source:
-      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/googlemock/googlemock.rdmanifest'
+  alpine: [gmock]
   arch: [gmock]
   debian: [google-mock]
   fedora: [gmock-devel]


### PR DESCRIPTION
I can see there exists a gmock package in the alpine repository. @at-wat is there any reason to use the source over the packaged version? 

https://pkgs.alpinelinux.org/package/v3.9/main/x86_64/gmock
