### PR TITLE
teraranger: 2.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14093,7 +14093,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Terabee/teraranger-release.git
-      version: 2.0.1-0
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/Terabee/teraranger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `2.1.0-2`:

- upstream repository: https://github.com/Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-0`

## teraranger

```
* Update package description
* Update links in Readme
* Set 64px mode to distance+ambient on start (#23 <https://github.com/Terabee/teraranger/issues/23>)
  Fix issue #22 <https://github.com/Terabee/teraranger/issues/22>
* Add pre-release flag for travis
* Repository/add travis ci (#26 <https://github.com/Terabee/teraranger/issues/26>)
* Merge pull request #24 <https://github.com/Terabee/teraranger/issues/24> from Terabee/pre-release
* Contributors: Morten Fyhn Amundsen, Pierre-Louis Kabaradjian
```
