### PR TITLE
teraranger: 2.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7406,6 +7406,17 @@ repositories:
       url: https://github.com/tradr-project/tensorflow_ros_cpp.git
       version: master
     status: maintained
+  teraranger:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Terabee/teraranger-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/Terabee/teraranger.git
+      version: master
+    status: maintained
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger` to `2.1.0-1`:

- upstream repository: https://github.com/Terabee/teraranger.git
- release repository: https://github.com/Terabee/teraranger-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## teraranger

```
* Update package description
* Update links in Readme
* Set 64px mode to distance+ambient on start (#23 <https://github.com/Terabee/teraranger/issues/23>)
  Fix issue #22 <https://github.com/Terabee/teraranger/issues/22>
* Add pre-release flag for travis
* Repository/add travis ci (#26 <https://github.com/Terabee/teraranger/issues/26>)
* Merge pull request #24 <https://github.com/Terabee/teraranger/issues/24> from Terabee/pre-release
* Contributors: Morten Fyhn Amundsen, Pierre-Louis Kabaradjian
```
