### PR TITLE
teraranger_array: 2.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7406,6 +7406,17 @@ repositories:
       url: https://github.com/tradr-project/tensorflow_ros_cpp.git
       version: master
     status: maintained
+  teraranger_array:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Terabee/teraranger_array-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/Terabee/teraranger_array.git
+      version: master
+    status: maintained
   tf2_web_republisher:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7467,6 +7467,8 @@ repositories:
     source:
       type: git
       url: https://github.com/Terabee/teraranger_array.git
+      version: master
+    status: maintained
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teraranger_array` to `2.0.0-1`:

- upstream repository: https://github.com/Terabee/teraranger_array.git
- release repository: https://github.com/Terabee/teraranger_array-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## teraranger_array

```
* Update package description
* Merge pull request #60 <https://github.com/Terabee/teraranger_array/issues/60> from FRC900/remove_lib_from_cmake
  Removed teraranger_array library from catkin_package LIBRARIES
* Merge remote-tracking branch 'origin/master' into remove_lib_from_cmake
* Merge pull request #59 <https://github.com/Terabee/teraranger_array/issues/59> from FRC900/cpp_msg_header
  Move header to start of RangeArray.msg
* Add travis config
* Removed teraranger_array library from catkin_package LIBRARIES
  This file isn't built, so packages referencing teraranger_array
  fail when searching for the non-existent library
* Move header to start of RangeArray.msg
  The cpp tools require the header to be the first entry in the
  message for ros::message_traits to recognize that the message
  in fact has a header.
* Update links in Readme
* Contributors: Kevin Jaget, Pierre-Louis Kabaradjian
```
