### PR TITLE
microstrain_3dmgx2_imu: 1.5.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3328,7 +3328,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
-      version: 1.5.12-0
+      version: 1.5.12-1
     source:
       type: git
       url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu` to `1.5.12-1`:

- upstream repository: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
- release repository: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.5.12-0`

## microstrain_3dmgx2_imu

```
* Added dependency on log4cxx.
* Contributors: Chad Rockey
```
