### PR TITLE
photo: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4588,7 +4588,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/bosch-ros-pkg/photo-release.git
-      version: 1.0.3-0
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `photo` to `1.0.3-1`:

- upstream repository: https://github.com/bosch-ros-pkg/photo.git
- release repository: https://github.com/bosch-ros-pkg/photo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.3-0`

## photo

```
* Fix /get-config problem with TEXT type (#8 <https://github.com/bosch-ros-pkg/photo/issues/8>)
  Fix a problem where, when trying to call the /get-config
  service on a text field, you would first get wrong data,
  and on the second call the node would crash.
* Fix release (#11 <https://github.com/bosch-ros-pkg/photo/issues/11>)
  * add opencv as dependency
  * style cleanup
* Merge pull request #6 <https://github.com/bosch-ros-pkg/photo/issues/6> from bosch-ros-pkg/Karsten1987-patch-1
  Make Karsten maintainer
* Make Karsten maintainer
* Fixed error in CMakeLists (#5 <https://github.com/bosch-ros-pkg/photo/issues/5>)
* Contributors: Babis Boloudakis, Karsten Knese, Philip Roan
```
