### PR TITLE
depthcloud_encoder: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -943,7 +943,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
-      version: 0.1.0-0
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/RobotWebTools/depthcloud_encoder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthcloud_encoder` to `0.1.1-1`:

- upstream repository: https://github.com/RobotWebTools/depthcloud_encoder.git
- release repository: https://github.com/RobotWebTools-release/depthcloud_encoder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-0`

## depthcloud_encoder

```
* Add dynamic reconfigure gen as dependency chain (#14 <https://github.com/RobotWebTools/depthcloud_encoder/issues/14>)
* Contributors: Jihoon Lee
```
