### PR TITLE
mir_robot: 1.0.4-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2541,7 +2541,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.0.3-0
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.4-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.3-0`

## mir_actions

```
* Update mir_msgs and mir_actions to MiR 2.3.1
* Contributors: Martin Günther
```

## mir_description

```
* Add legacyModeNS param to gazebo_ros_control plugin
  This enables the new behavior of the plugin (pid_gains parameter are now
  in the proper namespace).
* re-added gazebo friction parameters for the wheels (#19 <https://github.com/dfki-ric/mir_robot/issues/19>)
* Contributors: Martin Günther, niniemann
```

## mir_driver

```
* Remove garbage file
* Contributors: Martin Günther
```

## mir_dwb_critics

- No changes

## mir_gazebo

```
* Fix gazebo launch file
  Before this commit, the mobile base plugin couldn't initialize, because
  subst_value didn't work.
* Contributors: Martin Günther
```

## mir_msgs

```
* Update mir_msgs and mir_actions to MiR 2.3.1
  The following changes were made to the actual mir_msgs:
  * rename mirMsgs -> mir_msgs
  * rename proximity -> Proximity
  * rename serial -> Serial
  * keep MirStatus msg (was replaced by RobotStatus in MiR software 2.0)
* Contributors: Martin Günther
```

## mir_navigation

```
* Rviz config: Add planned paths + costmap from real MiR
* Contributors: Martin Günther
```

## mir_robot

- No changes
