### PR TITLE
imu_tools: 1.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2372,7 +2372,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.2.0-0
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.1-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.0-0`

## imu_complementary_filter

```
* Remove junk xml (#93 <https://github.com/ccny-ros-pkg/imu_tools/issues/93>)
* Fix C++14 builds (#89 <https://github.com/ccny-ros-pkg/imu_tools/issues/89>)
* Contributors: David V. Lu!!, Paul Bovbel
```

## imu_filter_madgwick

```
* Skip messages and warn if computeOrientation fails
* Contributors: Martin Günther
```

## imu_tools

- No changes

## rviz_imu_plugin

```
* Fix includes, typos and log messages
* print ros_warn and give unit quaternion to ogre to prevent rviz crash (#90 <https://github.com/ccny-ros-pkg/imu_tools/issues/90>)
* Contributors: Jackey-Huo, Martin Günther
```
