### PR TITLE
phidgets_drivers: 0.7.8-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -3569,7 +3569,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.7-0
+      version: 0.7.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.8-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.7-0`

## libphidget21

- No changes

## phidgets_api

```
* Install udev rules on binary package installation
* Contributors: Martin Günther
```

## phidgets_drivers

- No changes

## phidgets_high_speed_encoder

```
* phidgets_high_speed_encoder: fix missing tick2rad values (#30 <https://github.com/ros-drivers/phidgets_drivers/issues/30>)
* Contributors: Charles Brian Quinn
```

## phidgets_ik

- No changes

## phidgets_imu

- No changes
