### PR TITLE
sick_tim: 0.0.16-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14996,7 +14996,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.15-0
+      version: 0.0.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.16-1`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.15-0`

## sick_tim

```
* travis CI: Switch to Docker
* Avoid runtime error if ROS time is 0
  See #76 <https://github.com/uos/sick_tim/issues/76>
* Contributors: Martin Günther
```
