### PR TITLE
rosthrottle-release: 1.2.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6325,6 +6325,23 @@ repositories:
       url: https://github.com/OUXT-Polaris/rostate_machine.git
       version: master
     status: developed
+  rosthrottle-release:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/rosthrottle-release.git
+      version: 1.2.0
+    release:
+      packages:
+      - rosthrottle
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UTNuclearRoboticsPublic/rosthrottle-release.git
+      version: 1.2.0-2
+    source:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/rosthrottle.git
+      version: 1.2.0
+    status: maintained
   roswww:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosthrottle-release` to `1.2.0-2`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/rosthrottle.git
- release repository: https://github.com/UTNuclearRoboticsPublic/rosthrottle-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
