### PR TITLE
Add libmodbus5 to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2356,6 +2356,11 @@ libmodbus-dev:
   debian: [libmodbus-dev]
   fedora: [libmodbus-devel]
   ubuntu: [libmodbus-dev]
+libmodbus5:
+  debian: [libmodbus5]
+  fedora: [libmodbus]
+  gentoo: [dev-libs/libmodbus]
+  ubuntu: [libmodbus5]
 libmongoclient-dev:
   debian: [libmongoclient-dev]
   fedora: [mongo-cxx-driver]


### PR DESCRIPTION
Key added for:
- [Debian](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libmodbus5) 
- [Ubuntu](https://packages.ubuntu.com/search?keywords=libmodbus5&searchon=names&suite=all&section=all) 
