### PR TITLE
add carla Python API to the depends

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -71,6 +71,16 @@ canopen-pip:
   ubuntu:
     pip:
       packages: [canopen]
+carla-pip:
+  debian:
+    pip:
+      packages: [carla]
+  fedora:
+    pip:
+      packages: [carla]
+  ubuntu:
+    pip:
+      packages: [carla]
 casadi-pip:
   debian:
     pip:


### PR DESCRIPTION
Carla Released Python API as a pip package. (https://github.com/carla-simulator/carla/pull/1608)
So, I want to add this package to the rosdep as carla-pip.