### PR TITLE
jointstick: 0.9.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5191,6 +5191,21 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     status: maintained
+  jointstick:
+    doc:
+      type: git
+      url: https://github.com/gstavrinos/jointstick
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gstavrinos/jointstick-release
+      version: 0.9.1-1
+    source:
+      type: git
+      url: https://github.com/gstavrinos/jointstick
+      version: master
+    status: maintained
   joystick_drivers:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5194,16 +5194,16 @@ repositories:
   jointstick:
     doc:
       type: git
-      url: https://github.com/gstavrinos/jointstick
+      url: https://github.com/gstavrinos/jointstick.git
       version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/gstavrinos/jointstick-release
+      url: https://github.com/gstavrinos/jointstick-release.git
       version: 0.9.1-1
     source:
       type: git
-      url: https://github.com/gstavrinos/jointstick
+      url: https://github.com/gstavrinos/jointstick.git
       version: master
     status: maintained
   joystick_drivers:


### PR DESCRIPTION
Increasing version of package(s) in repository `jointstick` to `0.9.1-1`:

- upstream repository: https://github.com/gstavrinos/jointstick
- release repository: https://github.com/gstavrinos/jointstick-release
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jointstick

```
* First release
```
