### PR TITLE
jointstick: 0.9.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2495,16 +2495,16 @@ repositories:
   jointstick:
     doc:
       type: git
-      url: https://github.com/gstavrinos/jointstick
+      url: https://github.com/gstavrinos/jointstick.git
       version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/gstavrinos/jointstick-release
+      url: https://github.com/gstavrinos/jointstick-release.git
       version: 0.9.1-2
     source:
       type: git
-      url: https://github.com/gstavrinos/jointstick
+      url: https://github.com/gstavrinos/jointstick.git
       version: master
     status: maintained
   joystick_drivers:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2492,6 +2492,21 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     status: maintained
+  jointstick:
+    doc:
+      type: git
+      url: https://github.com/gstavrinos/jointstick
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gstavrinos/jointstick-release
+      version: 0.9.1-2
+    source:
+      type: git
+      url: https://github.com/gstavrinos/jointstick
+      version: master
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jointstick` to `0.9.1-2`:

- upstream repository: https://github.com/gstavrinos/jointstick
- release repository: https://github.com/gstavrinos/jointstick-release
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jointstick

```
* First release
```
