### PR TITLE
rosbridge_suite: 0.11.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11815,7 +11815,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.0-0
+      version: 0.11.1-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.1-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.0-0`

## rosapi

- No changes

## rosbridge_library

```
* fixed logwarn msg formatting in publishers (#398 <https://github.com/RobotWebTools/rosbridge_suite/issues/398>)
* Contributors: Gautham P Das
```

## rosbridge_msgs

- No changes

## rosbridge_server

- No changes

## rosbridge_suite

- No changes
