### PR TITLE
uav_testing: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7774,6 +7774,27 @@ repositories:
       url: https://github.com/ros-teleop/twist_mux_msgs.git
       version: melodic-devel
     status: maintained
+  uav_testing:
+    doc:
+      type: git
+      url: https://github.com/osrf/uav_testing.git
+      version: master
+    release:
+      packages:
+      - ksql_airport
+      - mcmillan_airfield
+      - sand_island
+      - yosemite_valley
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/uav_testing-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/uav_testing.git
+      version: master
+    status: maintained
   um7:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uav_testing` to `0.0.1-1`:

- upstream repository: https://github.com/osrf/uav_testing.git
- release repository: https://github.com/ros-gbp/uav_testing-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ksql_airport

```
* adding san carlos airport and vicinity, as ksql
* Contributors: Tully Foote
```

## mcmillan_airfield

```
* Adding in mcmillan airfield launch with terrain and texture
* Contributors: Tully Foote
```

## sand_island

```
* adding an example on sand island
* Contributors: Tully Foote
```

## yosemite_valley

```
* adding yosemite
* Contributors: Tully Foote
```
