### PR TITLE
sicktoolbox_wrapper: 2.5.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13432,6 +13432,22 @@ repositories:
       url: https://github.com/SICKAG/sick_visionary_t.git
       version: indigo-devel
     status: maintained
+  sicktoolbox_wrapper:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox_wrapper.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
+      version: 2.5.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox_wrapper.git
+      version: indigo-devel
+    status: maintained
   simple_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox_wrapper` to `2.5.4-1`:

- upstream repository: https://github.com/ros-drivers/sicktoolbox_wrapper.git
- release repository: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## sicktoolbox_wrapper

```
* Merge pull request #6 <https://github.com/ros-drivers/sicktoolbox_wrapper/issues/6> from SantoshBanisetty/kinetic-devel
  Kinetic-devel and readme
* updated Readme
* Kinetic-devel and readme
* Contributors: b2256, santosh banisetty
```
