### PR TITLE
cv_camera: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -836,6 +836,21 @@ repositories:
       type: git
       url: https://github.com/whoenig/crazyflie_ros.git
       version: master
+  cv_camera:
+    doc:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/OTL/cv_camera-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    status: maintained
   dataspeed_can:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera` to `0.4.0-1`:

- upstream repository: https://github.com/OTL/cv_camera
- release repository: https://github.com/OTL/cv_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cv_camera

```
* Update for Melodic release
  Use libopencv-dev instead of opencv3
* Add link to ROS2 fork
* Improve README.md style
* Add capture_delay parameter
* Fix rescaling coefficient calculation (#15)
* Remove mail address of contributors
* Fix topic names
  Before this change, /image_raw, /camera_info is published.
  But that is not designed. As in README.md, it publishes
  ~image_raw, ~camera_info, that means it contains node name
  as prefix. This is broken so long time ago, (and test was
  failing.)
* Add contributers in README
* Format code
* Automatic rescaling camera info with rescale_camera_info parameter (#10) (#13)
* update to use non deprecated pluginlib macro (#9)
* Contributors: Mikael Arguedas, Oleg Kalachev, Takashi Ogura
```
