### PR TITLE
launch: 0.8.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -416,10 +416,12 @@ repositories:
       packages:
       - launch
       - launch_testing
+      - launch_testing_ament_cmake
+      - test_launch_testing
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-1`

## launch

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

```
* Make launchtest junit XML match pytest XML more closely (#228 <https://github.com/ros2/launch/issues/228>)
* Merge apex_launchtest functionality into launch_testing (#215 <https://github.com/ros2/launch/issues/215>)
* Contributors: Michel Hidalgo, Peter Baughman
```

## test_launch_testing

```
* Merge apex_launchtest functionality into launch_testing (#215 <https://github.com/ros2/launch/issues/215>)
* Contributors: Michel Hidalgo
```
