### PR TITLE
rcutils: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -712,7 +712,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`

## rcutils

```
* Add function rcutils_string_array_cmp (#144 <https://github.com/ros2/rcutils/issues/144>)
* Rename result variable for clarity. (#157 <https://github.com/ros2/rcutils/issues/157>)
* Add in utilities needed for log location (#155 <https://github.com/ros2/rcutils/issues/155>)
* remove macros from source file (#156 <https://github.com/ros2/rcutils/issues/156>)
* Migrate launch tests to new launch_testing features & API (#140 <https://github.com/ros2/rcutils/issues/140>)
* Use GCC extension for printf-like functions (#154 <https://github.com/ros2/rcutils/issues/154>)
* Fix leak in test_logging.cpp (#153 <https://github.com/ros2/rcutils/issues/153>)
* Fix leak in test_logging_macros.cpp (#152 <https://github.com/ros2/rcutils/issues/152>)
* Fix remaining leaks in test_string_map.cpp (#151 <https://github.com/ros2/rcutils/issues/151>)
* Fix a leak in test_array_list.cpp (#149 <https://github.com/ros2/rcutils/issues/149>)
* Contributors: Chris Lalancette, Dirk Thomas, Jacob Perron, Michel Hidalgo, Steven! Ragnarök, Thomas Moulard
```
