### PR TITLE
yaml_cpp_vendor: 6.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1265,7 +1265,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       type: git
       url: https://github.com/ros2/yaml_cpp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `6.0.1-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `6.0.0-1`

## yaml_cpp_vendor

```
* Pass CMAKE_TOOLCHAIN_FILE if crosscompiling (#6 <https://github.com/ros2/yaml_cpp_vendor/issues/6>)
* Contributors: Esteve Fernandez
```
