### PR TITLE
test_interface_files: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1108,6 +1108,17 @@ repositories:
       url: https://github.com/ros2/teleop_twist_keyboard.git
       version: dashing
     status: maintained
+  test_interface_files:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/test_interface_files-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: master
+    status: maintained
   tinydir_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## test_interface_files

```
* add WStrings message (#4 <https://github.com/ros2/test_interface_files/issues/4>)
* Refactor interface messages (#3)
  
  Rename messages towards consolidation
  
  Refactor message fields
  
  Add fields to cover test cases
  
  Move string fields to Strings.msg
  
  Comment out fields that have issues to be resolved
  
  Remove old interface files
* Rename messages to align with IDL terminology
* rename package, remove all dependencies, and only install the interface files
* move package content into the root of the repo
* Merge: test_msgs package from ros2/rcl_interfaces
  The commit messages have been rewritten to reference the tickets in the original repository
```
