### PR TITLE
Revert "mrpt1: 1.5.7-5 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7081,7 +7081,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt1-release.git
-      version: 1.5.7-5
+      version: 1.5.7-4
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git


### PR DESCRIPTION
Reverts ros/rosdistro#21040
@jlblancoc

Binary file changes cannot be packaged into a debian increment. 

Example sourcedeb job failing. http://build.ros.org/view/Kbin_uX64/job/Ksrc_uX__mrpt1__ubuntu_xenial__source/19/console

