### PR TITLE
rosidl_typesupport: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1011,7 +1011,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 0.7.0-2
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-2`
