### PR TITLE
rosidl_typesupport_opensplice: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1070,7 +1070,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_opensplice` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_opensplice.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`
