### PR TITLE
rcl_logging: 0.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -643,7 +643,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `0.2.1-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-1`

## rcl_logging_log4cxx

```
* Changing the default location for log files to be a local directory instead of /var/log/ros on linux due to permission issues. (#9 <https://github.com/ros2/rcl_logging/issues/9>)
* Removes debugging fprintf
* Review fixes.
* Move basename down to rcutils layer.
* Prototype to put things in ~/.ros/log
* Changing the default location for log files to be a local directory instead of /var/log/ros on linux due to permission issues.
* Change the API to add an allocator to logging initialize. (#10 <https://github.com/ros2/rcl_logging/issues/10>)
* Added include dir to installation of rcl_logging_log4cxx. (#7 <https://github.com/ros2/rcl_logging/issues/7>)
* Contributors: Chris Lalancette, Nick Burek, Rasmus Skovgaard Andersen, Steven! Ragnarök, burekn
```

## rcl_logging_noop

```
* Changing the default location for log files to be a local directory instead of /var/log/ros on linux due to permission issues. (#9 <https://github.com/ros2/rcl_logging/issues/9>)
* Prototype to put things in ~/.ros/log
* Change the API to add an allocator to logging initialize. (#10 <https://github.com/ros2/rcl_logging/issues/10>)
* Contributors: Chris Lalancette, Steven! Ragnarök
```
