### PR TITLE
launch_ros: 0.8.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -435,11 +435,12 @@ repositories:
     release:
       packages:
       - launch_ros
+      - launch_testing_ros
       - ros2launch
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-1`

## launch_ros

- No changes

## launch_testing_ros

```
* try local import (#20 <https://github.com/ros2/launch_ros/issues/20>)
* Merge apex_launchtest_ros functionality into launch_testing_ros (#8 <https://github.com/ros2/launch_ros/issues/8>)
* Contributors: Dirk Thomas, Michel Hidalgo
```

## ros2launch

- No changes
