### PR TITLE
rclcpp: 0.7.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -664,7 +664,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.7.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.1-1`

## rclcpp

```
* Added new way to specify QoS settings for publishers and subscriptions. (#713 <https://github.com/ros2/rclcpp/issues/713>)
  * The new way requires that you specify a history depth when creating a publisher or subscription.
  * In the past it was possible to create one without specifying any history depth, but these signatures have been deprecated.
* Deprecated ``shared_ptr`` and raw pointer versions of ``Publisher<T>::publish()``. (#709 <https://github.com/ros2/rclcpp/issues/709>)
* Implemented API to set callbacks for liveliness and deadline QoS events for publishers and subscriptions. (#695 <https://github.com/ros2/rclcpp/issues/695>)
* Fixed a segmentation fault when publishing a parameter event when they ought to be disabled. (#714 <https://github.com/ros2/rclcpp/issues/714>)
* Changes required for upcoming pre-allocation API. (#711 <https://github.com/ros2/rclcpp/issues/711>)
* Changed ``Node::get_node_names()`` to return the full node names rather than just the base name. (#698 <https://github.com/ros2/rclcpp/issues/698>)
* Remove logic made redundant by the ros2/rcl#255 <https://github.com/ros2/rcl/issues/255> pull request. (#712 <https://github.com/ros2/rclcpp/issues/712>)
* Various improvements for ``rclcpp::Clock``. (#696 <https://github.com/ros2/rclcpp/issues/696>)
  * Fixed uninitialized bool in ``clock.cpp``.
  * Fixed up includes of ``clock.hpp/cpp``.
  * Added documentation for exceptions to ``clock.hpp``.
  * Adjusted function signature of getters of ``clock.hpp/cpp``.
  * Removed raw pointers to ``Clock::create_jump_callback``.
  * Removed unnecessary ``rclcpp`` namespace reference from ``clock.cpp``.
  * Changed exception to ``bad_alloc`` on ``JumpHandler`` allocation failure.
  * Fixed missing ``nullptr`` check in ``Clock::on_time_jump``.
  * Added ``JumpHandler::callback`` types.
  * Added warning for lifetime of Clock and JumpHandler
* Fixed bug left over from the pull request #495 <https://github.com/ros2/rclcpp/pull/495>. (#708 <https://github.com/ros2/rclcpp/issues/708>)
* Changed the ``IntraProcessManager`` to be capable of storing ``shared_ptr<const T>`` in addition to ``unique_ptr<T>``. (#690 <https://github.com/ros2/rclcpp/issues/690>)
* Contributors: Alberto Soragna, Dima Dorezyuk, M. M, Michael Carroll, Michael Jeronimo, Tully Foote, William Woodall, ivanpauno, jhdcs
```

## rclcpp_action

```
* Added return code to CancelGoal service response. (#710 <https://github.com/ros2/rclcpp/issues/710>)
* Contributors: Jacob Perron, William Woodall
```

## rclcpp_components

```
* Updated to support changes to ``Node::get_node_names()``. (#698 <https://github.com/ros2/rclcpp/issues/698>)
* Contributors: jhdcs
```

## rclcpp_lifecycle

```
* Added new way to specify QoS settings for publishers and subscriptions. (#713 <https://github.com/ros2/rclcpp/issues/713>)
* Deprecated ``shared_ptr`` and raw pointer versions of ``Publisher<T>::publish()``. (#709 <https://github.com/ros2/rclcpp/issues/709>)
* Implemented API to set callbacks for liveliness and deadline QoS events for publishers and subscriptions. (#695 <https://github.com/ros2/rclcpp/issues/695>)
* Changed the ``IntraProcessManager`` to be capable of storing ``shared_ptr<const T>`` in addition to ``unique_ptr<T>``. (#690 <https://github.com/ros2/rclcpp/issues/690>)
* Contributors: M. M, William Woodall, ivanpauno
```
