### PR TITLE
sros2: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1076,6 +1076,25 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: master
     status: developed
+  sros2:
+    doc:
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    release:
+      packages:
+      - sros2
+      - sros2_cmake
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/sros2-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## sros2

```
* Merge pull request #107 <https://github.com/ros2/sros2/issues/107> from mikaelarguedas/autogenerate_artifacts
* complete xml and not yaml files for create_permission (#104 <https://github.com/ros2/sros2/issues/104>)
* Fix bug preventing generate_policy verb from working with publishers and services
* Add missing attributes to test permissions XML file
* add reference to schema in generated permission files (#84 <https://github.com/ros2/sros2/issues/84>)
* Correct sros2 cli test folder location (#83 <https://github.com/ros2/sros2/issues/83>)
* Merge pull request #72 <https://github.com/ros2/sros2/issues/72> from ros2/xml_profile
* Contributors: Jacob Perron, Michael Carroll, Mikael Arguedas, Ruffin
```

## sros2_cmake

```
* make sros2_cmake use generate_artifacts command (#108 <https://github.com/ros2/sros2/issues/108>)
* default keystore in install space insted of build space (#103 <https://github.com/ros2/sros2/issues/103>)
* make sros2_cmake an ament package (#101 <https://github.com/ros2/sros2/issues/101>)
* remove unnecessary build dependencies (#100 <https://github.com/ros2/sros2/issues/100>)
* linter invocation fixup (#95 <https://github.com/ros2/sros2/issues/95>)
* command needs to be a list and not a string (#96 <https://github.com/ros2/sros2/issues/96>)
* Add CMake lint test to sros2_cmake (#90 <https://github.com/ros2/sros2/issues/90>)
* fix status print to match commands invoked
* Contributors: Jacob Perron, Mikael Arguedas
```
