### PR TITLE
message_filters: 3.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -467,7 +467,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `3.1.1-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.1.0-1`

## message_filters

```
* changes to avoid deprecated API's (#26 <https://github.com/ros2/message_filters/issues/26>)
* Merge pull request #25 <https://github.com/ros2/message_filters/issues/25> from ros2/ivanpauno/deprecate-shared-ptr-publish
* adding code import references in comments (#6 <https://github.com/ros2/message_filters/issues/6>)
* Make format string agree with argument type. (#24 <https://github.com/ros2/message_filters/issues/24>)
* Contributors: Steven! Ragnarök, Tully Foote, William Woodall, ivanpauno
```
