### PR TITLE
rosbag2: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -918,6 +918,32 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  rosbag2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
+    release:
+      packages:
+      - ros2bag
+      - rosbag2
+      - rosbag2_converter_default_plugins
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_test_common
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
+    status: maintained
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros2bag

```
* Fix issue with ros2bag record python frontend (#100 <https://github.com/ros2/rosbag2/issues/100>)
* Consistent node naming across ros2cli tools (#60 <https://github.com/ros2/rosbag2/issues/60>)
* Contributors: AAlon, Sagnik Basu
```

## rosbag2

```
* Handle message type name with multiple namespace parts (#114 <https://github.com/ros2/rosbag2/issues/114>)
* fix compilation against master (#111 <https://github.com/ros2/rosbag2/issues/111>)
* fix logging signature (#107 <https://github.com/ros2/rosbag2/issues/107>)
* Compile tests (#103 <https://github.com/ros2/rosbag2/issues/103>)
* Contributors: Dirk Thomas, Jacob Perron, Karsten Knese
```

## rosbag2_converter_default_plugins

```
* fix compilation against master (#111 <https://github.com/ros2/rosbag2/issues/111>)
* fix logging signature (#107 <https://github.com/ros2/rosbag2/issues/107>)
* use fastrtps static instead of dynamic (#104 <https://github.com/ros2/rosbag2/issues/104>)
* Contributors: Dirk Thomas, Karsten Knese
```

## rosbag2_storage

```
* fix logging signature (#107 <https://github.com/ros2/rosbag2/issues/107>)
* Contributors: Dirk Thomas
```

## rosbag2_storage_default_plugins

```
* fix line length of logging macros (#110 <https://github.com/ros2/rosbag2/issues/110>)
* fix logging signature (#107 <https://github.com/ros2/rosbag2/issues/107>)
* Contributors: Dirk Thomas, Karsten Knese
```

## rosbag2_test_common

```
* changes to avoid deprecated API's (#115 <https://github.com/ros2/rosbag2/issues/115>)
* fix compilation against master (#111 <https://github.com/ros2/rosbag2/issues/111>)
* Compile tests (#103 <https://github.com/ros2/rosbag2/issues/103>)
* enforce unique node names (#86 <https://github.com/ros2/rosbag2/issues/86>)
* Contributors: Dirk Thomas, Karsten Knese, William Woodall
```

## rosbag2_tests

```
* fix compilation against master (#111 <https://github.com/ros2/rosbag2/issues/111>)
* use fastrtps static instead of dynamic (#104 <https://github.com/ros2/rosbag2/issues/104>)
* Compile tests (#103 <https://github.com/ros2/rosbag2/issues/103>)
* remove duplicate repos (#102 <https://github.com/ros2/rosbag2/issues/102>)
* removed dependency to ros1_bridge package (#90 <https://github.com/ros2/rosbag2/issues/90>)
* Contributors: DensoADAS, Dirk Thomas, Karsten Knese
```

## rosbag2_transport

```
* ignore cast function type warning (#116 <https://github.com/ros2/rosbag2/issues/116>)
* changes to avoid deprecated API's (#115 <https://github.com/ros2/rosbag2/issues/115>)
* Handle message type name with multiple namespace parts (#114 <https://github.com/ros2/rosbag2/issues/114>)
* fix compilation against master (#111 <https://github.com/ros2/rosbag2/issues/111>)
* fix logging signature (#107 <https://github.com/ros2/rosbag2/issues/107>)
* use fastrtps static instead of dynamic (#104 <https://github.com/ros2/rosbag2/issues/104>)
* enforce unique node names (#86 <https://github.com/ros2/rosbag2/issues/86>)
* disable cppcheck (#91 <https://github.com/ros2/rosbag2/issues/91>)
* Consistent node naming across ros2cli tools (#60 <https://github.com/ros2/rosbag2/issues/60>)
* Contributors: AAlon, Dirk Thomas, Jacob Perron, Karsten Knese, William Woodall
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

```
* Pass CMAKE_TOOLCHAIN_FILE if crosscompiling (#112 <https://github.com/ros2/rosbag2/issues/112>)
* Contributors: Esteve Fernandez
```
