### PR TITLE
ros1_bridge: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -866,6 +866,21 @@ repositories:
       url: https://github.com/ros2/robot_state_publisher.git
       version: ros2
     status: maintained
+  ros1_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros1_bridge-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    status: developed
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
