### PR TITLE
rosbag2: 0.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -953,7 +953,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros2/rosbag2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.1.1-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* fix condition to only apply pragma for GCC 8+ (#117 <https://github.com/ros2/rosbag2/issues/117>)
* Contributors: Dirk Thomas
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
