### PR TITLE
rviz: 6.0.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1118,6 +1118,31 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: master
     status: developed
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: ros2
+    release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz-release.git
+      version: 6.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: ros2
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.0.0-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Made changes to avoid newly deprecated API's related to publishers and subscriptions. (#399 <https://github.com/ros2/rviz/issues/399>)
* Updated to be compatible with new QoS settings.  (#392 <https://github.com/ros2/rviz/issues/392>)
* Fixed a crash on shutdown by properly freeing the ``transformation_manager``. (#386 <https://github.com/ros2/rviz/issues/386>)
* Contributors: M. M, Michael Jeronimo, William Woodall
```

## rviz_default_plugins

```
* Made changes to avoid newly deprecated API's related to publishers and subscriptions. (#399 <https://github.com/ros2/rviz/issues/399>)
* Made changes to avoid newly deprecated API's related to publish calls that used ``shared_ptr``. signature (#398 <https://github.com/ros2/rviz/issues/398>)
* Changed to use the ``ament_include_directories_order`` macro to ensure header include path ordering is correct. (#384 <https://github.com/ros2/rviz/issues/384>)
* Made changes to fix interoperability with ``robot_state_publisher``. #14 <https://github.com/ros2/rviz/issues/14> (#378 <https://github.com/ros2/rviz/issues/378>)
* Contributors: Karsten Knese, William Woodall, ivanpauno
```

## rviz_ogre_vendor

```
* Suppress ogre_vendor warnings in clang+libcxx build. The -w flag was not strong enough for Clang builds. (#389 <https://github.com/ros2/rviz/issues/389>)
  Signed-off-by: Emerson Knapp <mailto:eknapp@amazon.com>
* Pass through only the stdlib flag to the vendor build, instead of all C++ flags (#388 <https://github.com/ros2/rviz/issues/388>)
  Signed-off-by: Emerson Knapp <mailto:eknapp@amazon.com>
* Pass through CXX flags to OGRE vendor build (#381 <https://github.com/ros2/rviz/issues/381>)
  * Pass through CXX flags
  Signed-off-by: Emerson Knapp <mailto:eknapp@amazon.com>
  * fixup
  Signed-off-by: William Woodall <mailto:william@osrfoundation.org>
  * re-add removed libc++ flag, because OSX build always needs it
  Signed-off-by: Emerson Knapp <mailto:eknapp@amazon.com>
* Propagate toolchain-file to external-project (#374 <https://github.com/ros2/rviz/issues/374>)
  If defined, propagate the CMAKE_TOOLCHAIN_FILE argument to the cmake
  argument of freetype, zlib and ogre projects.
  Change-Id: Ibf2802b96c2238a06191e78a1b2a3128769a83af
  Signed-off-by: Louis Mayencourt <mailto:louis.mayencourt@arm.com>
* Contributors: Emerson Knapp, lmayencourt
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
