### PR TITLE
yp-spur: 1.16.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16155,7 +16155,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.15.3-0
+      version: 1.16.0-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.16.0-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.15.3-0`
