### PR TITLE
ypspur_ros: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16170,7 +16170,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/ypspur_ros-release.git
-      version: 0.2.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/openspur/ypspur_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.3.0-1`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-0`

## ypspur_ros

```
* Add parameter to set expire duration of cmd_vel (#55 <https://github.com/openspur/ypspur_ros/issues/55>)
* Ignore outdated JointTrajectory command (#54 <https://github.com/openspur/ypspur_ros/issues/54>)
* Fix exception type (#52 <https://github.com/openspur/ypspur_ros/issues/52>)
* Fix subprocess handling (#48 <https://github.com/openspur/ypspur_ros/issues/48>)
* Add device error status diagnostic output (#46 <https://github.com/openspur/ypspur_ros/issues/46>)
* Fix test dependencies and update manifest (#42 <https://github.com/openspur/ypspur_ros/issues/42>)
* Contributors: Atsushi Watanabe
```
