### PR TITLE
neonavigation: 0.4.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7717,7 +7717,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.3.1-0
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.4.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.1-0`

## costmap_cspace

```
* costmap_cspace: add const begin/end to PointcloudAccumurator (#294 <https://github.com/at-wat/neonavigation/issues/294>)
* Contributors: Naotaka Hatao
```

## joystick_interrupt

```
* Add LICENSE file (#270 <https://github.com/at-wat/neonavigation/issues/270>)
* Contributors: Atsushi Watanabe
```

## map_organizer

```
* Add LICENSE file (#270 <https://github.com/at-wat/neonavigation/issues/270>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

```
* Add LICENSE file (#270 <https://github.com/at-wat/neonavigation/issues/270>)
* Contributors: Atsushi Watanabe
```

## neonavigation_launch

```
* trajectory_tracker: remove unused parameters (#274 <https://github.com/at-wat/neonavigation/issues/274>)
* Contributors: Yuta Koga
```

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: limit negative cost to avoid infinite search loop (#288 <https://github.com/at-wat/neonavigation/issues/288>)
* trajectory_tracker: remove unused parameters (#274 <https://github.com/at-wat/neonavigation/issues/274>)
* Support melodic (#266 <https://github.com/at-wat/neonavigation/issues/266>)
* Contributors: Atsushi Watanabe, Yuta Koga
```

## safety_limiter

```
* safety_limiter: fix backward motion limit (#292 <https://github.com/at-wat/neonavigation/issues/292>)
* safety_limiter: fix CloudBuffering test start timing (#279 <https://github.com/at-wat/neonavigation/issues/279>)
* Fix package dependencies (#268 <https://github.com/at-wat/neonavigation/issues/268>)
* Contributors: Atsushi Watanabe, Yuta Koga
```

## track_odometry

```
* track_odometry: fix z_filter unit to seconds (#290 <https://github.com/at-wat/neonavigation/issues/290>)
* track_odometry: add project_posture option to tf_projection node (#286 <https://github.com/at-wat/neonavigation/issues/286>)
* track_odometry: refactor tf_projection (#285 <https://github.com/at-wat/neonavigation/issues/285>)
* track_odometry: set missing child_frame_id in tf_projection (#283 <https://github.com/at-wat/neonavigation/issues/283>)
* Contributors: Atsushi Watanabe, Yuta Koga
```

## trajectory_tracker

```
* trajectory_tracker: speed up simulation on rostest (#280 <https://github.com/at-wat/neonavigation/issues/280>)
* trajectory_tracker: linear velocity adaptive gain control (#276 <https://github.com/at-wat/neonavigation/issues/276>)
* trajectory_tracker: remove unused parameters (#274 <https://github.com/at-wat/neonavigation/issues/274>)
* trajectory_tracker: fix remained distance for path with two poses (#272 <https://github.com/at-wat/neonavigation/issues/272>)
* Add LICENSE file (#270 <https://github.com/at-wat/neonavigation/issues/270>)
* Support melodic (#266 <https://github.com/at-wat/neonavigation/issues/266>)
* Contributors: Atsushi Watanabe, Yuta Koga
```
