### PR TITLE
manually enable PR testing for rosbag2

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -955,6 +955,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2-release.git
       version: 0.1.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosbag2.git
       version: master


### PR DESCRIPTION
This should enable PR testing for rosbag2