### PR TITLE
fiducials: 0.11.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3127,7 +3127,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/fiducials-release.git
-      version: 0.10.0-0
+      version: 0.11.0-1
     source:
       type: git
       url: https://github.com/UbiquityRobotics/fiducials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fiducials` to `0.11.0-1`:

- upstream repository: https://github.com/UbiquityRobotics/fiducials
- release repository: https://github.com/UbiquityRobotics-release/fiducials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.10.0-0`

## aruco_detect

```
* Compatibilty with Melodic
  
  remove opencv3 dependancy, opencv3 is no longer a package in melodic, so we use cv_bridge
  
  Fix build on OpenCV 3.2
* Import empy with full path to avoid pip conflict
* Use subprocess for cairosvg to avoid lack of python2 support
* call genMarker with correct arguments with no joblib
* Check ignoreID's in TF publishing
* Added topic that enables/disables Aruco detections
* Added rosdeps for cairo and joblib
* Add params for determining weighting of observations; prevent compiler warnings
* add cli argument for paper size to create markers
* Contributors: Jack Kilian, Jim Vaughan, Rohan Agrawal, Tim Übelhör, jack
```

## fiducial_msgs

- No changes

## fiducial_slam

```
* Compatibilty with Melodic, remove opencv3 dependancy
  opencv3 is no longer a package in melodic, so we use cv_bridge
  to get the correct opencv transitively
* New fusion with planar-based error estimation
  * Estimate variance of fiducial obsevations based on how well they place the robot on the floor upright
  * use Kalman + David method of fusing estimates
  * split out Transform with Variance, do some cleanup
  * Simple unit tests for core fusion code
  * remove hokey outlier rejection
* Add support for overriding covariance diagonal
* Add fiducial transform array stamp (#156 <https://github.com/UbiquityRobotics/fiducials/issues/156>)
* Add publish_tf rosparam functionality and updated launch file accordingly (#154 <https://github.com/UbiquityRobotics/fiducials/issues/154>)
  * Added publish_tf rosparam to disable publishing pose tf
  * Change default publish_tf to True and fix 'if' formatting
* Contributors: Jack Kilian, Jim Vaughan, Rohan Agrawal
```

## fiducials

- No changes
