### PR TITLE
qt_gui_core: 1.0.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -587,6 +587,29 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/qt_gui_core-release.git
+      version: 1.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    status: maintained
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.0.4-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## qt_dotgraph

```
* skip pydot/pygraphviz tests when unavailable (#161 <https://github.com/ros-visualization/qt_gui_core/issues/161>)
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui

```
* fix dictionary changes size during iteration (#166 <https://github.com/ros-visualization/qt_gui_core/issues/166>)
* fix typo (#164 <https://github.com/ros-visualization/qt_gui_core/issues/164>)
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui_app

```
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui_cpp

```
* support TinyXML2 version 2.2.0 on Xenial (#169 <https://github.com/ros-visualization/qt_gui_core/issues/169>)
* set default C++ standard to 14
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```

## qt_gui_py_common

```
* remove obsolete maintainer (#159 <https://github.com/ros-visualization/qt_gui_core/issues/159>)
```
