### PR TITLE
keystroke: 0.3.0-2 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -714,7 +714,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/RoverRobotics/ros2-keystroke-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
     source:
       type: git
       url: https://github.com/RoverRobotics/ros2-keystroke.git


### PR DESCRIPTION
Increasing version of package(s) in repository `keystroke` to `0.3.0-2`:

- upstream repository: https://github.com/RoverRobotics/ros2-keystroke.git
- release repository: https://github.com/RoverRobotics/ros2-keystroke-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.0-1`

## keystroke

```
* Fix crash on headless Linux server
* Fix crash on unknown keyboard key
* Reduce default linear scale
* Setup script tweaks
* Change license to BSD
```
