### PR TITLE
rqt_py_console: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1180,6 +1180,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_py_console-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros2-gbp/rqt_py_console-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_py_console

```
* spyderlib -> spyder (#5 <https://github.com/ros-visualization/rqt_py_console/issues/5>)
* ros2 port (#3 <https://github.com/ros-visualization/rqt_py_console/issues/3>)
* autopep8 (#2 <https://github.com/ros-visualization/rqt_py_console/issues/2>)
* Contributors: Mike Lautman
```
