### PR TITLE
rqt_plot: 1.0.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1196,6 +1196,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_graph.git
       version: crystal-devel
     status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_plot-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.0.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
