### PR TITLE
rqt_console: 1.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1180,6 +1180,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_console-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: crystal-devel
+    status: maintained
   rqt_graph:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `1.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_console

```
* remove unnecesary find_package call (#9 <https://github.com/ros-visualization/rqt_console/issues/9>)
```
