### PR TITLE
rqt_service_caller: 1.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1261,6 +1261,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: crystal-devel
     status: maintained
+  rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_service_caller-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: crystal-devel
+    status: maintained
   rqt_shell:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `1.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros2-gbp/rqt_service_caller-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
