### PR TITLE
rqt_msg: 1.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1196,6 +1196,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_graph.git
       version: crystal-devel
     status: maintained
+  rqt_msg:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_msg-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `1.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros2-gbp/rqt_msg-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
