### PR TITLE
rqt_image_view: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1200,21 +1200,6 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
-  rqt_image_view:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/rqt_image_view.git
-      version: crystal-devel
-    release:
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.0.0-1
-    source:
-      type: git
-      url: https://github.com/ros-visualization/rqt_image_view.git
-      version: crystal-devel
-    status: maintained
   rqt_console:
     doc:
       type: git
@@ -1244,6 +1229,21 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
+      version: crystal-devel
+    status: maintained
+  rqt_image_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_view-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
       version: crystal-devel
     status: maintained
   rqt_msg:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1223,7 +1223,6 @@ repositories:
     release:
       tags:
         release: release/dashing/{package}/{version}
-
       url: https://github.com/ros2-gbp/rqt_console-release.git
       version: 1.0.1-1
     source:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1180,6 +1180,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_image_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_view-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_image_view

```
* fix various compiler warnings (#20 <https://github.com/ros-visualization/rqt_image_view/issues/20>)
* Notifying developers that rqt_image_view is not available for windows (#19 <https://github.com/ros-visualization/rqt_image_view/issues/19>)
* Ros2 port (#18 <https://github.com/ros-visualization/rqt_image_view/issues/18>)
* Contributors: Dirk Thomas, Mike Lautman
```
