### PR TITLE
rqt_srv: 1.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1226,6 +1226,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: crystal-devel
     status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_srv-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    status: maintained
   rqt_top:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_srv` to `1.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_srv.git
- release repository: https://github.com/ros2-gbp/rqt_srv-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_srv

```
* Fixing CMakeLists.txt (#3 <https://github.com/ros-visualization/rqt_srv/issues/3>)
* Contributors: Mike Lautman
```
