### PR TITLE
geometry2: 0.11.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -341,7 +341,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.0-1`

## tf2

- No changes

## tf2_eigen

```
* also export Eigen3 include directories (#102 <https://github.com/ros2/geometry2/issues/102>)
* Contributors: Marcus Scheunemann
```

## tf2_geometry_msgs

- No changes

## tf2_msgs

```
* Tf2_msgs including actions (#109 <https://github.com/ros2/geometry2/issues/109>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_ros

```
* use node interfaces throughout tf2_ros (#108 <https://github.com/ros2/geometry2/issues/108>)
* changes to avoid deprecated API's (#107 <https://github.com/ros2/geometry2/issues/107>)
* Fix call to create_publisher after API changed (#105 <https://github.com/ros2/geometry2/issues/105>)
* Use node interfaces for static transform broadcaster (#104 <https://github.com/ros2/geometry2/issues/104>)
* Contributors: Emerson Knapp, Karsten Knese, William Woodall
```

## tf2_sensor_msgs

- No changes
