### PR TITLE
sicktoolbox: 1.0.104-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13447,6 +13447,22 @@ repositories:
       url: https://github.com/SICKAG/sick_visionary_t.git
       version: indigo-devel
     status: maintained
+  sicktoolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox.git
+      version: catkin
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-gbp/sicktoolbox-release.git
+      version: 1.0.104-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/sicktoolbox.git
+      version: catkin
+    status: maintained
   sicktoolbox_wrapper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicktoolbox` to `1.0.104-2`:

- upstream repository: https://github.com/ros-drivers/sicktoolbox.git
- release repository: https://github.com/ros-gbp/sicktoolbox-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## sicktoolbox

- No changes
