### PR TITLE
skip devel job for ros1_bridge in Dashing

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -936,6 +936,7 @@ repositories:
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
       version: 0.7.0-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master


### PR DESCRIPTION
Since the devel job doesn't have any ROS 1 environment set up.