### PR TITLE
tork_moveit_tutorial: 0.0.6-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16277,7 +16277,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/tork-a/tork_moveit_tutorial-release.git
-      version: 0.0.3-0
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/tork-a/tork_moveit_tutorial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tork_moveit_tutorial` to `0.0.6-1`:

- upstream repository: https://github.com/tork-a/tork_moveit_tutorial.git
- release repository: https://github.com/tork-a/tork_moveit_tutorial-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.3-0`

## tork_moveit_tutorial

```
* Enable to run both indigo and kinetic (#27 <https://github.com/tork-a/tork_moveit_tutorial/issues/27>)
  
    * mod for PyQt4/PyQt5 compatible codes
    * mod for ROS Kinetic (PyQt4->PyQt5) and gazobo_ros dependency
  
* Fix #13 <https://github.com/tork-a/tork_moveit_tutorial/issues/13> , #14 <https://github.com/tork-a/tork_moveit_tutorial/issues/14> , #15 <https://github.com/tork-a/tork_moveit_tutorial/issues/15> , #16 <https://github.com/tork-a/tork_moveit_tutorial/issues/16> , (#17 <https://github.com/tork-a/tork_moveit_tutorial/issues/17>)
  
    * Fix wrong link strings
    * Correct minor typos
    * Add section for license
    * Add link to origian GitHub page
    * Fix if/then sentences
    * mod for kinetic tutorial, correct typos, change '<br>' to 2 spaces (markdown new line)
  
* remove footer in CC section, close #14 <https://github.com/tork-a/tork_moveit_tutorial/issues/14> (#22 <https://github.com/tork-a/tork_moveit_tutorial/issues/22>)
* enable to compile both indigo and kinetic document (#25 <https://github.com/tork-a/tork_moveit_tutorial/issues/25>)
  
    * migrate to circleci2
    * enable to compile both indigo and kinetic
    * replace indigo to <$ROS_DISTRO>  usg gpp to preprocess ROS_DISTRO, see  http://files.nothingisreal.com/software/gpp/gpp.html, https://randomdeterminism.wordpress.com/2012/06/01/how-i-stopped-worring-and-started-using-markdown-like-tex/
  
* Update moveit-tutorial_ja_robot-simulator.md (#21 <https://github.com/tork-a/tork_moveit_tutorial/issues/21>)
* Fix dpkg error in CircleCI (#19 <https://github.com/tork-a/tork_moveit_tutorial/issues/19>)
  
    * Specify the version of sphinx and recommonmark
    * Fix dpkg error in CircleCI
  
* [tork_moveit_tutorial/script] fix import module name (#10 <https://github.com/tork-a/tork_moveit_tutorial/issues/10>)
  
    * [tork_moveit_tutorial/doc] add missing bar in function reference.
    * [tork_moveit_tutorial/script/nextage_moveit_tutorial_poses_botharms.py] fix arguments for pose target 1.
    * [tork_moveit_tutorial/script] fix import package name: moveit_tutorial_tools -> tork_moveit_tutorial.
  
* Contributors: Kei Okada, Masaki Murooka, Ryosuke Tajima, Yosuke Yamamoto
```
