### PR TITLE
rtmros_nextage: 0.8.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13031,7 +13031,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.8.4-0
+      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/tork-a/rtmros_nextage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.8.5-1`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.4-0`

## nextage_calibration

- No changes

## nextage_description

- No changes

## nextage_gazebo

```
* add ar_track_alvar dependency and gazebo model path to nextage_gazebo/models (#362 <https://github.com/tork-a/rtmros_nextage/issues/362>)
* Contributors: Kei Okada, Yamamoto Yosuke
```

## nextage_ik_plugin

- No changes

## nextage_moveit_config

- No changes

## nextage_ros_bridge

```
* add ar_track_alvar dependency and gazebo model path to nextage_gazebo/models (#362 <https://github.com/tork-a/rtmros_nextage/issues/362>)
* Contributors: Kei Okada, Yosuke Yamamoto
```

## rtmros_nextage

- No changes
