### PR TITLE
cnn_bridge: 0.8.4-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -641,6 +641,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cnn_bridge:
+    doc:
+      type: git
+      url: https://github.com/wew84/cnn_bridge-doc.git
+      version: 0.8.4
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/wew84/cnn_bridge-release.git
+      version: 0.8.4-2
+    source:
+      type: git
+      url: https://github.com/wew84/cnn_bridge.git
+      version: 0.8.4
+    status: developed
   cob_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cnn_bridge` to `0.8.4-2`:

- upstream repository: https://github.com/wew84/cnn_bridge.git
- release repository: https://github.com/wew84/cnn_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cnn_bridge

```
* Moved source to repo
* Initial commit
* Contributors: Noam C. Golombek
```
