### PR TITLE
Add libavdevice-dev lib

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1517,6 +1517,9 @@ libavahi-core-dev:
   fedora: [avahi-devel]
   gentoo: [net-dns/avahi]
   ubuntu: [libavahi-core-dev]
+libavdevice-dev:
+  debian: [libavdevice-dev]
+  ubuntu: [libavdevice-dev]
 libb64-dev:
   arch: [libb64]
   debian: [libb64-dev]


### PR DESCRIPTION
debian:[https://packages.debian.org/stretch/libavdevice-dev](https://packages.debian.org/stretch/libavdevice-dev)
ubuntu: [https://packages.ubuntu.com/bionic/libavdevice-dev](https://packages.ubuntu.com/bionic/libavdevice-dev)