### PR TITLE
rosthrottle: 1.2.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6393,6 +6393,13 @@ repositories:
       url: https://github.com/OUXT-Polaris/rostate_machine.git
       version: master
     status: developed
+  rosthrottle:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UTNuclearRoboticsPublic/rosthrottle-release.git
+      version: 1.2.0-3
+    status: maintained
   roswww:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6394,6 +6394,10 @@ repositories:
       version: master
     status: developed
   rosthrottle:
+    doc:
+      type: git
+      url: https://github.com/UTNuclearRoboticsPublic/rosthrottle.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rosthrottle` to `1.2.0-3`:

- upstream repository: https://github.com/UTNuclearRoboticsPublic/rosthrottle.git
- release repository: https://github.com/UTNuclearRoboticsPublic/rosthrottle-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
