### PR TITLE
Include boost-python2-devel in boost dep for Fedora 29+

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -286,7 +286,7 @@ boost:
     squeeze: [libboost1.42-all-dev]
     stretch: [libboost-all-dev]
     wheezy: [libboost-all-dev]
-  fedora: [boost-devel]
+  fedora: [boost-devel, boost-python2-devel]
   freebsd: [boost-python-libs]
   gentoo: ['dev-libs/boost[python]']
   macports: [boost]


### PR DESCRIPTION
https://apps.fedoraproject.org/packages/boost-python2-devel

Fedora 28 is EOL very soon, anything prior to that was EOL long ago.

Blocks builds of `camera_calibration_parsers`. Thanks!