### PR TITLE
industrial_robot_status_controller: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4912,7 +4912,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
-      version: 0.1.1-0
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/gavanderhoorn/industrial_robot_status_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_robot_status_controller` to `0.1.2-1`:

- upstream repository: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
- release repository: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-0`

## industrial_robot_status_controller

```
* Fix potential build ordering problem with industrial_msgs pkg. (#4 <https://github.com/gavanderhoorn/industrial_robot_status_controller/issues/4>)
* Contributors: Bianca Homberg
```

## industrial_robot_status_interface

- No changes
