### PR TITLE
Add rdl release to melodic distribution file

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5412,6 +5412,29 @@ repositories:
       url: https://github.com/roboception/rc_visard_ros.git
       version: master
     status: developed
+  rdl:
+    doc:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    release:
+      packages:
+      - rdl
+      - rdl_benchmark
+      - rdl_cmake
+      - rdl_dynamics
+      - rdl_msgs
+      - rdl_ros_tools
+      - rdl_urdfreader
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.com/jlack/rdl_release.git
+      version: 3.2.0-1
+    source:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    status: developed
   realtime_tools:
     doc:
       type: git


### PR DESCRIPTION
First release of rdl packages to melodic and increasing version of packages in repository from the kinetic release to 3.2.0-0:

upstream repository: https://gitlab.com/jlack/rdl.git
release repository: https://gitlab.com/jlack/rdl_release.git
distro file: melodic/distribution.yaml
bloom version: 0.8.0
previous version for package: 1.1.0-0