### PR TITLE
apriltag: 3.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -130,6 +130,17 @@ repositories:
       url: https://github.com/pr2/app_manager.git
       version: kinetic-devel
     status: unmaintained
+  apriltag:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/AprilRobotics/apriltag-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/aprilrobotics/apriltag.git
+      version: master
+    status: maintained
   ar_track_alvar:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.1.0-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/AprilRobotics/apriltag-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
