### PR TITLE
apriltag: 3.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -216,6 +216,17 @@ repositories:
       url: https://github.com/pr2/app_manager.git
       version: kinetic-devel
     status: unmaintained
+  apriltag:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AprilRobotics/apriltag-release.git
+      version: 3.1.0-2
+    source:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    status: maintained
   apriltags2_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.1.0-2`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/AprilRobotics/apriltag-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
