### PR TITLE
toposens: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7555,6 +7555,27 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/topics_rviz_plugin.git
       version: melodic
     status: maintained
+  toposens:
+    doc:
+      type: git
+      url: https://gitlab.com/toposens/public/ts-ros
+      version: master
+    release:
+      packages:
+      - toposens
+      - toposens_driver
+      - toposens_markers
+      - toposens_msgs
+      - toposens_pointcloud
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.com/toposens/public/toposens-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/toposens/public/ts-ros
+      version: master
+    status: developed
   towr:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.0.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ts-ros.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## toposens

- No changes

## toposens_driver

```
* Exec CI on 8 runners
* Debugged driver tests in CI pipeline
* Added setup delay to Hz tests
* Contributors: Adi Singh, Christopher Lang, Sebastian Dengler
```

## toposens_markers

```
* Exec CI on 8 runners
* Debugged driver tests in CI pipeline
* Added setup delay to Hz tests
* Contributors: Adi Singh, Christopher Lang, Sebastian Dengler
```

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Exec CI on 8 runners
* Debugged driver tests in CI pipeline
* Added setup delay to Hz tests
* Contributors: Adi Singh, Christopher Lang, Sebastian Dengler
```
