### PR TITLE
Fix libgsl rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2090,7 +2090,7 @@ libgsl:
     jessie: [libgsl0-dev]
     stretch: [libgsl-dev]
     wheezy: [libgsl0-dev]
-  fedora: [gsl]
+  fedora: [gsl-devel]
   gentoo: [sci-libs/gsl]
   macports: [gsl]
   ubuntu:


### PR DESCRIPTION
Looks like the dev package is referenced by the other rules.

https://apps.fedoraproject.org/packages/gsl-devel