### PR TITLE
Fix gfortran rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -990,7 +990,7 @@ gforth:
 gfortran:
   arch: [gcc-fortran]
   debian: [gfortran]
-  fedora: [gcc-fortran]
+  fedora: [gcc-gfortran]
   gentoo: ['sys-devel/gcc[fortran]']
   ubuntu: [gfortran]
 gifsicle:


### PR DESCRIPTION
This package name changed a *long* time ago.

Listed as a subpackage of gcc: https://apps.fedoraproject.org/packages/gcc