### PR TITLE
object_msgs: 0.4.0-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -511,6 +511,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros2
     status: maintained
+  object_msgs:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_object_msgs.git
+      version: 0.4.0
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_msgs-release.git
+      version: 0.4.0-0
+    source:
+      type: git
+      url: https://github.com/intel/ros2_object_msgs.git
+      version: master
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_msgs` to `0.4.0-0`:

- upstream repository: https://github.com/intel/ros2_object_msgs.git
- release repository: https://github.com/ros2-gbp/ros2_object_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## object_msgs

```
* Merge pull request #3 <https://github.com/RachelRen05/ros2_object_msgs/issues/3> from chaoli2/master
  Revert "update object message type to support multiple device"
* Revert "update object message type to support multiple device"
  This reverts commit a2dcbd98a705e881692e636a34d1029afd41fb90.
* Merge pull request #2 <https://github.com/RachelRen05/ros2_object_msgs/issues/2> from chaoli2/support_parallel
  update object message type to support multiple device
* update object message type to support multiple device
  Signed-off-by: Chao Li <mailto:chao1.li@intel.com>
* Contributors: Chao Li
```
