### PR TITLE
Add pymavlink package definition for Debian

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2998,6 +2998,9 @@ python-pylint:
       packages: [pylint]
   ubuntu: [pylint]
 python-pymavlink:
+  debian:
+    pip:
+      packages: [pymavlink]
   fedora:
     pip:
       packages: [pymavlink]


### PR DESCRIPTION
Package `python-pymavlink` lacks a rosdep definition for Debian. This P/R adds this definition.