### PR TITLE
rtt_ros_integration: 2.9.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13140,7 +13140,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_ros_integration-release.git
-      version: 2.9.1-0
+      version: 2.9.2-1
     source:
       type: git
       url: https://github.com/orocos/rtt_ros_integration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_ros_integration` to `2.9.2-1`:

- upstream repository: https://github.com/orocos/rtt_ros_integration.git
- release repository: https://github.com/orocos-gbp/rtt_ros_integration-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.1-0`

## rtt_actionlib

- No changes

## rtt_actionlib_msgs

- No changes

## rtt_common_msgs

- No changes

## rtt_diagnostic_msgs

- No changes

## rtt_dynamic_reconfigure

- No changes

## rtt_geometry_msgs

- No changes

## rtt_kdl_conversions

- No changes

## rtt_nav_msgs

- No changes

## rtt_ros

```
* Merge pull request #111 <https://github.com/orocos/rtt_ros_integration/issues/111> from orocos/fix-110 into 2.9.2
  * Declare loadROSService() methods as static to fix name clashes (fix #110 <https://github.com/orocos/rtt_ros_integration/issues/110>)
* Merge pull request #99 <https://github.com/orocos/rtt_ros_integration/issues/99> from disRecord/feat/ros-time-type-fix
  * Fix ros::time and ros::duration typekit by replacing PrimitiveType with StructType.
* rtt_ros: remove extra semicolon after namespace closing bracket
* Contributors: Johannes Meyer, disRecord
```

## rtt_ros_comm

- No changes

## rtt_ros_integration

- No changes

## rtt_ros_msgs

- No changes

## rtt_rosclock

```
* Merge pull request #112 <https://github.com/orocos/rtt_ros_integration/issues/112> from honeybee-robotics-forks/fix-rtt-rosclock-thread-segfault into 2.9.2
  * rtt_rosclock: fixing isSelf segfault when using simclock with ownthread operation caller
* Contributors: Johannes Meyer, Jonathan Bohren
```

## rtt_roscomm

```
* Merge pull request #111 <https://github.com/orocos/rtt_ros_integration/issues/111> from orocos/fix-110 into 2.9.2
  * Declare loadROSService() methods as static to fix name clashes (fix #110 <https://github.com/orocos/rtt_ros_integration/issues/110>)
* Merge pull request #109 <https://github.com/orocos/rtt_ros_integration/issues/109> from orocos/fix/rtt_roscomm-python-interpreter into 2.9.2
  * rtt_roscomm: fix hard-coded path to python interpreter in shebang of create_boost_header.py
* Merge pull request #106 <https://github.com/orocos/rtt_ros_integration/issues/106> from ahoarau/patch-2 into 2.9.2
  * add topicLatched to scripting
* Contributors: Antoine Hoarau, Johannes Meyer
```

## rtt_rosdeployment

- No changes

## rtt_rosgraph_msgs

- No changes

## rtt_rosnode

```
* Merge pull request #116 <https://github.com/orocos/rtt_ros_integration/issues/116> from ahoarau/patch-3 into 2.9.2
  Defaults the number of spinner threads
* Defaults the number of spinner threads
  To the number of CPUs available
* Merge pull request #111 <https://github.com/orocos/rtt_ros_integration/issues/111> from orocos/fix-110 into 2.9.2
  Declare loadROSService() methods as static to fix name clashes
* Declare loadROSService() methods as static to fix name clashes (fix #110 <https://github.com/orocos/rtt_ros_integration/issues/110>)
* Merge pull request #98 <https://github.com/orocos/rtt_ros_integration/issues/98> from disRecord/feat/get-node-name
  rtt_rosnode: Add getNodeName() and getNamespace() operations.
* rtt_rosnode: Add getNodeName() and getNamespace() operations.
* Contributors: Antoine Hoarau, Johannes Meyer, disRecord
```

## rtt_rospack

- No changes

## rtt_rosparam

- No changes

## rtt_sensor_msgs

- No changes

## rtt_shape_msgs

- No changes

## rtt_std_msgs

- No changes

## rtt_std_srvs

- No changes

## rtt_stereo_msgs

- No changes

## rtt_tf

- No changes

## rtt_trajectory_msgs

- No changes

## rtt_visualization_msgs

- No changes
