### PR TITLE
librealsense: 2.16.5-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -467,6 +467,23 @@ repositories:
       url: https://github.com/ros2/launch_ros.git
       version: master
     status: developed
+  librealsense:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    release:
+      packages:
+      - librealsense2
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/librealsense-release.git
+      version: 2.16.5-0
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    status: maintained
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `2.16.5-0`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/ros2-gbp/librealsense-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`
