### PR TITLE
log4cpp: 2.9.1-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -2253,7 +2253,10 @@ repositories:
       url: https://github.com/orocos-toolchain/log4cpp.git
       version: toolchain-2.9
     release:
+      tags:
+        release: release/lunar/{package}/{version}
       url: https://github.com/orocos-gbp/log4cpp-release.git
+      version: 2.9.1-1
     source:
       type: git
       url: https://github.com/orocos-toolchain/log4cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log4cpp` to `2.9.1-1`:

- upstream repository: https://github.com/orocos-toolchain/log4cpp.git
- release repository: https://github.com/orocos-gbp/log4cpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
