### PR TITLE
add libqt5multimedia5-plugins

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3078,6 +3078,11 @@ libqt5-widgets:
   rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu: [libqt5widgets5]
+libqt5multimedia5-plugins:
+  arch: [qt5-multimedia]
+  debian: [libqt5multimedia5-plugins]
+  fedora: [qt5-qtmultimedia]
+  ubuntu: [libqt5multimedia5-plugins]
 libqt5x11extras5-dev:
   arch: [qt5-x11extras]
   debian: [libqt5x11extras5-dev]


### PR DESCRIPTION
debian: https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libqt5multimedia5-plugins
ubuntu: https://packages.ubuntu.com/search?keywords=libqt5multimedia5-plugins

I couldn't find matching packages for multimedia-**plugins** for the other architectures:
 - arch
 - fedora
 - freebsd
 - gentoo

for those only qt5multimedia seems to be available which already is covered by rosdep key `qtmultimedia5-dev`