### PR TITLE
rtt_geometry: 2.9.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13079,7 +13079,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_geometry-release.git
-      version: 2.9.1-0
+      version: 2.9.2-1
     source:
       type: git
       url: https://github.com/orocos/rtt_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.9.2-1`:

- upstream repository: https://github.com/orocos/rtt_geometry.git
- release repository: https://github.com/orocos-gbp/rtt_geometry-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.1-0`

## eigen_typekit

- No changes

## kdl_typekit

```
* kdl_typekit: remove duplicate template instantiations and moved/removed include directives (fix #27 <https://github.com/orocos/rtt_geometry/issues/27>)
* Contributors: Johannes Meyer
```

## rtt_geometry

- No changes
