### PR TITLE
roslisp_common: 0.2.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6286,7 +6286,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/roslisp_common-release.git
-      version: 0.2.10-0
+      version: 0.2.11-1
     source:
       type: git
       url: https://github.com/ros/roslisp_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp_common` to `0.2.11-1`:

- upstream repository: https://github.com/ros/roslisp_common.git
- release repository: https://github.com/ros-gbp/roslisp_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.10-0`
