### PR TITLE
cnn_bridge: 0.8.4-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1323,6 +1323,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cnn_bridge:
+    doc:
+      type: git
+      url: https://github.com/wew84/cnn_bridge.git
+      version: 0.8.4
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/wew84/cnn_bridge-release.git
+      version: 0.8.4-2
+    source:
+      type: git
+      url: https://github.com/wew84/cnn_bridge.git
+      version: 0.8.4
+    status: developed
   cob_android:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cnn_bridge` to `0.8.4-2`:

- upstream repository: https://github.com/wew84/cnn_bridge.git
- release repository: https://github.com/wew84/cnn_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cnn_bridge

```
* Moved source to repo
* Initial commit
* Contributors: Noam C. Golombek
```
