### PR TITLE
mapviz: 1.1.1-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6998,7 +6998,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 1.1.0-0
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.1.1-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-0`

## mapviz

```
* Set main window as in focus on start #630 <https://github.com/swri-robotics/mapviz/issues/630>
* Specify default configuration extension on save
* Contributors: Daniel D'Souza, mattrich37, mrichardson
```

## mapviz_plugins

```
* Textured Marker Adjustments (#611 <https://github.com/swri-robotics/mapviz/issues/611>, #616 <https://github.com/swri-robotics/mapviz/issues/616>) (#625 <https://github.com/swri-robotics/mapviz/issues/625>)
* fixed issue #623 <https://github.com/swri-robotics/mapviz/issues/623> by updating UI field to read "Draw Style:" (#624 <https://github.com/swri-robotics/mapviz/issues/624>)
* Contributors: mattrich37
```

## multires_image

- No changes

## tile_map

- No changes
