### PR TITLE
nmea_msgs: 2.0.0-1 in 'crystal/distribution.yaml'

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -914,6 +914,22 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros2
     status: maintained
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_msgs-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    status: maintained
   object_msgs:
     release:
       tags:


### PR DESCRIPTION
Releasing version 2.0.0-1 of `nmea_msgs` in crystal.

* upstream repository: https://github.com/ros-drivers/nmea_msgs.git
* release repository: https://github.com/ros2-gbp/nmea_msgs-release.git
* distro file: crystal/distribution.yaml

## nmea_msgs
```
* Initial release for ROS 2
* Contributors: Andreas Klintberg, Edward Venator
```