### PR TITLE
[dep] hdf5-tools.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1277,6 +1277,9 @@ hdf5:
   gentoo: [sci-libs/hdf5]
   macports: [hdf5]
   ubuntu: [libhdf5-serial-dev]
+hdf5-tools:
+  debian: [hdf5-tools]
+  ubuntu: [hdf5-tools]
 hostapd:
   arch: [hostapd]
   debian: [hostapd]


### PR DESCRIPTION
- debian https://packages.debian.org/search?keywords=hdf5-tools
- fedora: Not added. I'm not sure if there's an equivalent package. https://github.com/deepmind/torch-hdf5/issues/77 might suggest `hdf5-devel` (which is already listed in rosdep as `hdf5`) covers capability that is included in hdf5-tools, but I can't find a proof.
- gentoo: Not added. Similar to fedora, not sure if already-listed `sci-libs/hdf5` covers -tools.
- Ubuntu: https://packages.ubuntu.com/search?keywords=hdf5-tools. Looks like available `xenial` onward.