### PR TITLE
ros2_intel_realsense: 2.0.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -995,6 +995,24 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: developed
+  ros2_intel_realsense:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: 2.0.3
+    release:
+      packages:
+      - realsense_camera_msgs
+      - realsense_ros2_camera
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: 2.0.3
+    status: maintained
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_realsense` to `2.0.3-1`:

- upstream repository: https://github.com/intel/ros2_intel_realsense.git
- release repository: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## realsense_camera_msgs

- No changes

## realsense_ros2_camera

```
* Merge pull request #18 <https://github.com/intel/ros2_intel_realsense/issues/18> from nuclearsandwich/add-dependencies-to-package.xml
  Add eigen as a build dependency for ros2debian
* Add eigen as a build dependency.
* Contributors: Chris Ye, Steven! Ragnarök
```
