### PR TITLE
cob_android: 0.1.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1338,7 +1338,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_android-release.git
-      version: 0.1.4-0
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_android.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_android` to `0.1.5-1`:

- upstream repository: https://github.com/ipa320/cob_android.git
- release repository: https://github.com/ipa320/cob_android-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.4-0`

## cob_android

- No changes

## cob_android_msgs

- No changes

## cob_android_resource_server

- No changes

## cob_android_script_server

```
* Merge pull request #36 <https://github.com/ipa320/cob_android/issues/36> from benmaidel/feature/trigger_action
  Feature/trigger action
* add support for trigger_action buttons
* fix wrong parameter comparison
* Contributors: Benjamin Maidel, Felix Messmer
```

## cob_android_settings

- No changes
