### PR TITLE
cob_common: 0.6.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1401,7 +1401,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.11-0
+      version: 0.6.12-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.6.12-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.11-0`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

```
* Merge pull request #269 <https://github.com/ipa320/cob_common/issues/269> from fmessmer/fixed_link_helper_macro
  add helper macro for fixed links
* add helper macro for fixed links
* Contributors: Felix Messmer, fmessmer
```

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

- No changes
