### PR TITLE
cob_control: 0.7.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1432,7 +1432,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.4-0
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.4-0`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

```
* Merge pull request #206 <https://github.com/ipa320/cob_control/issues/206> from fmessmer/improve_lookat_extension
  improve lookat extension
* do not start lookat if KinematicExtension service failed
* Contributors: Felix Messmer, fmessmer
```

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

```
* Merge pull request #206 <https://github.com/ipa320/cob_control/issues/206> from fmessmer/improve_lookat_extension
  improve lookat extension
* implement lookat_pointing_frame
* fix lookat_chain offset, allow KinematicExtension to fail, param-config converter functions
* Contributors: Felix Messmer, fmessmer
```
