### PR TITLE
cob_manipulation: 0.7.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1571,7 +1571,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.7.1-0
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.2-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.1-0`

## cob_collision_monitor

- No changes

## cob_grasp_generation

- No changes

## cob_lookat_action

```
* Merge pull request #137 <https://github.com/ipa320/cob_manipulation/issues/137> from fmessmer/improve_lookat
  improve cob_lookat_action
* implement base_active using docker_control/move_base_linear
* check fjt server connected
* improve time_from_start computation
* fail when target_frame is too old
* less debug output
* revert execute flag
* revert base_active
* fix negative axes
* use IkSolverPos_LMA
* fix lookat_chain pointing offset, simplify lookat joints, normalize angles, add fjt path tolerances, fix fjt preemption
* Revert "use JL solver"
  This reverts commit 1f71da01ee09ea134d6c2b587f02f34bd0b24f18.
* use JL solver
* experimental: base_active
* add launch file
* improve preemption, improve timing lookupTransform, improve validity checks, wip debugging
* Contributors: Felix Messmer, fmessmer
```

## cob_manipulation

- No changes

## cob_moveit_bringup

- No changes

## cob_moveit_interface

- No changes

## cob_obstacle_distance_moveit

- No changes

## cob_pick_place_action

- No changes
