### PR TITLE
rc_dynamics_api: 0.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5394,7 +5394,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_dynamics_api-release.git
-      version: 0.7.1-0
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_dynamics_api` to `0.8.0-1`:

- upstream repository: https://github.com/roboception/rc_dynamics_api.git
- release repository: https://github.com/roboception-gbp/rc_dynamics_api-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.1-0`

## rc_dynamics_api

```
* BREAKING CHANGE: major refactoring to comply to naming conventions
* improve cleanup of requested streams
* add support for http status code 429: too many requests
* improve error handling and messages
* add state getters for rc_dynamics, rc_slam, rc_stereo_ins
* return UNKNOWN if dynamics state is not accessible
* improve startup behaviour of RemoteInterface
```
