### PR TITLE
rc_genicam_api: 2.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10353,7 +10353,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.1.0-0
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.2.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.0-0`

## rc_genicam_api

```
* gc_info does not report not implemented parameters any more
* gc_info can now also only print specified nodes (which can be a category) by appending the node name with '?' to the device id.
* gc_stream can now measure frequency and latency of incomming buffers
* Windows: look for transport layer in folder of rc_genicam_api.dll
* support modern cmake
  - A "meta target" for all Genicam targets is defined, rc_genicam_api::genicam, on which rc_genicam_api::rc_genicam_api depends publicly.
  - Compile options and definitions of rc_genicam_api are set to private, only /DGENICAM_NO_AUTO_IMPLIB is public
  - Install paths are defined using GNUInstallDirs
* update Baumer GenTL providers to 2.9.2.22969
  - Support for payload type Multi-part added
  - The GigE Producer now find devices connected to virtual interfaces for Linux
```
