### PR TITLE
rc_visard: 2.6.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5425,13 +5425,15 @@ repositories:
     release:
       packages:
       - rc_hand_eye_calibration_client
+      - rc_pick_client
+      - rc_tagdetect_client
       - rc_visard
       - rc_visard_description
       - rc_visard_driver
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.5.0-0
+      version: 2.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.6.1-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.5.0-0`

## rc_hand_eye_calibration_client

- No changes

## rc_pick_client

- No changes

## rc_tagdetect_client

- No changes

## rc_visard

```
* "fix" CMakeLists.txt so it's not treated as invalid metapackage
```

## rc_visard_description

- No changes

## rc_visard_driver

- No changes
