### PR TITLE
mavros: 0.30.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3259,7 +3259,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.29.2-0
+      version: 0.30.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.30.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.29.2-0`

## libmavconn

- No changes

## mavros

```
* Filter heartbeats by component id as well
  This addresses #1107 <https://github.com/mavlink/mavros/issues/1107> and #1227 <https://github.com/mavlink/mavros/issues/1227>, by filtering incoming heartbeats
  by component ids before publishing the state.
* mavros/src/plugins/command.cpp: log if command's wait ack timeout (#1222 <https://github.com/mavlink/mavros/issues/1222>)
  * mavros/src/plugins/command.cpp: log if command's wait ack timeout
  * mavros/src/plugins/command.cpp: log timeout in wait_ack_for
* local_position fix #1220 <https://github.com/mavlink/mavros/issues/1220>: initialize flags
* plugin waypoint: fix spelling
* Fix leading space before setpoint_raw
  This causes an error when running roslaunch:
  ```
  error loading <rosparam> tag:
  file /opt/ros/kinetic/share/mavros/launch/apm_config.yaml contains invalid YAML:
  while parsing a block mapping
  in "<string>", line 4, column 1:
  startup_px4_usb_quirk: false
  ^
  expected <block end>, but found '<block mapping start>'
  in "<string>", line 103, column 2:
  setpoint_raw:
  ^
  XML is <rosparam command="load" file="$(arg config_yaml)"/>
  The traceback for the exception was written to the log file
  ```
* global_position.cpp: spell in comment
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Josh Veitch-Michaelis, Nico van Duijn, Sergey Zobov, Vladimir Ermakov
```

## mavros_extras

```
* Fixed an issue when the laser scan topic contains NaN values they where being sent as 0 distances. (#1218 <https://github.com/mavlink/mavros/issues/1218>)
* extras #1223 <https://github.com/mavlink/mavros/issues/1223>: Add eigen aligned allocators to plugin classes.
* gps_rtk: fix multi segment messages
* Update the readme
* Contributors: Dr.-Ing. Amilcar do Carmo Lucas, Jaime Machuca, Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
