### PR TITLE
Mark Indigo as EOL

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -36,7 +36,7 @@ distributions:
   indigo:
     distribution: [indigo/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/indigo-cache.yaml.gz
-    distribution_status: active
+    distribution_status: end-of-life
     distribution_type: ros1
   jade:
     distribution: [jade/distribution.yaml]


### PR DESCRIPTION
Indigo is now End of Life.

Announcement: https://discourse.ros.org/t/indigo-igloo-officially-eol/9211
Final Sync: https://discourse.ros.org/t/new-packages-for-indigo-2019-05-10/9107