### PR TITLE
rviz: 6.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1486,7 +1486,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 6.0.0-2
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.1.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `6.0.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Updated to use the new specification for types from the ROS node graph API. (#387 <https://github.com/ros2/rviz/issues/387>)
* Contributors: Jacob Perron
```

## rviz_default_plugins

```
* Updated to use the new specification for types from the ROS node graph API. (#387 <https://github.com/ros2/rviz/issues/387>)
* Contributors: Jacob Perron
```

## rviz_ogre_vendor

```
* Upgraded to OGRE 1.10.12 to get a macOS fix but also not break any APIs by upgrading to OGRE 1.11 (#380 <https://github.com/ros2/rviz/issues/380>)
  Signed-off-by: Emerson Knapp <mailto:eknapp@amazon.com>
* Contributors: Emerson Knapp
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
