### PR TITLE
launch: 0.8.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -462,7 +462,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.8.1-2
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.1-2`

## launch

```
* Moved some common code to LaunchDescriptionSource (#234 <https://github.com/ros2/launch/issues/234>)
* Please flake8 on launch package. (#241 <https://github.com/ros2/launch/issues/241>)
* Allow substitution in variable_name of LaunchConfiguration substitutions (#235 <https://github.com/ros2/launch/issues/235>)
* Add support for custom launch log file handling (#233 <https://github.com/ros2/launch/issues/233>)
* Contributors: Michel Hidalgo, ivanpauno
```

## launch_testing

```
* add non-asserting waitFor method (#243 <https://github.com/ros2/launch/issues/243>)
* Enable reuse of launch testing functionality (#236 <https://github.com/ros2/launch/issues/236>)
* Stop randomizing ROS_DOMAIN_ID by default in launch tests (#240 <https://github.com/ros2/launch/issues/240>)
* Contributors: Dirk Thomas, Michel Hidalgo
```

## launch_testing_ament_cmake

```
* Revert "Include cmake extras for testing (#245 <https://github.com/ros2/launch/issues/245>)"
* Include cmake extras for testing (#245 <https://github.com/ros2/launch/issues/245>)
* [add_launch_test] Correct default python executable for windows debug (#239 <https://github.com/ros2/launch/issues/239>)
* Convert retreived path to CMake path for use. (#244 <https://github.com/ros2/launch/issues/244>)
* Move CMake path conversion to add_launch_test function.
* Enable reuse of launch testing functionality (#236 <https://github.com/ros2/launch/issues/236>)
* Contributors: Jacob Perron, Michel Hidalgo, Steven! Ragnarök, ivanpauno
```
