### PR TITLE
geometry2: 0.11.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -363,7 +363,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.11.1-1
+      version: 0.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.11.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.1-1`

## tf2

- No changes

## tf2_eigen

```
* Port tf2_kdl (#90 <https://github.com/ros2/geometry2/issues/90>)
  * tf2_eigen, leftover from the cherry-pick
  While cherry-picking changes to get isometry3d in
  * Update tf2_eigen, add toMsg2
  Convert a Eigen::Vector3d type to a geometry_msgs::msg::Vector3
  while avoiding overloading issues with previous definitions
  * Default to C++14
  * Define _USE_MATH_DEFINES so Windows gets M_PI symbol.
* Contributors: Víctor Mayoral Vilches
```

## tf2_geometry_msgs

- No changes

## tf2_msgs

- No changes

## tf2_ros

```
* Remove stray semicolon which causes compiler error when using -Werror=pedantic (#112 <https://github.com/ros2/geometry2/issues/112>)
* Contributors: Michael Jeronimo
```

## tf2_sensor_msgs

- No changes
