### PR TITLE
launch_ros: 0.8.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -482,7 +482,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.1-1`

## launch_ros

```
* Fix deprecation warnings (#25 <https://github.com/ros2/launch_ros/issues/25>)
* Corrected matches_action usage in lifecycle_pub_sub example (#21 <https://github.com/ros2/launch_ros/issues/21>)
* Contributors: Jacob Perron, ivanpauno
```

## launch_testing_ros

```
* fix example test logic (#28 <https://github.com/ros2/launch_ros/issues/28>)
* Add custom LaunchTestRunner with ROS specific preamble (#26 <https://github.com/ros2/launch_ros/issues/26>)
* Fix deprecation warnings (#25 <https://github.com/ros2/launch_ros/issues/25>)
* Contributors: Dirk Thomas, Jacob Perron, Michel Hidalgo
```

## ros2launch

```
* fix calling of print_arguments_of_launch_description() (#27 <https://github.com/ros2/launch_ros/issues/27>)
* Launch autocomplete doesnt require dot (#24 <https://github.com/ros2/launch_ros/issues/24>)
* Contributors: Matt Hansen, William Woodall
```
