### PR TITLE
rosbag2: 0.1.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1083,7 +1083,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.1.2-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-1`

## ros2bag

```
* remove disclaimer (#122 <https://github.com/ros2/rosbag2/issues/122>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* Contributors: Karsten Knese
```

## rosbag2

```
* Fixes an init race condition (#93 <https://github.com/ros2/rosbag2/issues/93>)
  * This could probably be a race condition, for ex: When we've create a subscriber in the API, and the subscriber has the data already available in the callback (Cause of existing publishers) the db entry for the particular topic would not be availalble, which in turn returns an SqliteException. This is cause write_->create_topic() call is where we add the db entry for a particular topic. And, this leads to crashing before any recording.
  Locally I solved it by adding the db entry first, and if
  create_subscription fails, remove the topic entry from the db and also
  erase the subscription.
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix comments for pull request https://github.com/ros2/rosbag2/pull/93
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Added unit test case for remove_topics from db
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix unit tests failing by adding dependent test macros
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fixes the linter errors
* Contributors: Sriram Raghunathan
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

```
* Fixes an init race condition (#93 <https://github.com/ros2/rosbag2/issues/93>)
  * This could probably be a race condition, for ex: When we've create a subscriber in the API, and the subscriber has the data already available in the callback (Cause of existing publishers) the db entry for the particular topic would not be availalble, which in turn returns an SqliteException. This is cause write_->create_topic() call is where we add the db entry for a particular topic. And, this leads to crashing before any recording.
  Locally I solved it by adding the db entry first, and if
  create_subscription fails, remove the topic entry from the db and also
  erase the subscription.
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix comments for pull request https://github.com/ros2/rosbag2/pull/93
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Added unit test case for remove_topics from db
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix unit tests failing by adding dependent test macros
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fixes the linter errors
* Contributors: Sriram Raghunathan
```

## rosbag2_storage_default_plugins

```
* Indexing of messages.timestamp to avoid runtime-copy. (#121 <https://github.com/ros2/rosbag2/issues/121>)
  Extended SqliteStorage::initialize() to add an index for the message table's timestamp column.
  Without this, the ORDER BY query in prepare_for_reading() causes expensive table duplication,
  which also has potential for out-of-disk or out-of-memory errors.
* Fixes an init race condition (#93 <https://github.com/ros2/rosbag2/issues/93>)
  * This could probably be a race condition, for ex: When we've create a subscriber in the API, and the subscriber has the data already available in the callback (Cause of existing publishers) the db entry for the particular topic would not be availalble, which in turn returns an SqliteException. This is cause write_->create_topic() call is where we add the db entry for a particular topic. And, this leads to crashing before any recording.
  Locally I solved it by adding the db entry first, and if
  create_subscription fails, remove the topic entry from the db and also
  erase the subscription.
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix comments for pull request https://github.com/ros2/rosbag2/pull/93
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Added unit test case for remove_topics from db
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix unit tests failing by adding dependent test macros
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fixes the linter errors
* Contributors: Felix-El, Sriram Raghunathan
```

## rosbag2_test_common

```
* clean up test dependencies for rosbag2_test_common (#118 <https://github.com/ros2/rosbag2/issues/118>)
  * clean up test dependencies for rosbag2_test_common
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
  * use build and exec depend
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* Contributors: Karsten Knese
```

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Fixes an init race condition (#93 <https://github.com/ros2/rosbag2/issues/93>)
  * This could probably be a race condition, for ex: When we've create a subscriber in the API, and the subscriber has the data already available in the callback (Cause of existing publishers) the db entry for the particular topic would not be availalble, which in turn returns an SqliteException. This is cause write_->create_topic() call is where we add the db entry for a particular topic. And, this leads to crashing before any recording.
  Locally I solved it by adding the db entry first, and if
  create_subscription fails, remove the topic entry from the db and also
  erase the subscription.
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix comments for pull request https://github.com/ros2/rosbag2/pull/93
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Added unit test case for remove_topics from db
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fix unit tests failing by adding dependent test macros
  Signed-off-by: Sriram Raghunathan <mailto:rsriram7@visteon.com>
  * Fixes the linter errors
* Update troubleshooting reference to index.ros.org (#120 <https://github.com/ros2/rosbag2/issues/120>)
  Signed-off-by: Michael Carroll <mailto:michael@openrobotics.org>
* Contributors: Michael Carroll, Sriram Raghunathan
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
