### PR TITLE
ros_testing: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1052,6 +1052,21 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: dashing
     status: maintained
+  ros_testing:
+    release:
+      packages:
+      - ros2test
+      - ros_testing
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_testing-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: master
+    status: developed
   ros_workspace:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/ros2-gbp/ros_testing-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros2test

```
* Add ros_testing metapackage and ros2test CLI package (#1 <https://github.com/ros2/ros_testing/issues/1>)
* Contributors: Michel Hidalgo
```

## ros_testing

```
* Add ros_testing metapackage and ros2test CLI package (#1 <https://github.com/ros2/ros_testing/issues/1>)
* Contributors: Michel Hidalgo
```
