### PR TITLE
demos: 0.7.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -249,6 +249,7 @@ repositories:
       version: master
     release:
       packages:
+      - action_tutorials
       - composition
       - demo_nodes_cpp
       - demo_nodes_cpp_native
@@ -262,11 +263,13 @@ repositories:
       - logging_demo
       - pendulum_control
       - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
       - topic_monitor
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.7.4-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.3-1`

## action_tutorials

```
* Add action_tutorials package (#339 <https://github.com/ros2/demos/issues/339>)
* Contributors: Jacob Perron
```

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Fix deprecation warnings (#334 <https://github.com/ros2/demos/issues/334>)
* Contributors: Jacob Perron
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

```
* Add lifecycle rostest (#336 <https://github.com/ros2/demos/issues/336>)
* Contributors: Michel Hidalgo
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* rclcpp QoS Demos (Liveliness, Lifespan, Deadline) (#320 <https://github.com/ros2/demos/issues/320> and #338 <https://github.com/ros2/demos/issues/338>)
* Contributors: Emerson Knapp
```

## quality_of_service_demo_py

```
* rclpy QoS Demos (Liveliness, Lifespan, Deadline) (#338 <https://github.com/ros2/demos/issues/338>)
* Contributors: Emerson Knapp
```

## topic_monitor

```
* Fix deprecation warnings (#334 <https://github.com/ros2/demos/issues/334>)
* Update expected type name in topic monitor (#335 <https://github.com/ros2/demos/issues/335>)
* Contributors: Jacob Perron
```
