### PR TITLE
urdfdom_headers: 1.0.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1699,7 +1699,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `1.0.4-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.3-1`
