### PR TITLE
joystick_drivers: 2.2.1-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -686,7 +686,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `2.2.1-1`:

- upstream repository: https://github.com/ros2/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.2.0-1`
