### PR TITLE
depthimage_to_laserscan: 2.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -276,6 +276,22 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: master
     status: developed
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
+      version: 2.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    status: maintained
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `2.2.1-1`:

- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## depthimage_to_laserscan

```
* Port depthimage_to_laserscan to ROS2.
* Import ROS2 changes from https://github.com/ros2/depthimage_to_laserscan.git to upstream
* Contributors: Chad Rockey, Chris Lalancette, Mikael Arguedas, Shane Loretz, dhood
```
