### PR TITLE
variants: 0.7.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1721,6 +1721,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: developed
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: crystal
+    release:
+      packages:
+      - desktop
+      - ros_base
+      - ros_core
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
