### PR TITLE
Clean up Gazebo rules for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -876,7 +876,7 @@ gazebo:
     buster: [gazebo7]
     jessie: [gazebo7]
     stretch: [gazebo7]
-  fedora: [gazebo-devel]
+  fedora: [gazebo]
   gentoo: [sci-electronics/gazebo]
   slackware: [gazebo]
   ubuntu:
@@ -893,7 +893,6 @@ gazebo:
     zesty: [gazebo7]
 gazebo5:
   arch: [gazebo]
-  fedora: [gazebo]
   gentoo: [=sci-electronics/gazebo-5*]
   ubuntu: [gazebo5]
 gazebo7:
@@ -902,7 +901,6 @@ gazebo7:
     buster: [gazebo7]
     jessie: [gazebo7]
     stretch: [gazebo7]
-  fedora: [gazebo]
   gentoo: [=sci-electronics/gazebo-7*]
   slackware: [gazebo]
   ubuntu: [gazebo7]
@@ -911,7 +909,7 @@ gazebo9:
     buster: [gazebo9]
     stretch: [gazebo9]
   fedora:
-    '30': [gazebo-devel]
+    '30': [gazebo]
   gentoo: [sci-electronics/gazebo]
   openembedded: []
   ubuntu:
@@ -1910,7 +1908,6 @@ libftgl-dev:
   ubuntu: [libftgl-dev]
 libgazebo5-dev:
   arch: [gazebo]
-  fedora: [gazebo-devel]
   gentoo: [=sci-electronics/gazebo-5*]
   ubuntu: [libgazebo5-dev]
 libgazebo7-dev:
@@ -1919,8 +1916,6 @@ libgazebo7-dev:
     buster: [libgazebo7-dev]
     jessie: [libgazebo7-dev]
     stretch: [libgazebo7-dev]
-  fedora:
-    '25': [gazebo-devel]
   gentoo: [=sci-electronics/gazebo-7*]
   opensuse: [gazebo-devel]
   slackware: [gazebo]
@@ -1929,6 +1924,8 @@ libgazebo9-dev:
   debian:
     buster: [libgazebo9-dev]
     stretch: [libgazebo9-dev]
+  fedora:
+    '30': [gazebo-devel]
   gentoo: [sci-electronics/gazebo]
   openembedded: [libgazebo9@meta-ros]
   ubuntu:


### PR DESCRIPTION
Removing stale Fedora rules for older versions of Gazebo which aren't packaged for any current releases of Fedora.

Fedora 31 will likely have Gazebo 9, but we can cross that bridge when we get there. Fedora 29 has Gazebo 8, which has no key.

https://apps.fedoraproject.org/packages/gazebo