### PR TITLE
Drop Python 2 OpenCV in Fedora 30+

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2495,7 +2495,9 @@ python-omniorb:
 python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]
-  fedora: [opencv-python]
+  fedora:
+    '*': null
+    '29': [opencv-python]
   gentoo: ['media-libs/opencv[python]']
   opensuse: [python-opencv]
   slackware: [opencv]


### PR DESCRIPTION
Fedora 30 dropped a TON of Python 2 packages, and it looks like this was one of them.

https://src.fedoraproject.org/rpms/opencv/c/6bc0464efe1d43f05f0da40205a80ce96582c30d?branch=f30
https://apps.fedoraproject.org/packages/opencv