### PR TITLE
fastrtps: update source version to sync with release version.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -364,7 +364,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-RTPS.git
-      version: c776f0f0964e697f93b51590688569567a7056f3
+      version: v1.8.0
     status: developed
   gazebo_ros_pkgs:
     doc:


### PR DESCRIPTION
Use v1.8.0 for `fastrtps` source to get recent interface breaking changes.