### PR TITLE
Add autograd-pip to Python

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -33,6 +33,9 @@ autograd-pip:
   debian:
     pip:
       packages: [autograd]
+  fedora:
+    pip:
+      packages: [autograd]
   ubuntu:
     pip:
       packages: [autograd]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,6 +29,10 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+autograd-pip:
+  '*':
+    pip:
+      packages: [autograd]
 autolab-core-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -30,7 +30,10 @@ adafruit-pca9685-pip:
     pip:
       packages: [adafruit-pca9685]
 autograd-pip:
-  '*':
+  debian:
+    pip:
+      packages: [autograd]
+  ubuntu:
     pip:
       packages: [autograd]
 autolab-core-pip:


### PR DESCRIPTION
We'd like to add https://github.com/HIPS/autograd to be pip-installable via a rosdep key. I am not entirely sure whether the below syntax is correct (do we need to specify debian/ubuntu/etc explicitly?) - or whether I even choose the right key - could you please advise?

Thank you very much,
Wolfgang