### PR TITLE
Add boost-python3-devel 'boost' rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -287,7 +287,7 @@ boost:
     squeeze: [libboost1.42-all-dev]
     stretch: [libboost-all-dev]
     wheezy: [libboost-all-dev]
-  fedora: [boost-devel, boost-python2-devel]
+  fedora: [boost-devel, boost-python2-devel, boost-python3-devel]
   freebsd: [boost-python-libs]
   gentoo: ['dev-libs/boost[python]']
   macports: [boost]


### PR DESCRIPTION
Some ROS 2 packages are using this key, and it appears that the expectation is that all of the boost development packages are present.