### PR TITLE
Add python-dev to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4573,6 +4573,10 @@ psutils:
   fedora: [psutils]
   gentoo: [psutils]
   ubuntu: [psutils]
+python-dev:
+  debian: [python-dev]
+  ubuntu: [python-dev]
+  fedora: [python-devel]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4575,8 +4575,8 @@ psutils:
   ubuntu: [psutils]
 python-dev:
   debian: [python-dev]
+  fedora: [python2-devel]
   ubuntu: [python-dev]
-  fedora: [python-devel]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]


### PR DESCRIPTION
Debian: https://packages.debian.org/stretch/python-dev
Fedora: https://apps.fedoraproject.org/packages/python2-devel
Ubuntu: https://packages.ubuntu.com/xenial/python-dev

This package contains Python headers and development tools. Specifically it provides the `python-config` utility which could be used by packages to read configuration files.