### PR TITLE
ros2_object_analytics: 0.5.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1052,6 +1052,25 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: developed
+  ros2_object_analytics:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_object_analytics.git
+      version: master
+    release:
+      packages:
+      - object_analytics_msgs
+      - object_analytics_node
+      - object_analytics_rviz
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_object_analytics-release.git
+      version: 0.5.4-1
+    source:
+      type: git
+      url: https://github.com/intel/ros2_object_analytics.git
+      version: master
+    status: maintained
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_object_analytics` to `0.5.4-1`:

- upstream repository: https://github.com/intel/ros2_object_analytics.git
- release repository: https://github.com/ros2-gbp/ros2_object_analytics-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
