### PR TITLE
fmi_adapter_ros2: 0.1.4-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -550,7 +550,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
-      version: 0.1.3-0
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -542,7 +542,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: master
+      version: crystal
     release:
       packages:
       - fmi_adapter
@@ -554,7 +554,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: master
+      version: crystal
     status: developed
   gazebo_ros_pkgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.4-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/boschresearch/fmi_adapter_ros2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.3-0`

## fmi_adapter

```
* Fixed link to FMU-SDK.
```

## fmi_adapter_examples

```
* Fixed link to FMU-SDK.
```
