### PR TITLE
geometry2: 0.11.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -404,7 +404,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.11.2-1
+      version: 0.11.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.11.3-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.2-1`

## tf2

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_msgs

- No changes

## tf2_ros

```
* stop spinning TransformListener thread node in destructor (#114 <https://github.com/ros2/geometry2/issues/114>)
* Store dedicated transform listener thread as a std::unique_ptr (#111 <https://github.com/ros2/geometry2/issues/111>)
* enable pedantic for tf2_ros (#115 <https://github.com/ros2/geometry2/issues/115>)
* Contributors: Hunter L. Allen, Karsten Knese, bpwilcox
```

## tf2_sensor_msgs

- No changes
