### PR TITLE
Adding ros_cvb_camera_driver to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11597,7 +11597,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
-      version: kinetic-devel
+      version: master
   ros_emacs_utils:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11593,6 +11593,11 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: kinetic-devel
     status: maintained
+  ros_cvb_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
+      version: kinetic-devel
   ros_emacs_utils:
     doc:
       type: git


### PR DESCRIPTION
I'd like ros_cvb_camera_driver to be indexed and documented on ros.org