### PR TITLE
fmi_adapter_ros2: 0.1.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -366,6 +366,24 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: v1.8.0
     status: developed
+  fmi_adapter_ros2:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: dashing
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
+      version: 0.1.5-1
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: dashing
+    status: developed
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.5-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/boschresearch/fmi_adapter_ros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## fmi_adapter

```
* Adapted to new Dashing features, including QoS, parameter declaration and node composition.
```

## fmi_adapter_examples

```
* Added example of launch file with new node composition feature.
```
