### PR TITLE
apriltag_ros: 3.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -141,6 +141,21 @@ repositories:
       url: https://github.com/aprilrobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_ros:
+    doc:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag_ros.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/AprilRobotics/apriltag_ros-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag_ros.git
+      version: master
+    status: maintained
   ar_track_alvar:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.1.0-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
