### PR TITLE
cnn_bridge: 0.8.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -661,7 +661,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wew84/cnn_bridge-release.git
-      version: 0.8.4-4
+      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/wew84/cnn_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cnn_bridge` to `0.8.5-1`:

- upstream repository: https://github.com/wew84/cnn_bridge.git
- release repository: https://github.com/wew84/cnn_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.4-4`

## cnn_bridge

```
* Implemented video share
* Minor bug fixes
* Contributors: Noam C. Golombek
```
