### PR TITLE
cnn_bridge: 0.8.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1343,7 +1343,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wew84/cnn_bridge-release.git
-      version: 0.8.4-2
+      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/wew84/cnn_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cnn_bridge` to `0.8.5-1`:

- upstream repository: https://github.com/wew84/cnn_bridge.git
- release repository: https://github.com/wew84/cnn_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.4-2`

## cnn_bridge

```
* Implemented video share
* Minor bug fixes
* Contributors: Noam C. Golombek
```
