### PR TITLE
behaviortree_cpp: 2.5.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -160,6 +160,12 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  behaviortree_cpp:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
+      version: 2.5.2-1
   behaviortree_cpp_v3:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `2.5.2-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
