### PR TITLE
release pilz_robots 0.5.4-1 and prbt_grippers 0.0.4-1

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4774,7 +4774,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git
@@ -5064,7 +5064,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/prbt_grippers-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/PilzDE/prbt_grippers.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4760,7 +4760,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       packages:
       - pilz_control


### PR DESCRIPTION
# Increasing version of package(s) in repository `pilz_robots` to `0.5.4-1`:

- upstream repository: 
- release repository: 
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.3-1`

## pilz_control

- No changes

## pilz_robots

- No changes

## pilz_testutils

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* increased modbus response timeout to 20ms
* publish brake test requests obtained from safety controller via modbus
* sto_modbus_adapter waits for the services to appear instead of throwing exceptions
* Add ability to execute a braketest on each drive.
* Add service to access the active operation mode
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

- No changes

## prbt_support

```
* instantiate pg70 xacro macro (due to change in prbt_grippers)
* Contributors: Pilz GmbH and Co. KG
```

# Increasing version of package(s) in repository `prbt_grippers` to `0.0.4-1`:

- upstream repository: https://github.com/PilzDE/prbt_grippers.git
- release repository: https://github.com/PilzDE/prbt_grippers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.3-1`

## prbt_grippers

- No changes

## prbt_pg70_support

```
* define xacro macro for the pg70
* Contributors: Pilz GmbH and Co. KG
```

