### PR TITLE
qb_device: 2.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9930,7 +9930,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
-      version: 2.0.1-0
+      version: 2.1.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbdevice-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `2.1.0-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-0`

## qb_device

- No changes

## qb_device_bringup

```
* Improve inheritance for other devices
* Update documentation
* Add a simulator mode to debug joint trajectories
* Add specific joint limits for the delta
* Add interactive markers startup activation
* Fix set/reset use_waypoints at each launch
```

## qb_device_control

```
* Improve inheritance for other devices
* Fix minor style issues
```

## qb_device_description

- No changes

## qb_device_driver

```
* Improve inheritance for other devices
* Update documentation
* Fix minor style issues
```

## qb_device_hardware_interface

```
* Add comments for future changes
* Add a simulator mode to debug joint trajectories
* Fix minor style issues
* Fix position limits initialization
* Fix minor style issues
```

## qb_device_msgs

- No changes

## qb_device_srvs

- No changes

## qb_device_utils

```
* Update documentation
* Fix minor style issues
```
