### PR TITLE
qb_move: 2.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9970,7 +9970,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 2.0.0-0
+      version: 2.1.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `2.1.0-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-0`

## qb_move

- No changes

## qb_move_control

```
* Add an interactive marker to control the device
* Fix minor style issues
```

## qb_move_description

```
* Fix description values
* Fix utilities to build delta URDF easily
```

## qb_move_hardware_interface

```
* Fix minor style issues
* Add an interactive marker to control the device
* Fix minor style issues
```
