### PR TITLE
qb_chain: 2.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9901,11 +9901,12 @@ repositories:
       packages:
       - qb_chain
       - qb_chain_control
+      - qb_chain_controllers
       - qb_chain_description
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
-      version: 2.0.0-0
+      version: 2.1.0-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbchain-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `2.1.0-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-0`

## qb_chain

```
* Add delta controller
```

## qb_chain_control

```
* Update demo points and launch settings
* Add a simulator mode to debug joint trajectories
* Fix default control duration of launch files
* Add delta controller
```

## qb_chain_description

```
* Fix description values
* Add delta URDF model
```
