### PR TITLE
Adding mosquitto-dev tag to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4125,6 +4125,10 @@ mosquitto:
   debian: [mosquitto]
   fedora: [mosquitto]
   ubuntu: [mosquitto]
+mosquitto-dev:
+  debian: [libmosquitto-dev]
+  fedora: [mosquitto-devel]
+  ubuntu: [libmosquitto-dev]
 mpg123:
   arch: [mpg123]
   debian: [mpg123]


### PR DESCRIPTION
Xenial: https://packages.ubuntu.com/xenial/libmosquitto-dev
Bionic: https://packages.ubuntu.com/bionic/libmosquitto-dev
Stretch: https://packages.debian.org/stretch/libmosquitto-dev
Fedora 29/30: https://apps.fedoraproject.org/packages/mosquitto-devel
Fedora 28: https://rpmfind.net/linux/RPM/fedora/updates/28/x86_64/Packages/m/mosquitto-devel-1.6.1-1.fc28.x86_64.html

This is a dependency of a package in the [Autoware Project](https://github.com/autowarefoundation/autoware).