### PR TITLE
abseil_cpp: 0.4.0-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -17,7 +17,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.2.3-0
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.4.0-1`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.3-0`

## abseil_cpp

```
* updated to version 2019-05-28
* ensure that -fPIC is set
* fixes
* Contributors: Alexander Rössler, Davide Faconti
```
