### PR TITLE
alpine: remove remaining source deps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1650,9 +1650,7 @@ libconfig-dev:
   gentoo: ['dev-libs/libconfig[cxx]']
   ubuntu: [libconfig-dev]
 libconsole-bridge-dev:
-  alpine:
-    source:
-      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/console-bridge/console-bridge.rdmanifest'
+  alpine: [console_bridge-dev]
   arch: [console-bridge]
   debian: [libconsole-bridge-dev]
   fedora: [console-bridge-devel]
@@ -3866,9 +3864,7 @@ log4cplus:
   fedora: [log4cplus-devel]
   ubuntu: [liblog4cplus-dev]
 log4cxx:
-  alpine:
-    source:
-      uri: 'https://github.com/at-wat/alpine-ros-sources/raw/master/log4cxx/log4cxx.rdmanifest'
+  alpine: [log4cxx-dev]
   arch: [log4cxx]
   cygwin: [liblog4cxx-devel]
   debian:


### PR DESCRIPTION
I have upstreamed the remaining deps for melodic-core into Alpine Linux edge testing!

- [x] log4cxx: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/log4cxx (Merged: https://github.com/alpinelinux/aports/pull/7590)
- [x] console_bridge: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/console_bridge ( https://github.com/alpinelinux/aports/pull/7633)