### PR TITLE
ddynamic_reconfigure: 0.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -980,6 +980,12 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
       version: default
     status: developed
+  ddynamic_reconfigure:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure.git
+      version: 0.2.0-0
   ddynamic_reconfigure_python:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure` to `0.2.0-0`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## ddynamic_reconfigure

```
* Merge branch 'refactor-functions' into 'erbium-devel'
  Accept functions callback per individual variable
  See merge request control/ddynamic_reconfigure!12
* Extend readme
* Add string and cleanup implementation
* Add enums and callbacks
* Accept functions callback per individual variable
* Contributors: Victor Lopez
```
