### PR TITLE
sick_scan: 1.3.21-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7244,7 +7244,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 0.0.16-0
+      version: 1.3.21-0
     status: developed
   sick_tim:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `1.3.21-0`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.16-0`
