### PR TITLE
test_interface_files: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1666,11 +1666,15 @@ repositories:
       version: dashing
     status: maintained
   test_interface_files:
+    doc:
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: master
     release:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros2/test_interface_files.git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`
