### PR TITLE
fastrtps: 1.8.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -368,7 +368,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 1.8.0-1
+      version: 1.8.0-2
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `1.8.0-2`:

- upstream repository: https://github.com/eProsima/Fast-RTPS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.8.0-1`
