### PR TITLE
rclcpp: 0.7.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -863,7 +863,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.7.4-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.3-1`

## rclcpp

```
* Rename parameter options (#745 <https://github.com/ros2/rclcpp/issues/745>)
* Bionic use of strerror_r (#742 <https://github.com/ros2/rclcpp/issues/742>)
* Enforce parameter ranges (#735 <https://github.com/ros2/rclcpp/issues/735>)
* removed not used parameter client (#740 <https://github.com/ros2/rclcpp/issues/740>)
* ensure removal of guard conditions of expired nodes from memory strategy (#741 <https://github.com/ros2/rclcpp/issues/741>)
* Fix typo in log warning message (#737 <https://github.com/ros2/rclcpp/issues/737>)
* Throw nice errors when creating a publisher with intraprocess communication and incompatible qos policy (#729 <https://github.com/ros2/rclcpp/issues/729>)
* Contributors: Alberto Soragna, Dirk Thomas, Jacob Perron, William Woodall, ivanpauno, roderick-koehle
```

## rclcpp_action

```
* Guard against calling null goal response callback (#738 <https://github.com/ros2/rclcpp/issues/738>)
* Contributors: Jacob Perron
```

## rclcpp_components

```
* Rename parameter options (#745 <https://github.com/ros2/rclcpp/issues/745>)
* don't use global arguments for components loaded into the manager (#736 <https://github.com/ros2/rclcpp/issues/736>)
* Contributors: Dirk Thomas, William Woodall
```

## rclcpp_lifecycle

```
* Rename parameter options (#745 <https://github.com/ros2/rclcpp/issues/745>)
* Contributors: William Woodall
```
