### PR TITLE
rviz: 6.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1607,7 +1607,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 6.1.0-1
+      version: 6.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.1.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `6.1.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fixed the installation destination of OGRE media resources which contain a ``dirname`` (#404 <https://github.com/ros2/rviz/issues/404>)
* Contributors: Dirk Thomas
```

## rviz_rendering_tests

```
* Updated test to match changes from #404 <https://github.com/ros2/rviz/issues/404>
* Contributors: Dirk Thomas
```

## rviz_visual_testing_framework

- No changes
