### PR TITLE
ros2_object_analytics: 0.5.4-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1111,7 +1111,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_object_analytics-release.git
-      version: 0.5.4-1
+      version: 0.5.4-2
     source:
       type: git
       url: https://github.com/intel/ros2_object_analytics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_object_analytics` to `0.5.4-2`:

- upstream repository: https://github.com/intel/ros2_object_analytics.git
- release repository: https://github.com/ros2-gbp/ros2_object_analytics-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.4-1`
