### PR TITLE
uuv_simulator: 0.6.12-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8215,7 +8215,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uuvsimulator/uuv_simulator-release.git
-      version: 0.6.10-0
+      version: 0.6.12-0
     source:
       type: git
       url: https://github.com/uuvsimulator/uuv_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uuv_simulator` to `0.6.12-0`:

- upstream repository: https://github.com/uuvsimulator/uuv_simulator.git
- release repository: https://github.com/uuvsimulator/uuv_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.6.10-0`

## uuv_assistants

- No changes

## uuv_auv_control_allocator

- No changes

## uuv_control_cascaded_pid

- No changes

## uuv_control_msgs

- No changes

## uuv_control_utils

- No changes

## uuv_descriptions

```
* uuv_descriptions: add xacro as a runtime dependency
  If xacro is not installed then it is not possible to spawn ROVs using upload_rexrov.launch.
* Contributors: Russ
```

## uuv_gazebo

- No changes

## uuv_gazebo_plugins

- No changes

## uuv_gazebo_ros_plugins

- No changes

## uuv_gazebo_ros_plugins_msgs

- No changes

## uuv_gazebo_worlds

- No changes

## uuv_sensor_ros_plugins

- No changes

## uuv_sensor_ros_plugins_msgs

- No changes

## uuv_simulator

- No changes

## uuv_teleop

- No changes

## uuv_thruster_manager

- No changes

## uuv_trajectory_control

- No changes

## uuv_world_plugins

- No changes

## uuv_world_ros_plugins

- No changes

## uuv_world_ros_plugins_msgs

- No changes
