### PR TITLE
vision_opencv: 2.1.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1851,7 +1851,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.1.2-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.1-1`

## cv_bridge

```
* Suppress Boost Python warning. (#279 <https://github.com/ros-perception/vision_opencv/issues/279>)
* silence unused return value warnings (#276 <https://github.com/ros-perception/vision_opencv/issues/276>)
* Contributors: Karsten Knese, Michael Carroll
```

## image_geometry

- No changes

## vision_opencv

- No changes
