### PR TITLE
image_common: 2.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -466,7 +466,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `2.1.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_transport

```
* Update to use new count APIs (#128 <https://github.com/ros-perception/image_common/issues/128>)
* use latest ros2 API (#127 <https://github.com/ros-perception/image_common/issues/127>)
* Contributors: Karsten Knese, Michael Carroll
```
