### PR TITLE
demos: 0.7.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -279,7 +279,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.7.6-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.5-1`

## action_tutorials

```
* Remove the action_msgs dependency CMake code (#364 <https://github.com/ros2/demos/issues/364>)
* Contributors: Jacob Perron
```

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

```
* Fix memory leak in the dummy robot examples. (#361 <https://github.com/ros2/demos/issues/361>)
* Contributors: Chris Lalancette
```

## dummy_robot_bringup

- No changes

## dummy_sensors

```
* Fix memory leak in the dummy robot examples. (#361 <https://github.com/ros2/demos/issues/361>)
* Contributors: Chris Lalancette
```

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes
