### PR TITLE
ros2_intel_realsense: 2.0.4-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1098,7 +1098,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.3-2
+      version: 2.0.4-2
     source:
       type: git
       url: https://github.com/intel/ros2_intel_realsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_realsense` to `2.0.4-2`:

- upstream repository: https://github.com/intel/ros2_intel_realsense.git
- release repository: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.3-2`

## realsense_camera_msgs

```
* update maintainer
* 2.0.3
* update changelog
* Contributors: Chris Ye
```

## realsense_ros2_camera

```
* Merge pull request #50 <https://github.com/intel/ros2_intel_realsense/issues/50> from ahuizxc/dashing
  fix compiling failure after ros2 core updated and remove some warnings.
* fix compiling failure after ros2 core updated and remove some warnings.
* Merge pull request #44 <https://github.com/intel/ros2_intel_realsense/issues/44> from ahuizxc/master
  add depthimage to laser scan launch file
* add depthimage to laser scan
* enable librealsensev2.17.1
  enable librealsensev2.17.1
* update package.xml and readme
* enable librealsensev2.17.1
* Merge pull request #39 <https://github.com/intel/ros2_intel_realsense/issues/39> from challen-zhou/master
  Add options to enable/disable color-aligned point cloud
* Change aligned pointcloud format from XYZ to XYZRGB
* Add options to enable/disable color-aligned point cloud
  Since the default 2 point cloud process cost too much computation,
  add option to enable/disable(default) color-aligned point cloud.
* Merge pull request #36 <https://github.com/intel/ros2_intel_realsense/issues/36> from challen-zhou/master
  Add pointcloud aligned with color
* Add pointcloud aligned with color
  Add pointcloud generate from depth which aligned to color,
  no RGB channel since this pointcloud one-to-one matches with color image.
* Merge pull request #32 <https://github.com/intel/ros2_intel_realsense/issues/32> from challen-zhou/master
  Update depth alignment function to align with librealsense
* Merge pull request #30 <https://github.com/intel/ros2_intel_realsense/issues/30> from ahuizxc/master
  pass the format test and fix ctrl+c error
* Update depth alignment function to align with librealsense
  Update depth alignment function to align with librealsense since
  librealsense already upstreamed to ROS2/Crystal, also we can benifit from
  the future librealsense optimization.
* fix ctrl+c error
* pass the format test
* Merge pull request #29 <https://github.com/intel/ros2_intel_realsense/issues/29> from ahuizxc/master
  fixed bug that camera not work when enable_depth=False
* fixed bug that camera not work when enable_depth=False
* Merge pull request #23 <https://github.com/intel/ros2_intel_realsense/issues/23> from intel/fix_ctest
  fix error when run CTest
* fix error when run CTest
  * set Realsense device not exist by default, disable testapi when Realsense device not plugin
  * fix format error when run CTest
* Merge pull request #22 <https://github.com/intel/ros2_intel_realsense/issues/22> from RachelRen05/update_readme
  update project to install debain package dependency
* update readme.md
  * update project to install debain package dependency
  * add rviz default configuration and support ros2 launch
* update maintainer
* 2.0.3
* update changelog
* Merge pull request #18 <https://github.com/intel/ros2_intel_realsense/issues/18> from nuclearsandwich/add-dependencies-to-package.xml
  Add eigen as a build dependency for ros2debian
* Add eigen as a build dependency.
* Contributors: Chris Ye, Gary Liu, RachelRen05, Sharron LIU, Steven! Ragnarök, Xiaojun Huang, ahuizxc, challenzhou
```
