### PR TITLE
joystick_drivers: 2.3.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -484,7 +484,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `2.3.2-1`:

- upstream repository: https://github.com/ros2/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.3.1-1`
