### PR TITLE
Add installation of librealsense2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3166,6 +3166,11 @@ libreadline-dev:
   gentoo: [sys-libs/readline]
   macports: [readline]
   ubuntu: [libreadline-dev]
+librealsense2:
+  ubuntu:
+    xenial:
+      source:
+        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
 libreadline-java:
   arch: [java-readline]
   debian: [libreadline-java]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3174,12 +3174,12 @@ libreadline-java:
   ubuntu: [libreadline-java]
 librealsense2:
   ubuntu:
-    xenial:
-      source:
-        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_xenial.rdmanifest'
     bionic:
       source:
         uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_bionic.rdmanifest'
+    xenial:
+      source:
+        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_xenial.rdmanifest'
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3166,17 +3166,17 @@ libreadline-dev:
   gentoo: [sys-libs/readline]
   macports: [readline]
   ubuntu: [libreadline-dev]
-librealsense2:
-  ubuntu:
-    xenial:
-      source:
-        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
 libreadline-java:
   arch: [java-readline]
   debian: [libreadline-java]
   fedora: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
+librealsense2:
+  ubuntu:
+    xenial:
+      source:
+        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3176,10 +3176,10 @@ librealsense2:
   ubuntu:
     xenial:
       source:
-        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_xenial.rdmanifest'
+        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_xenial.rdmanifest'
     bionic:
       source:
-        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_bionic.rdmanifest'
+        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_bionic.rdmanifest'
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3176,7 +3176,10 @@ librealsense2:
   ubuntu:
     xenial:
       source:
-        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
+        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_xenial.rdmanifest'
+    bionic:
+      source:
+        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_bionic.rdmanifest'
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]


### PR DESCRIPTION
realsense2_camera depend on librealsense2 installation.
librealsense2 is not available yet in ubuntu's official release.
Therefor, to promote the release of realsense2_camera package I propose to add a script for librealsense2's installation here.