### PR TITLE
realsense2_camera: 2.2.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10508,7 +10508,7 @@ repositories:
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: 2.2.6
+      version: kinetic-devel
     status: maintained
   realsense_camera:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10497,6 +10497,18 @@ repositories:
       type: git
       url: https://github.com/intel-ros/realsense.git
       version: development
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/IntelRealSense/realsense-ros-release.git
+      version: 2.2.6-1
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: 2.2.6
     status: maintained
   realsense_camera:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10495,7 +10495,7 @@ repositories:
   realsense2_camera:
     doc:
       type: git
-      url: https://github.com/intel-ros/realsense.git
+      url: https://github.com/IntelRealSense/realsense-ros.git
       version: development
     release:
       packages:
@@ -10508,7 +10508,7 @@ repositories:
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: kinetic-devel
+      version: development
     status: maintained
   realsense_camera:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5503,6 +5503,24 @@ repositories:
       url: https://gitlab.com/jlack/rdl.git
       version: master
     status: developed
+  realsense2_camera:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: development
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_description
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/IntelRealSense/realsense-ros-release.git
+      version: 2.2.6-1
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: development
+    status: maintained
   realtime_tools:
     doc:
       type: git

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3166,6 +3166,11 @@ libreadline-dev:
   gentoo: [sys-libs/readline]
   macports: [readline]
   ubuntu: [libreadline-dev]
+librealsense2:
+  ubuntu:
+    xenial:
+      source:
+        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
 libreadline-java:
   arch: [java-readline]
   debian: [libreadline-java]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3174,12 +3174,12 @@ libreadline-java:
   ubuntu: [libreadline-java]
 librealsense2:
   ubuntu:
-    xenial:
-      source:
-        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_xenial.rdmanifest'
     bionic:
       source:
         uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_bionic.rdmanifest'
+    xenial:
+      source:
+        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_xenial.rdmanifest'
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3166,17 +3166,17 @@ libreadline-dev:
   gentoo: [sys-libs/readline]
   macports: [readline]
   ubuntu: [libreadline-dev]
-librealsense2:
-  ubuntu:
-    xenial:
-      source:
-        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
 libreadline-java:
   arch: [java-readline]
   debian: [libreadline-java]
   fedora: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
+librealsense2:
+  ubuntu:
+    xenial:
+      source:
+        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3176,10 +3176,10 @@ librealsense2:
   ubuntu:
     xenial:
       source:
-        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_xenial.rdmanifest'
+        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_xenial.rdmanifest'
     bionic:
       source:
-        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_bionic.rdmanifest'
+        uri: 'https://raw.githubusercontent.com/IntelRealSense/realsense-ros/development/realsense2_camera/librealsense2_bionic.rdmanifest'
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3176,7 +3176,10 @@ librealsense2:
   ubuntu:
     xenial:
       source:
-        uri: "https://github.com/IntelRealSense/realsense-ros/blob/development/realsense2_camera/librealsense2.rdmanifest"
+        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_xenial.rdmanifest'
+    bionic:
+      source:
+        uri: 'https://raw.githubusercontent.com/doronhi/realsense/debian/realsense2_camera/librealsense2_bionic.rdmanifest'
 libsensors4-dev:
   arch: [lm_sensors]
   debian: [libsensors4-dev]


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.6-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
