### PR TITLE
rtabmap/rtabmap_ros: 0.19.3 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7078,7 +7078,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.6-0
+      version: 0.19.3-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -7093,7 +7093,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.6-0
+      version: 0.19.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` and `rtabmap_ros` to `0.19.3`:

- upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.17.6`