### PR TITLE
revert apriltag release

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -222,6 +222,16 @@ repositories:
       url: https://github.com/pr2/app_manager.git
       version: kinetic-devel
     status: unmaintained
+  apriltags2_ros:	
+    doc:	
+      type: git	
+      url: https://github.com/dmalyuta/apriltags2_ros.git	
+      version: master	
+    source:	
+      type: git	
+      url: https://github.com/dmalyuta/apriltags2_ros.git	
+      version: master	
+    status: maintained
   ar_track_alvar:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -222,27 +222,6 @@ repositories:
       url: https://github.com/pr2/app_manager.git
       version: kinetic-devel
     status: unmaintained
-  apriltag:
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/AprilRobotics/apriltag-release.git
-      version: 3.1.0-1
-    source:
-      type: git
-      url: https://github.com/aprilrobotics/apriltag.git
-      version: master
-    status: maintained
-  apriltags2_ros:
-    doc:
-      type: git
-      url: https://github.com/dmalyuta/apriltags2_ros.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/dmalyuta/apriltags2_ros.git
-      version: master
-    status: maintained
   ar_track_alvar:
     doc:
       type: git


### PR DESCRIPTION
It's not building on any platform and is taking many hours to fail

Reverting #21256 @wxmerkt 

![image](https://user-images.githubusercontent.com/447804/58777717-795fa780-8584-11e9-9433-db28b161a465.png)


Hours of elapsed time per compilation unit on armhf
```
09:07:43.571 [ 21%] Building C object CMakeFiles/apriltag.dir/tagCircle21h7.c.o
09:07:43.577 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagCircle21h7.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagCircle21h7.c
09:07:44.651 [ 24%] Building C object CMakeFiles/apriltag.dir/tag36h11.c.o
09:07:44.657 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tag36h11.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tag36h11.c
09:07:46.804 [ 27%] Building C object CMakeFiles/apriltag.dir/tagStandard41h12.c.o
09:07:46.810 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagStandard41h12.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagStandard41h12.c
09:07:59.314 [ 30%] Building C object CMakeFiles/apriltag.dir/tagCustom48h12.c.o
09:07:59.320 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagCustom48h12.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagCustom48h12.c
11:31:24.696 [ 33%] Building C object CMakeFiles/apriltag.dir/tag16h5.c.o
11:31:24.702 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tag16h5.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tag16h5.c
11:31:25.892 [ 36%] Building C object CMakeFiles/apriltag.dir/common/time_util.c.o
11:31:25.898 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/common/time_util.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common/time_util.c
11:31:27.240 [ 39%] Building C object CMakeFiles/apriltag.dir/common/image_u8.c.o
11:31:27.246 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/common/image_u8.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common/image_u8.c
11:31:30.571 [ 42%] Building C object CMakeFiles/apriltag.dir/common/zmaxheap.c.o
11:31:30.578 /usr/lib/ccache/arm-linux-gnueabihf-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/common/zmaxheap.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common/zmaxheap.c
```

Many minutes on amd64
```
00:04:12.016 [  9%] Building C object CMakeFiles/apriltag.dir/apriltag.c.o
00:04:12.016 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/apriltag.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/apriltag.c
00:04:12.578 [ 12%] Building C object CMakeFiles/apriltag.dir/tag25h9.c.o
00:04:12.579 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tag25h9.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tag25h9.c
00:04:12.666 [ 15%] Building C object CMakeFiles/apriltag.dir/tagCircle49h12.c.o
00:04:12.667 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagCircle49h12.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagCircle49h12.c
00:19:44.687 [ 18%] Building C object CMakeFiles/apriltag.dir/tagStandard52h13.c.o
00:19:44.688 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagStandard52h13.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagStandard52h13.c
00:27:26.357 [ 21%] Building C object CMakeFiles/apriltag.dir/tagCircle21h7.c.o
00:27:26.357 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagCircle21h7.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagCircle21h7.c
00:27:26.417 [ 24%] Building C object CMakeFiles/apriltag.dir/tag36h11.c.o
00:27:26.417 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tag36h11.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tag36h11.c
00:27:26.566 [ 27%] Building C object CMakeFiles/apriltag.dir/tagStandard41h12.c.o
00:27:26.566 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagStandard41h12.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagStandard41h12.c
00:27:27.498 [ 30%] Building C object CMakeFiles/apriltag.dir/tagCustom48h12.c.o
00:27:27.499 /usr/lib/ccache/x86_64-linux-gnu-gcc  -Dapriltag_EXPORTS -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/. -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0 -I/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/common -I/apriltag  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC   -o CMakeFiles/apriltag.dir/tagCustom48h12.c.o   -c /tmp/binarydeb/ros-kinetic-apriltag-3.1.0/tagCustom48h12.c
```


Build failure from dpkg-shlibdeps on all platforms
```
11:32:57.811 	dpkg-shlibdeps -Tdebian/ros-kinetic-apriltag.substvars -l/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/debian/ros-kinetic-apriltag//opt/ros/kinetic/lib/ debian/ros-kinetic-apriltag/opt/ros/kinetic/bin/apriltag_demo debian/ros-kinetic-apriltag/opt/ros/kinetic/lib/arm-linux-gnueabihf/libapriltag.so.3.1.0
11:32:58.834 dpkg-shlibdeps: error: couldn't find library libapriltag.so.3 needed by debian/ros-kinetic-apriltag/opt/ros/kinetic/bin/apriltag_demo (ELF format: 'elf32-littlearm-hfabi'; RPATH: '')
11:33:02.215 dpkg-shlibdeps: error: cannot continue due to the error above
11:33:02.215 Note: libraries are not searched in other binary packages that do not have any shlibs or symbols file.
11:33:02.215 To help dpkg-shlibdeps find private libraries, you might need to use -l.
11:33:02.236 dh_shlibdeps: dpkg-shlibdeps -Tdebian/ros-kinetic-apriltag.substvars -l/tmp/binarydeb/ros-kinetic-apriltag-3.1.0/debian/ros-kinetic-apriltag//opt/ros/kinetic/lib/ debian/ros-kinetic-apriltag/opt/ros/kinetic/bin/apriltag_demo debian/ros-kinetic-apriltag/opt/ros/kinetic/lib/arm-linux-gnueabihf/libapriltag.so.3.1.0 returned exit code 2
11:33:02.241 debian/rules:47: recipe for target 'override_dh_shlibdeps' failed
11:33:02.241 make[1]: *** [override_dh_shlibdeps] Error 2
```

