### PR TITLE
nonpersistent_voxel_layer: 1.2.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4108,6 +4108,22 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  nonpersistent_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
+      version: 1.2.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: melodic-devel
+    status: maintained
   novatel_gps_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nonpersistent_voxel_layer` to `1.2.3-2`:

- upstream repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
- release repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
