### PR TITLE
rtt: 2.9.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13109,7 +13109,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt-release.git
-      version: 2.9.1-1
+      version: 2.9.2-1
     source:
       type: git
       url: https://github.com/orocos-toolchain/rtt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt` to `2.9.2-1`:

- upstream repository: https://github.com/orocos-toolchain/rtt.git
- release repository: https://github.com/orocos-gbp/rtt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.1-1`
