### PR TITLE
rtt: 2.9.2-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -5523,7 +5523,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/orocos-gbp/rtt-release.git
-      version: 2.9.1-1
+      version: 2.9.2-1
     source:
       type: git
       url: https://github.com/orocos-toolchain/rtt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt` to `2.9.2-1`:

- upstream repository: https://github.com/orocos-toolchain/rtt.git
- release repository: https://github.com/orocos-gbp/rtt-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.1-1`
