### PR TITLE
rtt_geometry: 2.9.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13128,7 +13128,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_geometry-release.git
-      version: 2.9.2-1
+      version: 2.9.3-1
     source:
       type: git
       url: https://github.com/orocos/rtt_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_geometry` to `2.9.3-1`:

- upstream repository: https://github.com/orocos/rtt_geometry.git
- release repository: https://github.com/orocos-gbp/rtt_geometry-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.2-1`

## eigen_typekit

- No changes

## kdl_typekit

```
* Merge pull request #30 <https://github.com/orocos/rtt_geometry/issues/30> from achim-k/toolchain-2.9
  kdl_typekit: Use ownProperty() instead of add() to fix memory leak.
* Merge pull request #29 <https://github.com/orocos/rtt_geometry/issues/29> from orocos/travis-ros-industrial-ci
  Use ROS industrial_ci for Travis CI builds
* kdl_typekit: fixed corba unit test if no nameserver is running yet (e.g. on Travis)
* Contributors: Achim Krauch, Johannes Meyer
```

## rtt_geometry

- No changes
