### PR TITLE
remove indigo packages failing to index

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7365,11 +7365,6 @@ repositories:
       type: git
       url: https://github.com/sukha-cn/micros_rtt.git
       version: master
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/sukha-cn/micros_rtt-release.git
-      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/sukha-cn/micros_rtt.git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10731,14 +10731,6 @@ repositories:
       url: https://github.com/asmodehn/pyros-rosinterface-rosrelease.git
       version: 0.4.0-0
     status: developed
-  pyros_setup:
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/asmodehn/pyros-setup-release.git
-      version: 0.0.8-0
-    status: end-of-life
-    status_description: Now pip package only, not useful when using ROS packages anymore.
   pyros_test:
     doc:
       type: git


### PR DESCRIPTION
The release repo has been deleted.
 It was eol'd in #13177

```
00:08:48.870   - fetch "pyros_setup"
00:08:49.088 DEBUG:rosdistro:Skipped "github_manifest_provider()": Could not git ls-remote repository "https://github.com/asmodehn/pyros-setup-release.git"
00:08:49.088 DEBUG:rosdistro:Skip non-bitbucket url "https://github.com/asmodehn/pyros-setup-release.git"
00:08:49.088 DEBUG:rosdistro:Skipped "bitbucket_manifest_provider()": Cannot handle non bitbucket url.
00:08:49.324 DEBUG:rosdistro:Skipped "git_manifest_provider()": Unable to fetch package.xml: Could not clone repository "https://github.com/asmodehn/pyros-setup-release.git" at reference "release/indigo/pyros_setup/0.0.8-0"
```

The url is 404