### PR TITLE
panda_moveit_config: 0.7.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4583,7 +4583,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/panda_moveit_config-release.git
-      version: 0.7.1-0
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.2-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.1-0`

## panda_moveit_config

```
* removing unused attempts param (#26 <https://github.com/ros-planning/panda_moveit_config/issues/26>)
* virtual joint quaternion->rpy
* fixing the virtual joint issue by adding the broadcaster (#23 <https://github.com/ros-planning/panda_moveit_config/issues/23>)
* changing the end effector parent group (#20 <https://github.com/ros-planning/panda_moveit_config/issues/20>)
  * changing the end effector parent group
  * changing virtual joint to floating for use with moveit_visual_tools
* Fix incorrect SRDF path (#19 <https://github.com/ros-planning/panda_moveit_config/issues/19>)
* Contributors: Dave Coleman, Mike Lautman
```
