### PR TITLE
novatel_gps_driver: 3.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4120,7 +4120,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 3.7.0-0
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.8.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.7.0-0`

## novatel_gps_driver

```
* Add fix for messages build order (#41 <https://github.com/swri-robotics/novatel_gps_driver/issues/41>)
* Add clocksteering parsing (#40 <https://github.com/swri-robotics/novatel_gps_driver/issues/40>)
* Only unlogall for the current port (#36 <https://github.com/swri-robotics/novatel_gps_driver/issues/36>)
* Contributors: Matthew, P. J. Reed
```

## novatel_gps_msgs

```
* Add clocksteering parsing (#40 <https://github.com/swri-robotics/novatel_gps_driver/issues/40>)
* Contributors: Matthew
```
