### PR TITLE
ariles_ros: 1.1.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -186,7 +186,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/asherikov/ariles-release.git
-      version: 1.1.1-1
+      version: 1.1.5-1
     status: developed
   astuff_sensor_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ariles_ros` to `1.1.5-1`:

- upstream repository: https://github.com/asherikov/ariles.git
- release repository: https://github.com/asherikov/ariles-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-1`

## ariles_ros

```
* Sync to 1.1.5.
* Remove setup.sh and other helpers from the package.
* More thorough testing.
```
