### PR TITLE
gazebo_ros_pkgs: 2.5.19-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3543,7 +3543,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.18-1
+      version: 2.5.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.19-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.5.18-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Accept 0 and 1 as booleans to support URDF to SDF boolean conversion; establish function parity with melodic (#928 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/928>)
* Contributors: ampleh
```

## gazebo_ros

```
* Add output arg to launch files, plus some small fixes (#905 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/905>)
  * Add output arg to empty_world
  * add output arg to elevator_world
  * add output arg to range_world
  * don't set use_sim_time in range_world
  Instead parse it to empty world, where it will be set.
  * add xml prolog to all launch files
  * Remove unnecessary arg in range_world.launch
* Contributors: Matthijs van der Burgh
```

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

```
* Remove extra angle bracket (#893 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/893>)
* Contributors: David V. Lu!!
```
