### PR TITLE
ets_ros2: 0.1.1-2 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -460,6 +460,25 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: ros2
     status: maintained
+  ets_ros2:
+    doc:
+      type: git
+      url: https://github.com/brunodmt/ets_ros2.git
+      version: master
+    release:
+      packages:
+      - ets_cpp_client
+      - ets_msgs
+      - ets_plugin
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/brunodmt/ets_ros2-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/brunodmt/ets_ros2.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ets_ros2` to `0.1.1-2`:

- upstream repository: https://github.com/brunodmt/ets_ros2.git
- release repository: https://github.com/brunodmt/ets_ros2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ets_cpp_client

```
* Add some more parameters
  Specifically acceleration, engine_running, world_placement (x,y,z,
  heading,pitch,roll)
* Add trailer_connected value
* Add RPM value
* Add missing CMakeLists files
* Initial commit
* Contributors: Bruno Demartino, Hernán Gonzalez
```

## ets_msgs

```
* Add some more parameters
  Specifically acceleration, engine_running, world_placement (x,y,z,
  heading,pitch,roll)
* Add trailer_connected value
* Add RPM value
* Add missing CMakeLists files
* Initial commit
* Contributors: Bruno Demartino, Hernán Gonzalez
```

## ets_plugin

```
* Add some more parameters
  Specifically acceleration, engine_running, world_placement (x,y,z,
  heading,pitch,roll)
* Add trailer_connected value
* Add RPM value
* Fixed unused-parameter warnings
* Add missing CMakeLists files
* Initial commit
* Contributors: Bruno Demartino, Hernán Gonzalez
```
