### PR TITLE
Add RHEL rule for python3-catkin-pkg-modules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4870,6 +4870,7 @@ python3-catkin-pkg-modules:
   fedora: [python3-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]
   openembedded: [python3-catkin-pkg@meta-ros]
+  rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg-modules]
 python3-dev:
   debian: [python3-dev]


### PR DESCRIPTION
Like Fedora, the Python 2 and Python 3 packages can be installed side-by-side in RHEL. The Python 3 subpackage was made available fairly recently.

https://apps.fedoraproject.org/packages/python-catkin_pkg
https://koji.fedoraproject.org/koji/buildinfo?buildID=1247290