### PR TITLE
web_video_server: 0.2.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15831,7 +15831,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/web_video_server-release.git
-      version: 0.2.0-0
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/RobotWebTools/web_video_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `0.2.1-1`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/RobotWebTools-release/web_video_server-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-0`

## web_video_server

```
* Restream buffered frames with minimum publish rate (#88 <https://github.com/RobotWebTools/web_video_server/issues/88>)
  * Restream buffered frames with minimum publish rate
  * Implement restreaming for ros_compressed_streamer
* Update travis config (#89 <https://github.com/RobotWebTools/web_video_server/issues/89>)
* Fall back to mjpeg if ros_compressed is unavailable (#87 <https://github.com/RobotWebTools/web_video_server/issues/87>)
* Contributors: Jihoon Lee, Viktor Kunovski, sfalexrog
```
