### PR TITLE
std_stamped_msgs: 0.0.2-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13840,6 +13840,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  std_stamped_msgs:
+    doc:
+      type: git
+      url: https://github.com/hakuturu583/std_stamped_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/hakuturu583/std_stamped_msgs-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/hakuturu583/std_stamped_msgs.git
+      version: master
+    status: developed
   stdr_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_stamped_msgs` to `0.0.2-0`:

- upstream repository: https://github.com/hakuturu583/std_stamped_msgs.git
- release repository: https://github.com/hakuturu583/std_stamped_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
