### PR TITLE
std_stamped_msgs: 0.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7437,6 +7437,21 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: groovy-devel
     status: maintained
+  std_stamped_msgs:
+    doc:
+      type: git
+      url: https://github.com/hakuturu583/std_stamped_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/hakuturu583/std_stamped_msgs-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/hakuturu583/std_stamped_msgs.git
+      version: master
+    status: developed
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_stamped_msgs` to `0.0.2-0`:

- upstream repository: https://github.com/hakuturu583/std_stamped_msgs.git
- release repository: https://github.com/hakuturu583/std_stamped_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`
