### PR TITLE
rosbag2_bag_v2: 0.0.6-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1217,6 +1217,25 @@ repositories:
       url: https://github.com/ros2/rosbag2.git
       version: dashing
     status: maintained
+  rosbag2_bag_v2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    release:
+      packages:
+      - ros1_rosbag_storage_vendor
+      - rosbag2_bag_v2_plugins
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
+      version: 0.0.6-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    status: developed
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_bag_v2` to `0.0.6-2`:

- upstream repository: https://github.com/ros2/rosbag2_bag_v2.git
- release repository: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros1_rosbag_storage_vendor

```
* removed dependency to ros1_bridge package (#90 <https://github.com/ros2/rosbag2_bag_v2/issues/90>)
  * removed dependency to ros1_bridge package:
  * checking if package is available
  * if not skipping (with warnings)
  * now rosbag2_tests builds on systems without ros1
  * check ros1 deps correctly on all packages
  * add ros1_bridge to test package
  * silently try to find the bridge
* Contributors: DensoADAS
```

## rosbag2_bag_v2_plugins

```
* warn when roscpp is not found (#4 <https://github.com/ros2/rosbag2_bag_v2/issues/4>)
  Signed-off-by: osrf <mailto:karsten@openrobotics.org>
* New type identification (#3 <https://github.com/ros2/rosbag2_bag_v2/issues/3>)
  * update logging macros
  Signed-off-by: osrf <mailto:karsten@openrobotics.org>
  * correct typo in filename
  Signed-off-by: osrf <mailto:karsten@openrobotics.org>
  * use new type identification
  Signed-off-by: osrf <mailto:karsten@openrobotics.org>
* compile tests (#2 <https://github.com/ros2/rosbag2_bag_v2/issues/2>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* remove duplicate repos (#1 <https://github.com/ros2/rosbag2_bag_v2/issues/1>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* correct missing linter errors (#96 <https://github.com/ros2/rosbag2_bag_v2/issues/96>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* removed dependency to ros1_bridge package (#90 <https://github.com/ros2/rosbag2_bag_v2/issues/90>)
  * removed dependency to ros1_bridge package:
  * checking if package is available
  * if not skipping (with warnings)
  * now rosbag2_tests builds on systems without ros1
  * check ros1 deps correctly on all packages
  * add ros1_bridge to test package
  * silently try to find the bridge
* Contributors: DensoADAS, Karsten Knese
```
