### PR TITLE
khi_robot: 1.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5569,7 +5569,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `khi_robot` to `1.1.2-1`:

- upstream repository: https://github.com/Kawasaki-Robotics/khi_robot.git
- release repository: https://github.com/Kawasaki-Robotics/khi_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-1`

## khi_duaro_description

```
* add KHI CAD Data Disclaimer to README (#20 <https://github.com/Kawasaki-Robotics/khi_robot/issues/20>)
  * add KHI CAD Data Disclaimer to README
  * add KHI CAD Data Disclaimer to README_2
  * add KHI license tag to package.xml
  * modify CAD data message of README
* Contributors: Hiroki Matsui
```

## khi_duaro_gazebo

```
* add USE_SOURCE_PERMISSIONS in CMakeLists.txt files those package have executable scripts (#18 <https://github.com/Kawasaki-Robotics/khi_robot/issues/18>)
* Contributors: Yosuke Yamamoto
```

## khi_duaro_ikfast_plugin

- No changes

## khi_duaro_moveit_config

```
* add USE_SOURCE_PERMISSIONS in CMakeLists.txt files those package have executable scripts (#18 <https://github.com/Kawasaki-Robotics/khi_robot/issues/18>)
* Contributors: Yosuke Yamamoto
```

## khi_robot

- No changes

## khi_robot_bringup

- No changes

## khi_robot_control

```
* Enable to build release package on i386/arm (#19 <https://github.com/Kawasaki-Robotics/khi_robot/issues/19>)
  * .travis.yml: add test for i386/armhf/arm64
  * install QEMU for running ARM containers
  * display CMAKE_SYSTEM_NAME variables and so on
  * skip build and test for ARM containers
  * using CMAKE_SYSTEM_PROCESSOR does not returns correct target machine on the docker system. To solve this issue, we use CMAKE_LIBRARY_ARCHITECTURE to find current target machine
  * CMAKE_LIBRARY_ARCHTECTURE is gnueabihf/gnueabi
* Contributors: Kei Okada
```

## khi_robot_msgs

- No changes

## khi_rs007l_moveit_config

```
* add USE_SOURCE_PERMISSIONS in CMakeLists.txt files those package have executable scripts (#18 <https://github.com/Kawasaki-Robotics/khi_robot/issues/18>)
* Contributors: Yosuke Yamamoto
```

## khi_rs007n_moveit_config

```
* add USE_SOURCE_PERMISSIONS in CMakeLists.txt files those package have executable scripts (#18 <https://github.com/Kawasaki-Robotics/khi_robot/issues/18>)
* Contributors: Yosuke Yamamoto
```

## khi_rs080n_moveit_config

- No changes

## khi_rs_description

```
* add KHI CAD Data Disclaimer to README (#20 <https://github.com/Kawasaki-Robotics/khi_robot/issues/20>)
  * add KHI CAD Data Disclaimer to README
  * add KHI CAD Data Disclaimer to README_2
  * add KHI license tag to package.xml
  * modify CAD data message of README
* Contributors: Hiroki Matsui
```

## khi_rs_gazebo

```
* minor fix (#10 <https://github.com/Kawasaki-Robotics/khi_robot/issues/10>)
* Contributors: matsui_hiro
```

## khi_rs_ikfast_plugin

- No changes
