### PR TITLE
agni_tf_tools: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -93,7 +93,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agni_tf_tools` to `0.1.2-1`:

- upstream repository: https://github.com/ubi-agni/agni_tf_tools.git
- release repository: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-1`

## agni_tf_tools

```
* fix compiler warnings
* cmake: cleanup, correctly announce exported lib
* Contributors: Robert Haschke
```
