### PR TITLE
agni_tf_tools: update source branch to master

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -154,7 +154,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
-      version: indigo-devel
+      version: master
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -163,7 +163,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
-      version: indigo-devel
+      version: master
     status: maintained
   agvs_common:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -140,7 +140,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
-      version: indigo-devel
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -149,7 +149,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
-      version: indigo-devel
+      version: master
     status: maintained
   agvs_common:
     doc:

--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -64,7 +64,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
-      version: indigo-devel
+      version: master
     release:
       tags:
         release: release/lunar/{package}/{version}
@@ -73,7 +73,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
-      version: indigo-devel
+      version: master
     status: maintained
   angles:
     doc:


### PR DESCRIPTION
The branch `indigo-devel` was replaced by `master`.