### PR TITLE
mavros: 0.31.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6522,7 +6522,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.30.0-1
+      version: 0.31.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.31.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.30.0-1`

## libmavconn

```
* readme: fix udp-pb formatting
* Contributors: Vladimir Ermakov
```

## mavros

```
* readme: fix udp-pb formatting
* launch config: landing_target: fix and improve parameter list
* remove duplicated landing_target parameters
* enum_to_string: simplify landing_target_type_from_str
* enum_to_string: update enumerations and checksum
* extras: landing target: improve usability and flexibility
* remove landing_target from blacklist
* update to use pymavlink generator
* px4_config: landing_target: minor correction
* mav_frame: add frames of reference to wiki page; reference them on config
* landing_target: removed child_frame_id
* landing_target: minor code tweak/restructure
* landing_target: uncrustify code
* landing_target: updated to TF2 and Eigen math
* landing_target: adapted to latest master code
* landing_target: added timestamp and target size fields [!Won't compile unless a new mavlink release!]
* landing_target: first commit
* Switch to double-reflections instead of axes-reassignments
* specialize transform_frame_ned_enu and transform_frame_enu_ned for type
  Vector3d such that input vectors containing a NAN can be correctly transformed
* Update README.md
  update misspelling
* Contributors: Julian Kent, Martina Rivizzigno, Shingo Matsuura, TSC21, Vladimir Ermakov
```

## mavros_extras

```
* landing_target: fix landing target pose input topic naming
* fix naming for file
* mavros_plugins: fix landing_target plugin init
* landing_target: change topic subscription naming
* extras: mavros_plugins.xml: fix malform on XML file
* landing_target: use m_uas
* visualization: set the frame and child frame id back to map and base_link
* general fixup to update the landing_target codebase
* extras: landing target: improve usability and flexibility
* ident correction
* landing_target: use Eigen::Quaterniond::Identity()
* visualization: small correction on cb
* landing_target: ident correct
* landing_target: ident correction
* renamed copter_visualization to just visualization
* landing_target: target orientation: assess it is not possible
* copter_visualization: add target_size and landing_target subscriber in copter_visualization node, so to publish a marker of the target
* uas_stringify: changed UAS::idx_frame() to UAS::frame_from_str()
* landing_target: removed child_frame_id
* landing_target: minor code tweak/restructure
* landing_target: small correction on math
* landing_target: uncrustify code
* landing_target: updated to TF2 and Eigen math
* landing_target: adapted to latest master code
* landing_target: corrected pkt parser order
* landing_target: added stringify usage on code
* landing_target: added timestamp and target size fields [!Won't compile unless a new mavlink release!]
* landing_target: removed PoseWithCovarianceStamped include
* landing_target: remove the need of local_position subscription
* landing_target: fixed local_position subscriber topic name
* landing_target: updated notation and applied correct math to conversions
* landing_target: first commit
* Contributors: TSC21
```

## mavros_msgs

```
* mavros_msgs: LandingTarget: update msg description link
* extras: landing target: improve usability and flexibility
* Contributors: TSC21
```

## test_mavros

- No changes
