### PR TITLE
cob_command_tools: 0.6.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1394,7 +1394,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.11-0
+      version: 0.6.12-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.12-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.11-0`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

- No changes

## cob_script_server

```
* Merge pull request #247 <https://github.com/ipa320/cob_command_tools/issues/247> from fmessmer/fix_variable_overflow_serialization_exception
  replace ScriptState number with datetime for uniqueness
* replace ScriptState number with datetime for uniqueness
* Contributors: Felix Messmer, fmessmer
```

## cob_teleop

- No changes

## generic_throttle

- No changes

## service_tools

- No changes
