### PR TITLE
cob_driver: 0.6.14-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1484,7 +1484,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.6.13-0
+      version: 0.6.14-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.6.14-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.13-0`

## cob_base_drive_chain

- No changes

## cob_bms_driver

```
* Merge pull request #393 <https://github.com/ipa320/cob_driver/issues/393> from fmessmer/add_int_bms_parameter
  add int bms parameter types
* get rid of c++11 compile options
* fix key name
* add int bms parameter types
* Merge pull request #392 <https://github.com/ipa320/cob_driver/issues/392> from fmessmer/max_time_remaining
  clamp time_remaining when current is zero
* clamp time_remaining when current is zero
* Contributors: Felix Messmer, fmessmer
```

## cob_camera_sensors

- No changes

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

- No changes

## cob_mimic

- No changes

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

- No changes

## cob_relayboard

- No changes

## cob_scan_unifier

- No changes

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

- No changes
