### PR TITLE
catkin: 0.7.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1167,7 +1167,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.14-0
+      version: 0.7.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.18-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.14-0`

## catkin

```
* add catkin_make(_isolated) default parameters for Windows developers (#1011 <https://github.com/ros/catkin/issues/1011>)
* fix order of bin/lib in PATH on Windows (#1010 <https://github.com/ros/catkin/issues/1010>)
* clarify consequences of running setup.py manually (#1009 <https://github.com/ros/catkin/issues/1009>)
* update docs for dynamic reconfigure (#1001 <https://github.com/ros/catkin/issues/1001>)
```
