### PR TITLE
rail_manipulation_msgs: 0.0.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5362,7 +5362,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
-      version: 0.0.12-0
+      version: 0.0.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_manipulation_msgs` to `0.0.13-1`:

- upstream repository: https://github.com/GT-RAIL/rail_manipulation_msgs.git
- release repository: https://github.com/gt-rail-release/rail_manipulation_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.12-0`

## rail_manipulation_msgs

```
* New service message, takes a segmented object list in, returns a segmented object list after some processing has been done
* Contributors: David Kent
```
