### PR TITLE
rail_segmentation: 0.1.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5369,6 +5369,22 @@ repositories:
       url: https://github.com/GT-RAIL/rail_manipulation_msgs.git
       version: melodic-devel
     status: maintained
+  rail_segmentation:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rail_segmentation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gt-rail-release/rail_segmentation.git
+      version: 0.1.13-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/GT-RAIL/rail_segmentation.git
+      version: melodic-devel
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.13-1`:

- upstream repository: https://github.com/GT-RAIL/rail_segmentation.git
- release repository: https://github.com/gt-rail-release/rail_segmentation.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rail_segmentation

```
* Safer wait for point cloud that checks timestamps
* Switched continuous point cloud polling for waitForMessage
* Added an option to publish marker labels for each cluster for debugging
* Added a flag to the segmentation zone config to require a table; if this is set to true, segmentation will only be performed if a surface was successfully detected in the current segmentation zone.
* New service for re-calculating (or filling in uncalculated) features of segmented objects, assuming that at minimum the point cloud field is set
* Exposed cluster tolerance as a parameter
* Optional parameter for cropping the workspace before table detection (defaults to false so it won't change behavior for anything currently using rail_segmentation), which potentially speeds up segmentation but may cause table detection to fail more often when segmenting in small, cluttered segmentation zones
* Contributors: David Kent
```
