### PR TITLE
rospack: 2.4.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12140,7 +12140,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.4.4-0
+      version: 2.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.4.5-1`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.4.4-0`

## rospack

```
* add ros_environment as dependency (#97 <https://github.com/ros/rospack/issues/97>)
```
