### PR TITLE
ros: 1.14.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11418,7 +11418,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.14.4-0
+      version: 1.14.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.14.6-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.14.4-0`

## mk

- No changes

## rosbash

```
* add roscd, rosls support for Windows (#210 <https://github.com/ros/ros/issues/210>)
* exclude files when completing roslaunch args (#211 <https://github.com/ros/ros/issues/211>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

- No changes
