### PR TITLE
Update doc branches that were missed.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -216,7 +216,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: crystal
+      version: dashing
     release:
       packages:
       - actionlib_msgs
@@ -1851,7 +1851,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/variants.git
-      version: crystal
+      version: dashing
     release:
       packages:
       - desktop


### PR DESCRIPTION
The dashing doc branches should be used for these repositories.