### PR TITLE
ets_ros2: 0.1.2-2 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -473,7 +473,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/brunodmt/ets_ros2-release.git
-      version: 0.1.1-2
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/brunodmt/ets_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ets_ros2` to `0.1.2-2`:

- upstream repository: https://github.com/brunodmt/ets_ros2.git
- release repository: https://github.com/brunodmt/ets_ros2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-2`

## ets_cpp_client

```
* Add parking brake status
* Contributors: Hernán Gonzalez
```

## ets_msgs

```
* Add parking brake status
* Contributors: Hernán Gonzalez
```

## ets_plugin

```
* Remove unused nav_msgs dependency
* Add parking brake status
* Contributors: Bruno Demartino, Hernán Gonzalez
```
