### PR TITLE
qt_gui_core: 1.0.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -784,7 +784,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.0.6-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.5-1`

## qt_dotgraph

- No changes

## qt_gui

```
* add missing QtCore import (#178 <https://github.com/ros-visualization/qt_gui_core/issues/178>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
