### PR TITLE
add pugixml to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4597,6 +4597,10 @@ psutils:
   fedora: [psutils]
   gentoo: [psutils]
   ubuntu: [psutils]
+pugixml-dev:
+  debian: [libpugixml-dev]
+  fedora: [pugixml]
+  ubuntu: [libpugixml-dev]
 python-dev:
   debian: [python-dev]
   fedora: [python2-devel]


### PR DESCRIPTION
## Description
I would like to add pugixml-dev package to base.yaml
Debian: https://packages.debian.org/search?keywords=pugixml-dev&searchon=names&suite=stable&section=all
Fedora: https://apps.fedoraproject.org/packages/s/pugixml
Ubuntu: https://packages.ubuntu.com/search?keywords=pugixml-dev&searchon=names&suite=all&section=all

Added key is "pugixml-dev", not "pugixml" because it was used in distribution.yaml as below. 

## distribution.yaml in Indigo and Jade
I have a concern about distribution.yaml in Indigo and Jade. They seem to be using distributed wrapper for pugixml.
Indigo: https://github.com/ros/rosdistro/blob/master/indigo/distribution.yaml#L10654
Jade: https://github.com/ros/rosdistro/blob/bede3a3127935c5e364322dc04f63a935e35a36d/jade/distribution.yaml#L4762
I wanted to use pugixml in kinetic and melodic, but rather than adding this distribution to kinetic and melodic, I thought it was better to point to official released package in base.yaml.
Please let me know if I have to point to this distribution. 

Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>