### PR TITLE
actionlib-enhanced: 0.0.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -120,7 +120,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fannibal/actionlib-enhanced-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
   adi_driver:
     doc:
       type: git


### PR DESCRIPTION
remove a logdebug causing unnecessary delay in the "action_server" program.