### PR TITLE
Remove spinnaker_camera_driver

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3288,7 +3288,6 @@ repositories:
     release:
       packages:
       - flir_camera_driver
-      - spinnaker_camera_driver
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3286,8 +3286,6 @@ repositories:
       url: https://github.com/ros-drivers/flir_camera_driver.git
       version: kinetic-devel
     release:
-      packages:
-      - flir_camera_driver
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git


### PR DESCRIPTION
It's failing to build http://build.ros.org/view/Kbin_uX32/job/Kbin_uX32__spinnaker_camera_driver__ubuntu_xenial_i386__binary/
```
16:27:12 In file included from /tmp/binarydeb/ros-kinetic-spinnaker-camera-driver-0.1.3/include/spinnaker_camera_driver/camera.h:32:0,
16:27:12                  from /tmp/binarydeb/ros-kinetic-spinnaker-camera-driver-0.1.3/src/camera.cpp:25:
16:27:12 /tmp/binarydeb/ros-kinetic-spinnaker-camera-driver-0.1.3/include/spinnaker_camera_driver/set_property.h:29:23: fatal error: Spinnaker.h: No such file or directory
16:27:12 compilation terminated.
```

It looks like a missing dependency or include path.

Partial reversion of #19175 FYI @mhosmar-cpr