### PR TITLE
qb_chain: 2.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9909,7 +9909,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbchain-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_chain` to `2.1.1-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbchain-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbchain-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.0-1`

## qb_chain

- No changes

## qb_chain_control

- No changes

## qb_chain_controllers

```
* Fix dependencies
```

## qb_chain_description

- No changes
