### PR TITLE
librealsense2: 2.23.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6011,7 +6011,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: tag
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -6020,7 +6020,7 @@ repositories:
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
-      version: tag
+      version: master
     status: maintained
   libsegwayrmp:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6007,6 +6007,21 @@ repositories:
       url: https://github.com/IntelRealSense/librealsense.git
       version: legacy
     status: maintained
+  librealsense2:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: tag
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/IntelRealSense/librealsense2-release.git
+      version: 2.23.0-1
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: tag
+    status: maintained
   libsegwayrmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.23.0-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
