### PR TITLE
sros2: 0.7.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1651,7 +1651,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`

## sros2

```
* Guard against empty ROS graph when generating policy (#118 <https://github.com/ros2/sros2/issues/118>)
* Guard against invalid key names (#117 <https://github.com/ros2/sros2/issues/117>)
* Contributors: Jacob Perron
```

## sros2_cmake

- No changes
