### PR TITLE
rmw_opensplice: 0.7.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1047,7 +1047,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_opensplice` to `0.7.2-1`:

- upstream repository: https://github.com/ros2/rmw_opensplice.git
- release repository: https://github.com/ros2-gbp/rmw_opensplice-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.1-1`
