### PR TITLE
launch: 0.8.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -531,7 +531,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.8.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.3-1`

## launch

```
* Fix build_cop #214 <https://github.com/ros2/launch/issues/214> (#259 <https://github.com/ros2/launch/issues/259>)
* Fix get_launch_arguments to not crash on conditional sub entities (#257 <https://github.com/ros2/launch/issues/257>)
* Use stderr logger instead of buffer (#258 <https://github.com/ros2/launch/issues/258>)
* Line buffering of logger output (#255 <https://github.com/ros2/launch/issues/255>)
* Contributors: Jacob Perron, Peter Baughman, ivanpauno
```

## launch_testing

```
* Fix proc lookup for processes with multiple command-line arguments (#229 <https://github.com/ros2/launch/issues/229>)
* Contributors: Peter Baughman
```

## launch_testing_ament_cmake

- No changes
