### PR TITLE
rviz: 6.1.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1632,7 +1632,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 6.1.1-1
+      version: 6.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.1.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `6.1.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Changed the clock used to stamp publications, using one attached to a node instead so ``use_sim_time`` will work. (#407 <https://github.com/ros2/rviz/issues/407>)
* Contributors: Scott K Logan
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fixed a bug in the STL loader where an STL would be loaded twice and produce an error. (#410 <https://github.com/ros2/rviz/issues/410>)
  * Also fixed a warning about a missing material, by adding BaseWhiteNoLighting to the ``rviz_rendering`` resource group.
  * Previous to Ogre 1.11, materials would be searched in all groups With 1.11, this is no longer true.
  * In RViz, we try to put materials in our own resource group, but we need the Ogre fallback material.
* Contributors: Martin Idel
```

## rviz_rendering_tests

```
* Fixed a bug in the STL loader where an STL would be loaded twice and produce an error. (#410 <https://github.com/ros2/rviz/issues/410>)
* Contributors: Martin Idel
```

## rviz_visual_testing_framework

- No changes
