### PR TITLE
image_pipeline: 1.13.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2384,11 +2384,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.12.23-0
+      version: 1.13.0-1
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
       version: indigo
+    status: developed
   image_transport_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.13.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.12.23-0`

## camera_calibration

```
* Merge pull request #356 <https://github.com/ros-perception/image_pipeline/issues/356> from sevangelatos/feature/calibrator_rolling_shutter
* Add max-chessboard-speed option to allow more accurate calibration of rolling shutter cameras.
* Merge pull request #334 <https://github.com/ros-perception/image_pipeline/issues/334> from Fruchtzwerg94/patch-2
  Scale pixels down from 16 to 8 bits instead of just clipping
* Merge pull request #340 <https://github.com/ros-perception/image_pipeline/issues/340> from k-okada/286
  use waitKey(0) instead of while loop
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Scale pixels down from 16 to 8 bits instead of just clipping
  Clipping 16 bit pixels just to 8 bit pixels leads to white images if the original image uses the full range of the 16 bits. Instead the pixel should be scaled down to 8 bits.
* Contributors: Joshua Whitley, Kei Okada, Philipp, Spiros Evangelatos, Yoshito Okada, stevemacenski
```

## depth_image_proc

```
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Contributors: Joshua Whitley, Yoshito Okada, stevemacenski
```

## image_pipeline

```
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Contributors: Joshua Whitley, Yoshito Okada, stevemacenski
```

## image_proc

```
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Contributors: Joshua Whitley, Yoshito Okada, stevemacenski
```

## image_publisher

```
* Merge pull request #358 <https://github.com/ros-perception/image_pipeline/issues/358> from lucasw/image_pub_dr_private_namespace
* Use a shared_ptr for the dynamic reconfigure pointer, and create it with the private node handle so that the parameters for the dynamic reconfigure server are in the private namespace and two image publishers can coexist in the same manager #357 <https://github.com/ros-perception/image_pipeline/issues/357>
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Contributors: Joshua Whitley, Lucas Walter, Yoshito Okada, stevemacenski
```

## image_rotate

```
* Merge pull request #382 <https://github.com/ros-perception/image_pipeline/issues/382> from garaemon/intiialzie-prev-stamp
  Fix tf timeout of image_rotate
* Initialize prev_stamp_ as ros::Timw::now()
  * If prev_stamp_ is initialized as 0.0, tf may wait transformation for
  long duration at the first time. In order to give up the wait in
  reasonable duration, initialize prev_stamp_ as current time.
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Contributors: Joshua Whitley, Ryohei Ueda, Yoshito Okada, stevemacenski
```

## image_view

```
* Implemented extracting raw image data (#329 <https://github.com/ros-perception/image_pipeline/issues/329>)
  Implementation of the raw image extraction if the file extension is .raw. This file extension is not supported by cv::imwrite so there is be no conflict. The raw files only containing the pixel data without any meta data which allows usage in MATLAB or other tools.
* Merge pull request #375 <https://github.com/ros-perception/image_pipeline/issues/375> from fizyr-forks/opencv4
* Fix OpenCV4 compatibility.
* Merge pull request #337 <https://github.com/ros-perception/image_pipeline/issues/337> from yoshito-okada/fix_image_view_nodelet
  Fix threading issue in image_view nodelet. Closes #331 <https://github.com/ros-perception/image_pipeline/issues/331>.
* Merge pull request #394 <https://github.com/ros-perception/image_pipeline/issues/394> from angeltop/indigo
  image_view: video recorder fix for conversion of fps to ros::Duration
* Merge pull request #379 <https://github.com/ros-perception/image_pipeline/issues/379> from fizyr-forks/boost-1.69
  Fix boost 1.69 compatibility
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding stevemacenski as maintainer to get emails
* adding autonomoustuff mainainer
* Merge pull request #343 <https://github.com/ros-perception/image_pipeline/issues/343> from fkie-forks/work_around_opencv_highgui_bug
  Work around OpenCV highgui bug
  I had to remove the GTK workaround, since it creates symbol collisions between GTK2 and GTK3.
* Refresh GUI on image update as well
* Use WallTimer for backwards compatibility with ROS Indigo
* Switch to SteadyTimer as suggested in review
* Remove unused signals from find_package(Boost COMPONENTS ...)
  The signals library was not used at all, and it has been removed from
  boost 1.69. As a result, the package doesn't build anymore with boost
  1.69 without this change.
* While we're at it, work around the mutex assertion failure on exit
* Work around an OpenCV bug with GTK and threading
* add ThreadSageImage class to encapsilate mutex operation for image
* handle window in single thread
* Contributors: Hans Gaiser, Joshua Whitley, Maarten de Vries, Philipp, Timo Röhling, Yoshito Okada, angeltop, stevemacenski
```

## stereo_image_proc

```
* Merge pull request #375 <https://github.com/ros-perception/image_pipeline/issues/375> from fizyr-forks/opencv4
* Fix OpenCV4 compatibility.
* Merge pull request #338 <https://github.com/ros-perception/image_pipeline/issues/338> from k-okada/arg_sync
* add approximate_sync args in stereo_image_proc.launch
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Merge pull request #392 <https://github.com/ros-perception/image_pipeline/issues/392> from bknight-i3drobotics/patch-1
* Fix typo
  Typo in line: 14. Changed 'sterel algorithm' to 'stereo algorithm'
* add approximate_sync args in stereo_image_proc.launch
* Contributors: Hans Gaiser, Joshua Whitley, Kei Okada, Steven Macenski, Yoshito Okada, bknight-i3drobotics, stevemacenski
```
