### PR TITLE
apriltag_msgs: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -160,6 +160,24 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_msgs:
+    doc:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
+    release:
+      packages:
+      - apriltag_msgs
+      - apriltag_ros
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/christianrauch/apriltag_ros-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
+    status: developed
   behaviortree_cpp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/christianrauch/apriltag_ros.git
- release repository: https://github.com/christianrauch/apriltag_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
