### PR TITLE
sophus: 1.0.2-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1640,6 +1640,13 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: dashing
     status: maintained
+  sophus:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.0.2-0
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.0.2-0`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`
