### PR TITLE
ecl_tools: 1.0.1-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -302,6 +302,25 @@ repositories:
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0.x
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0.x
+    status: maintained
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `1.0.1-2`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
