### PR TITLE
py_trees: 1.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -772,6 +772,21 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: dashing
     status: maintained
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/1.2.x
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/stonier/py_trees-release.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/1.2.x
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `1.2.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## py_trees

```
* [decorators] ``StatusToBlackboard`` reflects the status of it's child to the blackboard, #195 <https://github.com/splintered-reality/py_trees/pull/195>
* [decorators] ``EternalGuard`` decorator that continuously guards a subtree (c.f. Unreal conditions), #195 <https://github.com/splintered-reality/py_trees/pull/195>
* [idioms] ``eternal_guard`` counterpart to the decorator whose conditions are behaviours, #195 <https://github.com/splintered-reality/py_trees/pull/195>
```
