### PR TITLE
laser_assembler: 1.7.7-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2897,7 +2897,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/laser_assembler-release.git
-      version: 1.7.6-0
+      version: 1.7.7-2
     source:
       type: git
       url: https://github.com/ros-perception/laser_assembler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_assembler` to `1.7.7-2`:

- upstream repository: https://github.com/ros-perception/laser_assembler.git
- release repository: https://github.com/ros-gbp/laser_assembler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.7.6-0`

## laser_assembler

- No changes
