### PR TITLE
laser_filters: 1.8.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2930,7 +2930,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.6-0
+      version: 1.8.7-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.7-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.8.6-0`

## laser_filters

```
* Merge pull request #77 <https://github.com/ros-perception/laser_filters/issues/77> from bionade24/indigo-devel
  Removed boost signals from CMakeLists.txt
* Removed boost signals from CMakeLists.txt
  With boost=>1.69 there signals isn't available anymore. As it's not necessary, it should be removed to be compatible to all boost versions.
* Merge pull request #76 <https://github.com/ros-perception/laser_filters/issues/76> from peci1/fix_travis
  Fix Travis and move on to Kinetic and Lunar.
* Fix Travis and move on to Kinetic and Lunar.
* Merge pull request #73 <https://github.com/ros-perception/laser_filters/issues/73> from peci1/patch-1
  Added error message when the filter chain failed.
* Added error message when the filter chain failed.
* Merge pull request #62 <https://github.com/ros-perception/laser_filters/issues/62> from at-wat/optimize-shadows-filter
  Reduce computation cost of ScanShadowsFilter
* Merge pull request #63 <https://github.com/ros-perception/laser_filters/issues/63> from procopiostein/indigo-devel
  set values for variables that could be used uninitialized
* Add some comments to ScanShadowDetector
* set values for variables that could be used uninitialized
* Reduce computation cost of ScanShadowsFilter
  ScanShadowsFilter required a lot of CPU power mainly due to atan2.
  This commit reduces computation cost of the filter.
  * Remove atan2 and directly compare tangent values
  * Add a test to check geometric calculation
* Apply ROS recommended indent style to ScanShadowsFilter
* Contributors: Atsushi Watanabe, Jonathan Binney, Martin Pecka, Oskar Roesler, Procópio Stein
```
