### PR TITLE
fetch_simple_linear_controller: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1583,6 +1583,21 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_ros.git
       version: melodic-devel
     status: maintained
+  fetch_simple_linear_controller:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/fetch_simple_linear_controller.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gt-rail-release/fetch_simple_linear_controller-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/fetch_simple_linear_controller.git
+      version: melodic-devel
+    status: maintained
   fetch_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_simple_linear_controller` to `0.0.1-1`:

- upstream repository: https://github.com/GT-RAIL/fetch_simple_linear_controller.git
- release repository: https://github.com/gt-rail-release/fetch_simple_linear_controller-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## fetch_simple_linear_controller

```
* Generalized code from the FetchIt challenge
* Initial commit
* Contributors: David Kent
```
