### PR TITLE
pyros_test: 0.0.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5203,6 +5203,21 @@ repositories:
       url: https://github.com/ipab-slmc/pybind11_catkin.git
       version: master
     status: developed
+  pyros_test:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pyros-dev/pyros-test-release.git
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-test.git
+      version: devel
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_test` to `0.0.6-1`:

- upstream repository: https://github.com/pyros-dev/pyros-test.git
- release repository: https://github.com/pyros-dev/pyros-test-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## pyros_test

```
* Merge pull request #5 <https://github.com/asmodehn/pyros-test/issues/5> from asmodehn/string_sub_node
  implementing a simple string_sub_node
* implementing a simple string_sub_node
* now able to name nodes via first command argument.
* Contributors: AlexV, alexv
```
