### PR TITLE
move_base_flex: 0.2.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6918,7 +6918,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.2.3-0
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.4-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.3-0`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Reduce log verbosity by combining lines and using more DEBUG
* Concurrency container refactoring
* Prevent LOST goals when replanning
* Set as canceled, when goals are preempted by a new plan
* move setAccepted to abstract action
* moved listener notification down after setVelocity
* fix: Correctly fill in the ExePathResult fields
* Fix controller_patience when controller_max_retries is -1
* Change current_twist for last_cmd_vel on exe_path/feedback
* Replace recursive mutexes with normal ones when not needed
* Give feedback with outcome and message for success and error cases from the plugin.
```

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* Add check_point_cost service
* Lock costmaps on clear_costmaps service
* Replace recursive mutexes with normal ones when not needed
```

## mbf_msgs

```
* Add check_point_cost service
* Change current_twist for last_cmd_vel on exe_path/feedback
```

## mbf_simple_nav

- No changes

## mbf_utility

```
* Add check_point_cost service
```

## move_base_flex

- No changes
