### PR TITLE
nmea_gps_plugin: 0.0.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4074,6 +4074,21 @@ repositories:
       url: https://github.com/astuff/network_interface.git
       version: release
     status: developed
+  nmea_gps_plugin:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
+      version: master
+    status: developed
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_gps_plugin` to `0.0.1-3`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
- release repository: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
