### PR TITLE
nmea_gps_plugin: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7907,6 +7907,21 @@ repositories:
       url: https://github.com/ros-drivers/nmea_comms.git
       version: jade-devel
     status: maintained
+  nmea_gps_plugin:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
+      version: master
+    status: developed
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_gps_plugin` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
- release repository: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
