### PR TITLE
Adding boost-python rosdep key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -317,11 +317,6 @@ boost:
     xenial: [libboost-all-dev]
     yakkety: [libboost-all-dev]
     zesty: [libboost-all-dev]
-boost-python:
-  alpine: [boost-python2]
-  debian: [libboost-python-dev]
-  fedora: [boost-python2-devel]
-  ubuntu: [libboost-python-dev]
 box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]
@@ -1584,6 +1579,11 @@ libboost-program-options-dev:
   fedora: [boost-devel]
   openembedded: [boost@openembedded-core]
   ubuntu: [libboost-program-options-dev]
+libboost-python:
+  alpine: [boost-python2]
+  debian: [libboost-python-dev]
+  fedora: [boost-python2-devel]
+  ubuntu: [libboost-python-dev]
 libboost-random:
   debian:
     jessie: [libboost-random1.55.0]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -317,6 +317,11 @@ boost:
     xenial: [libboost-all-dev]
     yakkety: [libboost-all-dev]
     zesty: [libboost-all-dev]
+boost-python:
+  alpine: [boost-python2]
+  debian: [libboost-python-dev]
+  fedora: [boost-python2-devel]
+  ubuntu: [libboost-python-dev]
 box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]


### PR DESCRIPTION
Alpine: https://pkgs.alpinelinux.org/packages?name=*boost-python*&branch=edge
Debian: https://packages.debian.org/search?keywords=libboost-python-dev
Fedora: https://apps.fedoraproject.org/packages/boost-python2-devel
Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=libboost-python-dev&searchon=names

This is so the Python bindings for Boost can be installed without installing the whole of Boost (libboost-all-*). Required by a dependency of the Autoware project.