### PR TITLE
doosan_robot: 0.9.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2386,7 +2386,6 @@ repositories:
       - doosan_robotics
       - dsr_control
       - dsr_description
-      - dsr_example_cpp
       - dsr_example_py
       - dsr_gazebo
       - dsr_launcher
@@ -2395,10 +2394,12 @@ repositories:
       - moveit_config_m0617
       - moveit_config_m1013
       - moveit_config_m1509
+      - robotiq_gazebo
+      - serial_node_example
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/doosan-robotics/doosan-robot-release.git
-      version: 0.9.6-1
+      version: 0.9.8-1
     source:
       type: git
       url: https://github.com/doosan-robotics/doosan-robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `doosan_robot` to `0.9.8-1`:

- upstream repository: https://github.com/doosan-robotics/doosan-robot.git
- release repository: https://github.com/doosan-robotics/doosan-robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.9.6-1`

## doosan_robot

- No changes

## doosan_robotics

- No changes

## dsr_control

- No changes

## dsr_description

- No changes

## dsr_example_py

```
* change dsr_example_py dir
* Contributors: doosan-robotics
```

## dsr_gazebo

- No changes

## dsr_launcher

- No changes

## dsr_msgs

- No changes

## moveit_config_m0609

- No changes

## moveit_config_m0617

- No changes

## moveit_config_m1013

- No changes

## moveit_config_m1509

- No changes

## robotiq_gazebo

- No changes

## serial_node_example

- No changes
