### PR TITLE
Revert "abseil_cpp: 0.4.0-1 in 'lunar/distribution.yaml' [bloom] (#21…

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -17,7 +17,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.4.0-1
+      version: 0.2.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
…374)"

This reverts commit 609b5971c0e0c92e5cbdfdb8d55ca659037ec20f.

This hopefully fixes the regression in ros_type_introspection: http://build.ros.org/view/Lbin_uX64/job/Lbin_uX64__ros_type_introspection__ubuntu_xenial_amd64__binary/12/ .  @facontidavide FYI.