### PR TITLE
pyros_utils: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5284,6 +5284,21 @@ repositories:
       url: https://github.com/asmodehn/pyros-test.git
       version: devel
     status: maintained
+  pyros_utils:
+    doc:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pyros-dev/pyros-utils-release.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/asmodehn/pyros-utils.git
+      version: devel
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyros_utils` to `0.1.4-1`:

- upstream repository: https://github.com/pyros-dev/pyros-utils.git
- release repository: https://github.com/pyros-dev/pyros-utils-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## pyros_utils

```
* catkin > 0.2
* Contributors: alexv
```
