### PR TITLE
mcl_3dl: update indigo source branch

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7163,7 +7163,7 @@ repositories:
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git
-      version: master
+      version: indigo-devel
     status: developed
   mcl_3dl_msgs:
     doc:
@@ -7178,7 +7178,7 @@ repositories:
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl_msgs.git
-      version: master
+      version: indigo-devel
     status: developed
   md49_base_controller:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7154,7 +7154,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -7169,7 +7169,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/at-wat/mcl_3dl_msgs.git
-      version: master
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}


### PR DESCRIPTION
The master branch of mcl_3dl package is no longer buildable on Indigo environment.
This commit update mcl_3dl source branch to indigo-devel which is the final Indigo compatible commit.