### PR TITLE
neonavigation: update indigo source branch

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8489,7 +8489,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/at-wat/neonavigation.git
-      version: master
+      version: indigo-devel
     release:
       packages:
       - costmap_cspace
@@ -8516,7 +8516,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git
-      version: master
+      version: indigo-devel
     release:
       packages:
       - costmap_cspace_msgs
@@ -8537,7 +8537,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/at-wat/neonavigation_rviz_plugins.git
-      version: master
+      version: indigo-devel
     release:
       packages:
       - neonavigation_rviz_plugins

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8510,7 +8510,7 @@ repositories:
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git
-      version: master
+      version: indigo-devel
     status: developed
   neonavigation_msgs:
     doc:
@@ -8531,7 +8531,7 @@ repositories:
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git
-      version: master
+      version: indigo-devel
     status: developed
   neonavigation_rviz_plugins:
     doc:
@@ -8549,7 +8549,7 @@ repositories:
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_rviz_plugins.git
-      version: master
+      version: indigo-devel
     status: developed
   nerian_sp1:
     doc:


### PR DESCRIPTION
The master branch of neonavigation package is no longer buildable on Indigo environment.
This commit update neonavigation source branch to indigo-devel which is the final Indigo compatible commit.