### PR TITLE
py_trees_ros: 1.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -870,6 +870,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees.git
       version: release/1.2.x
     status: maintained
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/1.1.x
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: devel
+    status: developed
   py_trees_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `1.1.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## py_trees_ros

```
* [actions] bugfix action client, don't cancel if not RUNNING
* [conversions] bugfix msg_to_behaviour for decorators
* [watchers] bugfix tree-watchers dot-graph to string functionality
* [watchers] bugfix missing tip in deserialised tree-watcher tree
```
