### PR TITLE
pilz_industrial_motion: 0.4.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4858,7 +4858,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.3-0
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.4-1`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.3-0`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

- No changes

## pilz_msgs

- No changes

## pilz_robot_programming

```
* Add python api methods for brake tests
```

## pilz_trajectory_generation

```
* fixed an error that led to trajectories not strictly increasing in time
* Contributors: Pilz GmbH and Co. KG
```
