### PR TITLE
pilz_robots: 0.4.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9163,7 +9163,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.4.8-0
+      version: 0.4.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.4.9-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.8-0`

## pilz_control

- No changes

## pilz_robots

- No changes

## pilz_testutils

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* increased modbus response timeout to 20ms
* publish brake test requests obtained from safety controller via modbus
* sto_modbus_adapter waits for the services to appear instead of throwing exceptions
* Add ability to execute a braketest on each drive.
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

- No changes

## prbt_support

```
* instantiate pg70 xacro macro (due to change in prbt_grippers)
* Contributors: Pilz GmbH and Co. KG
```
