### PR TITLE
omron_os32c_driver: 1.0.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8324,7 +8324,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/omron-release.git
-      version: 0.1.3-0
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/omron.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omron_os32c_driver` to `1.0.0-0`:

- upstream repository: https://github.com/ros-drivers/omron.git
- release repository: https://github.com/ros-drivers-gbp/omron-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.1.3-0`

## omron_os32c_driver

```
* feat: ~reconnect_timeout parameter
  Driver will automatically reconnect if no connection can be established
  or if a scan has not be received for the specified number of seconds.
* Added reflection measurement and frequency param
* Use TCP/IP polling instead of UDP
* Contributors: Rein Appeldoorn, Tom de Winter
```
