### PR TITLE
webots_ros: 2.0.3-1 in 'kinetic/distribution.yaml' [bloom] 

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15906,7 +15906,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/omichel/webots_ros-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/omichel/webots_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros` to `2.0.3-1`:

   - upstream repository: https://github.com/omichel/webots_ros.git
   - release repository: https://github.com/omichel/webots_ros-release.git
   - distro file: `kinetic/distribution.yaml`
   - bloom version: `0.8.0`
   - previous version for package: `2.0.2-1`
