### PR TITLE
Revert "abseil_cpp: 0.4.0-1 in 'melodic/distribution.yaml' [bloom] (#…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -19,12 +19,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.4.0-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/Eurecat/abseil-cpp.git
       version: master
-    status: developed
   acado:
     doc:
       type: git


### PR DESCRIPTION
…21375)"

This reverts commit 683c8e698451aed045562721ab680edee16e6fdb.

This is causing the build for [ros_type_introspection](http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ros_type_introspection__ubuntu_bionic_amd64__binary/) to fail, so revert it here.