### PR TITLE
toposens: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7801,14 +7801,16 @@ repositories:
     release:
       packages:
       - toposens
+      - toposens_description
       - toposens_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
+      - toposens_sync
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.0.0-3
+      version: 1.1.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.1.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-3`

## toposens

```
* Added support for ROS Kinetic on Ubuntu 16.04
* Enhanced setup guide for all packages
* Added urdf for turtlebot with TS3
* Added sync integration for multiple device operation
* Contributors: Adi Singh, Sebastian Dengler, Christopher Lang
```

## toposens_description

```
* Added support for ROS Kinetic on Ubuntu 16.04
* Enhanced setup guide for all packages
* Added urdf for turtlebot with TS3
* Contributors: Adi Singh, Sebastian Dengler
```

## toposens_driver

- No changes

## toposens_markers

- No changes

## toposens_msgs

- No changes

## toposens_pointcloud

- No changes

## toposens_sync

```
* Added sync integration for multiple device operation
* Contributors: Christopher Lang, Sebastian Dengler
```
