### PR TITLE
cloudwatch_logger: 2.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1293,7 +1293,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_logger-release.git
-      version: 2.0.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchlogs-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_logger` to `2.1.0-2`:

- upstream repository: https://github.com/aws-robotics/cloudwatchlogs-ros1.git
- release repository: https://github.com/aws-gbp/cloudwatch_logger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-1`

## cloudwatch_logger

```
* Update package.xml for 2.1.0 release
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
* Adds a new parameter for a list of node names to ignore logs from. (#24 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/24>)
  * Adds a new parameter for a list of node names to ignore logs from.
* Removing old file that has already been refactored out into separate files.
* Contributors: Nick Burek, Ryan Newell
```
