### PR TITLE
cloudwatch_common: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -630,7 +630,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.0.1-0
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.0.2-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-0`

## cloudwatch_logs_common

```
* Adding old release to change log
* Update package.xml for 1.0.2 release
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
* Increase test timeout to fix flakiness (#21 <https://github.com/aws-robotics/cloudwatch-common/issues/21>)
  - Increase the test timeout to 5000ms because sometimes
  SendLogsToCloudWatch isn't being called fast enough and so the tests
  fail.
* Fixes issue with DescribeLogStreams being called to get the next token
  - Call DescribeLogStreams only one on startup
  - Implements a state machine to manage the core run loop instead of checking if the log stream exists every tick.
* Update success logs' severity to DEBUG in cloudwatch_facade.cpp
* Release 1.0.1 (#14 <https://github.com/aws-robotics/cloudwatch-common/issues/14>)
  * Release 1.0.1
  * 1.0.1
* adding unit tests for cloudwatch facade
* Merge pull request #4 <https://github.com/aws-robotics/cloudwatch-common/issues/4> from juanrh/improve-coverage-cloudwatch_logger
  Improve coverage cloudwatch logger
* Make LogManagerFactory mockeable
* Make cloudwatch_logs_common shared lib to use it in other libs
* Merge pull request #1 <https://github.com/aws-robotics/cloudwatch-common/issues/1> from xabxx/master
  [Bug Fix] Resolved false-positive error log messages
* Resolved false-positive error log messages
* Contributors: AAlon, Abby Xu, Nick Burek, Ross Desmond, Ryan Newell, Tim Robinson, Yuan "Forrest" Yu, hortala, ryanewel
```

## cloudwatch_metrics_common

```
* Adding old release to change log
* Update package.xml for 1.0.2 release
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
* Release 1.0.1 (#14 <https://github.com/aws-robotics/cloudwatch-common/issues/14>)
  * Release 1.0.1
  * 1.0.1
* Contributors: AAlon, Ryan Newell, ryanewel
```
