### PR TITLE
h264_video_encoder: 1.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4056,7 +4056,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/h264_video_encoder-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_video_encoder` to `1.1.2-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git
- release repository: https://github.com/aws-gbp/h264_video_encoder-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-1`

## h264_video_encoder

```
* Update package.xml for 1.1.2 release
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
* fix issue with uninitialized frame number (#19 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/19>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Add gtest and gmock as test dependencies
* Update package.xml
* Merge pull request #8 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/8> from ryanewel/master
  increases unit test code coverage
* increases unit test code coverage
* Contributors: AAlon, M. M, Ross Desmond, Ryan Newell, ryanewel
```
