### PR TITLE
py_trees_ros: 1.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -879,7 +879,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `1.1.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-1`

## py_trees_ros

```
* [tests] add missing tests/__init.py,  #94 <https://github.com/splintered-reality/py_trees_ros/pull/94>
* [infra] add missing ros2topic dependency,  #94 <https://github.com/splintered-reality/py_trees_ros/pull/94>
```
