### PR TITLE
joystick_drivers: 1.13.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5249,7 +5249,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.12.0-0
+      version: 1.13.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.13.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.12.0-0`

## joy

```
* Merge pull request #120 <https://github.com/ros-drivers/joystick_drivers/issues/120> from furushchev/remap
  add joy_remap and its sample
* Merge pull request #128 <https://github.com/ros-drivers/joystick_drivers/issues/128> from ros-drivers/fix/tab_errors
  Cleaning up Python indentation.
* Merge pull request #111 <https://github.com/ros-drivers/joystick_drivers/issues/111> from matt-attack/indigo-devel
  Add Basic Force Feedback Support
* Merge pull request #126 <https://github.com/ros-drivers/joystick_drivers/issues/126> from clalancette/minor-formatting
* Put brackets around ROS_* macros.
  In some circumstances they may be defined to empty, so we need
  to have brackets to ensure that they are syntactically valid.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Merge pull request #122 <https://github.com/ros-drivers/joystick_drivers/issues/122> from lbucklandAS/fix-publish-timestamp
  Add timestamp to all joy messages
* Change error messages and set ps3 as default controller
* Better handle device loss
  Allow for loss and redetection of device with force feedback
* Add basic force feedback over usb
  Addresses #89 <https://github.com/ros-drivers/joystick_drivers/issues/89>
* Contributors: Chris Lalancette, Furushchev, Joshua Whitley, Lucas Buckland, Matthew, Matthew Bries
```

## joystick_drivers

- No changes

## ps3joy

```
* Merge pull request #128 <https://github.com/ros-drivers/joystick_drivers/issues/128> from ros-drivers/fix/tab_errors
* Cleaning up Python indentation.
* Merge pull request #123 <https://github.com/ros-drivers/joystick_drivers/issues/123> from cclauss/modernize-python2-code
* Modernize Python 2 code to get ready for Python 3
* Merge branch 'master' into indigo-devel
* Contributors: Joshua Whitley, Matthew, cclauss
```

## spacenav_node

- No changes

## wiimote

```
* Merge pull request #132 <https://github.com/ros-drivers/joystick_drivers/issues/132> from mistoll/clean_exit
* return instead of shutdown
* Merge pull request #128 <https://github.com/ros-drivers/joystick_drivers/issues/128> from ros-drivers/fix/tab_errors
* Cleaning up Python indentation.
* Merge pull request #125 <https://github.com/ros-drivers/joystick_drivers/issues/125> from mistoll/check_connection
* Check if wiimote is still connected.
* Merge pull request #123 <https://github.com/ros-drivers/joystick_drivers/issues/123> from cclauss/modernize-python2-code
* Modernize Python 2 code to get ready for Python 3
* Merge branch 'master' into indigo-devel
* Contributors: Joshua Whitley, Matthew, Michael Stoll, cclauss
```
