### PR TITLE
Add pyosmium

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,6 +203,19 @@ mercurial:
   osx:
     pip:
       packages: [mercurial]
+osmium:
+  debian:
+    pip:
+      [osmium]
+  ubuntu:
+    pip:
+      [osmium]
+  fedora:
+    pip:
+      [osmium]
+  gentoo:
+    pip:
+      [osmium]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -3077,9 +3090,6 @@ python-pynmea2:
   ubuntu:
     pip:
       packages: [pynmea2]
-python-pyosmium:
-  debian: [python-pyosmium]
-  ubuntu: [python-pyosmium]
 python-pypng:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,19 +203,6 @@ mercurial:
   osx:
     pip:
       packages: [mercurial]
-osmium-pip:
-  debian:
-    pip:
-      packages: [osmium]
-  fedora:
-    pip:
-      packages: [osmium]
-  gentoo:
-    pip:
-      packages: [osmium]
-  ubuntu:
-    pip:
-      packages: [osmium]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -277,6 +264,13 @@ pynput-pip:
   ubuntu:
     pip:
       packages: [pynput]
+pyosmium:
+  debian: [python-pyosmium]
+  fedora: [python3-pyosmium]
+  gentoo:
+    pip:
+      [osmium]
+  ubuntu: [python-pyosmium]
 pyper-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -269,7 +269,7 @@ pyosmium:
   fedora: [python3-pyosmium]
   gentoo:
     pip:
-      [osmium]
+      packages: [osmium]
   ubuntu: [python-pyosmium]
 pyper-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,7 +203,7 @@ mercurial:
   osx:
     pip:
       packages: [mercurial]
-osmium:
+osmium-pip:
   debian:
     pip:
       packages: [osmium]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -267,9 +267,6 @@ pynput-pip:
 pyosmium:
   debian: [python-pyosmium]
   fedora: [python3-pyosmium]
-  gentoo:
-    pip:
-      packages: [osmium]
   ubuntu: [python-pyosmium]
 pyper-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -264,6 +264,10 @@ pynput-pip:
   ubuntu:
     pip:
       packages: [pynput]
+pyosmium-pip:
+  ubuntu:
+    pip:
+      packages: [pyosmium]
 pyper-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,6 +203,10 @@ mercurial:
   osx:
     pip:
       packages: [mercurial]
+osmium-pip:
+  ubuntu:
+    pip:
+      packages: [osmium]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -264,10 +268,6 @@ pynput-pip:
   ubuntu:
     pip:
       packages: [pynput]
-pyosmium-pip:
-  ubuntu:
-    pip:
-      packages: [pyosmium]
 pyper-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -266,7 +266,6 @@ pynput-pip:
       packages: [pynput]
 pyosmium:
   debian: [python-pyosmium]
-  fedora: [python3-pyosmium]
   ubuntu: [python-pyosmium]
 pyper-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -206,16 +206,16 @@ mercurial:
 osmium:
   debian:
     pip:
-      [osmium]
-  ubuntu:
-    pip:
-      [osmium]
+      packages: [osmium]
   fedora:
     pip:
-      [osmium]
+      packages: [osmium]
   gentoo:
     pip:
-      [osmium]
+      packages: [osmium]
+  ubuntu:
+    pip:
+      packages: [osmium]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,10 +203,6 @@ mercurial:
   osx:
     pip:
       packages: [mercurial]
-osmium-pip:
-  ubuntu:
-    pip:
-      packages: [osmium]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -3081,6 +3077,9 @@ python-pynmea2:
   ubuntu:
     pip:
       packages: [pynmea2]
+python-pyosmium:
+  debian: [python-pyosmium]
+  ubuntu: [python-pyosmium]
 python-pypng:
   arch:
     pip:


### PR DESCRIPTION
Looking to add pyosmium, which enables the creation of OpenStreetMap files from GPS coordinates.

Debian/Ubuntu
https://packages.debian.org/buster/python-pyosmium
https://packages.ubuntu.com/disco/python-pyosmium

Fedora
https://apps.fedoraproject.org/packages/python3-osmium

Gentoo (pip):
https://pypi.org/project/osmium/