### PR TITLE
rr_openrover_basic: 0.7.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12975,8 +12975,8 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/RoverRobotics/rr_openrover_basic-release.git
-      version: 0.6.1-0
+      url: https://github.com/RoverRobotics-release/rr_openrover_basic-release.git
+      version: 0.7.1-2
     source:
       type: git
       url: https://github.com/RoverRobotics/rr_openrover_basic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_basic` to `0.7.1-2`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_basic
- release repository: https://github.com/RoverRobotics-release/rr_openrover_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.1-0`

## rr_openrover_basic

```
* Changed default port to /dev/rover
* Changed CMAke to install diagnostics.py
```
