### PR TITLE
Add python-wrapt

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4743,6 +4743,10 @@ python-wheel:
   fedora: [python-wheel]
   gentoo: [dev-python/wheel]
   ubuntu: [python-wheel]
+python-wrapt:
+  debian: [python-wrapt]
+  ubuntu: [python-wrapt]
+  fedora: [python2-wrapt]
 python-ws4py:
   debian: [python-ws4py]
   ubuntu: [python-ws4py]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4745,8 +4745,8 @@ python-wheel:
   ubuntu: [python-wheel]
 python-wrapt:
   debian: [python-wrapt]
-  ubuntu: [python-wrapt]
   fedora: [python2-wrapt]
+  ubuntu: [python-wrapt]
 python-ws4py:
   debian: [python-ws4py]
   ubuntu: [python-ws4py]


### PR DESCRIPTION
`wrapt` is the module for decorators, wrappers and monkey patching.

Debian: https://packages.debian.org/stretch/python-wrapt
Ubuntu: https://packages.ubuntu.com/xenial/python-wrapt
Fedora: https://apps.fedoraproject.org/packages/python2-wrapt