### PR TITLE
Adding pipeline_planner to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9216,6 +9216,10 @@ repositories:
       version: master
     status: maintained
   pipeline_planner:
+    doc:
+      type: git
+      url: https://github.com/SeaosRobotics/pipeline_planner_open.git
+      version: master
     source:
       type: git
       url: https://github.com/SeaosRobotics/pipeline_planner_open.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9215,6 +9215,12 @@ repositories:
       url: https://github.com/amineHorseman/pioneer_teleop.git
       version: master
     status: maintained
+  pipeline_planner:
+    source:
+      type: git
+      url: https://github.com/SeaosRobotics/pipeline_planner_open.git
+      version: master
+    status: maintained
   platform_automation_msgs:
     doc:
       type: git


### PR DESCRIPTION
I'd like my pipeline planner package to be indexed and documented on ros.org.