### PR TITLE
Add rule for python3-lttng

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4984,6 +4984,9 @@ python3-lark-parser:
   ubuntu:
     bionic: [python3-lark-parser]
     xenial: [python3-lark-parser]
+python3-lttng:
+  debian: [python3-lttng]
+  ubuntu: [python3-lttng]
 python3-lxml:
   debian: [python3-lxml]
   fedora: [python3-lxml]


### PR DESCRIPTION
Kind of a follow-up to #11991

`python3-lttng` contains the Python bindings to control LTTng tracing sessions

* https://packages.ubuntu.com/bionic/python3-lttng
* https://packages.debian.org/stretch/python3-lttng