### PR TITLE
Update python3-babeltrace rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4863,14 +4863,8 @@ python-zmq:
     xenial: [python-zmq]
     yakkety: [python-zmq]
 python3-babeltrace:
-  debian:
-    buster: [python3-babeltrace]
-    jessie: [python3-babeltrace]
-    stretch: [python3-babeltrace]
-  ubuntu:
-    bionic: [python3-babeltrace]
-    wily: [python3-babeltrace]
-    xenial: [python3-babeltrace]
+  debian: [python3-babeltrace]
+  ubuntu: [python3-babeltrace]
 python3-backoff-pip:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4868,6 +4868,7 @@ python3-babeltrace:
     jessie: [python3-babeltrace]
     stretch: [python3-babeltrace]
   ubuntu:
+    bionic: [python3-babeltrace]
     wily: [python3-babeltrace]
     xenial: [python3-babeltrace]
 python3-backoff-pip:


### PR DESCRIPTION
Since `bionic` is out.

Also, I've simplified the rule since it's the same package name for all versions.