### PR TITLE
Fix branch names for pilz_industrial_motion

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4855,7 +4855,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       packages:
       - pilz_extensions
@@ -4871,7 +4871,7 @@ repositories:
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git
-      version: kinetic-devel
+      version: melodic-devel
     status: developed
   pilz_robots:
     doc:


### PR DESCRIPTION
This led to failing builds here:
http://build.ros.org/job/Mdev__pilz_industrial_motion__ubuntu_bionic_amd64/