### PR TITLE
noid-ros-pkg: 0.0.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7977,7 +7977,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/seed-solutions/noid_ros_pkg.git
-      version: git
+      version: master
     release:
       packages:
       - noid_typef_bringup

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7991,7 +7991,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/seed-solutions/noid_ros_pkg.git
-      version: 0.0.5
+      version: master
     status: developed
   nonpersistent_voxel_layer:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7973,6 +7973,26 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: indigo-devel
     status: maintained
+  noid-ros-pkg:
+    doc:
+      type: git
+      url: https://github.com/seed-solutions/noid_ros_pkg.git
+      version: git
+    release:
+      packages:
+      - noid_typef_bringup
+      - noid_typef_description
+      - noid_typef_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/seed-solutions/noid_ros_pkg-release.git
+      version: 0.0.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/seed-solutions/noid_ros_pkg.git
+      version: 0.0.5
+    status: developed
   nonpersistent_voxel_layer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `noid-ros-pkg` to `0.0.5-1`:

- upstream repository: https://github.com/seed-solutions/noid-ros-pkg.git
- release repository: https://github.com/seed-solutions/noid_ros_pkg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## noid_typef_bringup

- No changes

## noid_typef_description

- No changes

## noid_typef_moveit_config

```
* updated
* Contributors: hi-kondo
```
