### PR TITLE
Adding xbot_talker to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16140,6 +16140,16 @@ repositories:
       url: https://github.com/xaxxontech/xaxxon_openlidar.git
       version: master
     status: maintained
+  xbot_talker:
+    doc:
+      type: git
+      url: https://github.com/DroidAITech/xbot_talker.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/DroidAITech/xbot_talker.git
+      version: master
+    status: maintained
   xiaoqiang:
     doc:
       type: git


### PR DESCRIPTION
I'd like my_repo xbot_talker to be indexed and documented on ros.org