### PR TITLE
ompl: 1.4.2-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -758,7 +758,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.4.2-1
+      version: 1.4.2-2
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.4.2-2`:

- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.4.2-1`
