### PR TITLE
[warehouse_ros][melodic] Correct the upstream version to kinetic-devel

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8640,7 +8640,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
-      version: jade-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -8649,7 +8649,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
-      version: jade-devel
+      version: kinetic-devel
     status: maintained
   web_video_server:
     doc:


### PR DESCRIPTION
It seems to me that the upstream version for `melodic` of `warehouse_ros` should be `kinetic-devel`.