### PR TITLE
rqt_ez_publisher: 0.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6808,6 +6808,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_dep.git
       version: master
     status: maintained
+  rqt_ez_publisher:
+    doc:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/OTL/rqt_ez_publisher-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/OTL/rqt_ez_publisher.git
+      version: melodic-devel
+    status: maintained
   rqt_graph:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_ez_publisher` to `0.5.0-1`:

- upstream repository: https://github.com/OTL/rqt_ez_publisher.git
- release repository: https://github.com/OTL/rqt_ez_publisher-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_ez_publisher

```
* Add congigure checkbox and publish button by rein, thank you
```
