### PR TITLE
warehouse_ros: Update source/doc branches to kinetic-devel

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15796,7 +15796,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
-      version: jade-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -15805,7 +15805,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
-      version: jade-devel
+      version: kinetic-devel
     status: maintained
   warthog:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8640,7 +8640,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
-      version: jade-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -8649,7 +8649,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
-      version: jade-devel
+      version: kinetic-devel
     status: maintained
   web_video_server:
     doc:


### PR DESCRIPTION
As @seanyen pointed out in #21626, the version 0.9.2 of warehouse_ros released into Kinetic and Melodic is based on the kinetic-devel branch. This PR reflects this status. Looks like I forgot to change this when I released last time(s).