### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1486,6 +1486,16 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/exotica_val_description-release.git
       version: 1.0.0-1
+  eyantra_drone:
+    doc:
+      type: git
+      url: https://github.com/simmubhangu/eyantra_drone.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/simmubhangu/eyantra_drone.git
+      version: master
+    status: developed
   eyeware-ros:
     doc:
       type: git


### PR DESCRIPTION
I would like to add eyantra_drone to be indexed and documented on ros.org