### PR TITLE
ros_workspace: 0.7.1-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -38,5 +38,20 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  ros_workspace:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 0.7.1-2
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `0.7.1-2`:

- upstream repository: https://github.com/nuclearsandwich/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros_workspace

```
* Reverted adding the COLCON_PREFIX_PATH env var. (#14 <https://github.com/ros2/ros_workspace/issues/14>)
* Contributors: Dirk Thomas
```
