### PR TITLE
Adding libcereal-dev for non-boost serialization needs

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1630,6 +1630,11 @@ libcegui-mk2-dev:
   fedora: [cegui]
   gentoo: [dev-games/cegui]
   ubuntu: [libcegui-mk2-dev]
+libcereal-dev:
+  debian: [libcereal-dev]
+  fedora: [cereal-devel]
+  gentoo: [dev-libs/cereal]
+  ubuntu: [libcereal-dev]
 libceres-dev:
   debian:
     buster: [libceres-dev]


### PR DESCRIPTION
We use serialization for some storage of large data types, but are trying to move away from Boost depends.  Cereal is a substitute for boost serialization that is lightweight and beats boost in benchmarks.

https://packages.ubuntu.com/xenial/libcereal-dev
https://packages.debian.org/stretch/libcereal-dev
https://apps.fedoraproject.org/packages/cereal-devel