### PR TITLE
Add nuitka for ubuntu and debian distribuitions in python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -213,6 +213,9 @@ mercurial:
   osx:
     pip:
       packages: [mercurial]
+nuitka:
+  debian: [nuitka]
+  ubuntu: [nuitka]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]


### PR DESCRIPTION
I'm not sure about naming convention within rospdep. As it is a python package I included it within python.yaml, and as there is a nuitka package available through `apt` I defined the dependency name with `-pip` suffix. 

If there is a better way to do it, please let me know.