### PR TITLE
mongodb_store: 0.5.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3547,6 +3547,10 @@ repositories:
       version: master
     status: maintained
   mongodb_store:
+    doc:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: melodic-devel
     release:
       packages:
       - mongodb_log
@@ -3555,7 +3559,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.5.0-5
+      version: 0.5.1-2
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.5.1-2`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.0-5`

## mongodb_log

- No changes

## mongodb_store

```
* added python-future to package.xml
* removed flags for most of files for simplicity, also included future.utils, may introduce undesireable dependency though
* resolved python2 backward compatibility issues
  not thouroughly checked though
  Added python version checks, where needed.
  Changes not adjusted to version:
  - print always with brackets
  - excepti XXX, e ==> except XXX as e
  as there is no problem with python2 to best of my knowledge
* adjusted python funtions for python3
* Contributors: Shingo Kitagawa, Volker Gabler
```

## mongodb_store_msgs

```
* Merge remote-tracking branch 'orginal/melodic-devel' into melodic-devel-py3
* Contributors: Volker Gabler
```
