### PR TITLE
mongodb_store: 0.4.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6869,6 +6869,10 @@ repositories:
       version: master
     status: developed
   mongodb_store:
+    doc:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: kinetic-devel
     release:
       packages:
       - libmongocxx_ros
@@ -6878,7 +6882,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.4.4-2
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.4.5-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.4-2`

## libmongocxx_ros

- No changes

## mongodb_log

- No changes

## mongodb_store

```
* Allow to bind mongod to host
  The existing solution bind the mongod server to all interfaces. This
  exposes the server to the outside. This could be a potensial security
  issue if someone has access to your network. This change allows you
  to only bind the server to the host specified by the
  mongodb_host parameter. The solution was created with a flag
  defaulting to false to prevent this from being a breaking change.
  Specifying the argument bind_to_host will add a bind argument to the
  executable:
  ```
  [..., "--bind_ip", self._mongo_host]
  ```
  Info: The bind_ip argument [supports hostnames, ipaddresses
  and socket
  paths](https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-bind-ip)
  so using localhost or 127.0.0.1 is valid for binding to
  localhost only. To bind to all interfaces use 0.0.0.0.
* adds service to reset all local overrides.
  Exposes a new service /config_manager/reset_params std_srvs/Trigger
  that will reset all local overrides their default value. This provides
  a ROS compatible way of getting back to the default values.
* Contributors: Jørgen Borgesen, Nick Hawes, Marc Hanheide
```

## mongodb_store_msgs

- No changes
