### PR TITLE
phidgets_drivers: 0.7.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9090,7 +9090,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.8-1
+      version: 0.7.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.9-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.8-1`

## libphidget21

```
* Update libphidget to version 2.1.9.20190409 (#34 <https://github.com/ros-drivers/phidgets_drivers/issues/34>)
* Contributors: Tim Fanselow
```

## phidgets_api

```
* Add missing OnInputChange handler (#33 <https://github.com/ros-drivers/phidgets_drivers/issues/33>)
* Contributors: Kai Hermann
```

## phidgets_drivers

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_imu

- No changes
