### PR TITLE
Revert "toposens: 1.1.0-1 in 'melodic/distribution.yaml' [bloom] (#21…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7840,16 +7840,14 @@ repositories:
     release:
       packages:
       - toposens
-      - toposens_description
       - toposens_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
-      - toposens_sync
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.1.0-1
+      version: 1.0.0-3
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
…595)"

This reverts commit 31674306ebdf737af36833fcf3d2f72cfc85d39a.

It's been failing since it was merged a few days ago, so revert for now.  @ts-adi FYI; the failing builds are here: http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__toposens_pointcloud__ubuntu_bionic_amd64__binary/