### PR TITLE
rail_segmentation: 0.1.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5529,7 +5529,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/gt-rail-release/rail_segmentation.git
-      version: 0.1.14-1
+      version: 0.1.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_segmentation` to `0.1.15-1`:

- upstream repository: https://github.com/GT-RAIL/rail_segmentation.git
- release repository: https://github.com/gt-rail-release/rail_segmentation.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.14-1`

## rail_segmentation

```
* Minor update to fix an incorrect declaration of a static const variable under certain compilers
* Contributors: David Kent
```
