### PR TITLE
Add libqt5gstreamer-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3023,6 +3023,9 @@ libqt5-core:
   rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu: [libqt5core5a]
+libqt5-gstreamer-dev:
+  debian: [libqt5gstreamer-dev]
+  ubuntu: [libqt5gstreamer-dev]
 libqt5-gui:
   arch: [qt5-base]
   debian: [libqt5gui5]


### PR DESCRIPTION
For GStreamer rendering in Qt5 widgets.

Debian: https://packages.debian.org/sid/libqt5gstreamer-dev
Ubuntu: https://packages.ubuntu.com/xenial/libqt5gstreamer-dev