### PR TITLE
nmea_gps_plugin: 0.0.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7920,7 +7920,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_gps_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_gps_plugin` to `0.0.1-2`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
- release repository: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-1`
