### PR TITLE
nmea_gps_plugin: 0.0.1-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4147,7 +4147,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
-      version: 0.0.1-3
+      version: 0.0.1-4
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_gps_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_gps_plugin` to `0.0.1-4`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
- release repository: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-3`
