### PR TITLE
nmea_to_geopose: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4183,6 +4183,21 @@ repositories:
       url: https://github.com/ros-drivers/nmea_navsat_driver.git
       version: melodic-devel
     status: maintained
+  nmea_to_geopose:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_to_geopose.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/nmea_to_geopose-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_to_geopose.git
+      version: master
+    status: developed
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_to_geopose` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_to_geopose.git
- release repository: https://github.com/OUXT-Polaris/nmea_to_geopose-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## nmea_to_geopose

```
* update README.md
* change degree to radian
* update publish rule
* add launch files
* add publisher for the geopose
* add Eigen to the depends
* add quaternion_operation to the depends
* add README
* fix paraser function
* add GeoPose parse function
* add parser function
* initial commit
* Contributors: Masaya Kataoka
```
