### PR TITLE
realsense2_camera: 2.2.6-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10549,6 +10549,18 @@ repositories:
       type: git
       url: https://github.com/intel-ros/realsense.git
       version: development
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/IntelRealSense/realsense-ros-release.git
+      version: 2.2.6-2
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: development
     status: maintained
   realsense_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.6-2`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
