### PR TITLE
Add cobs to rosdep keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -994,6 +994,16 @@ python-click:
     wily:
       pip:
         packages: [click]
+python-cobs-pip:
+  debian:
+    pip:
+      packages: [cobs]
+  fedora:
+    pip:
+      packages: [cobs]
+  ubuntu:
+    pip:
+      packages: [cobs]
 python-colorama:
   arch: [python2-colorama]
   debian: [python-colorama]


### PR DESCRIPTION
Cobs is a python library for handling Consistent Overhead Byte Stuffing for serial communication

https://pypi.org/project/cobs/