### PR TITLE
teb_local_planner: 0.6.13-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14127,7 +14127,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.6.12-1
+      version: 0.6.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.6.13-1`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.12-1`

## teb_local_planner

```
* Avoiding h signature interpolation between coincident poses (thanks to Marco Bassa)
* New strategy for the deletion of detours: Detours are now determined w.r.t. the least-cost alternative and not w.r.t. just the goal heading.
  Deletion of additional alternatives applies if either an initial backward motion is detected, if the transition time is much bigger than the duration of the best teb
  and if a teb cannot be optimized (thanks to Marco Bassa).
  Optionally allowing the usage of the initial plan orientation when initializing new tebs.
* Contributors: Christoph Rösmann, Marco Bassa
```
