### PR TITLE
flir_boson_usb: 1.2.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3284,7 +3284,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/flir_boson_usb-release.git
-      version: 1.2.0-0
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/astuff/flir_boson_usb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_boson_usb` to `1.2.1-1`:

- upstream repository: https://github.com/astuff/flir_boson_usb.git
- release repository: https://github.com/astuff/flir_boson_usb-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.0-0`

## flir_boson_usb

```
* Merge pull request #3 <https://github.com/astuff/flir_boson_usb/issues/3> from valgur/patch-1
* Fix minor issues detected by catkin_lint
* Fixing installation of nodelet_plugins.xml.
* Contributors: Joe Driscoll, Joshua Whitley, Martin Valgur, Sam Rustan
```
