### PR TITLE
flir_boson_usb: 1.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1790,7 +1790,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/flir_boson_usb-release.git
-      version: 1.2.0-0
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/astuff/flir_boson_usb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_boson_usb` to `1.2.1-1`:

- upstream repository: https://github.com/astuff/flir_boson_usb.git
- release repository: https://github.com/astuff/flir_boson_usb-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.0-0`

## flir_boson_usb

```
* Merge pull request #3 <https://github.com/astuff/flir_boson_usb/issues/3> from valgur/patch-1
* Fix minor issues detected by catkin_lint
* Fixing installation of nodelet_plugins.xml.
* Contributors: Joe Driscoll, Joshua Whitley, Martin Valgur, Sam Rustan
```
