### PR TITLE
vrx: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8654,10 +8654,12 @@ repositories:
       - vrx_gazebo
       - wamv_description
       - wamv_gazebo
+      - wave_gazebo
+      - wave_gazebo_plugins
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.0.1-0
+      version: 1.1.0-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.1.0-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-0`

## usv_gazebo_plugins

```
* Refactor SpinPropeller to be more clear and match style of RotateEngine
* Publish joint state for chassis engine joint to fix tf tree issue
* addressed Brian's comments
* Connecting wave model to buoyancy plugin
* buoyancy now uses wave height
* capitalized brief sentences
* gazebo 7 vector3[] operator lhv error fixed try 2
* gazebo 7 vector3[] operator lhv error fixed
* gazebo <= 8 fixes for Mass and AngularVel
* complex objects + xacro cleanup
* force applied in correct place
* centroid + volume complete
* moved shape volume into its own file and renamed classes
* tiny refactor
* polyhedron class finished and tests passed
* implemented polyhedron based cube + cylinder submerged volume and cov
* rotation bug fix
* basic volume for box, sphere and cylinder
* removed old volume data structure + created skeleton for volume calc
* removed old volume data structure + created skeleton for volume calc
* added move constructor for buoyancy object and remove copy constructor
* added links and buoyancy object to plugin
* minor cleanup
* added pose for buoyancy element
* parsed buoyancy shape now saved as unique_ptr
* cleaned up parsing
* updated buoyancy xacro + parsing
* Setup buoyancy test build system + test world
* merging with default - need to check wind
* added wind capabilities
* Removing gazebo::msg::Param references and cleaning up for gazebo version < 8 compatibility.
* Removed gazebo messaging, introduces redundancy in model.sdf for ocean. USV and buoyancy plugins only get wave parameters once instead of every update.
* Move link error message.
* Another Nitpick fix (== nullptr) => !
* Nitpick fix (== nullptr) => !
* Clarify required and optional parameters, and remove unused confusing default declarations
* Put required parameters together and make it obvious which are required
* Retune PID for engineJoint with lower P gain, for more realistic behavior
* Add <enableAngle> bool parameter that controls if angle is adjustable or not
* C++ Code style fixes
* Add documentation about maxAngle and angleTopic
* updated documentation
* Attempt to fix build issue with .GetAngle().Radian()
* Attempt to fix build issue with Position() -> GetAngle() for old gazebo version
* Implement PID controller for engine joint to set joint angle
* changed sdf sytax for passing models to be effected by wind and addressed styling
* Attempt to fix build issues SetAngle->SetPosition
* Attempt to fix build issue with different setAngle setPosition implementation based on Gazebo version
* Implement turnable thruster joint
* Basic implementation of angle adjustable thrusters, still need to test, add joints, and change visuals
* merging with default
* fix build issue for gz <8
* merged. expanded xacro capabilities
* Rewrite implementation of setting windDirection
* documenting wind direction
* changing the interface from timePeriod to frequency
* cleaning up the includes order and white spaces
* cleanup
* adding ROS API to probe for wind speed
* enabling the user to input only the angle for wind direction
* increment
* documented
* incremental(basic testing passed)
* changed wind plugin(untested
* Initial testing of random seed with print statements
* Added wavegauge plugin to visualize physical wave height.  Setup example with buoy world.  Implemented simplified wave height calculation in WavefieldSampler for regularly spaced grid (steepness=1=0).
* verifying with examples
* toward buoy examples
* merging default into named branch
* removed currentVarVel from member variable list and fixed indentation for directives
* made gzmsg more efficient
* Implemented changed after PR is reviewed - V1
  Remove Ros dependency (regarding time)
  fixed typoes
  fixed wrong comments
  Exposed seed value to user
  Updated purpose of SDF params in the header file
  lines are now shorted than 80 chars
  added comments around explaining the calculations done
* made wind speed randomized
* merging default to update the feature branch
* Remove more trailing whitespace
  Redundant codepath in usv_gazwebo_dynamics_plugin removed.  Euler values now derived identically between gazebo 7 and 9.
* Fix trailing whitespace
* Fix line breaks
* Alter patch to use .Ign method to convert between gazebo::math and Ignition::math types
* Add support for Kinetic/Gazebo-7
  The ignition types are mostly kept, with code transforming from the methods deprecated in gazebo-8
* Changing license text
* Adding two packages from asv_wave_sim as a part of VRC
* Issue #23: Coordinate the physics and visualization of the wave field
  1. Use the asv_wave_sim_gazebo_plugins package for wave field visualisation and depth calculation.
  2. Update the buoyancy and dynamics plugins for buoyancy calculations.
  3. Update sdf and xacro for models that require buoyancy.
  4. Replace the ocean model with ocean_waves in the sandisland world.
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, MarshallRawson, Rhys Mainwaring <mailto:rhys.mainwaring@me.com>, Rumman Waqar <mailto:rumman.waqar05@gmail.com>, Tyler Lum <mailto:tylergwlum@gmail.com>, Youssef Khaky <mailto:youssefkhaky@hotmail.com>, YoussefKhaky <mailto:youssefkhaky@hotmail.com.com>
```

## vrx_gazebo

```
* Merged in issue#94-buoyancy (pull request #122)
  Issue#94 buoyancy
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* changing buoy buoyancy to sphere, adding feature to generator
* Merge from default.
* Merged in rename_scan_dock (pull request #133)
  renaming "dock" and "scan and dock" files to match new task names
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* renaming files to match new task names
* updating default values in example
* now interpreting time of spawned objects relative to start of running state
* removed overidden OnFinished method
* clean up: removed overriden methods that made no alterations from parent class
* added a gzmsg where missing to overriden methods
* added a gzmsg to default implementations of OnReady, OnRunning, OnFinished
* New score policy.
* Update scores.
* Light buoy with 2 seconds off.
* Now impliments Enviornment variable instad of debug sdf parameters
* Incremental
* ready for detailed lidar spec input
* updated markers + polyform models for wave buoyancy
* functional. no recording
* added wind to navigation task
* Add extra_gazebo_args to all launch files and remove recording arg
* Light buoy should now be synced with scoring and visual plugin through the definition in scan_and_dock_b.launch
* updated vrx model buoyancy plugin
* Add playback.launch to play back recorded log files
* Add recording functionality to sandisland, and add extra_gazebo_args to optionally choose record path
* Incremental
* no longer supported for gz7 or older
* clunky version - but visuals and placards stay with dock for 2018
* working version with dock buoyancy, but need to attach placards
* first cut - dock elements work, but to build a full dock need to add joints between elements
* changing perception transition
* attempt build gz <=7 issue
* attempt fix build issue
* incremental
* Added allowences for post_Y and moved wamv_imu, wamv_gps default locations to be within compliance
* attempt fix gz 7 compatability issue
* functionsal. needs cleaning
* initializing sampleCount to 0 and change to int
* added wind capabilities
* Merged in add-wind-support-for-yaml-world-gen (pull request #115)
  added support for wind in yaml world gen and updates wiki
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Style
* testing side by side scaling
* latest case
* case 2
* case 0
* Testing scalability of new implementation - updated hgignore vmrc->vrx
* code styling
* styling
* styling
* incremental
* build
* merge
* removed unused header
* incremental
* finished rename
* added support for wind in yaml world gen and updates wiki
* added support for default wamv effects on vrx.launch and sandisland.launch
* incremental
* Reshow instructions after some speed change updates (match with twist_teleop_keyboard)
* Remove extra diffdrive yaml file
* Implement new getch function to fix output issues
* Remove set_thrust_angle parameter
* Reverse angles when teleoperation.
* merge
* incremental
* incremental
* incremental
* styling fixes
* made more user friendly
* Now builds. Currently, the MOC in CMake requires the header and source file to be in the same directory.
* fixed ros issues
* merging default
* Add new .yaml file for joy teleop to publish thrust angles
* Add settable max_angle parameter upon usv_keydrive launch startup
* Add ability to change thrust angle speed
* Add key2thrust_angle.py node that allows for h and ; to control thruster angle
* Merge from default.
* Merge from default, conflicts and style.
* Merge default
* fixed builf issues
* Merged in remove-README (pull request #111)
  removed README.txt from yaml_world_genreeration and created wiki page instead
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Add style checker.
* removed README.txt from yaml_world_genreeration and created wiki page instead
* finish rename
* fix build issue
* incremental
* fix build issue
* renamed xacro
* updates xacro
* fix build issues
* incremental
* Merged in Issue#90_YAML_world_genreation (pull request #102)
  Issue#90 YAML world generation
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* No markdown
* Use markdown
* Fix typos.
* Added thruster compliance
* added more flexibility to permitted parameters
* fixed math error
* Partially fix compile issues in code with Task msg, still issue with FormatTime and duration
* Attempt to fix build issue by adding Qt5IncludeDirs and spreading out find_packages
* added roslaunch params
* styling
* filled out the SensorCompliance. It is formatted by the sensors_compliance files
* Attempt to implement basic GUI overlay to show VRX Task Info. Stuck on build issues with Qt5
* added white spaceing to make more readable
* edited launch file
* incremental
* merge for api update
* merged with Issue#97-yaml-thruster-configuration for api update
* fixed launch file
* changed sdf sytax for passing models to be effected by wind and addressed styling
* Changing name of ocean model in sandisland test
* adding pdf for pr
* Remove unneeded images and add documentation
* adding to docs and allowing for both PMS and CWR wavefield models
* merged. expanded xacro capabilities
* Add back unused functions in utils.py for future compliance tests
* Move gazebo thruster config tags to new function
* Update python files using flake8, all files pass
* Update Changelog and remove available_sensors param
* Remove unnecessary files
* Add generate_wamv launch and bin files
* Clean create_xacro_file() function and add comments
* Remove old sensor and thruster config files
* Remove unused utils.py functions
* Remove unneeded files and improve clarity with documentation
* Added support for any parameter to be evaluated as lambda vs string. updated README.
* fixed functional evaluation bug
* testing wave fields
* Added support for ** xacro inserts. used as normal parameters, but prfaced with /**. (this is to help with the wind and ave plugins in the future.
* Added wind xacro (utilizes xacro inserts). NOTE: wind plugin only applies force to one link per model
* Working implementation of generate_wamv, which takes both sensor and yaml files
* adding exponential increase in wave field and LaTeX doc^C
* CMakeLists improvement and spacing
* changelog update
* added more to README.txt, added scene_macro and sandisland2 to give more confiuration flexibilty to the worlds. NOTE: time SDF is being written into the world file correctly(I think), but gazebo appears to not change anything under the scene tab in the gui.
* Make thruster config with yaml work without affecting use of sensor yaml config, still need to clean up
* Move engine.xacro to thrusters directory to allow for different types of thrusters
* more README stuff
* Merge
* increment
* Copy similar sensor yaml files for thrusters, needs to be adjusted, particularly utils.py
* increment
* merging default into branch
* README incremental
* added more comments
* Added Quick Start Instructions
* added README for filling out the YAML file
* fixed for real this time
* fixed build problem
* Merged in yaml_sensor_configuration (pull request #99)
  Yaml sensor configuration
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* added README
* updated README
* Merged in ykhky/vrx/Issue#49-collision-detection (pull request #94)
  Issue#49 collision detection
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* calling on collision
* spelling correcting
* move variables to correct section in header file
* OnCollision virtual + documenting stuff+ renaming variables
* remove extra bracket
* logging collisions and timestamps
* spacing
* removing world name hard code
* remove cout + adding buffer to nav task
* formatting + exposing collision buffer
* Doc format
* counter + cleanup
* frequency of collision reporting reduced to 1/3 Hz
* added collision detection node
* restored sensors params to sandisland.launch
* Added wavegauge plugin to visualize physical wave height.  Setup example with buoy world.  Implemented simplified wave height calculation in WavefieldSampler for regularly spaced grid (steepness=1=0).
* removed directory xacro checking and variance features
* incremental
* incremental
* Added sequence override option in YAML
* verifying with examples
* increased flexibility of compliance.py
* fixed xacro parsing bug
* Added support for sequence breakout specified in yaml file
* Added xacros for feild elements
* toward buoy examples
* Added launch file
* Script will now be installed, added coordinate generation
* merge
* incremental
* merge
* now auto-generates the world.xacro(may need to be changed to devel) file in src
* incremental
* merge, added launch file
* incremental
* merge
* made branch
* fixed build issue for real this time
* fixed build issue
* commited setup.py, removed unrelated files from vrx_gazebo_python
* scripts will now be installed
* updated readme, changed operation procedure, still not installed
* fixed styling problems with flake8, updated readme
* incremental
* Add mono_camera mesh and .sdf .config files with correct collision and inertia
* changed directory, added launch file support
* incremental, now supports macros with no parameters
* made boiler plate usage more flexible
  H: Enter commit message.  Lines beginning with 'HG:' are removed.
* incremental
* Add sensor_post_arm.dae
* Break sensor_post.dae into two files, then fix model
* Add fixed joint and position arm relative to post
* Add sensor post mesh with correct collision and inertia
* merging default into named branch
* incremental
* Added readme
* moved script. Improved File System
* Flip the ground stations and spread the posts.
* added chairs
* Adding chairs.
* Change cpu case collision box from 1 box to 2 boxes
* incremental
* Add CPU cases only in VRX configuration + remove redundant pose info
* removed pose 0 tags from models
* Tweak indentation.
* documentation, incremental
* incremental
* incremental
* fixed battery/model.sdf
* Add 3D Lidar mesh and put it on WAM-V
* Fix formatting (tab->spaces, etc.)
* Fix .sdf file
* Add CPU case model to WAM-V
* review commented implemented
* finished ground station without chairs
* added table
* added tent and antenna model
* incremental
* incremental
* Added Batteries to vrx_gazebo/models(sdf format) and macro(urdf format) to place on wamv
* Updated texture with a flat area in the beach to place the tents in the future.
* Tweaks.
* Using WAM-V yaw in setting where objects are moved during perception task
* Minor tweak.
* moving station keeping goal closer to wam-v spawn point
* turning wind off to better test - tweaking waypoints in wayfinding task example
* Tweaking positions and adding post and navigation course.
* Restoring cameras and laser visuals and creating demo.launch
* Sandisland texture, sensor meshes and extra objects.
* Restore generate_xxx
* Tweak CMakeLists.txt
* Run the plugin at 1Hz sim time.
* Use sim time to update the light buoy plugin.
* Fix placard symbols.
* Deterministic sequence in light buoy plugin
* Use a ROS subscription for changing the color sequence.
* Modify velodyne configuration to set intensity filtering
  Alter ocean laser retro to be filtered by the lidar sensor
* Remove more trailing whitespace
  Redundant codepath in usv_gazwebo_dynamics_plugin removed.  Euler values now derived identically between gazebo 7 and 9.
* Fix trailing whitespace
* Use auto keyword
* Fix ign method for staionkeeping_scoing_plugin
* Alter patch to use .Ign method to convert between gazebo::math and Ignition::math types
* Fix indention
* Add support for Kinetic/Gazebo-7
  The ignition types are mostly kept, with code transforming from the methods deprecated in gazebo-8
* adding a rqt config file for a perspective task tutorial
* Issue #23: Coordinate the physics and visualization of the wave field
  1. Use the asv_wave_sim_gazebo_plugins package for wave field visualisation and depth calculation.
  2. Update the buoyancy and dynamics plugins for buoyancy calculations.
  3. Update sdf and xacro for models that require buoyancy.
  4. Replace the ocean model with ocean_waves in the sandisland world.
* Red placards and rearrange a bit the sensors.
* Port to VRX code using Gazebo9.
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, MarshallRawson, Rhys Mainwaring <mailto:rhys.mainwaring@me.com>, Rumman Waqar <mailto:rumman.waqar05@gmail.com>, Tyler Lum <mailto:tylergwlum@gmail.com>, Youssef Khaky <mailto:youssefkhaky@hotmail.com>, m1chaelm
```

## wamv_description

```
* added dummy link for robot state publisher
* functional. no recording
* linting
* Merged default into issue#94-buoyancy
* merge
* merging default
* Merge from default, conflicts and style.
* Refix engine.xacro to have revolute joint
* Remove old engine.xacro file
* Merged in Issue#90_YAML_world_genreation (pull request #102)
  Issue#90 YAML world generation
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* merge for api update
* Implement turnable thruster joint
* Remove unnecessary files
* Add namespace to thruster config parameters and look in thrusters directory for valid engine types
* merge
* merge
* incremental
* incremental
* updated readme, changed operation procedure, still not installed
* fixed styling problems with flake8, updated readme
* changed directory, added launch file support
* incremental, now supports macros with no parameters
* Change cpu case collision box from 1 box to 2 boxes
* Move boxes forward to prevent collision with gps
* Tweak indentation.
* added a variance function parameter and fixed some bugs
* incremental
* incremental
* Fix formatting (tab->spaces, etc.)
* Add CPU case model to WAM-V
* incremental
* incremental
* Added script to interpret a yaml and auto generate appropriate xacro macro file while checking for compliance
* Added Batteries to vrx_gazebo/models(sdf format) and macro(urdf format) to place on wamv
* Sandisland texture, sensor meshes and extra objects.
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, MarshallRawson, Rumman Waqar <mailto:rumman.waqar05@gmail.com>, Tyler Lum <mailto:tylergwlum@gmail.com>
```

## wamv_gazebo

```
* wamv_gps.xacro edited online with Bitbucket
* Update camera resolution
* Using 16 beam lasers
* default urdf is now 32 beam lidar
* completed lidar specs
* ready for detailed lidar spec input
* added rviz config
* Merged default into issue#94-buoyancy
* merging with default - need to check wind
* Added allowences for post_Y and moved wamv_imu, wamv_gps default locations to be within compliance
* temporary branch for comparing with wave_visualization
* Merged in Issue#100-wind-plugin (pull request #106)
  Issue#100 wind plugin moved to world plugin
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Put required parameters together and make it obvious which are required
* Add <enableAngle> bool parameter that controls if angle is adjustable or not
* filled out the SensorCompliance. It is formatted by the sensors_compliance files
* Implement turnable thruster joint
* Basic implementation of angle adjustable thrusters, still need to test, add joints, and change visuals
* merged. expanded xacro capabilities
* changing the interface from timePeriod to frequency
* adding ROS API to probe for wind speed
* enabling the user to input only the angle for wind direction
* Make thruster config with yaml work without affecting use of sensor yaml config, still need to clean up
* Move engine.xacro to thrusters directory to allow for different types of thrusters
* Merged default into Issue#97-yaml-thruster-configuration
* Clarify link relative position calculation
* Implement varying length lidar pole
* Change post angle for right camera
* Vary post mass as length changes
* Fix camera seeing itself by increasing clip distance
* incremental(basic testing passed)
* Fix post color issue by removing <visual> tag name
* Add gazebo tag for color, still not working
* Update wamv_gazebo.urdf.xacro file to use thruster yaml file if given
* Initial testing of random seed with print statements
* Change from visual mesh to cylinder, but color not working. Stil showing white
* Define positioning variables for improved clarity
* Scale post length to better match camera height
* Simplify all transformations: base->post->arm->camera
* Tweaked comments.
* Simplify all transformations: base->post->arm->lidar
* Implement post_Y parameter that allows the post to be rotated in the yaw direction
* Redo sensor post to lidar joints to cleaner (x,y,z,r,p,y) coordinates
* Temporary test setting xyz of lidar, next need to change frames to simplify all of this
* updated readme, changed operation procedure, still not installed
* Add second adjustment link to perfectly match sensor and base frames
* Add adjustment link and joint to make the lidar frame better match base frame
* Add adjustment link and joint to make the camera frame match base frame
* Integrate sensor post to camera urdf, with height parameter
* Fix issue with lidar seeing itself and set default lidar angle downwards towards water
* Add mono_camera mesh to urdf file and onto WAM-V
* Merged default into Issue#86-add-3d-lidar-mesh
* Add sensor_post_arm.dae
* Add sensor post to 3d lidar on WAM-V, including height parameter
* Fix default 3d lidar pose
* Add CPU cases only in VRX configuration + remove redundant pose info
* Move boxes forward to prevent collision with gps
* Add 3D Lidar mesh and put it on WAM-V
* Add CPU case model to WAM-V
* Added script to interpret a yaml and auto generate appropriate xacro macro file while checking for compliance
* Added Batteries to vrx_gazebo/models(sdf format) and macro(urdf format) to place on wamv
* Lower mast.
* turning wind off to better test - tweaking waypoints in wayfinding task example
* Tweak names.
* Adding gps mesh, collisions and inertia.
* Tweaking positions and adding post and navigation course.
* Restoring cameras and laser visuals and creating demo.launch
* Sandisland texture, sensor meshes and extra objects.
* Implemented changed after PR is reviewed - V1
  Remove Ros dependency (regarding time)
  fixed typoes
  fixed wrong comments
  Exposed seed value to user
  Updated purpose of SDF params in the header file
  lines are now shorted than 80 chars
  added comments around explaining the calculations done
* made wind speed randomized
* Modify velodyne configuration to set intensity filtering
  Alter ocean laser retro to be filtered by the lidar sensor
* Setting wave parameters by hand in source for testing
* setting default wind to zero
* Issue #23: Coordinate the physics and visualization of the wave field
  1. Use the asv_wave_sim_gazebo_plugins package for wave field visualisation and depth calculation.
  2. Update the buoyancy and dynamics plugins for buoyancy calculations.
  3. Update sdf and xacro for models that require buoyancy.
  4. Replace the ocean model with ocean_waves in the sandisland world.
* Red placards and rearrange a bit the sensors.
* Port to VRX code using Gazebo9.
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, MarshallRawson, Rhys Mainwaring <mailto:rhys.mainwaring@me.com>, Rumman Waqar <mailto:rumman.waqar05@gmail.com>, Tyler Lum <mailto:tylergwlum@gmail.com>, Youssef Khaky <mailto:youssefkhaky@hotmail.com>, YoussefKhaky <mailto:youssefkhaky@hotmail.com.com>
```

## wave_gazebo

```
* Generate changelog for new packages
* merge with default
* changing buoy buoyancy to sphere, adding feature to generator
* Tweaks
* ready
* Connecting wave model to buoyancy plugin
* working version with dock buoyancy, but need to attach placards
* first cut - dock elements work, but to build a full dock need to add joints between elements
* tweaks
* Merged in wave_visualization_refactor (pull request #114)
  Wave visual / physics refactor
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Restoring waves parameters.
* Smooth water.
* Style
* reducing wave height to something more reasonable
* removing the ocean_waves model.sdf since it is generated via erb
* Using Ruby to generate ocean wave model SDF
* testing side by side scaling
* case 0
* temporary branch for comparing with wave_visualization
* Testing scalability of new implementation - updated hgignore vmrc->vrx
* Removed gazebo messaging, introduces redundancy in model.sdf for ocean. USV and buoyancy plugins only get wave parameters once instead of every update.
* setting model back to original seastate
* style
* adding to docs and allowing for both PMS and CWR wavefield models
* addin PM spectrum
* testing wave fields
* adding exponential increase in wave field and LaTeX doc^C
* increment
* Clean up some of the diagnostic messages
* Added wavegauge plugin to visualize physical wave height.  Setup example with buoy world.  Implemented simplified wave height calculation in WavefieldSampler for regularly spaced grid (steepness=1=0).
* verifying with examples
* toward buoy examples
* Removing superfluous models and empty tests
* Changing license text
* Modifications from original source for integration in VRX
* Adding two packages from asv_wave_sim as a part of VRC
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jose Luis Rivero <mailto:jrivero@osrfoundation.org>, MarshallRawson
* Merged in wave_visualization_refactor (pull request #114)
  Wave visual / physics refactor
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Removed gazebo messaging, introduces redundancy in model.sdf for ocean. USV and buoyancy plugins only get wave parameters once instead of every update.
* Added wavegauge plugin to visualize physical wave height.  Setup example with buoy world.  Implemented simplified wave height calculation in WavefieldSampler for regularly spaced grid (steepness=1=0).
* Modifications from original source for integration in VRX
* Adding two packages from asv_wave_sim as a part of VRC
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>, Carlos Agüero <mailto:cen.aguero@gmail.com>, MarshallRawson
```

## wave_gazebo_plugins

```
* Generate changelog for new packages
* Merged in wave_visualization_refactor (pull request #114)
  Wave visual / physics refactor
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Restoring waves parameters.
* Smooth water.
* Style
* Removing gazebo::msg::Param references and cleaning up for gazebo version < 8 compatibility.
* Removed gazebo messaging, introduces redundancy in model.sdf for ocean. USV and buoyancy plugins only get wave parameters once instead of every update.
* style
* adding to docs and allowing for both PMS and CWR wavefield models
* addin PM spectrum
* adding exponential increase in wave field and LaTeX doc^C
* increment
* increment
* Clean up some of the diagnostic messages
* Added wavegauge plugin to visualize physical wave height.  Setup example with buoy world.  Implemented simplified wave height calculation in WavefieldSampler for regularly spaced grid (steepness=1=0).
* verifying with examples
* changing wind to waves
* Added an example to illustrate using request/response to transport the wave_params and fixed a couple tiny typos
* Overtly requiring C++14 for the wave_gazebo_plugins package - required for use of autos in lambda functions.  Only necessary for supporting Kinetic build.
* Setting wave parameters by hand in source for testing
* Removing superfluous models and empty tests
* Changing license text
* Modifications from original source for integration in VRX
* Adding two packages from asv_wave_sim as a part of VRC
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
* Merged in wave_visualization_refactor (pull request #114)
  Wave visual / physics refactor
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Removing gazebo::msg::Param references and cleaning up for gazebo version < 8 compatibility.
* Removed gazebo messaging, introduces redundancy in model.sdf for ocean. USV and buoyancy plugins only get wave parameters once instead of every update.
* Added wavegauge plugin to visualize physical wave height.  Setup example with buoy world.  Implemented simplified wave height calculation in WavefieldSampler for regularly spaced grid (steepness=1=0).
* Added an example to illustrate using request/response to transport the wave_params and fixed a couple tiny typos
* Overtly requiring C++14 for the wave_gazebo_plugins package - required for use of autos in lambda functions.  Only necessary for supporting Kinetic build.
* Setting wave parameters by hand in source for testing
* Modifications from original source for integration in VRX
* Adding two packages from asv_wave_sim as a part of VRC
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>
```
