### PR TITLE
vmrc project is being renamed to vrx. Remove old references

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15741,26 +15741,6 @@ repositories:
       url: https://github.com/JdeRobot/VisualStates.git
       version: master
     status: developed
-  vmrc:
-    doc:
-      type: hg
-      url: https://bitbucket.org/osrf/vmrc
-      version: default
-    release:
-      packages:
-      - usv_gazebo_plugins
-      - vmrc_gazebo
-      - wamv_description
-      - wamv_gazebo
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/vmrc-release.git
-      version: 0.3.2-0
-    source:
-      type: hg
-      url: https://bitbucket.org/osrf/vmrc/
-      version: default
-    status: developed
   volksbot_driver:
     doc:
       type: git


### PR DESCRIPTION
We are releasing new packages for the VRX project, previously named VMRC. In kinetic bloom is complaining about the duplicate entries belonging to the old VMRC.

This PR removes the old rosdistro entries for VMRC so we can bloom the new VRX which has the same packages. I'm not sure if there is a better way to handle the renaming transition.