### PR TITLE
Revert "apriltag: 3.1.1-1 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -222,12 +222,6 @@ repositories:
       url: https://github.com/pr2/app_manager.git
       version: kinetic-devel
     status: unmaintained
-  apriltag:
-    release:
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/AprilRobotics/apriltag-release.git
-      version: 3.1.1-1
   apriltags2_ros:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#21554

Apriltag is not building on kinetic and I haven't had bandwidth to figure out why (picking up the wrong lib destination folders)/provide a fix (it builds on Melodic and Dashing). Removing it from kinetic to avoid blocking any releases or spamming folks with the build errors.