### PR TITLE
microstrain_3dmgx2_imu: 1.5.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3496,11 +3496,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
-      version: 1.5.12-1
+      version: 1.5.13-1
     source:
       type: git
       url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
       version: indigo-devel
+    status: maintained
   microstrain_mips:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu` to `1.5.13-1`:

- upstream repository: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
- release repository: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.5.12-1`

## microstrain_3dmgx2_imu

```
* Merge pull request #11 <https://github.com/ros-drivers/microstrain_3dmgx2_imu/issues/11> from scpeters/fix_melodic_build
  Fix melodic build (backwards compatible alternative to #10 <https://github.com/ros-drivers/microstrain_3dmgx2_imu/issues/10>)
* from C++11, constexpr specifier is requred for double
* Contributors: Kei Okada, Tony Baltovski
```
