### PR TITLE
Rename vmrc to vrx.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15754,10 +15754,10 @@ repositories:
       url: https://github.com/JdeRobot/VisualStates.git
       version: master
     status: developed
-  vmrc:
+  vrx:
     doc:
       type: hg
-      url: https://bitbucket.org/osrf/vmrc
+      url: https://bitbucket.org/osrf/vrx
       version: default
     release:
       packages:
@@ -15767,11 +15767,11 @@ repositories:
       - wamv_gazebo
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/ros-gbp/vmrc-release.git
+      url: https://github.com/ros-gbp/vrx-release.git
       version: 0.3.2-0
     source:
       type: hg
-      url: https://bitbucket.org/osrf/vmrc/
+      url: https://bitbucket.org/osrf/vrx/
       version: default
     status: developed
   volksbot_driver:


### PR DESCRIPTION
Proposed as an alternative to #21670. This PR may fail CI as this release version is invalid. I think we still have to merge this before the new vrx release for Kinetic can be bloomed but if we synchronize the buildfarm should not be upset for too long.