### PR TITLE
vrx: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8660,7 +8660,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.1.1-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-1`

## usv_gazebo_plugins

```
* Reinterpret the wind 'gain' parameter.  Set defaults to zero
* updated style for buoyancy plugin
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Rumman Waqar <mailto:rumman.waqar05@gmail.com>
```

## vrx_gazebo

```
* Reinterpret the wind 'gain' parameter.  Set defaults to zero
* Add replaces cluase to vrx_gazebo
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## wamv_description

- No changes

## wamv_gazebo

- No changes

## wave_gazebo

```
* Missing ruby in build depend for wave_gazebo
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## wave_gazebo_plugins

- No changes
