### PR TITLE
teb_local_planner_tutorials: 0.2.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14156,7 +14156,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
-      version: 0.2.2-0
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner_tutorials` to `0.2.4-1`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner_tutorials-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.2-0`

## teb_local_planner_tutorials

```
* Update of teb parameters
* comply with tf2: fixed error when using the launch files (thanks to doisyg).
* Contributors: Christoph Rösmann, doisyg
```
