### PR TITLE
Adds unittest2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4555,6 +4555,13 @@ python-ujson:
     vivid:
       pip:
         packages: [ujson]
+python-unittest2:
+  debian: [python-unittest2]
+  fedora: [python-unittest2]
+  osx:
+    pip:
+      packages: [unittest2]
+  ubuntu: [python-unittest2]
 python-urlgrabber:
   arch: [urlgrabber]
   debian: [python-urlgrabber]


### PR DESCRIPTION
Added [unittest2](https://pypi.org/project/unittest2/) package to `python.yml`:
> unittest2 is a backport of the new features added to the unittest testing framework in Python 2.7 and onwards.

Ubuntu
https://packages.ubuntu.com/disco/python-unittest2
Debian
https://packages.debian.org/stretch/python-unittest2
Fedora
https://apps.fedoraproject.org/packages/python-unittest2
Pip
https://pypi.org/project/unittest2/
