### PR TITLE
vrx: 1.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15802,13 +15802,15 @@ repositories:
     release:
       packages:
       - usv_gazebo_plugins
-      - vmrc_gazebo
+      - vrx_gazebo
       - wamv_description
       - wamv_gazebo
+      - wave_gazebo
+      - wave_gazebo_plugins
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 0.3.2-0
+      version: 1.1.1-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx/


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.1.1-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.2-0`

## usv_gazebo_plugins

```
* Reinterpret the wind 'gain' parameter.  Set defaults to zero
* updated style for buoyancy plugin
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Rumman Waqar <mailto:rumman.waqar05@gmail.com>
```

## vrx_gazebo

```
* Reinterpret the wind 'gain' parameter.  Set defaults to zero
* Add replaces cluase to vrx_gazebo
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## wamv_description

- No changes

## wamv_gazebo

- No changes

## wave_gazebo

```
* Missing ruby in build depend for wave_gazebo
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```

## wave_gazebo_plugins

- No changes
