### PR TITLE
rcdiscover: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10472,6 +10472,22 @@ repositories:
       url: https://github.com/roboception/rc_visard_ros.git
       version: master
     status: developed
+  rcdiscover:
+    doc:
+      type: git
+      url: https://github.com/roboception/rcdiscover.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/roboception-gbp/rcdiscover-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rcdiscover.git
+      version: master
+    status: developed
   rcll_fawkes_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcdiscover` to `1.0.0-1`:

- upstream repository: https://github.com/roboception/rcdiscover.git
- release repository: https://github.com/roboception-gbp/rcdiscover-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rcdiscover

```
* fix wildcard matching
* allow filtering by interface
* print interface on which the device was found
* also build shared lib for use in other packages
* make it possible to release as ROS third party package
```
