### PR TITLE
webots_ros: 2.0.4-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -6493,7 +6493,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/omichel/webots_ros-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/omichel/webots_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros` to `2.0.4-1`:
  - upstream repository: https://github.com/omichel/webots_ros.git
  - release repository: https://github.com/omichel/webots_ros-release.git
  - distro file: `lunar/distribution.yaml`
  - bloom version: `0.8.0`
  - previous version for package: `2.0.3-1`
