### PR TITLE
webots_ros: 2.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8720,7 +8720,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/omichel/webots_ros-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/omichel/webots_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros` to `2.0.4-1`:
  - upstream repository: https://github.com/omichel/webots_ros.git
  - release repository: https://github.com/omichel/webots_ros-release.git
  - distro file: `melodic/distribution.yaml`
  - bloom version: `0.8.0`
  - previous version for package: `2.0.3-1`