### PR TITLE
libfranka: 0.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3106,6 +3106,22 @@ repositories:
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: melodic-devel
     status: maintained
+  libfranka:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: release/melodic/libfranka
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: 0.7.0-1
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/frankaemika/libfranka.git
+      version: master
+    status: developed
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.7.0-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
