### PR TITLE
toposens: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7841,14 +7841,16 @@ repositories:
     release:
       packages:
       - toposens
+      - toposens_description
       - toposens_driver
       - toposens_markers
       - toposens_msgs
       - toposens_pointcloud
+      - toposens_sync
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.0.0-3
+      version: 1.2.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.2.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-3`

## toposens

```
* Added compile options for c++17
* Contributors: Sebastian Dengler
```

## toposens_description

```
* Added rules to install launch, mesh, urdf & rviz files
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_driver

```
* Added support for armhf architectures
* Added rules to install launch files
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_markers

```
* Added launch files for armhf architectures
* Added rules to install launch & rviz files
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Added launch files for armhf architectures
* Added rules to install launch & rviz files
* Added visualization_msgs dependency
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_sync

```
* Added rules to install launch files
* Contributors: Christopher Lang, Sebastian Dengler
```
