### PR TITLE
toposens: 1.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14569,7 +14569,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.2.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-1`

## toposens

```
* Added compile options for c++17
* Contributors: Sebastian Dengler
```

## toposens_description

```
* Added rules to install launch, mesh, urdf & rviz files
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_driver

```
* Added support for armhf architectures
* Added rules to install launch files
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_markers

```
* Added launch files for armhf architectures
* Added rules to install launch & rviz files
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Added launch files for armhf architectures
* Added rules to install launch & rviz files
* Added visualization_msgs dependency
* Contributors: Christopher Lang, Sebastian Dengler
```

## toposens_sync

```
* Added rules to install launch files
* Contributors: Christopher Lang, Sebastian Dengler
```
