### PR TITLE
rosmon: 2.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12200,10 +12200,15 @@ repositories:
       url: https://github.com/xqms/rosmon.git
       version: master
     release:
+      packages:
+      - rosmon
+      - rosmon_core
+      - rosmon_msgs
+      - rqt_rosmon
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 1.0.10-0
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/xqms/rosmon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.1.0-1`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.10-0`

## rosmon

- No changes

## rosmon_core

```
* monitor: make fork() operation safe using external shim, PR #89
* launch: handle lowercase true/false in $(eval), PR #86
* launch: trim & simplify whitespace in subst contexts, PR #85
* monitor: remove exists check for /proc/.../stat, PR #82
* monitor: publish ROS diagnostics, PR #76
* ros_interface: handle namespaces correctly, PRs #78, #80
* launch: parse uppercase bool params, PR #79
* ui: muting/unmuting of individual nodes, PR #73
* cmake: add dependency for catkin_make builds, PR #75
* Contributors: Adrien BARRAL, Artur Miller, Cartoonman, Christian Jülg, David Walsh, Eric Fang, Max Schwarz
```

## rosmon_msgs

```
* Handle namespaces in service calls correctly, PR #80
* Add namespaces to status topics, PR #78
* Contributors: Artur Miller, David Walsh, Max Schwarz
```

## rqt_rosmon

```
* handle namespaces in service calls correctly, PR #80
* show node namespaces, PR #78
* add dependencies for catkin_make builds, PR #75
* Contributors: Artur Miller, Adrien BARRAL, David Walsh, Eric Fang, Max Schwarz
```
