### PR TITLE
mavros: 0.32.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6550,7 +6550,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.31.0-1
+      version: 0.32.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.32.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.31.0-1`

## libmavconn

- No changes

## mavros

```
* use direclty radians in yaml files
* A simple typo error has fixed. (#1260 <https://github.com/mavlink/mavros/issues/1260>)
  * fix: a typing error "alredy" to "already"
  * Fix: typo error (helth -> health)
* Contributors: Martina Rivizzigno, 강정석
```

## mavros_extras

```
* use direclty radians in yaml files
* add mav_cmd associated with each point in trajectory plugin
* Fix typo
* Address comments
* Send messages from callback
* Use MountControl Msg
* Add mount control class template
* Contributors: Jaeyoung-Lim, Martina Rivizzigno
```

## mavros_msgs

```
* add mav_cmd associated with each point in trajectory plugin
* Use MountControl Msg
* Define new MountControl.msg
* Contributors: Jaeyoung-Lim, Martina Rivizzigno
```

## test_mavros

- No changes
