### PR TITLE
libfranka: 0.7.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5965,7 +5965,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.5.0-1
+      version: 0.7.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.7.1-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.0-1`
