### PR TITLE
googletest: 1.8.9000-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -38,6 +38,20 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.8.9000-1
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: ros2
+    status: maintained
   ros_workspace:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.8.9000-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
