### PR TITLE
rosbridge_suite: 0.11.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6364,7 +6364,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.1-1
+      version: 0.11.2-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.2-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.1-1`

## rosapi

```
* constnames and constvalues in typedef (#412 <https://github.com/RobotWebTools/rosbridge_suite/issues/412>)
* Contributors: Kad91
```

## rosbridge_library

- No changes

## rosbridge_msgs

- No changes

## rosbridge_server

```
* yield infinite lock (#413 <https://github.com/RobotWebTools/rosbridge_suite/issues/413>)
* Add settings for websocket timeout (#410 <https://github.com/RobotWebTools/rosbridge_suite/issues/410>)
  * Add settings for websocket timeout
  * Error handling of StreamClosedError
* Contributors: Aurélien Labate
```

## rosbridge_suite

- No changes
