### PR TITLE
Deleting doosan_robot to documentation

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1087,11 +1087,6 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
-  doosan_robot:
-    doc:
-      type: git
-      url: https://github.com/doosan-robotics/doosan-robot.git
-      version: melodic-devel
   driver_common:
     doc:
       type: git


### PR DESCRIPTION
I want to delete my repository in melodic/distribution.yaml