### PR TITLE
gazebo_ros_pkgs: dashing branch

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -500,7 +500,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
+      version: dashing
     release:
       packages:
       - gazebo_dev
@@ -516,7 +516,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
+      version: dashing
     status: developed
   geometry2:
     doc:


### PR DESCRIPTION
We're breaking ABI on the `ros2` branch for Eloquent, so Dashing should now use the `dashing` branch.

Documented [here](https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-integration).