### PR TITLE
rosmon: 2.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12218,7 +12218,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/xqms/rosmon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.1.1-1`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.0-1`

## rosmon

- No changes

## rosmon_core

```
* rosmon_core: add _shim to installed targets, issue #91
* Contributors: Max Schwarz
```

## rosmon_msgs

- No changes

## rqt_rosmon

- No changes
