### PR TITLE
vrx: 1.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15825,7 +15825,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx/


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.1.2-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-1`

## usv_gazebo_plugins

```
* usv_gazebo_wind_plugin.hh changes
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Agüero <mailto:cen.aguero@gmail.com>, Rumman Waqar <mailto:rumman.waqar05@gmail.com>
```

## vrx_gazebo

```
* Merged in world-gen-bug-fix (pull request #145)
  world gen bug fix
  Approved-by: Tyler Lum <mailto:tylergwlum@gmail.com>
* Workaround to fix compile errors on Kinetic
  The version of ign-math2 present in Ubuntu Xenial (2.2.3) lacks
  of some features (Zero or Length) implemented starting on 2.3.x.
  This change add some preprocessors defines to workaround the
  problem. A more elegant solution would be ideal.
* World generator now imbeds the coordinate with axies specified by the yaml file for easy post gen sorting
* added a space parameter to the bounding boxes
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>, MarshallRawson, MarshallRawson <mailto:marshallrawson@osrfoundation.org>, Tyler Lum <mailto:tylergwlum@gmail.com>
```

## wamv_description

- No changes

## wamv_gazebo

```
* lidar.xacro edited online with Bitbucket
* fixed issue
* cpu cases now included when configured by yaml
* Contributors: Marshall Rawson <mailto:marshallrawson@osrfoundation.org>, MarshallRawson
```

## wave_gazebo

```
* fixed 2016 placard joint issue
* Contributors: MarshallRawson
```

## wave_gazebo_plugins

```
* Workaround to fix compile errors on Kinetic
  The version of ign-math2 present in Ubuntu Xenial (2.2.3) lacks
  of some features (Zero or Length) implemented starting on 2.3.x.
  This change add some preprocessors defines to workaround the
  problem. A more elegant solution would be ideal.
* Contributors: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
```
