### PR TITLE
jsk_3rdparty: 2.1.12-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5265,6 +5265,7 @@ repositories:
       - jsk_3rdparty
       - julius
       - julius_ros
+      - laser_filters_jsk_patch
       - libcmt
       - libsiftfast
       - lpg_planner
@@ -5282,7 +5283,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.12-1
+      version: 2.1.12-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.12-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.12-1`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## collada_urdf_jsk_patch

- No changes

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

- No changes

## julius_ros

- No changes

## laser_filters_jsk_patch

- No changes

## libcmt

- No changes

## libsiftfast

```
* enable to compile libsiftfast with current numpy.get_include() (#162 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/162> )
* Contributors: Kei Okada
```

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## respeaker_ros

```
* Make sample_respeaker.launch re-usable (#161 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/161>)
  
    * [respeaker_ros] add docs for each args in sample_respeaker.launch
    * make sample_respeaker.launch re-usable
  
* respeaker_ros: cleanup error messages (#155 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/155>)
* Contributors: Yuki Furuta, Kei Okada, Naoya Yamaguchi
```

## ros_speech_recognition

```
* fixes GoogleCloud auth (#158 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/158>)
* Contributors: jonasius
```

## rospatlite

- No changes

## rosping

- No changes

## rostwitter

- No changes

## slic

- No changes

## voice_text

```
* Fix install directory of text2wave to ./lib -> ./bin (#160 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/160>)
  text2wave Was wrongly  installed to CATKIN_PACKAGE_LIB_DESTINATION
  The launch file is assumed that it is installed under rospack find voice_text/bin
  https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/2.1.10/3rdparty/voice_text/launch/voice_text.launch#L29
* Contributors: Kei Okada
```
