### PR TITLE
jsk_3rdparty: 2.1.13-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5265,6 +5265,7 @@ repositories:
       - jsk_3rdparty
       - julius
       - julius_ros
+      - laser_filters_jsk_patch
       - libcmt
       - libsiftfast
       - lpg_planner
@@ -5282,7 +5283,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.12-1
+      version: 2.1.13-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.13-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.12-1`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## collada_urdf_jsk_patch

- No changes

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## jsk_3rdparty

- No changes

## julius

- No changes

## julius_ros

- No changes

## laser_filters_jsk_patch

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## respeaker_ros

```
* [respeaker_ros] increase timeout to pass the test (#170 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/170>)
  
    * default tts_action_names should be soundplay
    * [respeaker_ros] increase timeout to pass the test https://api.travis-ci.org/v3/job/554008643/log.txt
    * [respeaker_ros] add python-speechrocognition-pip to package.depends, because scripts/speech_to_text.py depends on it
  
* [respeaker_ros] Add test file for speech_to_text (#164 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/164>)
  
    * add test file for speech_to_text
  
* [respeaker_ros] add tts_action_names param: do not listen when the robot is speaking either japanese or english (#168 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/168>)
  
    * add tts_actions param: do not listen when the robot is speaking either japanese or english
  
* Contributors: Naoya Yamaguchi, Shingo Kitagawa
```

## ros_speech_recognition

- No changes

## rospatlite

- No changes

## rosping

- No changes

## rostwitter

- No changes

## slic

- No changes

## voice_text

```
* [voice_text] Call rosservice from python instead of bash (#166 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/166> )
  
    * rewrite text2wave with python
    * call rosservice from python instead of bash
  
* Contributors: Hideaki Ito
```
