### PR TITLE
ml_classifiers: 1.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -705,6 +705,21 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: dashing
     status: developed
+  ml_classifiers:
+    doc:
+      type: git
+      url: https://github.com/astuff/ml_classifiers.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/astuff/ml_classifiers-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/astuff/ml_classifiers.git
+      version: master
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ml_classifiers` to `1.0.1-1`:

- upstream repository: https://github.com/astuff/ml_classifiers.git
- release repository: https://github.com/astuff/ml_classifiers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ml_classifiers

```
* Merge pull request #3 <https://github.com/astuff/ml_classifiers/issues/3> from dirk-thomas/patch-1
* add build dep on ros_environment to ensure the env variable ROS_VERSION is defined
* Contributors: Dirk Thomas, Joshua Whitley
```
