### PR TITLE
Simplify python-argparse rule so it works on newer ubuntu distros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -459,8 +459,7 @@ python-argparse:
     pip:
       packages: [argparse]
   ubuntu:
-    '*':
-      packages: []
+    '*': []
     lucid: [python-argparse]
     maverick: [python-argparse]
     natty: [python-argparse]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -459,38 +459,12 @@ python-argparse:
     pip:
       packages: [argparse]
   ubuntu:
-    artful:
-      packages: []
-    bionic:
+    '*':
       packages: []
     lucid: [python-argparse]
     maverick: [python-argparse]
     natty: [python-argparse]
     oneiric: [python-argparse]
-    precise:
-      packages: []
-    quantal:
-      packages: []
-    raring:
-      packages: []
-    saucy:
-      packages: []
-    trusty:
-      packages: []
-    trusty_python3:
-      packages: []
-    utopic:
-      packages: []
-    vivid:
-      packages: []
-    wily:
-      packages: []
-    xenial:
-      packages: []
-    yakkety:
-      packages: []
-    zesty:
-      packages: []
 python-attrs:
   debian: [python-attr]
   fedora: [python2-attrs]


### PR DESCRIPTION
`python-argparse` is a rosdep key that resolves to the apt package `python-argparse` on old ubuntu distros. For newer distros it resolves to nothing. This PR simplifies the rule to use `'*'`. Without this it fails on `eoan`.

I tested on `eoan` and `bionic`.

Bionic
```
$ rosdep resolve python-argparse
#apt

```

Eoan
```
$ rosdep resolve python-argparse
#apt

```