### PR TITLE
abseil_cpp: 0.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -19,11 +19,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/Eurecat/abseil_cpp-release.git
-      version: 0.2.3-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/Eurecat/abseil-cpp.git
       version: master
+    status: developed
   acado:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abseil_cpp` to `0.4.2-1`:

- upstream repository: https://github.com/Eurecat/abseil-cpp.git
- release repository: https://github.com/Eurecat/abseil_cpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.3-1`
