### PR TITLE
epos2_motor_controller: 1.0.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1386,7 +1386,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/epos2_motor_controller-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/uos/epos2_motor_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos2_motor_controller` to `1.0.0-2`:

- upstream repository: https://github.com/uos/epos2_motor_controller.git
- release repository: https://github.com/uos-gbp/epos2_motor_controller-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-1`

## epos2_motor_controller

```
* First release,c ontributors: Jochen Sprickerhof, galenya, mmorta
```
