### PR TITLE
octomap_rviz_plugins: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4386,6 +4386,12 @@ repositories:
       url: https://github.com/OctoMap/octomap_ros.git
       version: melodic-devel
     status: unmaintained
+  octomap_rviz_plugins:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
+      version: 0.2.1-1
   odva_ethernetip:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4387,11 +4387,20 @@ repositories:
       version: melodic-devel
     status: unmaintained
   octomap_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
       version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: kinetic-devel
+    status: maintained
   odva_ethernetip:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `0.2.1-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## octomap_rviz_plugins

```
* Add Wolfgang Merkt to maintainers
* Update visualization on property changes with latched topics <https://github.com/OctoMap/octomap_rviz_plugins/issues/32>
* Update node frame from TF on every frame <https://github.com/OctoMap/octomap_rviz_plugins/issues/31>
* Fixed rendering of free-space voxels and pruning enclosed nodes <https://github.com/OctoMap/octomap_rviz_plugins/issues/30>
* Contributors: Armin Hornung, Matthias Nieuwenhuisen, Vladimir Ivan, Wolfgang Merkt
```
