### PR TITLE
ros2_tracing: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1304,6 +1304,28 @@ repositories:
       url: https://github.com/intel/ros2_object_analytics.git
       version: master
     status: maintained
+  ros2_tracing:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: master
+    release:
+      packages:
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: master
+    status: developed
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.1.0-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros2trace

```
* Add ros2cli extension that wraps tracetools_trace
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools

```
* Add symbol resolution utils
* Add tracepoint definitions and wrapper macro for tracepoint functions
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools_launch

```
* Add tracing integration into launch
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools_read

```
* Add trace reading functions
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools_test

```
* Add tracetools_test package with utilities
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools_trace

```
* Use proper arg parser and event names completers
* Add tracing utilities
* Contributors: Christophe Bedard, Ingo Lütkebohle
```
