### PR TITLE
jderobot-drones: 0.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5177,6 +5177,21 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
+  jderobot-drones:
+    release:
+      packages:
+      - drone_wrapper
+      - rqt_follow_road
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/nkhedekar/jderobot-drones-release.git
+      version: 0.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/drones.git
+      version: master
+    status: developed
   jog_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot-drones` to `0.0.3-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/nkhedekar/jderobot-drones-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## drone_wrapper

```
* removed packages requiring source builds
* Contributors: Nikhil Khedekar
```

## rqt_follow_road

- No changes
