### PR TITLE
slam_gmapping: 1.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7572,6 +7572,25 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/simple_rviz_plugin.git
       version: melodic
     status: maintained
+  slam_gmapping:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: melodic-devel
+    release:
+      packages:
+      - gmapping
+      - slam_gmapping
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/slam_gmapping-release.git
+      version: 1.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: melodic-devel
+    status: unmaintained
   slam_karto:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.4.0-1`:

- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## gmapping

```
* update license to BSD and maintainer to mailto:ros-orphaned-packages@googlegroups.com
  since original gmapping source and ROS openslam_gmapping package has been updated to the BSD-3 license, I think we have no reason to use CC for slam_gmapping package
* Contributors: Kei Okada
```

## slam_gmapping

```
* update license to BSD and maintainer to mailto:ros-orphaned-packages@googlegroups.com
  since original gmapping source and ROS openslam_gmapping package has been updated to the BSD-3 license, I think we have no reason to use CC for slam_gmapping package
* Contributors: Kei Okada
```
