### PR TITLE
toposens: 1.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7962,7 +7962,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.2.1-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.0-1`

## toposens

- No changes

## toposens_description

- No changes

## toposens_driver

- No changes

## toposens_markers

- No changes

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Added possibility to choose path for storing pcd file
* Contributors: Sebastian Dengler
```

## toposens_sync

- No changes
