### PR TITLE
autoware_msgs: 1.12.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -303,6 +303,30 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: developed
+  autoware_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
+      version: master
+    release:
+      packages:
+      - autoware_can_msgs
+      - autoware_config_msgs
+      - autoware_external_msgs
+      - autoware_map_msgs
+      - autoware_msgs
+      - autoware_system_msgs
+      - tablet_socket_msgs
+      - vector_map_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/messages-release.git
+      version: 1.12.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
+      version: master
+    status: developed
   aws_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.12.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
- release repository: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/messages-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## autoware_can_msgs

- No changes

## autoware_config_msgs

- No changes

## autoware_external_msgs

```
* Adding CHANGELOG for autoware_external_msgs and autoware_map_msgs.
* Merge branch 'master' into package_moves
* Merge pull request #3 from amc-nu/master
  Message repository split up
* Add autoware_external_msgs package
  Signed-off-by: amc-nu <mailto:abrahammonrroy@yahoo.com>
* Contributors: Servando, amc-nu, Joshua Whitley
```

## autoware_map_msgs

```
* Adding CHANGELOG for autoware_external_msgs and autoware_map_msgs.
* Updating autoware_map_msgs version for ROS release.
* Merge branch 'fix/remove_unnecessary_depend' into 'master'
  Removing unused depend in autoware_map_msgs.
  See merge request autowarefoundation/autoware.ai/messages!4
* Removing unused depend in autoware_map_msgs.
* Merge branch 'feature/autoware_map_msgs' into 'master'
  Add autoware_map_msgs package
  See merge request autowarefoundation/autoware.ai/messages!2
* add autoware_map_msgs
  Signed-off-by: mitsudome-r <mailto:ryohsuke.mitsudome@tier4.jp>
* Contributors: Abraham Cano, Geoffrey Biggs, Joshua Whitley, mitsudome-r
```

## autoware_msgs

- No changes

## autoware_system_msgs

- No changes

## tablet_socket_msgs

- No changes

## vector_map_msgs

- No changes
