### PR TITLE
nmea_gps_plugin: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4170,7 +4170,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
-      version: 0.0.1-4
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_gps_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_gps_plugin` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/nmea_gps_plugin.git
- release repository: https://github.com/OUXT-Polaris/nmea_gps_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-4`

## nmea_gps_plugin

```
* Merge pull request #2 <https://github.com/OUXT-Polaris/nmea_gps_plugin/issues/2> from OUXT-Polaris/develop
  Develop
* Merge pull request #1 <https://github.com/OUXT-Polaris/nmea_gps_plugin/issues/1> from OUXT-Polaris/feature/improve_lat_lon_accuracy
  fix     std::string NmeaGpsPlugin::convertToDmm(double value) function
* fix     std::string NmeaGpsPlugin::convertToDmm(double value) function
* Update README.md
* Contributors: Masaya Kataoka
* Merge pull request #2 <https://github.com/OUXT-Polaris/nmea_gps_plugin/issues/2> from OUXT-Polaris/develop
  Develop
* Merge pull request #1 <https://github.com/OUXT-Polaris/nmea_gps_plugin/issues/1> from OUXT-Polaris/feature/improve_lat_lon_accuracy
  fix     std::string NmeaGpsPlugin::convertToDmm(double value) function
* fix     std::string NmeaGpsPlugin::convertToDmm(double value) function
* Update README.md
* Contributors: Masaya Kataoka
* Merge pull request #2 <https://github.com/OUXT-Polaris/nmea_gps_plugin/issues/2> from OUXT-Polaris/develop
  Develop
* Merge pull request #1 <https://github.com/OUXT-Polaris/nmea_gps_plugin/issues/1> from OUXT-Polaris/feature/improve_lat_lon_accuracy
  fix     std::string NmeaGpsPlugin::convertToDmm(double value) function
* fix     std::string NmeaGpsPlugin::convertToDmm(double value) function
* Update README.md
* Contributors: Masaya Kataoka
```
