### PR TITLE
ros_canopen: 0.7.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11590,7 +11590,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.7.10-0
+      version: 0.7.11-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.7.11-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.10-0`

## can_msgs

- No changes

## canopen_402

- No changes

## canopen_chain_node

- No changes

## canopen_master

- No changes

## canopen_motor_node

```
* inherit LimitsHandle from LimitsHandleBase
* Contributors: Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

- No changes

## socketcan_interface

- No changes
