### PR TITLE
ros_canopen: 0.8.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6135,7 +6135,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.8.0-0
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.8.1-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-0`

## can_msgs

```
* Set C++ standard to c++14
* Contributors: Harsh Deshpande
```

## canopen_402

```
* Set C++ standard to c++14
* Contributors: Harsh Deshpande
```

## canopen_chain_node

```
* Set C++ standard to c++14
* implemented create*ListenerM helpers
* Replacing FastDelegate with std::function and std::bind.
* Contributors: Alexander Gutenkunst, Harsh Deshpande, Joshua Whitley, Mathias Lüdtke
```

## canopen_master

```
* Set C++ standard to c++14
* added Delegate helpers for backwards compatibility
* implemented create*ListenerM helpers
* Replacing FastDelegate with std::function and std::bind.
* Contributors: Harsh Deshpande, Joshua Whitley, Mathias Lüdtke
```

## canopen_motor_node

```
* Set C++ standard to c++14
* inherit LimitsHandle from LimitsHandleBase
* Contributors: Harsh Deshpande, Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

```
* Added configurable queue sizes
* Set C++ standard to c++14
* implemented create*ListenerM helpers
* Replacing FastDelegate with std::function and std::bind.
* Contributors: Harsh Deshpande, JeremyZoss, Joshua Whitley, Mathias Lüdtke, rchristopher
```

## socketcan_interface

```
* Set C++ standard to c++14
* implemented test for dispatcher
* Replacing typedefs in socketcan_interface with using aliases.
* added Delegate helpers for backwards compatibility
* implemented create*ListenerM helpers
* Replacing FastDelegate with std::function and std::bind.
* Contributors: Harsh Deshpande, Joshua Whitley, Mathias Lüdtke, pzzlr
```
