### PR TITLE
added pymap3d pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -271,6 +271,12 @@ pymap3d-pip:
   debian:
     pip:
       packages: [pymap3d]
+  fedora:
+    pip:
+      packages: [pymap3d]
+  osx:
+    pip:
+      packages: [pymap3d]
   ubuntu:
     pip:
       packages: [pymap3d]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -267,6 +267,13 @@ pyflakes3:
     bionic: [pyflakes3]
     xenial: [pyflakes3]
     zesty: [pyflakes3]
+pymap3d-pip:
+  debian:
+    pip:
+      packages: [pymap3d]
+  ubuntu:
+    pip:
+      packages: [pymap3d]
 pymodbustcp-pip:
   debian:
     pip:


### PR DESCRIPTION
Added a new PIP package: **pymap3d** that contains various 3-D geographic coordinate conversions.

The pip package can be found here: https://pypi.org/project/pymap3d/

> Pure Python (no prerequistes beyond Python itself) 3-D geographic coordinate conversions. API similar to popular $1000 Matlab Mapping Toolbox routines for