### PR TITLE
interactive_marker_twist_server: 1.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2584,7 +2584,6 @@ repositories:
       url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
       version: 1.2.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_marker_twist_server.git
       version: kinetic-devel

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2573,6 +2573,22 @@ repositories:
       url: https://github.com/RobotWebTools/interactive_marker_proxy.git
       version: master
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 1.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.2.0-0`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## interactive_marker_twist_server

```
* Fixed CMake warning and updated to package format 2. (#11 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/11>)
* Install the default config files. (#10 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/10>)
* Contributors: Tony Baltovski
```
