### PR TITLE
navigation2: 0.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -720,6 +720,50 @@ repositories:
       url: https://github.com/astuff/ml_classifiers.git
       version: master
     status: maintained
+  navigation2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: dashing-devel
+    release:
+      packages:
+      - costmap_queue
+      - dwb_controller
+      - dwb_core
+      - dwb_critics
+      - dwb_msgs
+      - dwb_plugins
+      - nav2_amcl
+      - nav2_behavior_tree
+      - nav2_bringup
+      - nav2_bt_navigator
+      - nav2_common
+      - nav2_costmap_2d
+      - nav2_dwb_controller
+      - nav2_dynamic_params
+      - nav2_lifecycle_manager
+      - nav2_map_server
+      - nav2_motion_primitives
+      - nav2_msgs
+      - nav2_navfn_planner
+      - nav2_robot
+      - nav2_rviz_plugins
+      - nav2_util
+      - nav2_voxel_grid
+      - nav2_world_model
+      - nav_2d_msgs
+      - nav_2d_utils
+      - navigation2
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/SteveMacenski/navigation2-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation2.git
+      version: dashing-devel
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.2.1-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
