### PR TITLE
ros2_tracing: 0.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1320,7 +1320,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.1.1-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-1`

## tracetools

```
* Disable tracing-related tests by default
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Disable tracing-related tests by default
* Contributors: Christophe Bedard
```
