### PR TITLE
tracetools_analysis: 0.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1979,6 +1979,21 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: dashing
     status: maintained
+  tracetools_analysis:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: master
+    status: developed
   uncrustify_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `0.1.1-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## tracetools_analysis

```
* Update metadata
* Contributors: Christophe Bedard
```
