### PR TITLE
lms1xx: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3201,6 +3201,21 @@ repositories:
       type: git
       url: https://github.com/pr2/linux_networking.git
       version: melodic-devel
+  lms1xx:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/lms1xx-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: melodic-devel
+    status: maintained
   lusb:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## lms1xx

```
* Updates for console bridge deprecated macros
* Fixed warning about inconsistent namespace redefinitions for xmlns:xacro.
* Fixed formatting
* Added inf to be set for min range
* Contributors: Dave Niewinski, Tony Baltovski
```
