### PR TITLE
cpr_multimaster_tools: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1954,7 +1954,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/cpr_multimaster_tools-release.git
-      version: 0.0.1-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_multimaster_tools` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
- release repository: https://github.com/clearpath-gbp/cpr_multimaster_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-0`

## clock_relay

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## cpr_multimaster_tools

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## message_relay

```
* Linter fixes.
* Updated maintainers.
* Contributors: Tony Baltovski
```

## multimaster_launch

```
* Removed roslint from multimaster_launch since there is no source files.
* Updated maintainers.
* Contributors: Tony Baltovski
```

## multimaster_msgs

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## tf2_relay

```
* Updated maintainers.
* Contributors: Tony Baltovski
```
