### PR TITLE
cpr_multimaster_tools: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -888,6 +888,28 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: developed
+  cpr_multimaster_tools:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
+      version: kinetic-devel
+    release:
+      packages:
+      - clock_relay
+      - cpr_multimaster_tools
+      - message_relay
+      - multimaster_launch
+      - multimaster_msgs
+      - tf2_relay
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/cpr_multimaster_tools-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
+      version: kinetic-devel
+    status: maintained
   crazyflie:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr_multimaster_tools` to `0.0.2-1`:

- upstream repository: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
- release repository: https://github.com/clearpath-gbp/cpr_multimaster_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## clock_relay

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## cpr_multimaster_tools

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## message_relay

```
* Linter fixes.
* Updated maintainers.
* Contributors: Tony Baltovski
```

## multimaster_launch

```
* Removed roslint from multimaster_launch since there is no source files.
* Updated maintainers.
* Contributors: Tony Baltovski
```

## multimaster_msgs

```
* Updated maintainers.
* Contributors: Tony Baltovski
```

## tf2_relay

```
* Updated maintainers.
* Contributors: Tony Baltovski
```
