### PR TITLE
um6: 1.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8350,6 +8350,21 @@ repositories:
       url: https://github.com/osrf/uav_testing.git
       version: master
     status: maintained
+  um6:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/um6.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/um6-release.git
+      version: 1.1.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/um6.git
+      version: indigo-devel
+    status: maintained
   um7:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `um6` to `1.1.2-1`:

- upstream repository: https://github.com/ros-drivers/um6.git
- release repository: https://github.com/ros-drivers-gbp/um6-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## um6

```
* Add update_rate ROS parameter to set IMU frequency
* Contributors: Jake Bruce, Mike Purvis
```
