### PR TITLE
librealsense2: 2.25.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6049,6 +6049,7 @@ repositories:
       url: https://github.com/IntelRealSense/librealsense2-release.git
       version: 2.25.0-3
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6047,7 +6047,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.23.0-1
+      version: 2.25.0-3
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.25.0-3`:

- upstream repository: https://github.com/doronhi/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.23.0-1`
