### PR TITLE
robot_body_filter: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5901,6 +5901,21 @@ repositories:
       url: https://github.com/snt-robotics/robot_activity.git
       version: master
     status: developed
+  robot_body_filter:
+    doc:
+      type: git
+      url: https://github.com/peci1/robot_body_filter.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/robot_body_filter-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/peci1/robot_body_filter.git
+      version: master
+    status: developed
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.1.0-1`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## robot_body_filter

```
* Increasing performance.
* More descriptive frame configurations. Added the possibility to leave out clipping, contains or shadow tests.
* Repurposed param ~transforms/timeout/reachable to be always used with remainingTime.
* More efficient point transformation
* Little improvements. Renamed the utils library to robot_body_filter_utils.
* Removed compiler pragmas - they seem no longer needed.
* Provided a fix for wrong box-ray intersections.
* Fixed bodies.h header guard.
* Fixed bug in cylinder shape creation.
* Fixed a bug in constructMarkerFromBody() - references do not correctly support polymorphism.
* Fixes for robot body filter. Added new bounding box types.
* Fixed a few bugs while running under a nodelet.
* Prepared remainingTime() to a situation where ROS time hasn't yet been initialized.
* Added possibility to update only robot pose only with every n-th point in point_by_point scans.
  Added possibility to publish bounding sphere and box markers.
* Renamed to robot_body_filter.
* Reworked as a laser filter combining contains and shadow tests.
* Make use of bodies.h and shapes.h from geometric_shapes.
* Enabling generic point types, removed PCL dependency, removed unnecessary params.
* Using all collision elements for each link instead of only the first one.
* Testing all intersections instead of only the first one.
* Merge branch 'master' into indigo-devel
* Add robot_self_filter namespace before bodies and shapes namespace.
  geometric_shapes package also provides bodies and shapes namespace
  and same classes and functions. If a program is linked with
  geometric_shapes and robot_self_filter, it may cause strange behavior
  because of symbol confliction.
* Contributors: Martin Pecka, Ryohei Ueda, Tomas Petricek
```
