### PR TITLE
smacha: 0.5.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13775,6 +13775,24 @@ repositories:
       url: https://github.com/ros-gbp/slam_karto-release.git
       version: 0.7.3-0
     status: maintained
+  smacha:
+    doc:
+      type: git
+      url: https://github.com/ReconCell/smacha.git
+      version: master
+    release:
+      packages:
+      - smacha
+      - smacha_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ReconCell/smacha-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/ReconCell/smacha.git
+      version: master
+    status: developed
   smartek_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacha` to `0.5.0-1`:

- upstream repository: https://github.com/ReconCell/smacha.git
- release repository: https://github.com/ReconCell/smacha-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
