### PR TITLE
jackal: 0.6.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2684,6 +2684,27 @@ repositories:
       url: https://github.com/ros-gbp/ivcon-release.git
       version: 0.1.7-0
     status: unmaintained
+  jackal:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: kinetic-devel
+    release:
+      packages:
+      - jackal_control
+      - jackal_description
+      - jackal_msgs
+      - jackal_navigation
+      - jackal_tutorials
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal-release.git
+      version: 0.6.3-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal.git
+      version: kinetic-devel
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.6.3-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jackal_control

- No changes

## jackal_description

```
* Added all extra fender changes
* Contributors: Dave Niewinski
* Made minor changes to syntax for kinetic warnings
* Contributors: Dave Niewinski
* Added stereo camera accessory.
* Removed unused variable jackal_description_dir
* Make urdf refer explicitly to jackal_description, rather than relying on current working directory being correct, for easier external includes
* Contributors: Arnold Kalmbach, Tony Baltovski, akalmbach
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
