### PR TITLE
epos2_motor_controller: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2912,6 +2912,21 @@ repositories:
       url: https://github.com/ensenso/ros_driver.git
       version: master
     status: developed
+  epos2_motor_controller:
+    doc:
+      type: git
+      url: https://github.com/uos/epos2_motor_controller.git
+      version: 1.0.0
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/uos-gbp/epos2_motor_controller-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/uos/epos2_motor_controller.git
+      version: master
+    status: maintained
   epson_g364_imu_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos2_motor_controller` to `1.0.0-1`:

- upstream repository: https://github.com/uos/epos2_motor_controller.git
- release repository: https://github.com/uos-gbp/epos2_motor_controller-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## epos2_motor_controller

```
* First release,c ontributors: Jochen Sprickerhof, galenya, mmorta
```
