### PR TITLE
spatio_temporal_voxel_layer: 1.3.5-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7753,7 +7753,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
-      version: 1.3.4-1
+      version: 1.3.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spatio_temporal_voxel_layer` to `1.3.5-2`:

- upstream repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
- release repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.3.4-1`
