### PR TITLE
warthog: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15941,7 +15941,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.0-0
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.1-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-0`

## warthog_control

- No changes

## warthog_description

```
* Tuned wheel friction to reduce drift when stopped
* Removed gazebo wheel physics as it was causing strangeness when turning, and defaults seem to work
* Contributors: Dave Niewinski, L. James Azzalini, Tony Baltovski
```

## warthog_msgs

- No changes
