### PR TITLE
rr_openrover_stack: 0.7.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13102,6 +13102,18 @@ repositories:
       version: master
     status: developed
     status_description: pre-release-version
+  rr_openrover_stack:
+    release:
+      packages:
+      - rr_control_input_manager
+      - rr_openrover_driver
+      - rr_openrover_driver_msgs
+      - rr_openrover_stack
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
+      version: 0.7.2-1
+    status: maintained
   rr_swiftnav_piksi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_stack` to `0.7.2-1`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_stack.git
- release repository: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rr_control_input_manager

```
* Changed rr_control_input_manager from a mux with fix input to latency manager for TwistStamped messages.
```

## rr_openrover_driver

```
* Changed name to rr_openrover_drive from rr_openrover_basic
* Refactored openrover_driver to accept Twist msgs instead of TwistStamped msgs
```

## rr_openrover_driver_msgs

```
* Separated rr_openrover_driver_msgs from the main driver package rr_openrover_driver (formerly rr_openrover_basic)
```

## rr_openrover_stack

```
* Collect the packages to operate the rover platform into a stack
* Changed repo name from rr_openrover_ros1 to rr_openrover_stack
* Refactor rr_control_input_manager from a MUX to a TwistStamped latency manager
```
