### PR TITLE
code_coverage: 0.2.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -771,7 +771,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/code_coverage-gbp.git
-      version: 0.2.3-0
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/mikeferguson/code_coverage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.2.4-1`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.3-0`

## code_coverage

```
* Merge pull request #11 <https://github.com/mikeferguson/code_coverage/issues/11> from agutenkunst/master
  Keep *.info.cleaned. Closes #10 <https://github.com/mikeferguson/code_coverage/issues/10>
* Keep *.info.cleaned. Closes #10 <https://github.com/mikeferguson/code_coverage/issues/10>
* Merge pull request #8 <https://github.com/mikeferguson/code_coverage/issues/8> from jschleicher/documentation
  documentation: degrade to test_depend
* documentation degrade to test_depend
  and note that build type should be set to Debug
* Contributors: Alexander Gutenkunst, Joachim Schleicher, Michael Ferguson
```
