### PR TITLE
rc_visard: 2.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5806,6 +5806,7 @@ repositories:
       packages:
       - rc_hand_eye_calibration_client
       - rc_pick_client
+      - rc_roi_manager_gui
       - rc_tagdetect_client
       - rc_visard
       - rc_visard_description
@@ -5813,7 +5814,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.6.4-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `2.7.0-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.6.4-1`

## rc_hand_eye_calibration_client

```
* add device parameter that can take serial number or GEV name
  (has precedence over old host parameter)
```

## rc_pick_client

```
* add BoxPick client rc_boxpick_client_node
* add device parameter that can take serial number or GEV name
  (has precedence over old host parameter)
```

## rc_roi_manager_gui

```
* first release
```

## rc_tagdetect_client

```
* add device parameter that can take serial number or GEV name
  (has precedence over old host parameter)
```

## rc_visard

```
* add rc_roi_manager_gui package
```

## rc_visard_description

- No changes

## rc_visard_driver

```
* replaced std_srvs/Trigger with rc_common_msgs/Trigger
* add support for setting exposure region via dynamic_reconfigure
```
