### PR TITLE
warthog: 0.1.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8929,6 +8929,25 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: kinetic-devel
     status: maintained
+  warthog:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog.git
+      version: kinetic-devel
+    release:
+      packages:
+      - warthog_control
+      - warthog_description
+      - warthog_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog.git
+      version: kinetic-devel
+    status: maintained
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.1-2`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## warthog_control

- No changes

## warthog_description

```
* Tuned wheel friction to reduce drift when stopped
* Removed gazebo wheel physics as it was causing strangeness when turning, and defaults seem to work
* Contributors: Dave Niewinski, L. James Azzalini, Tony Baltovski
```

## warthog_msgs

- No changes
