### PR TITLE
Add python3-sip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5224,6 +5224,11 @@ python3-setuptools:
   openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-setuptools]
+python3-sip:
+  debian: [python3-sip-dev]
+  fedora: [python3-sip]
+  gentoo: [dev-python/sip]
+  ubuntu: [python3-sip-dev]
 python3-sphinx:
   debian: [python3-sphinx]
   ubuntu: [python3-sphinx]


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-sip-dev
* Ubuntu https://packages.ubuntu.com/bionic/python3-sip-dev
* Fedora https://apps.fedoraproject.org/packages/python3-sip
* Gentoo https://packages.gentoo.org/packages/dev-python/sip

This is a python3 equivalent of the `python-sip` key which is used by

```
./orocos_kinematics_dynamics/python_orocos_kdl/package.xml
```
