### PR TITLE
Add python3-qt5-bindings-gl key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5165,6 +5165,11 @@ python3-qt5-bindings:
   opensuse: [python3-qt5]
   slackware: [python3-PyQt5]
   ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+python3-qt5-bindings-gl:
+  debian: [python3-pyqt5.qtopengl]
+  fedora: [python3-qt5]
+  gentoo: ['dev-python/PyQt5[opengl]']
+  ubuntu: [python3-pyqt5.qtopengl]
 python3-rospkg:
   alpine:
     pip:


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-pyqt5.qtopengl
* Ubuntu https://packages.ubuntu.com/bionic/python3-pyqt5.qtopengl
* Fedora https://apps.fedoraproject.org/packages/python3-qt5
* Gentoo https://packages.gentoo.org/packages/dev-python/PyQt5

This is a python3 equivalent to `python-qt5-bindings-gl` which is used by

```
./gl_dependency/package.xml
```