### PR TITLE
Add python3 key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4882,6 +4882,11 @@ python-zmq:
     wily: [python-zmq]
     xenial: [python-zmq]
     yakkety: [python-zmq]
+python3:
+  debian: [python3-dev]
+  fedora: [python3-devel]
+  gentoo: [dev-lang/python]
+  ubuntu: [python3-dev]
 python3-babeltrace:
   debian: [python3-babeltrace]
   ubuntu: [python3-babeltrace]


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-dev
* Ubuntu https://packages.ubuntu.com/bionic/python3-dev
* Fedora https://apps.fedoraproject.org/packages/python3-devel
* Gentoo https://packages.gentoo.org/packages/dev-lang/python

This is a python3 equivalent to `python` which is used by

```
./src/rospack/package.xml
./src/urdfdom_py/package.xml
./src/vision_opencv/cv_bridge/package.xml
```