### PR TITLE
Add python3-netifaces key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5027,6 +5027,11 @@ python3-mock:
   openembedded: [python3-mock@meta-ros]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
+python3-netifaces:
+  debian: [python3-netifaces]
+  fedora: [python3-netifaces]
+  gentoo: [dev-python/netifaces]
+  ubuntu: [python3-netifaces]
 python3-nose:
   debian: [python3-nose]
   gentoo: [dev-python/nose]


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-netifaces
* Ubuntu https://packages.ubuntu.com/bionic/python3-netifaces
* Fedora https://apps.fedoraproject.org/packages/python3-netifaces
* Gentoo https://packages.gentoo.org/packages/dev-python/netifaces

This is a python3 equivalent to `python-netifaces` which is used by

```
./ros_comm/rosgraph/package.xml
```