### PR TITLE
Add python3-coverage key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4922,6 +4922,11 @@ python3-catkin-pkg-modules:
   openembedded: [python3-catkin-pkg@meta-ros]
   rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg-modules]
+python3-coverage:
+  debian: [python3-coverage]
+  fedora: [python3-coverage]
+  gentoo: [dev-python/coverage]
+  ubuntu: [python3-coverage]
 python3-cryptography:
   debian: [python3-cryptography]
   fedora: [python3-cryptography]


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-coverage
* Ubuntu https://packages.ubuntu.com/bionic/python3-coverage
* Fedora https://apps.fedoraproject.org/packages/python3-coverage
* Gentoo https://packages.gentoo.org/packages/dev-python/coverage

This is a python3 equivalent to `python-coverage` which is used by

```
./rospack/package.xml
```