### PR TITLE
Add python3-catkin-pkg key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4915,6 +4915,11 @@ python3-cairo:
     slackpkg:
       packages: [py3cairo]
   ubuntu: [python3-cairo]
+python3-catkin-pkg:
+  debian: [python3-catkin-pkg]
+  fedora: [python3-catkin_pkg]
+  gentoo: [dev-python/catkin_pkg]
+  ubuntu: [python3-catkin-pkg]
 python3-catkin-pkg-modules:
   debian: [python3-catkin-pkg-modules]
   fedora: [python3-catkin_pkg]


### PR DESCRIPTION
I included links to upstream; though, for this one we want to use the package from packages.ros.org.

* Debian https://packages.debian.org/buster/python3-catkin-pkg
* Ubuntu https://packages.ubuntu.com/bionic/python3-catkin-pkg
* Fedora https://apps.fedoraproject.org/packages/python3-catkin_pkg
* Gentoo https://packages.gentoo.org/packages/dev-python/catkin_pkg

This is a python3 equivalent to `python-catkin-pkg` which is used by

```
./rospack/package.xml
./catkin/package.xml
./kdl_parser/kdl_parser_py/package.xml
```