### PR TITLE
Add python3-rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5165,6 +5165,11 @@ python3-qt5-bindings:
   opensuse: [python3-qt5]
   slackware: [python3-PyQt5]
   ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+python3-rosdep:
+  debian: [python3-rosdep]
+  fedora: [python3-rosdep]
+  gentoo: [dev-util/rosdep]
+  ubuntu: [python3-rosdep]
 python3-rospkg:
   alpine:
     pip:


### PR DESCRIPTION
This key is not using debian upstream package python3-rosdep2. Instead it is using the package python3-rosdep from packages.ros.org

* Debian - 
* Ubuntu - 
* Fedora https://apps.fedoraproject.org/packages/python3-rosdep
* Gentoo https://packages.gentoo.org/packages/dev-util/rosdep

This is a python3 equivalent to `python-rosdep` which is used by

```
./rospack/package.xml
```