### PR TITLE
jderobot_drones: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5222,6 +5222,20 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
+  jderobot_drones:
+    release:
+      packages:
+      - drone_wrapper
+      - rqt_drone_teleop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/JdeRobot/drones-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/JdeRobot/drones.git
+      version: master
+    status: developed
   jog_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `0.0.1-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## drone_wrapper

```
* updated makefile
* removed packages requiring source builds
* converted returns to numpy arrays
* made DroneWrapper importable
* Added files from colab-gsoc2019-Nikhil_Khedekar
* Contributors: Nikhil Khedekar
```

## rqt_drone_teleop

```
* updated makefile
* updated ui and functionality
* updated teleop
* added screenshot
* added mode 2 sticks
* changed casing and fixed image path for teleop
* corrected perspective
* shifted to a common teleop
* Contributors: Nikhil Khedekar
```
