### PR TITLE
jderobot_assets: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5222,6 +5222,17 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
+  jderobot_assets:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/JdeRobot/assets-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/JdeRobot/assets.git
+      version: kinetic-devel
+    status: developed
   jog_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `0.0.1-1`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jderobot_assets

```
* added position control
* added rescue people
* added visual_lander
* added catkin package with follow road and labyrinth models and worlds
* Contributors: Nikhil Khedekar
```
