### PR TITLE
Apriltag message and node release

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -161,21 +161,14 @@ repositories:
       version: master
     status: maintained
   apriltag_msgs:
-    doc:
-      type: git
-      url: https://github.com/christianrauch/apriltag_ros.git
-      version: master
     release:
-      packages:
-      - apriltag_msgs
-      - apriltag_ros
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/christianrauch/apriltag_ros-release.git
-      version: 2.0.0-1
+      url: https://github.com/christianrauch/apriltag_msgs-release.git
+      version: 2.0.0-2
     source:
       type: git
-      url: https://github.com/christianrauch/apriltag_ros.git
+      url: https://github.com/christianrauch/apriltag_msgs.git
       version: master
     status: developed
   behaviortree_cpp:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -171,6 +171,17 @@ repositories:
       url: https://github.com/christianrauch/apriltag_msgs.git
       version: master
     status: developed
+  apriltag_ros:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/christianrauch/apriltag_ros-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
+    status: developed
   behaviortree_cpp:
     release:
       tags:


### PR DESCRIPTION
I generated these updates to rosdistro manually as it involves changes to the package hierarchy that bloom couldn't process.

Previously, there was a single release repository for the two packages `apriltag_msgs` and `apriltag_ros` (where one included the other as git submodule). To avoid having to synchronise the version of both source repos when only one changes, I created two dedicated release repositories for `apriltag_msgs` and `apriltag_ros`.