### PR TITLE
jackal_desktop: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2705,6 +2705,24 @@ repositories:
       url: https://github.com/jackal/jackal.git
       version: kinetic-devel
     status: maintained
+  jackal_desktop:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - jackal_desktop
+      - jackal_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_desktop-release.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_desktop.git
+      version: kinetic-devel
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_desktop` to `0.3.2-1`:

- upstream repository: https://github.com/jackal/jackal_desktop.git
- release repository: https://github.com/clearpath-gbp/jackal_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jackal_desktop

- No changes

## jackal_viz

```
* Changed laser scan topics to /front/scan.
* Contributors: Tony Baltovski
```
