### PR TITLE
jackal_simulator: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2725,6 +2725,24 @@ repositories:
       url: https://github.com/jackal/jackal_desktop.git
       version: kinetic-devel
     status: maintained
+  jackal_simulator:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_simulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - jackal_gazebo
+      - jackal_simulator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_simulator-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_simulator.git
+      version: kinetic-devel
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_simulator` to `0.3.0-1`:

- upstream repository: https://github.com/jackal/jackal_simulator
- release repository: https://github.com/clearpath-gbp/jackal_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jackal_gazebo

```
* Add small hack to continue supporting the front_laser:=true arg, since that was prominently documented.
* Change from individual accessory args to a single "config" arg.
* Contributors: Mike Purvis
```

## jackal_simulator

- No changes
