### PR TITLE
ridgeback_desktop: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5963,6 +5963,24 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: kinetic-devel
     status: maintained
+  ridgeback_desktop:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ridgeback_desktop
+      - ridgeback_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_desktop.git
+      version: kinetic-devel
+    status: maintained
   robosense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_desktop
- release repository: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ridgeback_desktop

- No changes

## ridgeback_viz

```
* Updated laser scan topic.
* Contributors: Tony Baltovski
```
