### PR TITLE
warthog_desktop: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9005,6 +9005,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog.git
       version: kinetic-devel
     status: maintained
+  warthog_desktop:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    release:
+      packages:
+      - warthog_desktop
+      - warthog_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_desktop-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_desktop.git
+      version: indigo-devel
+    status: maintained
   web_video_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_desktop` to `0.0.1-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_desktop.git
- release repository: https://github.com/clearpath-gbp/warthog_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## warthog_desktop

```
* Initial commit.
* Contributors: Tony Baltovski
```

## warthog_viz

```
* Initial commit.
* Contributors: Tony Baltovski
```
