### PR TITLE
ridgeback_simulator: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6004,6 +6004,25 @@ repositories:
       type: git
       url: https://github.com/ridgeback/ridgeback_desktop.git
       version: kinetic-devel
+  ridgeback_simulator:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: melodic-devel
+    release:
+      packages:
+      - mecanum_gazebo_plugin
+      - ridgeback_gazebo
+      - ridgeback_gazebo_plugins
+      - ridgeback_simulator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_simulator.git
+      version: melodic-devel
     status: maintained
   robosense:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.1.0-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## mecanum_gazebo_plugin

- No changes

## ridgeback_gazebo

- No changes

## ridgeback_gazebo_plugins

```
* [ridgeback_gazebo_plugins] Updated dependency for Gazebo 9.
* Removing commented includes
* Changes to make the pkg compatible with Gazebo 9 libraries
* Contributors: Tony Baltovski, YoshuaNava
```

## ridgeback_simulator

- No changes
