### PR TITLE
seed_smartactuator_sdk: 0.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13578,7 +13578,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/seed-solutions/seed_smartactuator_sdk.git
-      version: pre-release
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -13588,7 +13588,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/seed-solutions/seed_smartactuator_sdk.git
-      version: prerelease
+      version: master
     status: developed
   segway_rmp:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13574,6 +13574,22 @@ repositories:
       url: https://github.com/JdeRobot/Scratch4Robots.git
       version: master
     status: developed
+  seed_smartactuator_sdk:
+    doc:
+      type: git
+      url: https://github.com/seed-solutions/seed_smartactuator_sdk.git
+      version: pre-release
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
+      version: 0.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/seed-solutions/seed_smartactuator_sdk.git
+      version: prerelease
+    status: developed
   segway_rmp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_smartactuator_sdk` to `0.0.3-1`:

- upstream repository: https://github.com/seed-solutions/seed_smartactuator_sdk.git
- release repository: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
