### PR TITLE
rqt_robot_monitor: 0.5.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7336,7 +7336,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_monitor-release.git
-      version: 0.5.8-0
+      version: 0.5.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_monitor` to `0.5.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_monitor.git
- release repository: https://github.com/ros-gbp/rqt_robot_monitor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.8-0`

## rqt_robot_monitor

```
* refactored code and made signaling more efficient
* stale messages appear now in the error pane
```
