### PR TITLE
rospy_wrapper: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12415,6 +12415,16 @@ repositories:
       url: https://github.com/uos/rospy_message_converter.git
       version: master
     status: maintained
+  rospy_wrapper:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/sean-hackett/rospy_wrapper-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/sean-hackett/rospy_wrapper.git
+      version: master
   rosserial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_wrapper` to `1.0.0-1`:

- upstream repository: https://github.com/sean-hackett/rospy_wrapper.git
- release repository: https://github.com/sean-hackett/rospy_wrapper-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rospy_wrapper

```
* first public release of rospy_wrapper
```
