### PR TITLE
rtabmap/rtabmap_ros: 0.19.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13206,7 +13206,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.17.6-0
+      version: 0.19.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -13221,7 +13221,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.17.6-0
+      version: 0.19.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repositories `rtabmap` and `rtabmap_ros` to `0.19.3-1`:

- upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.17.6-0`