### PR TITLE
add rules for pytest-mock

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3276,6 +3276,12 @@ python-pytest-dependency-pip:
   ubuntu:
     pip:
       packages: [pytest-dependency]
+python-pytest-mock:
+  arch: [python2-pytest-mock]
+  debian: [python-pytest-mock]
+  fedora: [python-pytest-mock]
+  gentoo: [dev-python/pytest-mock]
+  ubuntu: [python-pytest-mock]
 python-pytest-qt-pip:
   debian:
     pip:
@@ -5189,6 +5195,17 @@ python3-pytest:
   openembedded: [python3-pytest@meta-python]
   rhel: ['python%{python3_pkgversion}-pytest']
   ubuntu: [python3-pytest]
+python3-pytest-mock:
+  alpine: [py3-pytest-mock]
+  arch: [python-pytest-mock]
+  debian: [python3-pytest-mock]
+  fedora: [python3-pytest-mock]
+  gentoo: [dev-python/pytest-mock]
+  openembedded:
+    pip:
+      packages: [pytest-mock]
+  rhel: ['python%{python3_pkgversion}-pytest-mock']
+  ubuntu: [python3-pytest-mock]
 python3-qt5-bindings:
   arch: [python-pyqt5]
   debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5201,9 +5201,6 @@ python3-pytest-mock:
   debian: [python3-pytest-mock]
   fedora: [python3-pytest-mock]
   gentoo: [dev-python/pytest-mock]
-  openembedded:
-    pip:
-      packages: [pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-qt5-bindings:


### PR DESCRIPTION
- Debian https://packages.debian.org/buster/python3-pytest-mock
- Fedora https://apps.fedoraproject.org/packages/python-pytest-mock
- Gentoo https://packages.gentoo.org/packages/dev-python/pytest-mock
- Ubuntu https://packages.ubuntu.com/bionic/python3-pytest-mock

Add rosdep rules for pytest-mock, a thin wrapper around unittest.mock for pytest

Used in
```
./ament/ament_lint/ament_mypy/package.xml
```

Signed-off-by: Ted Kern <ted.kern@canonical.com>