### PR TITLE
pr2_ethercat_drivers: 1.8.19-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5290,7 +5290,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
-      version: 1.8.18-0
+      version: 1.8.19-1
     source:
       type: git
       url: https://github.com/pr2/pr2_ethercat_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.8.19-1`:

- upstream repository: https://github.com/pr2/pr2_ethercat_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.8.18-0`

## ethercat_hardware

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#76 <https://github.com/PR2/pr2_ethercat_drivers/issues/76>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## fingertip_pressure

- No changes

## pr2_ethercat_drivers

- No changes
