### PR TITLE
pr2_controllers: 1.10.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5275,7 +5275,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_controllers-release.git
-      version: 1.10.15-1
+      version: 1.10.16-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_controllers.git
+      version: melodic-devel
     status: unmaintained
   pr2_ethercat_drivers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.16-1`:

- upstream repository: https://github.com/pr2/pr2_controllers.git
- release repository: https://github.com/pr2-gbp/pr2_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.10.15-1`

## ethercat_trigger_controllers

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#393 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## joint_trajectory_action

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#394 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## pr2_calibration_controllers

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#394 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## pr2_controllers

- No changes

## pr2_controllers_msgs

- No changes

## pr2_gripper_action

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#394 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## pr2_head_action

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#394 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## pr2_mechanism_controllers

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#394 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## robot_mechanism_controllers

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#394 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## single_joint_position_action

```
* Make sure to include the correct boost libraries.
  This follows the principle of "include what you use", and
  also should in theory fix the problems on the build farm.
  (#394 <https://github.com/PR2/pr2_controllers/issues/394>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```
