### PR TITLE
rosdep: fix python-ipdb ubuntu value

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1980,8 +1980,7 @@ python-inputs-pip:
 python-ipdb:
   debian: [python-ipdb]
   gentoo: [dev-python/ipdb]
-  ubuntu:
-    packages: [python-ipdb]
+  ubuntu: [python-ipdb]
 python-itsdangerous:
   debian:
     buster: [python-itsdangerous]


### PR DESCRIPTION
'packages' is not a valid ubuntu version. This appears to have been a
typo and would prevent this package from working on any ubuntu version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ros/rosdistro/21839)
<!-- Reviewable:end -->
