### PR TITLE
cloudwatch_logger: 2.2.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1319,7 +1319,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_logger-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchlogs-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_logger` to `2.2.1-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatchlogs-ros1.git
- release repository: https://github.com/aws-gbp/cloudwatch_logger-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.2.0-1`

## cloudwatch_logger

```
* Increment version (#48 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/48>)
  * increment version for binary packaging fix
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * cleanup README
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Merge pull request #49 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/49> from aws-robotics/remove-debug-flag
  Minor updates for offline feature release
* 
  
    * remove debug flag (run with level info)
    * minor README changes
  
* install missing library (#47 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/47>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* increment version for offline logs feature (#46 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/46>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Fixing std_msgs, std_srvs dependency resolution (#44 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/44>)
  * Add build_depend on std_srvs, std_msgs
  * Add std_msgs to CMakeLists.txt
* Find std_srvs in CMakeLists.txt
* Offline Logs (#42 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/42>)
  * Working branch with offline feature
  cr https://code.amazon.com/reviews/CR-9548516
  * Addressed review comments
  * ROS-1775: Adapt Interfaces to CW Metrics
  cr https://code.amazon.com/reviews/CR-9600347
  * ROS-2223: Add ROS Service Method to LogNode
  cr https://code.amazon.com/reviews/CR-10013824
  * Read in parameters for UploaderOptions and FileManagerOptions
  - Read in the parameters for the UploadOptions struct and the
  FileManagerOptions struct so that we can create the CloudWatchOptions
  struct from them and initialize CloudWatchLogs with it.
  cr https://code.amazon.com/reviews/CR-10144869
  * Add sample configuration options, fix bugs
  - Add sample config options to the sample_configuration.yaml file
  - Fix bugs and finish off config feature
  * Add descriptions for config options
  * Don't publish on a timer when trigger_publish_size is set.
  - When the user has specifid a batch_trigger_publish_size, don't set a
  timer to publish logs, only publish when that size limit has been hit.
  * Fixing bugs, adding docs to parameter reader
  - Fix parameter reader to give a warning if a uploader option is missing
  instead of an error.
  - Add documentation for param reader functions
  - Re-order config file options to be alphabetical, set the defaults to
  the same as the app defaults.
  - Fix output flag not working when running sample_application.launch
  cr https://code.amazon.com/reviews/CR-10331731
  * ROS-2330: [Bug] CW Logs ROS1 Timer incorrectly created
  cr https://code.amazon.com/reviews/CR-10541864
  * Move parameters to README, remove unused parameters
  - Move most of the parameters out of the sample_configuration file and
  into the README instead.
  - Make function return codes void if the return value is always OK.
  - Clean up parameter reading
  * Improve README
  * Fix un-renamed function
  * Add stream_max_queue_size parameter
  - Add reading this parameter from config file and describing it in the
  advanced parameters section of the README.
  cr https://code.amazon.com/reviews/CR-10582850
  *  - support service changes
  - fix variable names
  - update build flags
* Use standard CMake macros for adding gtest/gmock tests (#37 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/37>)
  * modify cloudwatch_logger to use add_rostest_gmock()
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml to be compatible with specifying multiple package names
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Update package.xml for 2.1.0 release
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
* Adds a new parameter for a list of node names to ignore logs from. (#24 <https://github.com/aws-robotics/cloudwatchlogs-ros1/issues/24>)
  * Adds a new parameter for a list of node names to ignore logs from.
* Removing old file that has already been refactored out into separate files.
* Contributors: AAlon, Devin Bonnie, M. M, Nick Burek, Ryan Newell
```
