### PR TITLE
Add python3-defusedxml key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4923,6 +4923,11 @@ python3-cryptography:
   debian: [python3-cryptography]
   fedora: [python3-cryptography]
   ubuntu: [python3-cryptography]
+python3-defusedxml:
+  debian: [python3-defusedxml]
+  fedora: [python3-defusedxml]
+  gentoo: [dev-python/defusedxml]
+  ubuntu: [python3-defusedxml]
 python3-dev:
   debian: [python3-dev]
   fedora: [python3-devel]


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-defusedxml
* Ubuntu https://packages.ubuntu.com/bionic/python3-defusedxml
* Fedora https://apps.fedoraproject.org/packages/python3-defusedxml
* Gentoo https://packages.gentoo.org/packages/dev-python/defusedxml

This is a python3 equivalent to `python-defusedxml` which is used by

```
./ros_comm/rosmaster/package.xml
```