### PR TITLE
Add python3-gnupg key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4986,6 +4986,11 @@ python3-gitlab:
     xenial:
       pip:
         packages: [python-gitlab]
+python3-gnupg:
+  debian: [python3-gnupg]
+  fedora: [python3-gnupg]
+  gentoo: [dev-python/python-gnupg]
+  ubuntu: [python3-gnupg]
 python3-lark-parser:
   fedora:
     '*': [python3-lark-parser]


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-gnupg
* Ubuntu https://packages.ubuntu.com/bionic/python3-gnupg
* Fedora https://apps.fedoraproject.org/packages/python3-gnupg
* Gentoo https://packages.gentoo.org/packages/dev-python/python-gnupg

This is a python3 equivalent to `python-gnupg` which is used by

```
./ros_comm/rosbag/package.xml
```
