### PR TITLE
Add python3-opengl key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5061,6 +5061,11 @@ python3-opencv:
   openembedded: [opencv@meta-oe]
   ubuntu:
     bionic: [python3-opencv]
+python3-opengl:
+  debian: [python3-opengl]
+  fedora: [python3-pyopengl]
+  gentoo: [dev-python/pyopengl]
+  ubuntu: [python3-opengl]
 python3-pandas:
   debian: [python3-pandas]
   fedora: [python3-pandas]


### PR DESCRIPTION
* Debian https://packages.debian.org/buster/python3-opengl
* Ubuntu https://packages.ubuntu.com/bionic/python3-opengl
* Fedora https://apps.fedoraproject.org/packages/python3-pyopengl
* Gentoo https://packages.gentoo.org/packages/dev-python/pyopengl

This is a python3 equivalent to `python-opengl` which is used by

```
./rqt_pose_view/package.xml
```