### PR TITLE
Add some RHEL rules for existing keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -427,6 +427,7 @@ cmake:
   macports: [cmake]
   openembedded: [cmake@openembedded-core]
   opensuse: [cmake]
+  rhel: [cmake3]
   slackware:
     slackpkg:
       packages: [cmake]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1119,6 +1119,7 @@ python-crypto:
 python-cryptography:
   debian: [python-cryptography]
   gentoo: [dev-python/cryptography]
+  rhel: [python2-cryptography]
   ubuntu: [python-cryptography]
 python-cwiid:
   arch: [cwiid]
@@ -2135,6 +2136,7 @@ python-lxml:
   osx:
     pip:
       packages: [lxml]
+  rhel: [python-lxml]
   ubuntu: [python-lxml]
 python-lzf-pip:
   debian:
@@ -4922,6 +4924,7 @@ python3-coverage:
 python3-cryptography:
   debian: [python3-cryptography]
   fedora: [python3-cryptography]
+  rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
 python3-dev:
   debian: [python3-dev]
@@ -5003,6 +5006,7 @@ python3-lxml:
   debian: [python3-lxml]
   fedora: [python3-lxml]
   openembedded: [python3-lxml@meta-python]
+  rhel: ['python%{python3_pkgversion}-lxml']
   ubuntu: [python3-lxml]
 python3-matplotlib:
   arch: [python-matplotlib]


### PR DESCRIPTION
All packages available in either base or EPEL repositories:
```
$ yum list -q available --showduplicates cmake3 python2-cryptography python-lxml python36-cryptography python36-lxml
Available Packages
cmake3.x86_64                       3.13.5-1.el7         epel
python-lxml.x86_64                  3.2.1-4.el7          base
python2-cryptography.x86_64         1.7.2-2.el7          base
python36-cryptography.x86_64        2.3-2.el7            epel
python36-lxml.x86_64                4.2.5-3.el7          epel
```

For EPEL:
* cmake3: https://apps.fedoraproject.org/packages/cmake3
* python36-cryptography: https://apps.fedoraproject.org/packages/python3-cryptography
* python36-lxml: https://apps.fedoraproject.org/packages/python3-lxml