### PR TITLE
ros2_tracing: 0.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1368,7 +1368,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.2.0-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-1`

## tracetools

```
* Add option to compile out LTTng entirely
* Fix ament_target_dependencies() for tracetools status executable
* Remove bash scripts
* Enable tracing by default if LTTng is available
* Fix test_utils never getting built
* Contributors: Christophe Bedard, Ingo Lütkebohle, Tobias Blass
```

## tracetools_read

```
* Include event data in 'field not found' error message
* Remove cpu_id from list of ignored CTF fields
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Enable tracing by default if LTTng is available
* Contributors: Christophe Bedard, Tobias Blass
```
