### PR TITLE
ament_lint: 0.7.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -83,7 +83,9 @@ repositories:
     release:
       packages:
       - ament_clang_format
+      - ament_clang_tidy
       - ament_cmake_clang_format
+      - ament_cmake_clang_tidy
       - ament_cmake_copyright
       - ament_cmake_cppcheck
       - ament_cmake_cpplint
@@ -99,6 +101,7 @@ repositories:
       - ament_cppcheck
       - ament_cpplint
       - ament_flake8
+      - ament_lint
       - ament_lint_auto
       - ament_lint_cmake
       - ament_lint_common
@@ -111,7 +114,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.7.4-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.3-1`
