### PR TITLE
rosbag2: 0.1.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1464,7 +1464,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.1.4-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.3-1`

## ros2bag

- No changes

## rosbag2

```
* Exported pluginlib dependency to downstream packages (#144 <https://github.com/ros2/rosbag2/issues/144>)
* Contributors: Esteve Fernandez, Michel Hidalgo
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

```
* Exported pluginlib dependency to downstream packages (#144 <https://github.com/ros2/rosbag2/issues/144>)
* Contributors: Esteve Fernandez, Michel Hidalgo
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
