### PR TITLE
launch_ros: 0.8.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -661,7 +661,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.8.4-1
+      version: 0.8.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.5-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.4-1`

## launch_ros

```
* Use wildcard syntax in generated parameter YAML files (#48 <https://github.com/ros2/launch_ros/issues/48>)
* Contributors: Scott K Logan
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
