### PR TITLE
rviz: 6.1.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1897,7 +1897,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 6.1.2-1
+      version: 6.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.1.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `6.1.2-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix deprecation warnings with new Qt (#435 <https://github.com/ros2/rviz/issues/435>) (#436 <https://github.com/ros2/rviz/issues/436>)
* Contributors: William Woodall
```

## rviz_default_plugins

```
* Mojave compatibility (#414 <https://github.com/ros2/rviz/issues/414>) (#433 <https://github.com/ros2/rviz/issues/433>)
* Fix map display (#425 <https://github.com/ros2/rviz/issues/425>) (#432 <https://github.com/ros2/rviz/issues/432>)
* Contributors: Martin Idel, Jacob Perron, Karsten Knese
```

## rviz_ogre_vendor

```
* Mojave compatibility (#414 <https://github.com/ros2/rviz/issues/414>) (#433 <https://github.com/ros2/rviz/issues/433>)
* Contributors: Karsten Knese
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
