### PR TITLE
jderobot_drones: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5242,7 +5242,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 0.0.1-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.0.0-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-1`

## drone_wrapper

```
* corrected dependancies
* Contributors: Nikhil Khedekar
```

## rqt_drone_teleop

```
* corrected dependancies
* stop drone button now also stops code
* updated gui image
* removed launch and perspective
* Contributors: Nikhil Khedekar
```
