### PR TITLE
health_metric_collector: 2.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2299,7 +2299,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/health_metric_collector-release.git
-      version: 2.0.0-0
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/health-metrics-collector-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `health_metric_collector` to `2.0.1-1`:

- upstream repository: https://github.com/aws-robotics/health-metrics-collector-ros1.git
- release repository: https://github.com/aws-gbp/health_metric_collector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-0`

## health_metric_collector

```
* update changelog to be compatible with catkin_generate_changelog (#21 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/21>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* increment patch version (#20 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/20>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Use standard CMake macros for adding gtest/gmock tests (#16 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/16>)
  * modify health_metric_collector to use add_rostest_gmock()
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml to be compatible with specifying multiple package names
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* [Master branch] CE pipeline migration (#12 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/12>)
  * cherry picking Get dependencies from rosdep instead of building from release-v1 to master
  * cherry picking ce pipeline migration commit from release-v1 to master
  * untag dependency version
  * remove cloudwatch_metrics_collector as exec depend
* Release 2.0.0 (#9 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/9>)
  * Release 2.0.0
  * 2.0.0
* Update to use non-legacy ParameterReader API (#7 <https://github.com/aws-robotics/health-metrics-collector-ros1/issues/7>)
  * Update to use non-legacy ParameterReader API
  * increment package version
* Contributors: AAlon, Abby Xu, M. M
```
