### PR TITLE
ros_monitoring_msgs: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6506,7 +6506,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
-      version: 1.0.0-0
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/monitoringmessages-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_monitoring_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/aws-robotics/monitoringmessages-ros1.git
- release repository: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-0`

## ros_monitoring_msgs

```
* increment patch version (#19 <https://github.com/aws-robotics/monitoringmessages-ros1/issues/19>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Contributors: M. M
```
