### PR TITLE
tts: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8250,7 +8250,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/tts-release.git
-      version: 1.0.1-0
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/tts-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tts` to `1.0.2-1`:

- upstream repository: https://github.com/aws-robotics/tts-ros1.git
- release repository: https://github.com/aws-gbp/tts-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-0`

## tts

```
* update changelog to be compatible with catkin_generate_changelog (#28 <https://github.com/aws-robotics/tts-ros1/issues/28>)
  Signed-off-by: y² <mailto:forresty@amazon.com>
* increment patch version (#27 <https://github.com/aws-robotics/tts-ros1/issues/27>)
  Signed-off-by: y² <mailto:forresty@amazon.com>
* Release 1.0.1 (#9 <https://github.com/aws-robotics/tts-ros1/issues/9>)
  * Release 1.0.1
  * 1.0.1
* Merge pull request #2 <https://github.com/aws-robotics/tts-ros1/issues/2> from yyu/fix
  no assert_called() for older versions of mock
* no assert_called() for older versions of mock
* remove rostest from top level find_package (#1 <https://github.com/aws-robotics/tts-ros1/issues/1>)
  It's conditionally found in the testing section only so it's only a test_depend
* Contributors: AAlon, M. M, Tully Foote, Yuan "Forrest" Yu, y²
```
