### PR TITLE
warthog_simulator: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16059,6 +16059,24 @@ repositories:
       url: https://github.com/warthog-cpr/warthog_desktop.git
       version: indigo-devel
     status: maintained
+  warthog_simulator:
+    doc:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: kinetic-devel
+    release:
+      packages:
+      - warthog_gazebo
+      - warthog_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/warthog_simulator-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/warthog-cpr/warthog_simulator.git
+      version: kinetic-devel
+    status: maintained
   waypoint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_simulator` to `0.1.0-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_simulator.git
- release repository: https://github.com/clearpath-gbp/warthog_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## warthog_gazebo

```
* Set a blank default world
* Re added world selection in gazebo launch
* Removed unnecessary laser argument in world launch
* Added C11 compiling
* [warthog_gazebo] Updated joint names.
* Initial commit.
* Contributors: Dave Niewinski, Tony Baltovski
```

## warthog_simulator

```
* Initial commit.
* Contributors: Tony Baltovski
```
