### PR TITLE
jderobot_assets: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5229,11 +5229,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git
       version: kinetic-devel
+    status: developed
   jderobot_drones:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `0.0.2-1`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-1`

## jderobot_assets

```
* updated dependancies
* switched to car with beacon
* added follow_turtlebot
* added perspectives
* Contributors: Nikhil Khedekar
```
