### PR TITLE
rosparam_handler: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6895,6 +6895,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: lunar-devel
     status: maintained
+  rosparam_handler:
+    doc:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/cbandera/rosparam_handler-release.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/cbandera/rosparam_handler.git
+      version: master
+    status: maintained
   rosparam_shortcuts:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_handler` to `0.1.4-1`:

- upstream repository: https://github.com/cbandera/rosparam_handler.git
- release repository: https://github.com/cbandera/rosparam_handler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rosparam_handler

```
* update doc
* fix #57 <https://github.com/cbandera/rosparam_handler/issues/57>
  replace map/vec custom stream op by func
* update readme
* add toConfig
* Fix #47 <https://github.com/cbandera/rosparam_handler/issues/47>
  Do not print error message while retrieving param with default value.
* Contributors: Jeremie Deray, artivis
```
