### PR TITLE
distance_map: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2360,6 +2360,26 @@ repositories:
       url: https://github.com/piraka9011/dialogflow_ros.git
       version: kinetic-devel
     status: developed
+  distance_map:
+    release:
+      packages:
+      - distance_map
+      - distance_map_core
+      - distance_map_deadreck
+      - distance_map_msgs
+      - distance_map_node
+      - distance_map_opencv
+      - distance_map_rviz
+      - distance_map_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/artivis/distance_map-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/artivis/distance_map.git
+      version: master
+    status: maintained
   dmu_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `distance_map` to `0.1.0-1`:

- upstream repository: https://github.com/artivis/distance_map.git
- release repository: https://github.com/artivis/distance_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## distance_map

```
* Initial release
```

## distance_map_core

```
* Initial release
```

## distance_map_deadreck

```
* Initial release
```

## distance_map_msgs

```
* Initial release
```

## distance_map_node

```
* Initial release
```

## distance_map_opencv

```
* Initial release
```

## distance_map_rviz

```
* Initial release
```

## distance_map_tools

```
* Initial release
```
