### PR TITLE
distance_map: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1136,6 +1136,26 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  distance_map:
+    release:
+      packages:
+      - distance_map
+      - distance_map_core
+      - distance_map_deadreck
+      - distance_map_msgs
+      - distance_map_node
+      - distance_map_opencv
+      - distance_map_rviz
+      - distance_map_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/artivis/distance_map-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/artivis/distance_map.git
+      version: master
+    status: maintained
   driver_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `distance_map` to `0.1.0-1`:

- upstream repository: https://github.com/artivis/distance_map.git
- release repository: https://github.com/artivis/distance_map-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## distance_map

```
* Initial release
```

## distance_map_core

```
* Initial release
```

## distance_map_deadreck

```
* Initial release
```

## distance_map_msgs

```
* Initial release
```

## distance_map_node

```
* Initial release
```

## distance_map_opencv

```
* Initial release
```

## distance_map_rviz

```
* Initial release
```

## distance_map_tools

```
* Initial release
```
