### PR TITLE
nmea_comms: 1.2.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4299,6 +4299,21 @@ repositories:
       url: https://github.com/astuff/network_interface.git
       version: release
     status: developed
+  nmea_comms:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_comms.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_comms-release.git
+      version: 1.2.0-0
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_comms.git
+      version: jade-devel
+    status: maintained
   nmea_gps_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_comms` to `1.2.0-0`:

- upstream repository: https://github.com/ros-drivers/nmea_comms.git
- release repository: https://github.com/ros-drivers-gbp/nmea_comms-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## nmea_comms

```
* Fixed boost::thread_resource_error: Resource temporarily unavailable exception that was thrown using netcat to feed socket_node.cpp with NMEA sentences. (#5 <https://github.com/ros-drivers/nmea_comms/issues/5>)
* Contributors: Avio, Mike Purvis
```
