### PR TITLE
toposens: 1.2.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14756,7 +14756,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.2.2-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.1-1`

## toposens

- No changes

## toposens_description

- No changes

## toposens_driver

```
* Baudrate changed to 576000 to match TS3 firmware version 13
* Firmware version displayed at startup
* Contributors: Andrej Wallwitz, Georgiana Barbut
```

## toposens_markers

- No changes

## toposens_msgs

- No changes

## toposens_pointcloud

- No changes

## toposens_sync

- No changes
