### PR TITLE
fmilibrary_vendor: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -503,6 +503,12 @@ repositories:
       url: https://github.com/boschresearch/fmi_adapter_ros2.git
       version: dashing
     status: developed
+  fmilibrary_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/boschresearch/fmilibrary_vendor-release.git
+      version: 0.1.0-1
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/boschresearch/fmilibrary_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## fmilibrary_vendor

```
* Created vendor package for FMILibrary.
```
