### PR TITLE
ros1_ign: 0.6.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6393,7 +6393,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/osrf/ros1_ign-release.git
-      version: 0.6.0-2
+      version: 0.6.1-1
   ros_canopen:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_ign` to `0.6.1-1`:

- upstream repository: https://github.com/osrf/ros1_ign
- release repository: https://github.com/osrf/ros1_ign-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.0-2`

## ros1_ign

```
* Merge pull request #35 <https://github.com/osrf/ros1_ign_bridge/issues/35> from osrf/image_meta
  Add ros_ign_image to metapackage
* Add ros_ign_image to metapackage
  Signed-off-by: chapulina <mailto:louise@openrobotics.org>
  typo
  Signed-off-by: chapulina <mailto:louise@openrobotics.org>
* Contributors: Nate Koenig, chapulina
```

## ros1_ign_bridge

```
* Update README.md
* Contributors: Carlos Agüero
```

## ros1_ign_gazebo_demos

- No changes

## ros1_ign_image

- No changes

## ros1_ign_point_cloud

- No changes
