### PR TITLE
Adding rx_ros to documentation index for distro melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7627,6 +7627,21 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: melodic-devel
     status: developed
+  rx_ros:
+    doc:
+      type: git
+      url: https://github.com/rosin-project/rx_ros.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rosin-project/rx_ros-release.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/rosin-project/rx_ros.git
+      version: master
+    status: developed
   sainsmart_relay_usb:
     doc:
       type: hg


### PR DESCRIPTION
I'd like rx_ros to be indexed and documented on ros.org.