### PR TITLE
microstrain_mips: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3691,7 +3691,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/microstrain_mips-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/microstrain_mips.git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_mips` to `0.0.3-1`:

- upstream repository: https://github.com/ros-drivers/microstrain_mips.git
- release repository: https://github.com/ros-drivers-gbp/microstrain_mips-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.2-1`

## microstrain_mips

```
* Made diagnostic_updater build dep as well.
* Merge pull request #21 <https://github.com/ros-drivers/microstrain_mips/issues/21> from samkys/cleanup
  Cleanup
* Add roslint and cleaned up files accordingly.
* Cleaned up indentation levels, removed tabs and replaced with spaces, and updated curly brace locations according to: http://wiki.ros.org/CppStyleGuide section 6.
* Cleanup that was forgotten in last commit.
* Added static IMU message covariance population via parameters.
* Contributors: Sam, Tony Baltovski
```
