### PR TITLE
husky: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2403,6 +2403,33 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  husky:
+    doc:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: melodic-devel
+    release:
+      packages:
+      - husky_base
+      - husky_bringup
+      - husky_control
+      - husky_description
+      - husky_desktop
+      - husky_gazebo
+      - husky_msgs
+      - husky_navigation
+      - husky_robot
+      - husky_simulator
+      - husky_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/husky/husky.git
+      version: melodic-devel
+    status: maintained
   ibeo_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.4.0-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## husky_base

- No changes

## husky_bringup

- No changes

## husky_control

- No changes

## husky_description

- No changes

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

```
* Removed frontier_exploration temporarily for Melodic.
* Contributors: Tony Baltovski
```

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

- No changes
