### PR TITLE
Autoware.Auto: 0.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -38,6 +38,8 @@ repositories:
       url: https://gitlab.com/AutowareAuto/AutowareAuto-release.git
       version: 0.0.1-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://gitlab.com/AutowareAuto/AutowareAuto.git
       version: 0.0.1

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -6,6 +6,42 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  Autoware.Auto:
+    doc:
+      type: git
+      url: https://gitlab.com/AutowareAuto/AutowareAuto.git
+      version: 0.0.1
+    release:
+      packages:
+      - autoware_auto_algorithm
+      - autoware_auto_cmake
+      - autoware_auto_create_pkg
+      - autoware_auto_examples
+      - autoware_auto_geometry
+      - autoware_auto_msgs
+      - euclidean_cluster
+      - euclidean_cluster_nodes
+      - hungarian_assigner
+      - kalman_filter
+      - lidar_utils
+      - motion_model
+      - point_cloud_fusion
+      - ray_ground_classifier
+      - ray_ground_classifier_nodes
+      - udp_driver
+      - velodyne_driver
+      - velodyne_node
+      - voxel_grid
+      - voxel_grid_nodes
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/AutowareAuto/AutowareAuto-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://gitlab.com/AutowareAuto/AutowareAuto.git
+      version: 0.0.1
+    status: developed
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `Autoware.Auto` to `0.0.1-1`:

- upstream repository: https://gitlab.com/AutowareAuto/AutowareAuto.git
- release repository: https://gitlab.com/AutowareAuto/AutowareAuto-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
