### PR TITLE
robot_statemachine: 1.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11077,6 +11077,22 @@ repositories:
       version: kinetic-devel
     status: maintained
   robot_statemachine:
+    doc:
+      type: git
+      url: https://github.com/MarcoStb1993/robot_statemachine.git
+      version: master
+    release:
+      packages:
+      - robot_statemachine
+      - rsm_additions
+      - rsm_core
+      - rsm_msgs
+      - rsm_rqt_plugins
+      - rsm_rviz_plugins
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/MarcoStb1993/robot_statemachine-release.git
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/MarcoStb1993/robot_statemachine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_statemachine` to `1.1.1-1`:

- upstream repository: https://github.com/MarcoStb1993/robot_statemachine.git
- release repository: https://github.com/MarcoStb1993/robot_statemachine-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
