### PR TITLE
cob_extern: 0.6.13-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1562,6 +1562,16 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: developed
+  cob_extern_unmaintained:
+    release:
+      packages:
+      - libconcorde_tsp_solver
+      - libqsopt
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa320/cob_extern-release.git
+      version: 0.6.12-0
+    status: unmaintained
   cob_gazebo_plugins:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1548,17 +1548,15 @@ repositories:
     release:
       packages:
       - cob_extern
-      - libconcorde_tsp_solver
       - libdlib
       - libntcan
       - libpcan
       - libphidgets
-      - libqsopt
       - opengm
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.12-0
+      version: 0.6.13-1
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.13-1`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.12-0`

## cob_extern

```
* Merge pull request #99 <https://github.com/ipa320/cob_extern/issues/99> from fmessmer/travis_melodic
  [Melodic] melodify
* remove libqsopt
* remove libconcorde_tsp_solver
* Contributors: Benjamin Maidel, fmessmer
```

## libdlib

- No changes

## libntcan

- No changes

## libpcan

- No changes

## libphidgets

- No changes

## opengm

- No changes
