### PR TITLE
cob_extern: 0.6.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -764,6 +764,28 @@ repositories:
       url: https://github.com/ipa320/cob_environments.git
       version: indigo_dev
     status: maintained
+  cob_extern:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_extern.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_extern
+      - libdlib
+      - libntcan
+      - libpcan
+      - libphidgets
+      - opengm
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_extern-release.git
+      version: 0.6.13-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_extern.git
+      version: indigo_dev
+    status: maintained
   code_coverage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.13-1`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_extern

```
* Merge pull request #99 <https://github.com/ipa320/cob_extern/issues/99> from fmessmer/travis_melodic
  [Melodic] melodify
* remove libqsopt
* remove libconcorde_tsp_solver
* Contributors: Benjamin Maidel, fmessmer
```

## libdlib

- No changes

## libntcan

- No changes

## libpcan

- No changes

## libphidgets

- No changes

## opengm

- No changes
