### PR TITLE
cob_supported_robots: 0.6.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1745,7 +1745,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.11-0
+      version: 0.6.12-1
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.12-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.11-0`

## cob_supported_robots

```
* Merge pull request #21 <https://github.com/ipa320/cob_supported_robots/issues/21> from fmessmer/melodify
  [Melodic] add melodic checks
* add melodic support
* add cob4-22
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer
```
