### PR TITLE
cob_supported_robots: 0.6.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -786,6 +786,21 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: maintained
+  cob_supported_robots:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_supported_robots.git
+      version: indigo_release_candidate
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_supported_robots-release.git
+      version: 0.6.12-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_supported_robots.git
+      version: indigo_dev
+    status: maintained
   code_coverage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.12-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_supported_robots

```
* Merge pull request #21 <https://github.com/ipa320/cob_supported_robots/issues/21> from fmessmer/melodify
  [Melodic] add melodic checks
* add melodic support
* add cob4-22
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer
```
