### PR TITLE
cob_calibration_data: 0.6.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1400,7 +1400,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.11-0
+      version: 0.6.12-1
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.12-1`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.11-0`

## cob_calibration_data

```
* Merge pull request #154 <https://github.com/ipa320/cob_calibration_data/issues/154> from fmessmer/melodify
  [Melodic] add melodic checks
* add melodic support
* Merge pull request #153 <https://github.com/ipa320/cob_calibration_data/issues/153> from HannesBachter/add_cob4-22
  add cob4-22
* add cob4-22
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer, hyb
```
