### PR TITLE
cob_perception_common: 0.6.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -832,6 +832,31 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: maintained
+  cob_perception_common:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_perception_common.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_3d_mapping_msgs
+      - cob_cam3d_throttle
+      - cob_image_flip
+      - cob_object_detection_msgs
+      - cob_object_detection_visualizer
+      - cob_perception_common
+      - cob_perception_msgs
+      - cob_vision_utils
+      - ipa_3d_fov_visualization
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_perception_common-release.git
+      version: 0.6.14-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_perception_common.git
+      version: indigo_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.6.14-1`:

- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_3d_mapping_msgs

- No changes

## cob_cam3d_throttle

- No changes

## cob_image_flip

- No changes

## cob_object_detection_msgs

- No changes

## cob_object_detection_visualizer

- No changes

## cob_perception_common

- No changes

## cob_perception_msgs

- No changes

## cob_vision_utils

- No changes

## ipa_3d_fov_visualization

- No changes
