### PR TITLE
cob_hand: 0.6.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1594,7 +1594,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_hand-release.git
-      version: 0.6.5-0
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/ipa320/cob_hand.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_hand` to `0.6.6-1`:

- upstream repository: https://github.com/ipa320/cob_hand.git
- release repository: https://github.com/ipa320/cob_hand-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.5-0`

## cob_hand

- No changes

## cob_hand_bridge

- No changes
