### PR TITLE
cob_common: 0.7.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1448,7 +1448,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.6.12-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1436,7 +1436,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_common.git
-      version: indigo_release_candidate
+      version: kinetic_release_candidate
     release:
       packages:
       - cob_actions
@@ -1452,7 +1452,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git
-      version: indigo_dev
+      version: kinetic_dev
     status: developed
   cob_control:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.0-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.12-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

```
* Merge pull request #271 <https://github.com/ipa320/cob_common/issues/271> from benmaidel/feature/melodify
  [Melodic]
* fix default value
* more hardware_interface prefixing
* fixed xacro:if condition for melodic
* added hardware_interface prefix for transmission (melodic's cob_gazebo_ros_control plugin expects it)
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer
```

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

```
* Merge pull request #271 <https://github.com/ipa320/cob_common/issues/271> from benmaidel/feature/melodify
  [Melodic]
* more hardware_interface prefixing
* added hardware_interface prefix for transmission (melodic's cob_gazebo_ros_control plugin expects it)
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer
```
