### PR TITLE
cob_control: 0.7.6-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1479,7 +1479,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.6-1
+      version: 0.7.6-2
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.6-2`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.6-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

```
* Merge pull request #207 <https://github.com/ipa320/cob_control/issues/207> from fmessmer/fix_collision_velocity_filter
  fix collision_velocity_filter parameter initialization
* fix collision_velocity_filter parameter initializatin
* Contributors: Felix Messmer, fmessmer
```

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
