### PR TITLE
cob_control: 0.7.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -746,6 +746,37 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: indigo_dev
     status: maintained
+  cob_control:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_control.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_base_controller_utils
+      - cob_base_velocity_smoother
+      - cob_cartesian_controller
+      - cob_collision_velocity_filter
+      - cob_control
+      - cob_control_mode_adapter
+      - cob_control_msgs
+      - cob_footprint_observer
+      - cob_frame_tracker
+      - cob_model_identifier
+      - cob_obstacle_distance
+      - cob_omni_drive_controller
+      - cob_trajectory_controller
+      - cob_tricycle_controller
+      - cob_twist_controller
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_control-release.git
+      version: 0.7.7-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_control.git
+      version: kinetic_dev
+    status: maintained
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.7-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

```
* Merge pull request #208 <https://github.com/ipa320/cob_control/issues/208> from ipa-jba/melodic_dev
  [Melodic] melodify
* initialize tf buffer properly
* move include to where it is needed
* add missing tf2_ros dependency
* tf2ify/melodify collision_velocity_filter
* Contributors: Felix Messmer, Jannik Abbenseth
```

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

```
* Merge pull request #208 <https://github.com/ipa320/cob_control/issues/208> from ipa-jba/melodic_dev
  [Melodic] melodify
* acommodate kdl api change
* use streams instead of lexical cast (deprecated)
* use urdf ptr types
* Contributors: Felix Messmer, Jannik Abbenseth
```

## cob_omni_drive_controller

```
* Merge pull request #208 <https://github.com/ipa320/cob_control/issues/208> from ipa-jba/melodic_dev
  [Melodic] melodify
* use urdf::JointConstSharedPtr instead of boost...
* Contributors: Felix Messmer, Jannik Abbenseth
```

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

```
* Merge pull request #208 <https://github.com/ipa320/cob_control/issues/208> from ipa-jba/melodic_dev
  [Melodic] melodify
* use urdf::JointConstSharedPtr instead of boost...
* Contributors: Felix Messmer, Jannik Abbenseth
```

## cob_twist_controller

- No changes
