### PR TITLE
cob_gazebo_plugins: 0.7.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1576,7 +1576,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_gazebo_plugins-release.git
-      version: 0.7.2-0
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.2-0`

## cob_gazebo_plugins

- No changes

## cob_gazebo_ros_control

```
* Merge pull request #38 <https://github.com/ipa320/cob_gazebo_plugins/issues/38> from benmaidel/melodic-devel
  [Melodic]
* backwards compatibility wrt hardware interface prefix
* query physics engine type
* remove obsolete member variable
* adjust plugin readme
* fix get simulation time for older gazebo version
* fix interface_type inference
* joint_interface should have prefix 'hardware_interface'
* fix compilation error
* Contributors: Benjamin Maidel, Felix Messmer, Shohei Fujii, fmessmer
```
