### PR TITLE
cob_gazebo_plugins: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -869,6 +869,24 @@ repositories:
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
     status: maintained
+  cob_gazebo_plugins:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_gazebo_plugins.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_gazebo_plugins
+      - cob_gazebo_ros_control
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_gazebo_plugins-release.git
+      version: 0.7.3-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_gazebo_plugins.git
+      version: kinetic_dev
+    status: maintained
   cob_hand:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_gazebo_plugins

- No changes

## cob_gazebo_ros_control

```
* Merge pull request #38 <https://github.com/ipa320/cob_gazebo_plugins/issues/38> from benmaidel/melodic-devel
  [Melodic]
* backwards compatibility wrt hardware interface prefix
* query physics engine type
* remove obsolete member variable
* adjust plugin readme
* fix get simulation time for older gazebo version
* fix interface_type inference
* joint_interface should have prefix 'hardware_interface'
* fix compilation error
* Contributors: Benjamin Maidel, Felix Messmer, Shohei Fujii, fmessmer
```
