### PR TITLE
cob_calibration_data: 0.6.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -724,6 +724,21 @@ repositories:
       url: https://github.com/wew84/cnn_bridge.git
       version: 0.8.4
     status: developed
+  cob_calibration_data:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_calibration_data.git
+      version: indigo_release_candidate
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_calibration_data-release.git
+      version: 0.6.12-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_calibration_data.git
+      version: indigo_dev
+    status: maintained
   cob_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.12-1`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_calibration_data

```
* Merge pull request #154 <https://github.com/ipa320/cob_calibration_data/issues/154> from fmessmer/melodify
  [Melodic] add melodic checks
* add melodic support
* Merge pull request #153 <https://github.com/ipa320/cob_calibration_data/issues/153> from HannesBachter/add_cob4-22
  add cob4-22
* add cob4-22
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer, hyb
```
