### PR TITLE
fetch_ros: 0.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1867,7 +1867,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.8.1-0
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.8.2-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.1-0`

## fetch_calibration

- No changes

## fetch_depth_layer

- No changes

## fetch_description

```
* License: CC BY-NC-SA 4.0 (Remove ND) (#123 <https://github.com/fetchrobotics/fetch_ros/issues/123>)
  This addresses https://github.com/fetchrobotics/fetch_ros/issues/93
  It still does not address all points raised, but we believe this is
  better than CC-BY-NC-ND as it allows derivatives to be shared.
* Contributors: Alex Moriarty
```

## fetch_ikfast_plugin

- No changes

## fetch_maps

- No changes

## fetch_moveit_config

```
* Fixed chomp configuration for porting to moveit melodic-devel (#124 <https://github.com/fetchrobotics/fetch_ros/issues/124>)
* Merge pull request #122 <https://github.com/fetchrobotics/fetch_ros/issues/122> from dekent/melodic-devel
  Much more collision checking = much safer robot with minimal planning time increases
* Merge pull request #116 <https://github.com/fetchrobotics/fetch_ros/issues/116> from umhan35/moveit-costomap
  [moveit_config] allow moveit octomap params to be overridden
* add default moveit_octomap_sensor_params_file to move_group.launch
* allow moveit octomap params to be overridden
* Contributors: Carl Saldanha, David Kent, Yuma Hijioka, Zhao Han
```

## fetch_navigation

- No changes

## fetch_ros

- No changes

## fetch_teleop

```
* Merge pull request #118 <https://github.com/fetchrobotics/fetch_ros/issues/118> from 708yamaguchi/add-teleop-rosparam-melodic
  Select teleop part by rosparam for melodic
* select teleop part by rosparam
* Contributors: Carl Saldanha, Naoya Yamaguchi
```
