### PR TITLE
py_trees: 1.2.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -929,7 +929,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `1.2.2-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.1-1`

## py_trees

```
* [trees] standalone ``setup()`` method with timer for use on unmanaged trees, #198 <https://github.com/splintered-reality/py_trees/pull/198>
* [examples] fix api in ``skeleton_tree.py``,  #199 <https://github.com/splintered-reality/py_trees/pull/199>
```
