### PR TITLE
fetch_robots: 0.8.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1841,7 +1841,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.8.6-0
+      version: 0.8.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.8.7-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.6-0`

## fetch_bringup

```
* Move ds4drv dep from package.xml to sys-config deb (#48 <https://github.com/fetchrobotics/fetch_robots/issues/48>)
  ROS buildfarm doesn't support pip dependencies.
  Also removed outdated sixad line. We don't install sixad at all in 18.04.
* Update launch files to support PS4 teleop w/ds4drv
  - Teleop: Change default /joy/dev param to /dev/fetch_joy to match
  udev rules
  - Add ps4 flag/arg to default fetch.launch and freight.launch
  - As workaround to a weird bug, renamed 'joy' node to 'joy_node'
* remove respawn in fetch_bringup/launch/include/teleop.launch.xml (#44 <https://github.com/fetchrobotics/fetch_robots/issues/44>)
  We want to enable launching the teleop node and it's components separately, without duplicate nodes continually respawning.
* Merge pull request #37 <https://github.com/fetchrobotics/fetch_robots/issues/37> from 708yamaguchi/melodic-devel
  Add params for selecting teleop part for melodic
* add joystick deadzone parameter (#42 <https://github.com/fetchrobotics/fetch_robots/issues/42>)
* Add argument to select launching teleop (#40 <https://github.com/fetchrobotics/fetch_robots/issues/40>)
  - add argument to select launching teleop for Fetch
  - add argument to select launching teleop for freight
* add params for selecting teleop part
* Contributors: Andrew Parker, Carl Saldanha, Eric Relson, Naoya Yamaguchi, Shingo Kitagawa
```

## fetch_drivers

- No changes

## freight_bringup

```
* Move ds4drv dep from package.xml to sys-config deb (#48 <https://github.com/fetchrobotics/fetch_robots/issues/48>)
  ROS buildfarm doesn't support pip dependencies.
  Also removed outdated sixad line. We don't install sixad at all in 18.04.
* Update launch files to support PS4 teleop w/ds4drv
  - Teleop: Change default /joy/dev param to /dev/fetch_joy to match
  udev rules
  - Add ps4 flag/arg to default fetch.launch and freight.launch
  - As workaround to a weird bug, renamed 'joy' node to 'joy_node'
* add joystick deadzone parameter (#42 <https://github.com/fetchrobotics/fetch_robots/issues/42>)
* Add argument to select launching teleop (#40 <https://github.com/fetchrobotics/fetch_robots/issues/40>)
  - add argument to select launching teleop for Fetch
  - add argument to select launching teleop for freight
* Contributors: Andrew Parker, Eric Relson, Naoya Yamaguchi
```
