### PR TITLE
cob_robots: 0.6.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1689,7 +1689,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.11-0
+      version: 0.6.11-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.6.11-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.11-0`

## cob_bringup

```
* Merge pull request #775 <https://github.com/ipa320/cob_robots/issues/775> from fmessmer/add_cob4-25
  add cob4-25
* assign d435 serial numbers cob4-25
* add cob4-25
* Merge pull request #776 <https://github.com/ipa320/cob_robots/issues/776> from iirob/stuck_detector_shutdown
  Repaired missing shutdown on stuck detector
* Repaired missing shutdown on stuck detector
* Contributors: Felix Messmer, andreeatulbure, fmessmer
```

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

```
* Merge pull request #775 <https://github.com/ipa320/cob_robots/issues/775> from fmessmer/add_cob4-25
  add cob4-25
* add cob4-25
* Contributors: Felix Messmer, fmessmer
```

## cob_hardware_config

```
* Merge pull request #775 <https://github.com/ipa320/cob_robots/issues/775> from fmessmer/add_cob4-25
  add cob4-25
* update rviz config cob4-25
* additional flexisoft params
* add cob4-25
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_config

```
* Merge pull request #775 <https://github.com/ipa320/cob_robots/issues/775> from fmessmer/add_cob4-25
  add cob4-25
* add cob4-25
* Contributors: Felix Messmer, fmessmer
```

## cob_robots

- No changes
