### PR TITLE
cob_robots: 0.7.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1689,7 +1689,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.6.11-0
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1677,7 +1677,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_robots.git
-      version: indigo_release_candidate
+      version: kinetic_release_candidate
     release:
       packages:
       - cob_bringup
@@ -1693,7 +1693,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git
-      version: indigo_dev
+      version: kinetic_dev
     status: maintained
   cob_simulation:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.0-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.11-0`

## cob_bringup

```
* Merge pull request #779 <https://github.com/ipa320/cob_robots/issues/779> from HannesBachter/add_cob4-22
  add cob4-22
* add cob4-22
* Contributors: Florian Weisshardt, hyb
```

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

```
* Merge pull request #779 <https://github.com/ipa320/cob_robots/issues/779> from HannesBachter/add_cob4-22
  add cob4-22
* add cob4-22
* Contributors: Florian Weisshardt, hyb
```

## cob_hardware_config

```
* Merge pull request #780 <https://github.com/ipa320/cob_robots/issues/780> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* added laser_filters prefix for melodic
* fixed xacro:if condition for melodic
* Merge pull request #779 <https://github.com/ipa320/cob_robots/issues/779> from HannesBachter/add_cob4-22
  add cob4-22
* add cob4-22
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer, hyb
```

## cob_moveit_config

```
* Merge pull request #779 <https://github.com/ipa320/cob_robots/issues/779> from HannesBachter/add_cob4-22
  add cob4-22
* add cob4-22
* Contributors: Florian Weisshardt, hyb
```

## cob_robots

- No changes
