### PR TITLE
cob_android: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -724,6 +724,27 @@ repositories:
       url: https://github.com/wew84/cnn_bridge.git
       version: 0.8.4
     status: developed
+  cob_android:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_android.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_android
+      - cob_android_msgs
+      - cob_android_resource_server
+      - cob_android_script_server
+      - cob_android_settings
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_android-release.git
+      version: 0.1.6-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_android.git
+      version: indigo_dev
+    status: maintained
   cob_calibration_data:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_android` to `0.1.6-1`:

- upstream repository: https://github.com/ipa320/cob_android.git
- release repository: https://github.com/ipa320/cob_android-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_android

- No changes

## cob_android_msgs

- No changes

## cob_android_resource_server

- No changes

## cob_android_script_server

- No changes

## cob_android_settings

- No changes
