### PR TITLE
merge 'libzmq3-dev' into 'zeromq3'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3850,7 +3850,9 @@ libzip-dev:
   gentoo: [dev-libs/libzip]
   ubuntu: [libzip-dev]
 libzmq3-dev:
+  arch: [zeromq]
   debian: [libzmq3-dev]
+  fedora: [zeromq-devel]
   gentoo: [net-libs/cppzmq]
   openembedded: [zeromq@meta-oe]
   ubuntu: [libzmq3-dev]
@@ -5621,11 +5623,11 @@ zbar:
   gentoo: [media-gfx/zbar]
   ubuntu: [libzbar-dev]
 zeromq3:
-  arch: [zeromq3]
-  debian: [libzmq3-dev]
-  fedora: [zeromq3]
+  arch: [zeromq]
+  debian: [libzmq5]
+  fedora: [zeromq]
   gentoo: [zeromq]
-  ubuntu: [libzmq3-dev]
+  ubuntu: [libzmq5]
 zip:
   debian: [zip]
   fedora: [zip]


### PR DESCRIPTION
This PR resolves duplicated keys for ZeroMQ. Fixes #21879 .