### PR TITLE
Mark Bouncy as end-of-life.

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -12,7 +12,7 @@ distributions:
     distribution: [bouncy/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/bouncy-cache.yaml.gz
     distribution_status: active
-    distribution_type: ros2
+    distribution_type: end-of-life
   crystal:
     distribution: [crystal/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz


### PR DESCRIPTION
Bouncy's support window closed in June. http://www.ros.org/reps/rep-2000.html#bouncy-bolson-june-2018-june-2019