### PR TITLE
epos2_motor_controller: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2943,7 +2943,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/epos2_motor_controller-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/uos/epos2_motor_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `epos2_motor_controller` to `1.0.1-1`:

- upstream repository: https://github.com/uos/epos2_motor_controller.git
- release repository: https://github.com/uos-gbp/epos2_motor_controller-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-1`

## epos2_motor_controller

```
* fix for LIBFTDI_USE_FILE location in xenial and missing libftdipp1
```
