### PR TITLE
robot_body_filter: 1.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6381,7 +6381,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/robot_body_filter-release.git
-      version: 1.1.3-1
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/peci1/robot_body_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.1.4-1`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.3-1`

## robot_body_filter

```
* Fixed a bug in filtering unorganized point clouds.
* Contributors: Martin Pecka
```
