### PR TITLE
cob_simulation: 0.7.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1699,7 +1699,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_simulation.git
-      version: indigo_release_candidate
+      version: kinetic_release_candidate
     release:
       packages:
       - cob_bringup_sim
@@ -1714,7 +1714,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git
-      version: indigo_dev
+      version: kinetic_dev
     status: maintained
   cob_substitute:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1710,7 +1710,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.6.10-0
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.1-1`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.10-0`

## cob_bringup_sim

```
* Merge pull request #167 <https://github.com/ipa320/cob_simulation/issues/167> from floweisshardt/feature/spawn_with_explicit_package_and_type
  allow explicit definition of package and type for spawn object
* fix xacro file type
* fix naming of objects
* allow explicit definition of package and type for spawn object
* Merge pull request #166 <https://github.com/ipa320/cob_simulation/issues/166> from floweisshardt/fix/add_dependency_to_cob_gazebo_objects
  add dependency to cob_gazebo_objects which is used in spawn_object.py
* add dependency to cob_gazebo_objects which is used in spawn_object.py
* Contributors: Felix Messmer, floweisshardt
```

## cob_gazebo

- No changes

## cob_gazebo_objects

- No changes

## cob_gazebo_worlds

- No changes

## cob_simulation

- No changes
