### PR TITLE
cob_environments: 0.6.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -867,7 +867,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_environments-release.git
-      version: 0.6.9-1
+      version: 0.6.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_environments.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.6.10-1`:

- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.9-1`

## cob_default_env_config

```
* Merge pull request #134 <https://github.com/ipa320/cob_environments/issues/134> from floweisshardt/feature/spawn_with_explicit_package_and_type
  adapt to new yaml layout of spawn_object script
* adapt to new yaml layout of spawn_object script
* Contributors: Felix Messmer, floweisshardt
```

## cob_environments

- No changes
