### PR TITLE
cob_navigation: 0.6.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1650,7 +1650,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.7-0
+      version: 0.6.8-1
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.8-1`:

- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.7-0`

## cob_linear_nav

- No changes

## cob_map_accessibility_analysis

- No changes

## cob_mapping_slam

- No changes

## cob_navigation

- No changes

## cob_navigation_config

- No changes

## cob_navigation_global

- No changes

## cob_navigation_local

- No changes

## cob_navigation_slam

- No changes
