### PR TITLE
cob_navigation: 0.6.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -931,6 +931,30 @@ repositories:
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
     status: maintained
+  cob_navigation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_linear_nav
+      - cob_map_accessibility_analysis
+      - cob_mapping_slam
+      - cob_navigation
+      - cob_navigation_config
+      - cob_navigation_global
+      - cob_navigation_local
+      - cob_navigation_slam
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_navigation-release.git
+      version: 0.6.8-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_dev
+    status: maintained
   cob_perception_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.8-1`:

- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cob_linear_nav

- No changes

## cob_map_accessibility_analysis

- No changes

## cob_mapping_slam

- No changes

## cob_navigation

- No changes

## cob_navigation_config

- No changes

## cob_navigation_global

- No changes

## cob_navigation_local

- No changes

## cob_navigation_slam

- No changes
