### PR TITLE
actionlib: 1.12.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -63,7 +63,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.13-0
+      version: 1.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.12.0-1`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.11.13-0`

## actionlib

```
* Complete the full set of Ptr typedefs (#106 <https://github.com/ros/actionlib/issues/106>)
* action_server calls initialize in constructor (#120 <https://github.com/ros/actionlib/issues/120>)
* Print the correct error on waiting for result (#123 <https://github.com/ros/actionlib/issues/123>)
* Remove getState error when no goal is running (#97 <https://github.com/ros/actionlib/issues/97>)
* Update maintainer (#122 <https://github.com/ros/actionlib/issues/122>)
* Contributors: Alireza, Bence Magyar, Carl Saldanha, Christopher Wecht, Michael Carroll
```
