### PR TITLE
rosbridge_suite: 0.11.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12119,7 +12119,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.2-1
+      version: 0.11.3-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.3-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.2-1`

## rosapi

```
* Travis CI: Look for Python syntax errors and undefined name (#420 <https://github.com/RobotWebTools/rosbridge_suite/issues/420>)
  * Travis CI: Look for Python syntax errors and undefined name
  _It would be prudent to start running the tests in both 2 and 3._  https://github.com/RobotWebTools/rosbridge_suite/issues/401#issuecomment-512069249
  * Add names to protect the guilty
  * Five jobs, not six
  * Identity is not the same thing as equality in Python
  * Flake8 tests now pass on Python 2
* Contributors: cclauss
```

## rosbridge_library

- No changes

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Fixes #418 <https://github.com/RobotWebTools/rosbridge_suite/issues/418>: WebSocketClosedError Spam (#423 <https://github.com/RobotWebTools/rosbridge_suite/issues/423>)
  * not raising WebSocketClosedError for old tornado versions
* Contributors: lennartdopatka
```

## rosbridge_suite

- No changes
