### PR TITLE
pr2_controllers: 1.10.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5600,7 +5600,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/pr2_controllers-release.git
-      version: 1.10.16-1
+      version: 1.10.17-1
     source:
       type: git
       url: https://github.com/pr2/pr2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_controllers` to `1.10.17-1`:

- upstream repository: https://github.com/pr2/pr2_controllers.git
- release repository: https://github.com/pr2-gbp/pr2_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.10.16-1`

## ethercat_trigger_controllers

- No changes

## joint_trajectory_action

- No changes

## pr2_calibration_controllers

- No changes

## pr2_controllers

- No changes

## pr2_controllers_msgs

- No changes

## pr2_gripper_action

- No changes

## pr2_head_action

- No changes

## pr2_mechanism_controllers

- No changes

## robot_mechanism_controllers

```
* Remove actionlib typedefs defined in actionlib 1.12.0 (#396 <https://github.com/PR2/pr2_controllers/issues/396>)
  * check actinlib_VERSION to removing re-typedef ResultPtr and FeedbackPtr https://github.com/ros/actionlib/issues/106
  * Remove actionlib typedefs defined upstreamSigned-off-by: Shane Loretz <sloretz@osrfoundation.org>
* Contributors: Kei Okada, Shane Loretz
```

## single_joint_position_action

- No changes
