### PR TITLE
mavros: 0.32.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6671,7 +6671,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.32.0-1
+      version: 0.32.1-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.32.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.32.0-1`

## libmavconn

- No changes

## mavros

```
* uncrustify
* Removed tf loop
* made small edit to handle augmented gps fix
* added a check for gps fix before setting origin for global_position/local odometry topic
* Contributors: Eric, Lucas Hill
```

## mavros_extras

- No changes

## mavros_msgs

- No changes

## test_mavros

- No changes
