### PR TITLE
update branch names of several ROS core packages

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3665,7 +3665,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/gencpp.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -3674,7 +3674,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/gencpp.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   generic_control_toolbox:
     doc:
@@ -3731,7 +3731,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/genmsg.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -3741,7 +3741,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/genmsg.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   gennodejs:
     doc:
@@ -6803,7 +6803,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/message_runtime.git
-      version: groovy-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -6812,7 +6812,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/message_runtime.git
-      version: groovy-devel
+      version: kinetic-devel
     status: maintained
   metapackages:
     doc:
@@ -11751,7 +11751,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       packages:
       - rosgraph_msgs
@@ -11763,7 +11763,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   ros_control:
     doc:
@@ -14141,7 +14141,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/std_msgs.git
-      version: groovy-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -14150,7 +14150,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/std_msgs.git
-      version: groovy-devel
+      version: kinetic-devel
     status: maintained
   stdr_simulator:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2171,7 +2171,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/gencpp.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -2180,7 +2180,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/gencpp.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   generic_control_toolbox:
     doc:
@@ -2227,7 +2227,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/genmsg.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -2236,7 +2236,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/genmsg.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   gennodejs:
     doc:
@@ -3885,7 +3885,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/message_runtime.git
-      version: groovy-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -3894,7 +3894,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/message_runtime.git
-      version: groovy-devel
+      version: kinetic-devel
     status: maintained
   metapackages:
     doc:
@@ -6713,7 +6713,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       packages:
       - rosgraph_msgs
@@ -6725,7 +6725,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   ros_control:
     doc:
@@ -7184,7 +7184,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/rospack.git
-      version: lunar-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -7194,7 +7194,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/rospack.git
-      version: lunar-devel
+      version: melodic-devel
     status: maintained
   rosparam_handler:
     doc:
@@ -8308,7 +8308,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/std_msgs.git
-      version: groovy-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -8317,7 +8317,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/std_msgs.git
-      version: groovy-devel
+      version: kinetic-devel
     status: maintained
   swri_console:
     doc:


### PR DESCRIPTION
The `devel_branch` names in the GBP repos have already been updated.