### PR TITLE
navigation_msgs: 2.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -803,7 +803,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.0.1-0
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/navigation_msgs
- release repository: https://github.com/ros2-gbp/navigation_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-0`

## map_msgs

```
* Changed cmake code to use ``add_compile_options`` instead of setting only cxx flags.
* Contributors: Mikael Arguedas
```
