### PR TITLE
eigen3_cmake_module: 0.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -420,7 +420,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen3_cmake_module` to `0.1.1-1`:

- upstream repository: https://github.com/ros2/eigen3_cmake_module.git
- release repository: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-1`

## eigen3_cmake_module

```
* Handle Eigen3 3.3.4 chocolatey package (#3 <https://github.com/ros2/eigen3_cmake_module/issues/3>)
* Update README (#2 <https://github.com/ros2/eigen3_cmake_module/issues/2>)
* Contributors: Marya Belanger, Shane Loretz
```
