### PR TITLE
parameter_assertions: 0.0.0-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5221,17 +5221,6 @@ repositories:
       url: https://github.com/ros-planning/panda_moveit_config.git
       version: melodic-devel
     status: maintained
-  parameter_assertions:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/RoboJackets/rj-ros-common-release.git
-      version: 0.0.0-1
-    source:
-      type: git
-      url: https://github.com/RoboJackets/rj-ros-common.git
-      version: master
-    status: developed
   parrot_arsdk:
     release:
       tags:
@@ -6342,6 +6331,19 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_simulator.git
       version: melodic-devel
     status: maintained
+  rj-ros-common:
+    release:
+      packages:
+      - parameter_assertions
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RoboJackets/rj-ros-common-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/RoboJackets/rj-ros-common.git
+      version: master
+    status: developed
   robosense:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5221,6 +5221,17 @@ repositories:
       url: https://github.com/ros-planning/panda_moveit_config.git
       version: melodic-devel
     status: maintained
+  parameter_assertions:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RoboJackets/rj-ros-common-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/RoboJackets/rj-ros-common.git
+      version: master
+    status: developed
   parrot_arsdk:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_assertions` to 0.0.0-0:

* upstream repository: https://github.com/RoboJackets/rj-ros-common.git
* release repository: https://github.com/RoboJackets/rj-ros-common-release.git
* distro file: melodic/distribution.yaml
* previous version for package: null