### PR TITLE
cob_control: 0.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -791,7 +791,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_control.git
-      version: kinetic_release_candidate
+      version: melodic_release_candidate
     release:
       packages:
       - cob_base_controller_utils
@@ -816,7 +816,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git
-      version: kinetic_dev
+      version: melodic_dev
     status: maintained
   cob_driver:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -812,7 +812,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.7-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.0-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.7-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

```
* Merge pull request #209 <https://github.com/ipa320/cob_control/issues/209> from fmessmer/release_fixes
  [Melodic] release fixes
* proper cast of urdf pointer
* Contributors: Felix Messmer, fmessmer
```

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
