### PR TITLE
rj-ros-common: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6376,6 +6376,19 @@ repositories:
       url: https://github.com/ridgeback/ridgeback_simulator.git
       version: melodic-devel
     status: maintained
+  rj-ros-common:
+    release:
+      packages:
+      - parameter_assertions
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RoboJackets/rj-ros-common-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/RoboJackets/rj-ros-common.git
+      version: master
+    status: developed
   robosense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rj-ros-common` to `0.1.0-1`:

- upstream repository: https://github.com/RoboJackets/rj-ros-common.git
- release repository: https://github.com/RoboJackets/rj-ros-common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## parameter_assertions

```
* Added assertions for param, created a bunch more tests
* Refactored to not be a class and only do ros::shutdown
* Contributors: Oswin So
```
