### PR TITLE
add source entries for most ROS core packages for Noetic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,5 @@ indigo/* @tfoote
 kinetic/* @tfoote
 lunar/* @clalancette
 melodic/* @clalancette
+noetic/* @sloretz
 rosdep/* @ros/rosdeputies

--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -63,5 +63,10 @@ distributions:
     distribution_cache: http://repositories.ros.org/rosdistro_cache/melodic-cache.yaml.gz
     distribution_status: active
     distribution_type: ros1
+  noetic:
+    distribution: [noetic/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/noetic-cache.yaml.gz
+    distribution_status: prerelease
+    distribution_type: ros1
 type: index
 version: 4

--- a/index.yaml
+++ b/index.yaml
@@ -39,5 +39,8 @@ distributions:
   melodic:
     distribution: [melodic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/melodic-cache.yaml.gz
+  noetic:
+    distribution: [noetic/distribution.yaml]
+    distribution_cache: http://repositories.ros.org/rosdistro_cache/noetic-cache.yaml.gz
 type: index
 version: 3

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8,7 +8,7 @@ release_platforms:
   fedora:
   - '30'
   ubuntu:
-  - bionic  # to be change to the codename of 20.04 when available
+  - bionic
 repositories:
   catkin:
     source:
@@ -108,6 +108,12 @@ repositories:
       url: https://github.com/ros/ros_comm_msgs.git
       version: kinetic-devel
     status: maintained
+  ros_environment:
+    source:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: melodic
+    status: maintained
   rosconsole:
     source:
       test_pull_requests: true
@@ -121,12 +127,6 @@ repositories:
       type: git
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
-    status: maintained
-  ros_environment:
-    source:
-      type: git
-      url: https://github.com/ros/ros_environment.git
-      version: melodic
     status: maintained
   roslisp:
     source:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1,0 +1,151 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms:
+  debian:
+  - buster
+  fedora:
+  - '30'
+  ubuntu:
+  - bionic  # to be change to the codename of 20.04 when available
+repositories:
+  catkin:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/catkin.git
+      version: kinetic-devel
+    status: maintained
+  class_loader:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: melodic-devel
+    status: maintained
+  cmake_modules:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.4-devel
+    status: maintained
+  gencpp:
+    source:
+      type: git
+      url: https://github.com/ros/gencpp.git
+      version: kinetic-devel
+    status: maintained
+  geneus:
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
+    status: maintained
+  genlisp:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/genlisp.git
+      version: groovy-devel
+    status: maintained
+  genmsg:
+    source:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: kinetic-devel
+    status: maintained
+  gennodejs:
+    source:
+      type: git
+      url: https://github.com/RethinkRobotics-opensource/gennodejs.git
+      version: kinetic-devel
+    status: maintained
+  genpy:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: kinetic-devel
+    status: maintained
+  message_generation:
+    source:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: kinetic-devel
+    status: maintained
+  message_runtime:
+    source:
+      type: git
+      url: https://github.com/ros/message_runtime.git
+      version: kinetic-devel
+    status: maintained
+  pluginlib:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: melodic-devel
+    status: maintained
+  ros:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros.git
+      version: kinetic-devel
+    status: maintained
+  ros_comm:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: melodic-devel
+    status: maintained
+  ros_comm_msgs:
+    source:
+      type: git
+      url: https://github.com/ros/ros_comm_msgs.git
+      version: kinetic-devel
+    status: maintained
+  rosconsole:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/rosconsole.git
+      version: melodic-devel
+    status: maintained
+  roscpp_core:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: kinetic-devel
+    status: maintained
+  ros_environment:
+    source:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: melodic
+    status: maintained
+  roslisp:
+    source:
+      type: git
+      url: https://github.com/ros/roslisp.git
+      version: master
+    status: maintained
+  rospack:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: melodic-devel
+    status: maintained
+  std_msgs:
+    source:
+      type: git
+      url: https://github.com/ros/std_msgs.git
+      version: kinetic-devel
+    status: maintained
+type: distribution
+version: 2


### PR DESCRIPTION
This adds most ROS core repositories (source entries only) for Noetic to ease testing Python 3 compatibility.

Since there are no builds of Ubuntu 20.04 yet the platforms section used Ubuntu 18.04 / Bionic for now. So there should be no `bloom` releases made against Noetic at this point in time.

The goal is to use these entries with ros-infrastructure/ros_buildfarm_config#139 to get some early CI builds up and running.