### PR TITLE
Bouncy status EOL type ros2

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -11,8 +11,8 @@ distributions:
   bouncy:
     distribution: [bouncy/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/bouncy-cache.yaml.gz
-    distribution_status: active
-    distribution_type: end-of-life
+    distribution_status: end-of-life
+    distribution_type: ros2
   crystal:
     distribution: [crystal/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz


### PR DESCRIPTION
Follow up of https://github.com/ros/rosdistro/pull/21959 . Assuming `ardent` is configured correctly, it looks like the `end-of-life` belongs on `distribution_status` instead of `distribution_type` for `bouncy`