### PR TITLE
cob_robots: 0.7.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1697,7 +1697,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.1-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.0-1`

## cob_bringup

```
* Merge pull request #782 <https://github.com/ipa320/cob_robots/issues/782> from fmessmer/comment_ur_dependencies
  [Melodic] workaround missing dependencies
* comment unused dependency cob_collision_monitor
* comment realsense2_camera dependency
* add missing dependency to realsense2_camera
* comment sick_visionary_t
* comment ur dependencies
* Contributors: Felix Messmer, fmessmer
```

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

- No changes

## cob_hardware_config

```
* Merge pull request #782 <https://github.com/ipa320/cob_robots/issues/782> from fmessmer/comment_ur_dependencies
  [Melodic] workaround missing dependencies
* comment ur dependencies
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_config

- No changes

## cob_robots

- No changes
