### PR TITLE
v4l2_camera: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2155,6 +2155,21 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: dashing
     status: developed
+  v4l2_camera:
+    doc:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    status: developed
   variants:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.1.0-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## v4l2_camera

- No changes
