### PR TITLE
librealsense2: 2.25.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6141,7 +6141,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.23.0-1
+      version: 2.25.2-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6143,6 +6143,7 @@ repositories:
       url: https://github.com/IntelRealSense/librealsense2-release.git
       version: 2.25.2-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/doronhi/librealsense.git
       version: ros_debian

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6145,7 +6145,7 @@ repositories:
     source:
       type: git
       url: https://github.com/doronhi/librealsense.git
-      version: 2.25.2
+      version: ros_debian
     status: maintained
   libsegwayrmp:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6144,8 +6144,8 @@ repositories:
       version: 2.25.2-1
     source:
       type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: master
+      url: https://github.com/doronhi/librealsense.git
+      version: 2.25.2
     status: maintained
   libsegwayrmp:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.25.2-1`:

- upstream repository: https://github.com/doronhi/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.23.0-1`
