### PR TITLE
Add clang-tidy rules for Fedora and RHEL 8+

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -414,6 +414,10 @@ clang-tidy:
   debian:
     buster: [clang-tidy]
     stretch: [clang-tidy]
+  fedora: [clang-tools-extra]
+  rhel:
+    '*': [clang-tools-extra]
+    '7': null
   ubuntu:
     '*': [clang-tidy]
     trusty: null


### PR DESCRIPTION
Fedora package: https://apps.fedoraproject.org/packages/clang-tools-extra

RHEL 8 package listing (non-EPEL):
```
$ cat /etc/redhat-release 
Red Hat Enterprise Linux release 8.0 (Ootpa)
$ sudo dnf list -q --available --showduplicates clang-tools-extra
Available Packages
clang-tools-extra.i686            7.0.1-1.module+el8+2560+c32c7af1           AppStream
clang-tools-extra.x86_64          7.0.1-1.module+el8+2560+c32c7af1           AppStream
```

This package is not available in RHEL 7 or EPEL 7 at this time.