### PR TITLE
dbw_mkz_ros: 1.2.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2187,7 +2187,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.1.1-0
+      version: 1.2.3-1
     source:
       type: hg
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_mkz_ros` to `1.2.3-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_mkz_ros
- release repository: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-0`

## dbw_mkz

- No changes

## dbw_mkz_can

```
* Updated firmware versions
* Updated website maintenance link
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_description

- No changes

## dbw_mkz_joystick_demo

- No changes

## dbw_mkz_msgs

- No changes

## dbw_mkz_twist_controller

- No changes
