### PR TITLE
dbw_fca_ros: 1.0.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1303,7 +1303,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.0.1-0
+      version: 1.0.6-1
     source:
       type: hg
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `1.0.6-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-0`

## dbw_fca

- No changes

## dbw_fca_can

```
* Updated firmware versions
* Updated website maintenance link
* Contributors: Kevin Hallenbeck
```

## dbw_fca_description

- No changes

## dbw_fca_joystick_demo

- No changes

## dbw_fca_msgs

- No changes
