### PR TITLE
py_trees_js: 0.4.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -995,6 +995,17 @@ repositories:
       url: https://github.com/splintered-reality/py_trees.git
       version: release/1.2.x
     status: maintained
+  py_trees_js:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: release/0.4.x
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/stonier/py_trees_js-release.git
+      version: 0.4.0-1
+    status: developed
   py_trees_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.4.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/stonier/py_trees_js-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## py_trees_js

```
* Milestone - Polish & Release <https://github.com/splintered-reality/py_trees_js/milestone/5>
```
