### PR TITLE
rail_mesh_icp: 0.0.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6090,6 +6090,21 @@ repositories:
       url: https://github.com/GT-RAIL/rail_manipulation_msgs.git
       version: melodic-devel
     status: maintained
+  rail_mesh_icp:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rail_mesh_icp.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gt-rail-release/rail_mesh_icp-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/rail_mesh_icp.git
+      version: melodic-devel
+    status: maintained
   rail_segmentation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_mesh_icp` to `0.0.1-3`:

- upstream repository: https://github.com/GT-RAIL/rail_mesh_icp.git
- release repository: https://github.com/gt-rail-release/rail_mesh_icp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rail_mesh_icp

```
* clean up for ROS release
* Initial commit
* Contributors: Angel, Angel Andres Daruna
```
