### PR TITLE
Switch Crystal osrf_pycommon doc/source entries to point to crystal.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -982,7 +982,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
-      version: master
+      version: crystal
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -992,7 +992,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
-      version: master
+      version: crystal
     status: developed
   osrf_testing_tools_cpp:
     doc:


### PR DESCRIPTION
This more accurately reflects what we've released.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>