### PR TITLE
[crystal][laser_geometry] use crystal branch as the upstream.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -743,7 +743,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: ros2
+      version: crystal
     release:
       tags:
         release: release/crystal/{package}/{version}
@@ -752,7 +752,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: ros2
+      version: crystal
     status: maintained
   launch:
     doc:


### PR DESCRIPTION
A recent [change](https://github.com/ros-perception/laser_geometry/pull/46) from `ros2` branch of `laser_geometry` introduces a new dependency `eigen3_cmake_module` which doesn't exist on crystal. If someone builds the crystal from the upstream repository, it will hit build break. So I suggest to swap the source to `crystal` branch instead.