### PR TITLE
add pycryptodome

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5173,6 +5173,7 @@ python3-pycryptodome:
   osx:
     pip:
       packages: [pycryptodome]
+  rhel: ['python%{python3_pkgversion}-pycryptodomex']
   ubuntu: [python3-pycryptodome]
 python3-pydot:
   arch: [python-pydot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2980,6 +2980,15 @@ python-pycodestyle:
   gentoo: [dev-python/pycodestyle]
   rhel: [python-pycodestyle]
   ubuntu: [pycodestyle]
+python-pycryptodome:
+  arch: [python2-pycryptodome]
+  debian: [python-pycryptodome]
+  fedora: [python-pycryptodomex]
+  gentoo: [dev-python/pycryptodome]
+  osx:
+    pip:
+      packages: [pycryptodome]
+  ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]
   fedora: [python2-pycurl]
@@ -5153,6 +5162,15 @@ python3-pycodestyle:
   gentoo: [dev-python/pycodestyle]
   rhel: ['python%{python3_pkgversion}-pycodestyle']
   ubuntu: [python3-pycodestyle]
+python3-pycryptodome:
+  arch: [python-pycryptodome]
+  debian: [python3-pycryptodome]
+  fedora: [python3-pycryptodomex]
+  gentoo: [dev-python/pycryptodome]
+  osx:
+    pip:
+      packages: [pycryptodome]
+  ubuntu: [python3-pycryptodome]
 python3-pydot:
   arch: [python-pydot]
   debian: [python3-pydot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2989,6 +2989,7 @@ python-pycryptodome:
   osx:
     pip:
       packages: [pycryptodome]
+  rhel: [python-pycryptodomex]
   ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2981,6 +2981,7 @@ python-pycodestyle:
   rhel: [python-pycodestyle]
   ubuntu: [pycodestyle]
 python-pycryptodome:
+  alpine: [py3-pycryptodome]
   arch: [python2-pycryptodome]
   debian: [python-pycryptodome]
   fedora: [python-pycryptodomex]
@@ -5163,6 +5164,7 @@ python3-pycodestyle:
   rhel: ['python%{python3_pkgversion}-pycodestyle']
   ubuntu: [python3-pycodestyle]
 python3-pycryptodome:
+  alpine: [py3-pycryptodome]
   arch: [python-pycryptodome]
   debian: [python3-pycryptodome]
   fedora: [python3-pycryptodomex]


### PR DESCRIPTION
Trying to cover the same platforms as `python-crypto`: https://github.com/ros/rosdistro/blob/42df98bbea04a4a1260fb3a99db16f6148db8ba3/rosdep/python.yaml#L1084-L1093

* [Alpine](https://pkgs.alpinelinux.org/packages?name=pycryptodome&branch=edge) doesn't seem to have the package.
* [Arch](https://www.archlinux.org/packages/?q=pycryptodome)
* Debian: [Python 2](https://packages.debian.org/search?keywords=python-pycryptodome), [Python 3](https://packages.debian.org/search?keywords=python3-pycryptodome)
* [Fedora](https://apps.fedoraproject.org/packages/s/pycryptodome)
* [Gentoo](https://packages.gentoo.org/packages/dev-python/pycryptodome)
* macOS: [PyPI](https://pypi.org/project/pycryptodome/)
* Ubuntu: [Python 2](https://packages.ubuntu.com/search?keywords=python-pycryptodome&searchon=names), [Python 3](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-pycryptodome&searchon=names)

Used for ros/ros_comm#1609.