### PR TITLE
Add python3-rosdistro-modules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5227,6 +5227,13 @@ python3-rosdep:
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
   ubuntu: [python3-rosdep]
+python3-rosdistro-modules:
+  debian: [python3-rosdistro-modules]
+  fedora: [python3-rosdistro]
+  gentoo: [dev-python/rosdistro]
+  openembedded: [python3-rosdistro@meta-ros]
+  rhel: ['python%{python3_pkgversion}-rosdistro']
+  ubuntu: [python3-rosdistro-modules]
 python3-rospkg:
   alpine:
     pip:


### PR DESCRIPTION
This package is used in https://github.com/ros2/ros2cli/tree/claire_debugtools/ros2doctor to check ROS distribution and status. Package repo can be found at https://github.com/ros-infrastructure/rosdistro.

python3-rosdistro web indexes:
Debian: https://packages.debian.org/sid/python3-rosdistro
Ubuntu: https://packages.ubuntu.com/bionic/python3-rosdistro
Fedora: https://apps.fedoraproject.org/packages/python3-rosdistro
Openembedded: https://layers.openembedded.org/layerindex/recipe/60790/
Rhel: no index found