### PR TITLE
robot_one: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6522,6 +6522,17 @@ repositories:
       url: https://github.com/locusrobotics/robot_navigation.git
       version: tf2
     status: developed
+  robot_one:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/AlexanderSilvaB/robot-one-ros-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/AlexanderSilvaB/Robot-One-ROS.git
+      version: master
+    status: developed
   robot_pose_ekf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_one` to `0.1.1-1`:

- upstream repository: https://github.com/AlexanderSilvaB/Robot-One-ROS.git
- release repository: https://github.com/AlexanderSilvaB/robot-one-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## robot_one

```
* author in package
* version command
* Initial commit
* Initial commit
* Contributors: AlexanderSilvaB
```
