### PR TITLE
urg_stamped: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9089,7 +9089,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.2-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.3-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.2-0`

## urg_stamped

```
* Run prerelease-test on release- branch (#49 <https://github.com/seqsense/urg_stamped/issues/49>)
* Refactor logging (#48 <https://github.com/seqsense/urg_stamped/issues/48>)
* Drop ROS Indigo and Ubuntu Trusty support (#47 <https://github.com/seqsense/urg_stamped/issues/47>)
* Remove old_boost_fix.h (#42 <https://github.com/seqsense/urg_stamped/issues/42>)
* Contributors: Atsushi Watanabe
```
