### PR TITLE
add qttools5-dev to the rosdistro base.yaml file

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4713,6 +4713,7 @@ qtmultimedia5-dev:
   ubuntu: [qtmultimedia5-dev]
 qttools5-dev:
   debian: [qttools5-dev]
+  fedora: [qt5-qttools-devel]
   ubuntu: [qttools5-dev]
 qttools5-dev-tools:
   debian: [qttools5-dev-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4711,6 +4711,9 @@ qtmultimedia5-dev:
   freebsd: [qt5-multimedia]
   gentoo: ['dev-qt/qtmultimedia:5']
   ubuntu: [qtmultimedia5-dev]
+qttools5-dev:
+  debian: [qttools5-dev]
+  ubuntu: [qttools5-dev]
 qttools5-dev-tools:
   debian: [qttools5-dev-tools]
   fedora: [qt5-qttools-devel]


### PR DESCRIPTION
Currently for ubuntu 18.04, to use Qt LinguistTools to build catkin package we have dependency of qttools5-dev which is not currently included in the  `rosdep/base.yaml` file. This pull request add qttools5-dev to the file so rosdep can install such package. 

- Ubuntu Package link: https://packages.ubuntu.com/disco/qttools5-dev

- Debian Package link: https://packages.debian.org/buster/qttools5-dev

Could not find an equivalent package in Fedora distro.