### PR TITLE
ros1_ign: 0.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6692,7 +6692,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/osrf/ros1_ign-release.git
-      version: 0.6.2-1
+      version: 0.7.0-1
   ros_canopen:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_ign` to `0.7.0-1`:

- upstream repository: https://github.com/osrf/ros1_ign
- release repository: https://github.com/osrf/ros1_ign-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.2-1`

## ros1_ign

- No changes

## ros1_ign_bridge

```
* Merge pull request #38 <https://github.com/osrf/ros1_ign_bridge/issues/38> from osrf/unidirectional
  Support unidirectional bridge topics
* More examples
* Merge pull request #37 <https://github.com/osrf/ros1_ign_bridge/issues/37> from osrf/debug
  Adding debug and error statements
* Switch to characters supported by ros
* Merge branch 'debug' into unidirectional
* More output, and rosconsole depend
* Support specification of bridge direction
* Adding debug and error statements
* Contributors: Nate Koenig
```

## ros1_ign_gazebo_demos

- No changes

## ros1_ign_image

- No changes

## ros1_ign_point_cloud

- No changes
