### PR TITLE
neonavigation: 0.4.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7917,7 +7917,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.4.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.0-1`

## costmap_cspace

```
* costmap_cspace: fix costmap output for out-of-boundary overlay map (#361 <https://github.com/at-wat/neonavigation/issues/361>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Fix include directory priority (#308 <https://github.com/at-wat/neonavigation/issues/308>)
* planner_cspace, costmap_cspace: minor refactoring (#305 <https://github.com/at-wat/neonavigation/issues/305>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

```
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Contributors: Atsushi Watanabe
```

## map_organizer

```
* map_organizer: fix select_map test sequence (#333 <https://github.com/at-wat/neonavigation/issues/333>)
* map_organizer: add test for pointcloud_to_maps (#330 <https://github.com/at-wat/neonavigation/issues/330>)
* map_organizer: add simple test (#321 <https://github.com/at-wat/neonavigation/issues/321>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

```
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Fix include directory priority (#308 <https://github.com/at-wat/neonavigation/issues/308>)
* Contributors: Atsushi Watanabe
```

## neonavigation_launch

```
* trajectory_tracker: update demo params (#352 <https://github.com/at-wat/neonavigation/issues/352>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

```
* obj_to_pointcloud: add simple test (#322 <https://github.com/at-wat/neonavigation/issues/322>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

```
* planner_cspace: fix debug build compatibility (#368 <https://github.com/at-wat/neonavigation/issues/368>)
* planner_cspace: fix out-of-boundary validation (#362 <https://github.com/at-wat/neonavigation/issues/362>)
* planner_cspace: fix incomplete output path after search timeout (#357 <https://github.com/at-wat/neonavigation/issues/357>)
* planner_cspace: reduce position quantization error on planning (#351 <https://github.com/at-wat/neonavigation/issues/351>)
* planner_cspace: latch publish data in navigation test (#353 <https://github.com/at-wat/neonavigation/issues/353>)
* planner_cspace: improve grid search performance (#342 <https://github.com/at-wat/neonavigation/issues/342>)
* planner_cspace: optimize BlockmemGridmap (#315 <https://github.com/at-wat/neonavigation/issues/315>)
* planner_cspace: add a launch for planner performance evaluation (#343 <https://github.com/at-wat/neonavigation/issues/343>)
* planner_cspace: fix parallel memory access (#306 <https://github.com/at-wat/neonavigation/issues/306>)
* planner_cspace: remove hist mode of debug output (#336 <https://github.com/at-wat/neonavigation/issues/336>)
* planner_cspace: fix navigation test setup (#335 <https://github.com/at-wat/neonavigation/issues/335>)
* planner_cspace: add a navigation test case with map update (#334 <https://github.com/at-wat/neonavigation/issues/334>)
* planner_cspace: add const to the end pos (#332 <https://github.com/at-wat/neonavigation/issues/332>)
* planner_cspace: reject request if input frame are located at diffrent frame to the map (#327 <https://github.com/at-wat/neonavigation/issues/327>)
* planner_cspace: publish empty path immediately after planning aborted (#326 <https://github.com/at-wat/neonavigation/issues/326>)
* planner_cspace: revert default sw_wait parameter (#313 <https://github.com/at-wat/neonavigation/issues/313>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* planner_cspace: calculate path hysteresis in 3-DOF space (#304 <https://github.com/at-wat/neonavigation/issues/304>)
* Fix include directory priority (#308 <https://github.com/at-wat/neonavigation/issues/308>)
* planner_cspace: fix CyclicVector dimension of planner_2dof_serial_joints (#307 <https://github.com/at-wat/neonavigation/issues/307>)
* planner_cspace, costmap_cspace: minor refactoring (#305 <https://github.com/at-wat/neonavigation/issues/305>)
* Fix empty path publish (#301 <https://github.com/at-wat/neonavigation/issues/301>)
* planner_cspace: refactor CyclicVec (#300 <https://github.com/at-wat/neonavigation/issues/300>)
* planner_cspace: refactor rotation cache (#299 <https://github.com/at-wat/neonavigation/issues/299>)
* planner_cspace: fix path cost calculation and interpolation (#298 <https://github.com/at-wat/neonavigation/issues/298>)
* Contributors: Atsushi Watanabe, Daiki Maekawa, Yuta Koga
```

## safety_limiter

```
* safety_limiter: increase simulation test publish rate (#320 <https://github.com/at-wat/neonavigation/issues/320>)
* safety_limiter: add simulation test conditions for backward motion (#319 <https://github.com/at-wat/neonavigation/issues/319>)
* safety_limiter: add delay compensation (#316 <https://github.com/at-wat/neonavigation/issues/316>)
* safety_limiter: fix footprint radius calculation (#317 <https://github.com/at-wat/neonavigation/issues/317>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Contributors: Atsushi Watanabe, Yuta Koga
```

## track_odometry

```
* track_odometry: synchronize Odometry and IMU (#363 <https://github.com/at-wat/neonavigation/issues/363>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* Fix include directory priority (#308 <https://github.com/at-wat/neonavigation/issues/308>)
* Contributors: Atsushi Watanabe
```

## trajectory_tracker

```
* trajectory_tracker: update demo params (#352 <https://github.com/at-wat/neonavigation/issues/352>)
* Drop ROS Indigo and Ubuntu Trusty support (#310 <https://github.com/at-wat/neonavigation/issues/310>)
* planner_cspace: calculate path hysteresis in 3-DOF space (#304 <https://github.com/at-wat/neonavigation/issues/304>)
* Fix include directory priority (#308 <https://github.com/at-wat/neonavigation/issues/308>)
* Contributors: Atsushi Watanabe
```
