### PR TITLE
Add python3-qt5-bindings rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5235,6 +5235,7 @@ python3-qt5-bindings:
   gentoo: [dev-python/PyQt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
+  rhel: ['python%{python3_pkgversion}-qt5-devel']
   slackware: [python3-PyQt5]
   ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:


### PR DESCRIPTION
python3-qt5-devel is part of EPEL: https://apps.fedoraproject.org/packages/python3-qt5-devel