### PR TITLE
sdhlibrary_cpp: 0.2.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13627,6 +13627,21 @@ repositories:
       url: https://github.com/JdeRobot/Scratch4Robots.git
       version: master
     status: developed
+  sdhlibrary_cpp:
+    doc:
+      type: git
+      url: https://github.com/ipab-slmc/SDHLibrary-CPP.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipab-slmc/SDHLibrary-CPP-release.git
+      version: 0.2.10-1
+    source:
+      type: git
+      url: https://github.com/ipab-slmc/SDHLibrary-CPP.git
+      version: master
+    status: maintained
   seed_smartactuator_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdhlibrary_cpp` to `0.2.10-1`:

- upstream repository: https://github.com/ipab-slmc/SDHLibrary-CPP.git
- release repository: https://github.com/ipab-slmc/SDHLibrary-CPP-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## sdhlibrary_cpp

```
* Create LICENSE
* change license to Apache 2.0
* export library
* comment unused parameters
* remove extra semicolon
* fix arguments for formatted printing (-Wformat=)
* demo executables
* fix CAN handler casting
* deactivate undefined 'NTCAN_ERROR_NO_BAUDRATE' and 'NTCAN_ERROR_LOM'
* CMake support
* remove deprecated dynamic exception specifications (-Wdeprecated)
* fix ostream comparison
* SDHLibrary-CPP 0.0.2.10
* Contributors: Christian Rauch
```
