### PR TITLE
[rosdep] Alpine corrections

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3423,7 +3423,6 @@ python-qt4-gl:
   gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
   ubuntu: [python-qt4-gl]
 python-qt5-bindings:
-  alpine: [py3-qt5]
   arch: [python2-pyqt5]
   debian:
     buster: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
@@ -5228,6 +5227,7 @@ python3-pytest-mock:
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-qt5-bindings:
+  alpine: [py3-qt5]
   arch: [python-pyqt5]
   debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, sip]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2984,7 +2984,6 @@ python-pycodestyle:
   rhel: [python-pycodestyle]
   ubuntu: [pycodestyle]
 python-pycryptodome:
-  alpine: [py3-pycryptodome]
   arch: [python2-pycryptodome]
   debian: [python-pycryptodome]
   fedora: [python-pycryptodomex]


### PR DESCRIPTION
This is a followup to #22011 and #21095

I don't think there's any fallout to removing the pycryptodome Alpine definition since we caught it before use.

Before we merge this we should check with @russkel to make sure that they can report any ROS 2 packages which are mistakenly relying on the python2 key `python-qt5-bindings` instead of `python3-qt5-bindings`.

Edit: somehow the PR references were off.