### PR TITLE
rosidl_typesupport_opensplice: 0.6.3-1 in 'crystal/distributio…

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1680,7 +1680,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
-      version: 0.6.2-0
+      version: 0.6.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_opensplice` to `0.6.3-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_opensplice.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.2-0`
