### PR TITLE
jderobot_ground_robots: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5287,6 +5287,19 @@ repositories:
       url: https://github.com/JdeRobot/drones.git
       version: master
     status: developed
+  jderobot_ground_robots:
+    release:
+      packages:
+      - rqt_ground_robot_teleop
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/JdeRobot/ground_robots-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/JdeRobot/ground_robots.git
+      version: master
+    status: developed
   jog_arm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_ground_robots` to `0.0.1-1`:

- upstream repository: https://github.com/JdeRobot/ground_robots.git
- release repository: https://github.com/JdeRobot/ground_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_ground_robot_teleop

```
* updated dependancies
* added rqt_ground_robot_teleop
* Contributors: Nikhil Khedekar
```
