### PR TITLE
jderobot_assets: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5267,7 +5267,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 0.0.2-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `0.1.0-1`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.2-1`

## jderobot_assets

```
* updated perspective
* added mouse and world
* removed iris model from world file
* removed plugins
* added drone_hangar
* Contributors: Nikhil Khedekar
```
