### PR TITLE
jderobot_drones: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5281,7 +5281,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.0.1-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-1`

## drone_wrapper

```
* anonymised drone and added topics as parameters
* added new format launch files
* updated scripts and readme
* Contributors: Nikhil Khedekar
```

## rqt_drone_teleop

```
* added topics as parameters
* Contributors: Nikhil Khedekar
```
