### PR TITLE
ecl_tools: 1.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -460,6 +460,7 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
       version: 1.0.2-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_tools.git
       version: release/1.0.x

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -458,7 +458,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 1.0.1-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/stonier/ecl_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `1.0.2-1`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-2`

## ecl_build

```
* Cross-platform req and enable cxx11, cxx14
* Decouple warning levels from enabling standards
```
