### PR TITLE
warehouse_ros: 0.9.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9471,7 +9471,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.9.2-0
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.3-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.9.2-0`

## warehouse_ros

```
* Fix const char* -> std::string conversion
* Fix install location for warehouse_ros. (#43 <https://github.com/ros-planning/warehouse_ros/issues/43>)
* Contributors: Robert Haschke, Sean Yen
```
