### PR TITLE
dynamixel_sdk: 3.7.10-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -380,6 +380,21 @@ repositories:
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  dynamixel_sdk:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
+      version: 3.7.10-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: dashing-devel
+    status: developed
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.10-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## dynamixel_sdk

```
* Supported ROS 2 Dashing Diademata
* Contributors: Darby, Pyo
```
