### PR TITLE
dynamixel_sdk: 3.7.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1535,7 +1535,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.7.0-0
+      version: 3.7.11-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.11-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.7.0-0`

## dynamixel_sdk

```
* Updated C lib and DLL file
* Changed C# / win32 / protocol_combined output path
* Fixed "protocol_combined" example bug
* Fixed typo in bulk_read_write.py
* Contributors: Pyo, Zerom
```
