### PR TITLE
Removed udp_driver

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -28,7 +28,6 @@ repositories:
       - point_cloud_fusion
       - ray_ground_classifier
       - ray_ground_classifier_nodes
-      - udp_driver
       - velodyne_driver
       - velodyne_node
       - voxel_grid


### PR DESCRIPTION
This removes `udp_driver` from the Autoware.Auto repository so that we can release it from the `transport_drivers` repository.