### PR TITLE
people: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5307,7 +5307,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/wg-perception/people.git
-      version: kinetic
+      version: melodic
     release:
       packages:
       - face_detector
@@ -5323,7 +5323,7 @@ repositories:
     source:
       type: git
       url: https://github.com/wg-perception/people.git
-      version: kinetic
+      version: melodic
     status: maintained
   pepperl_fuchs:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5319,7 +5319,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.1.2-0
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/wg-perception/people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.2.0-1`:

- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.2-0`

## face_detector

```
* Whitespace cleanu (#73 <https://github.com/wg-perception/people/issues/73>)
* Remove and move unused includes (#70 <https://github.com/wg-perception/people/issues/70>)
* Contributors: David V. Lu!!, Shane Loretz
```

## leg_detector

```
* Cleanup (#73 <https://github.com/wg-perception/people/issues/73>)
  * General code cleanup (standard headers, whitespace, linting)
* Contributors: David V. Lu!!
```

## people_msgs

```
* Document name field in PositionMeasurement (#75 <https://github.com/wg-perception/people/issues/75>)
* Cleanup (#73 <https://github.com/wg-perception/people/issues/73>)
  * Fill in implied packages
  * Misc Whitespace cleanup
* Contributors: David V. Lu!!, Shane Loretz
```

## people_tracking_filter

```
* Fix bfl include directory (#76 <https://github.com/wg-perception/people/issues/76>)
* Whitespace cleanup (#73 <https://github.com/wg-perception/people/issues/73>)
* Contributors: David V. Lu!!, Lucas Chiesa
```

## people_velocity_tracker

```
* Whitespace cleanup (#73 <https://github.com/wg-perception/people/issues/73>)
* Contributors: David V. Lu!!
```
