### PR TITLE
vrx: 1.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16066,7 +16066,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.1.2-1
+      version: 1.2.0-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx/


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.2.0-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.2-1`

## usv_gazebo_plugins

```
* Deterministic wind.
* Add v3d plugin - this publishes a vecotr based on the world frame velocity in Gazebo
  Update gps configuration to add gazebo gps and v3d plugins to standard configuration
* Add plugin for ROS interface to gazebo GPS sensor.
* added cylinder placeholder
* incremental
* added plate and sphere models
* functional for cubes
* added force visual plugin
* Contributors: Carlos Aguero, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, MarshallRawson, Rumman Waqar <mailto:rumman.waqar05@gmail.com>
```

## vrx_gazebo

```
* Merged default into topic_namespace_generation
* Modify teleop examples to use namespaces
* Add a namespace parameter to the launch file.
* Merged default into topic_namespace_generation
* now installs the custom protobuf message types
* Adding dependency on wave_gazebo.
* Merged in floating_docks (pull request #146)
  Floating docks
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* fixed triangle for dynamic
* dock 016 dynamic base name fixed
* Tweak default duration.
* fixed triangle position
* incremental
* uperception scoring: updated ymal files and fixed end condition bug when not looping
* lowered gaines for waves
* styling and documentation
* perception plugin refactored to be more fllexible
* Fully functional solution, with urdf file modified when calling spawn_wamv.bash and giving proper model dirs to wamv_gazebo and wamv_description
* Fully functional solution, with model.config errors only when non_competition_mode:=false
* tracking dock model sdf's
* static dynamic refactor complete
* files renamed
* halfway through dock name refactor
* static dock preformance improved
* incremental
* scan_dock now dynamic dock
* added static dock counter parts
* adding static dock option
* merged with default
* Merged default into Add-Option-To-Hide-Gazebo-Topics
* Tweak in wait_until_gzserver_is_up().
* Merged in issue_92 (pull request #157)
  Fix issue #92
  Approved-by: Tyler Lum <mailto:tylergwlum@gmail.com>
* Camera control plugin.
* Clean launch file
* Improve sandisland.launch clarity
* Improve spawn_wamv.bash comments clarity
* Change argument from competition_mode to non_competition_mode to fix publishing errors
* Add competition_mode argument
* Concatenate original Gazebo Model Path to new value
* Rm fake vrx_gazebo/models and make it work, needs testing
* Change model names to No Model
* Use if and unless in launch file for roslaunch spawn
* Deterministic wind.
* Merged default into topic_namespace_generation
* Fix namepsaces to work with robotNamespace parameter
* Merge changes with default branch
* Merged default into gps_plugin
* Add v3d plugin - this publishes a vecotr based on the world frame velocity in Gazebo
  Update gps configuration to add gazebo gps and v3d plugins to standard configuration
* Add plugin for ROS interface to gazebo GPS sensor.
* Merged default into gps_plugin
* added more params to dock xacro
* fix nav_challenge
* resolved merge conflicts
* dock xacro fixed
* incremental
* added scoring plugin to the nav_challenge xacro for world generation
* Remove redundant sleep
* Update script to run rosrun xacro to make final urdf, seems to work well
* Add arg parsing for spawn_wamv, does not work with urdf.xacros yet
* Add wait for gzserver, might need testing
* Spawn wamv with bash script, still needs improvement
* Add fake models in vrx_gazebo, wamv_description, wamv_gazebo to avoid GAZEBO_MODEL_PATH errors
* Merged default into Add-Option-To-Hide-Gazebo-Topics
* Merged in wamv-lock-at-run-time (pull request #152)
  Wamv lock at run time
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Fix spacing in yaml
* Tweaks.
* Fix nav_challenge_deep
* Add nav_challenge scoring plugin and gates
* Update xacros/dock.xacro and xacros/scan_and_dock.xacro to match original (add missing parameters)
* Add verbose and paused option for improved playback
* Merged in ocean-wave-xacro (pull request #150)
  Ocean wave xacro
  Approved-by: Marshall Rawson <mailto:marshallrawson@osrfoundation.org>
* cleaning
* wamv-locked by plugin permanetely
* added spinning out detection
* Merged default into ocean-wave-xacro
* incremental
* incremental
* Change big shallow and deep world yaml to individual tasks
* nodes now shutdown and use safe_yaml
* VRX_DEBUG now linked to enable_ros_network
* fixed ambient light and fog
* print to rospy.loginfo
* fixed xacro insert block ordering issue
* includes the yaml files in repository
* functional?
* Change to default to true, as it should
* Add enable_ros_network argument
* incremental
* added plate and sphere models
* functional for cubes
* incremental
* made taskMsgPub and taskMsg protected
* Now published taskMsg in OnFinished
* added time stamp to OnFinsihed
* moved exit to scoring plugin.
* removed old debug msg
* Fix build issue by resolving typo with ROS_ERROR msg
* styling
* functional, does not shutdown gzclient
* functional
* approximate 4x4 dock block as a sphere
* merge
* Merged in compliance-refactor (pull request #139)
  Compliance refactor
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
  Approved-by: Tyler Lum <mailto:tylergwlum@gmail.com>
* fix print
* styling
* added overall compliance error
* Removed old print statments, Added yaml file confirmation ROSINFO message
* fixed dock inertial issues
* fixed error message
* example_sensor_config.yaml edited online with Bitbucket
* merge
* functional
* merge
* Contributors: Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, Marshall Rawson <mailto:marshallrawson@osrfoundation.org>, MarshallRawson, MarshallRawson <mailto:marshallrawson@osrfoundation.org>, Tyler Lum <mailto:tylergwlum@gmail.com>
```

## wamv_description

```
* Merge from topic_namespace_generation
* fix catkin make install issues with meshes
* Merged in Fix-RVIZ-Mesh-Issue (pull request #158)
  Fix RVIZ Mesh Issue
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Fully functional solution, with urdf file modified when calling spawn_wamv.bash and giving proper model dirs to wamv_gazebo and wamv_description
* Fully functional solution, with model.config errors only when non_competition_mode:=false
* Change all to package://vrx_gazebo
* Rm fake vrx_gazebo/models and make it work, needs testing
* Change model names to No Model
* Add sensor namepsace to planar lidar
  Remove gloabl namespace
* Add support for namespaces This includes thruster, camera and sensor namespaces, as well as a global namespace allowing multiple vehicles to be created without causing interference.
* Merged default into gps_plugin
* Clean up model.config files
* Add fake models in vrx_gazebo, wamv_description, wamv_gazebo to avoid GAZEBO_MODEL_PATH errors
* Contributors: Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, MarshallRawson, Tyler Lum <mailto:tylergwlum@gmail.com>
```

## wamv_gazebo

```
* Merge from topic_namespace_generation
* Update rviz configuration with new lidar topic
* lidar->lidars in topic names
* Merged default into topic_namespace_generation
* Alter launch file to fix tf frame error in navsat_transform_node
* Update rviz configuration to match namespaces
* Update localisation example launch file to support namespace.  The addition of a robot namespace also results in the creation of tf namespaces.  This patch upadtes the launch file to support this
* Modify xacro files to add further topic subnamespaces to sensor models
* Merged default into topic_namespace_generation
* fix catkin make install issues with meshes
* Merged in Fix-RVIZ-Mesh-Issue (pull request #158)
  Fix RVIZ Mesh Issue
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Fully functional solution, with urdf file modified when calling spawn_wamv.bash and giving proper model dirs to wamv_gazebo and wamv_description
* Fully functional solution, with model.config errors only when non_competition_mode:=false
* Change all to package://vrx_gazebo
* Rm fake vrx_gazebo/models and make it work, needs testing
* Change model names to No Model
* Move cameras into sensor namespace
  Add senosr namespace to p3d position feedback
* Remove extra slashes from topic names
* Merged default into topic_namespace_generation
* Fix namepsaces to work with robotNamespace parameter
* Merge changes with default branch
* Add sensor namepsace to planar lidar
  Remove gloabl namespace
* Add support for namespaces This includes thruster, camera and sensor namespaces, as well as a global namespace allowing multiple vehicles to be created without causing interference.
* Add v3d plugin - this publishes a vecotr based on the world frame velocity in Gazebo
  Update gps configuration to add gazebo gps and v3d plugins to standard configuration
* Add plugin for ROS interface to gazebo GPS sensor.
* Clean up model.config files
* Add fake models in vrx_gazebo, wamv_description, wamv_gazebo to avoid GAZEBO_MODEL_PATH errors
* fixed wamv_camera
* remove tab
* fix issue
* removed old debug msg
* added force visualization to wamv
* Contributors: Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, MarshallRawson, Rumman Waqar <mailto:rumman.waqar05@gmail.com>, Tyler Lum <mailto:tylergwlum@gmail.com>
```

## wave_gazebo

```
* Try to change material script to match the newly created texture, did not work
* Rewrite code to match with rendertotexture tutorial
* Hide minimap, water constant texture, try get plane to be reflection, shows reflection but wrong geometry
* Add texture material to water
* Remove enable/disable refl to fix render issue
* Change to ogre user camera pos and orient, try but fail shaders
* Scale plane and mesh to show it
* Flip plane to be flat, need to next hide the original water
* Test removing preset shader/texture to see if water will update, will not BIG CHANGES SOON
* Create new texture unit
* Change texture name, miniscreen and plane work but not water
* Try to change ocean to show the texture, did not work yet
* Change position and angle of camera
* Add reflection texture empty
* Remove textures
* Move ocean visual plane upwards
* Use gl_ModelViewProjectionMatrix to see colorful ocean
* Work off ocean model, clean out visual plugin and use new simple material scripts
* Merged default into topic_namespace_generation
* fix catkin make install issues with meshes
* Fix source paths and variable keywords
* merged with default
* removed sdf
* Copy over Fresnel materials files
* merge default
* Merged default into Add-Option-To-Hide-Gazebo-Topics
* Merged in xacro_for_oceanwaves (pull request #153)
  Modiying world definitions in wave_gazebo package to use xacro
  Approved-by: Carlos Agüero <mailto:cen.aguero@gmail.com>
* Style.
* Modiying world definitions in wave_gazebo package to use xacro
* Merged in ocean-wave-xacro (pull request #150)
  Ocean wave xacro
  Approved-by: Marshall Rawson <mailto:marshallrawson@osrfoundation.org>
* cleaning
* added spinning out detection
* incremental
* removed erb from CMake
* removed ocean-waves-sdf
* functional?
* incremental
* functional
* approximate 4x4 dock block as a sphere
* merge
* fixed dock inertial issues
* model.sdf.erb edited online with Bitbucket
* model.sdf.erb edited online with Bitbucket
* model.sdf.erb edited online with Bitbucket
* added <laser_retro>-1 flags to new wave visual links
* functional
* Install world_models in wave_gazebo
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, Jonathan Wheare <mailto:jonathan.wheare@flinders.edu.au>, Jose Luis Rivero <mailto:jrivero@osrfoundation.org>, Marshall Rawson <mailto:marshallrawson@osrfoundation.org>, MarshallRawson, MarshallRawson <mailto:marshallrawson@osrfoundation.org>, Tyler Lum <mailto:tylergwlum@gmail.com>
```

## wave_gazebo_plugins

```
* Go back to custom material, note if you change mytexture2 -> mytexture, it breaks it from resource group can't find error
* Try to change plane material to use existing reflection material and only edit the texture, but does not work
* Fix code quality to pass pipeline
* Try to change material script to match the newly created texture, did not work
* Add jpg texture mix with ocean, worked decently
* Try to add miniscreen to see the material/texture, but not working for some reason
* Disable clip plane each post render, working very well
* Turn on and off reflection and clip plane in pre/post render
* Rewrite code to match with rendertotexture tutorial
* Add reflection to plane
* Add comments and documentation and removed unneeded parts
* Hide minimap, water constant texture, try get plane to be reflection, shows reflection but wrong geometry
* Add texture material to water
* Go back to orig user camera
* Unsuccessful attempt to switch cameras
* Show difference between Ogre::Cam and gz:rend:Cam position
* Add code from book to use new camera, needs update
* Remove enable/disable refl to fix render issue
* Hide plane from texture
* Change to ogre user camera pos and orient, try but fail shaders
* BIG CLEANUP, removed old unused lines of code
* Add enableRefl and disableRelf
* Scale plane and mesh to show it
* Flip plane to be flat, need to next hide the original water
* Create new texture unit
* Change texture name, miniscreen and plane work but not water
* Try to change ocean to show the texture, did not work yet
* Put texture onto plane
* Make only one visualplugin to remove extra miniscreen
* Add rendertargetlistener to not show miniscreen (still shows because there are two)
* Try to implement it, did not work
* Add WavefieldRenderTargetListener, completely untested
* Update miniscreen continuously
* SUCCESSFULLY show small version in mini screen
* Add view to miniscreen, ugly
* Add miniscreen
* Change position and angle of camera
* Change angle to view something
* Save to image file, it is blank
* Add render texture
* Add texture
* Change to valid image
* Add plane image, looks weird
* Move user camera
* Added a light
* Add render updates
* Add RTShaderSystem
* Add static function variable to differentiate between Ogre names
* Fix scene, still not working
* Not working setup, likely need to use visualptr to get scene
* Add scene ptr
* Add viewport setup
* Add scene nodes and camera setup
* Add root, scenemgr
* Add unworking Ogre texture creation
* Work off ocean model, clean out visual plugin and use new simple material scripts
* Modiying world definitions in wave_gazebo package to use xacro
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Tyler Lum <mailto:tylergwlum@gmail.com>
```
