### PR TITLE
avt_vimba_camera: 0.0.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -332,7 +332,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
-      version: 0.0.11
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -341,7 +341,7 @@ repositories:
     source:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
-      version: 0.0.11
+      version: master
     status: maintained
   aws_common:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -328,6 +328,21 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
       version: master
     status: developed
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: 0.0.11
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/astuff/avt_vimba_camera-release.git
+      version: 0.0.11-1
+    source:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: 0.0.11
+    status: maintained
   aws_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.11-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## avt_vimba_camera

```
* Merge pull request #35 <https://github.com/astuff/avt_vimba_camera/issues/35> from willcbaker/feature/nodelet
  Feature/nodelet
* Update nodelet launch files
* Add nodelet
* Fix #31 <https://github.com/astuff/avt_vimba_camera/issues/31>
* Merge pull request #30 <https://github.com/astuff/avt_vimba_camera/issues/30> from chewwt/armv8
  add support for armv8
* add support for armv8
* Change frame observer to shared ptr
* Contributors: Miquel Massot, Will Baker, ruth
```
