### PR TITLE
turtlebot3_msgs: 2.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2188,6 +2188,21 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: master
     status: developed
+  turtlebot3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: dashing-devel
+    status: developed
   uncrustify_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## turtlebot3_msgs

```
* Supported ROS 2 Dashing Diademata
* Added Sound service file
* Contributors: Darby Lim, Pyo
```
