### PR TITLE
xsens_mtw_driver: 1.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16553,6 +16553,12 @@ repositories:
       url: https://github.com/ethz-asl/ethzasl_xsens_driver.git
       version: master
     status: maintained
+  xsens_mtw_driver:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/qleonardolp/xsens_mtw_driver-release.git
+      version: 1.0.3-1
   xv_11_laser_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xsens_mtw_driver` to `1.0.3-1`:

- upstream repository: https://github.com/qleonardolp/xsens_mtw_driver-release.git
- release repository: https://github.com/qleonardolp/xsens_mtw_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## xsens_mtw_driver

```
* Update github link
* Contributors: Leonardo Felipe L. S. dos Santos
```
