### PR TITLE
turtlebot3: 1.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8722,7 +8722,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 1.2.0-0
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `1.2.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.0-0`

## turtlebot3

```
* Fixed dwa local planner params for dwa_local_planner 1.16.2 #415 <https://github.com/ROBOTIS-GIT/turtlebot3/issues/415>
* This patch only applies to ROS 1 Melodic.
* Contributors: atinfinity, Kayman
```

## turtlebot3_bringup

```
* none
```

## turtlebot3_description

```
* none
```

## turtlebot3_example

```
* none
```

## turtlebot3_navigation

```
* Fixed dwa local planner params for dwa_local_planner 1.16.2 #415 <https://github.com/ROBOTIS-GIT/turtlebot3/issues/415>
* This patch only applies to ROS 1 Melodic.
* Contributors: atinfinity, Kayman
```

## turtlebot3_slam

```
* none
```

## turtlebot3_teleop

```
* none
```
