### PR TITLE
hls_lfcd_lds_driver: 2.0.0-1 in 'dashing/distribution.yaml' [b…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -653,6 +653,21 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: dashing
     status: maintained
+  hls_lfcd_lds_driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: dashing-devel
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls_lfcd_lds_driver` to `2.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## hls_lfcd_lds_driver

```
* Supported ROS 2 Dashing Diademata
* Added parameter for initilization and modified qos
* Reduced scope to boost-system dependency
* Fixed build warnings in ROS2 Dashing
* Contributors: Emerson Knapp, Darby Lim, Pyo
```
