### PR TITLE
schunk_modular_robotics: 0.6.13-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13583,7 +13583,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - schunk_description

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13595,7 +13595,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.12-0
+      version: 0.6.13-1
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.13-1`:

- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.12-0`

## schunk_description

```
* Merge pull request #213 <https://github.com/ipa320/schunk_modular_robotics/issues/213> from PilzDE/remove-gazebo-depend
  drop gazebo_ros dependency
* drop gazebo_ros dependency
  Fixes #209 <https://github.com/ipa320/schunk_modular_robotics/issues/209>
* Merge pull request #208 <https://github.com/ipa320/schunk_modular_robotics/issues/208> from christian-rauch/rm_visual_tip
  remove visual representation of virtual SDH grasp and tip links
* remove visual representation of virtual SDH grasp and tip links
* Contributors: Christian Rauch, Joachim Schleicher
```

## schunk_libm5api

```
* Merge pull request #207 <https://github.com/ipa320/schunk_modular_robotics/issues/207> from christian-rauch/no_abs
  Deactivate definition of 'abs' function
* do not use self defined 'abs' function
* Contributors: Christian Rauch
```

## schunk_modular_robotics

- No changes

## schunk_powercube_chain

- No changes

## schunk_sdh

```
* Merge pull request #212 <https://github.com/ipa320/schunk_modular_robotics/issues/212> from christian-rauch/sdhlib_source
  Replace binary sdh library with source SDHLibrary-CPP
* add source dependency on 'sdhlibrary_cpp'
* remove binary distribution of SDHLibrary-CPP
* Merge pull request #210 <https://github.com/ipa320/schunk_modular_robotics/issues/210> from christian-rauch/sdh_only_services
  backport services to SDH only node
* use private namespace for sdh_only node
* backport temperature publisching to sdh_only node
* backport services to sdh_only node
* Contributors: Christian Rauch
```

## schunk_simulated_tactile_sensors

- No changes
