### PR TITLE
schunk_modular_robotics: 0.6.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8101,7 +8101,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git
-      version: melodic_release_candidate
+      version: indigo_dev
     release:
       packages:
       - schunk_description
@@ -8113,7 +8113,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git
       version: indigo_dev
-    status: maintained
+    status: developed
   sdhlibrary_cpp:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8108,7 +8108,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/schunk_modular_robotics-release.git
-      version: 0.6.12-0
+      version: 0.6.13-1
     source:
       type: git
       url: https://github.com/ipa320/schunk_modular_robotics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `schunk_modular_robotics` to `0.6.13-1`:

- upstream repository: https://github.com/ipa320/schunk_modular_robotics.git
- release repository: https://github.com/ipa320/schunk_modular_robotics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.12-0`

## schunk_description

```
* Merge pull request #213 <https://github.com/ipa320/schunk_modular_robotics/issues/213> from PilzDE/remove-gazebo-depend
  drop gazebo_ros dependency
* drop gazebo_ros dependency
  Fixes #209 <https://github.com/ipa320/schunk_modular_robotics/issues/209>
* Merge pull request #208 <https://github.com/ipa320/schunk_modular_robotics/issues/208> from christian-rauch/rm_visual_tip
  remove visual representation of virtual SDH grasp and tip links
* remove visual representation of virtual SDH grasp and tip links
* Contributors: Christian Rauch, Joachim Schleicher
```
