### PR TITLE
warehouse_ros_mongo: 0.9.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9477,6 +9477,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: kinetic-devel
     status: maintained
+  warehouse_ros_mongo:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros_mongo-release.git
+      version: 0.9.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: melodic-devel
+    status: maintained
   warthog:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `0.9.0-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/ros-gbp/warehouse_ros_mongo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## warehouse_ros_mongo

```
* Use std pointers
* Fix catkin issues
* Refactored Warehouse ROS for pluginlib
* Contributors: Christian Rauch, Connor Brew, Dave Coleman, Robert Haschke, v4hn
```
