### PR TITLE
ecl_tools: 0.61.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1674,7 +1674,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
-      version: 0.61.7-0
+      version: 0.61.8-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/0.61-melodic
     status: maintained
   eigen_stl_containers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.8-1`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.61.7-0`

## ecl_build

```
* cross platform enabling of cx11
```
