### PR TITLE
Add ifcfg-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -154,6 +154,19 @@ gunicorn:
   fedora: [python-gunicorn]
   gentoo: [www-servers/gunicorn]
   ubuntu: [gunicorn]
+ifcfg-pip:
+  debian:
+    pip:
+      packages: [ifcfg]
+  fedora:
+    pip:
+      packages: [ifcfg]
+  osx:
+    pip:
+      packages: [ifcfg]
+  ubuntu:
+    pip:
+      packages: [ifcfg]
 imgaug-pip:
   debian:
     pip:
@@ -5002,16 +5015,6 @@ python3-gnupg:
   fedora: [python3-gnupg]
   gentoo: [dev-python/python-gnupg]
   ubuntu: [python3-gnupg]
-python3-ifcfg:
-  debian: [python3-ifcfg]
-  fedora: [python3-ifcfg]
-  gentoo: [dev-python/ifcfg]
-  openembedded: [python3-ifcfg@meta-python]
-  osx:
-    pip:
-      packages: [ifcfg]
-  rhel: [python3-ifcfg]
-  ubuntu: [python3-ifcfg]
 python3-lark-parser:
   fedora:
     '*': [python3-lark-parser]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5000,6 +5000,16 @@ python3-gnupg:
   fedora: [python3-gnupg]
   gentoo: [dev-python/python-gnupg]
   ubuntu: [python3-gnupg]
+python3-ifcfg:
+  debian: [python3-ifcfg]
+  fedora: [python3-ifcfg]
+  gentoo: [dev-python/ifcfg]
+  openembedded: [python3-ifcfg@meta-python]
+  osx:
+    pip:
+      packages: [ifcfg]
+  rhel: [python3-ifcfg]
+  ubuntu: [python3-ifcfg]
 python3-lark-parser:
   fedora:
     '*': [python3-lark-parser]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5227,6 +5227,13 @@ python3-rosdep:
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
   ubuntu: [python3-rosdep]
+python3-rosdistro-modules:
+  debian: [python3-rosdistro-modules]
+  fedora: [python3-rosdistro]
+  gentoo: [dev-python/rosdistro]
+  openembedded: [python3-rosdistro@meta-ros]
+  rhel: ['python%{python3_pkgversion}-rosdistro']
+  ubuntu: [python3-rosdistro-modules]
 python3-rospkg:
   alpine:
     pip:


### PR DESCRIPTION
This package is used in [ros2doctor network feature](https://github.com/ros2/ros2cli/blob/claire/ros2doctor-network/ros2doctor/ros2doctor/api/network.py) to check network configuration. 
Package repo can be found at https://github.com/ftao/python-ifcfg, and it is compatible with Python2 and Python3.
Web index: https://pypi.org/project/ifcfg/, no platform specific package index found. 
Explicit vendor package can be found at https://github.com/ros2/ifcfg_vendor