### PR TITLE
fetch_robots: 0.8.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1940,7 +1940,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.8.7-1
+      version: 0.8.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.8.8-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.7-1`

## fetch_bringup

- No changes

## fetch_drivers

```
* Binary Drivers 0.8.8 (#52 <https://github.com/fetchrobotics/fetch_robots/issues/52>)
  
    * Sync drivers with internal release 2018.8_stable.
    * This fixes https://github.com/fetchrobotics/fetch_ros/issues/70
  
* Merge pull request #1647 <https://github.com/fetchrobotics/fetch_drivers/issues/1647> from moriarty/opensource-fixes
  This addresses https://github.com/fetchrobotics/fetch_ros/issues/70
* Docker based testing 2.0 (#1332 <https://github.com/fetchrobotics/fetch_drivers/issues/1332>)
* More LED Diagnostics [2018.8] (#1510 <https://github.com/fetchrobotics/fetch_drivers/issues/1510>)
* Merge pull request #1504 <https://github.com/fetchrobotics/fetch_drivers/issues/1504> from dbking77/publish_gyro_offset_age.8
  
    * Extra gyro diagnostics 2018.8
    * Publish gyro offset age.
    * Record interval average for gyro offset.
    * Publish average gyro temperature.
  
* Merge pull request #1398 <https://github.com/fetchrobotics/fetch_drivers/issues/1398> from dbking77/slower_gyro_drift_fix-2018.8
  
    * Put slightly more aggressive filter on wheel motion detector.
    * Also don't keep gyro output enabled for a long time unless robot has been moving for a while.
  
* Backport driver creation system [2018.8] (#1369 <https://github.com/fetchrobotics/fetch_drivers/issues/1369>)
* Merge pull request #1364 <https://github.com/fetchrobotics/fetch_drivers/issues/1364> from dbking77/combined_gyro_zeroing_fix_2018.8
* Merge pull request #1335 <https://github.com/fetchrobotics/fetch_drivers/issues/1335> from dbking77/combined_gyro_output_disable_delay_2018.8
* Merge pull request #1306 <https://github.com/fetchrobotics/fetch_drivers/issues/1306> from dbking77/charger_config_improvements_for_2018.8
* Merge pull request #1309 <https://github.com/fetchrobotics/fetch_drivers/issues/1309> from dbking77/accel_direction_fixup_for_2018.8
* added nav command sub to light driver (#1314 <https://github.com/fetchrobotics/fetch_drivers/issues/1314>)
* Support for mainboard rev I and J
* Merge pull request #1259 <https://github.com/fetchrobotics/fetch_drivers/issues/1259> from dbking77/imu_param_description_fix
* Merge branch '2018.6_stable' into master
* Merge pull request #1202 <https://github.com/fetchrobotics/fetch_drivers/issues/1202> from moriarty/compatibility-fixes
  
    * [ROS][C++] Indigo & Melodic Compatibility fixes
    * [C++] urdf/model.h upstream compatibility ptr
    * This fixes #1181 <https://github.com/fetchrobotics/fetch_drivers/issues/1181>
    * and can fix fetchrobotics/fetch_ros#86 <https://github.com/fetchrobotics/fetch_ros/issues/86>
    * [C++] additional [-Werror=catch-value=] fixes
    * [C++] catch errors by const ref
  
* More extensive docker stuff as well as a fix for testing master (#1186 <https://github.com/fetchrobotics/fetch_drivers/issues/1186>)
* Use std::isnan instead of isnan
* Add missing catkin dependencies for actionlib messages
* Move header files shared by driver and firmware to shared directory. (#1167 <https://github.com/fetchrobotics/fetch_drivers/issues/1167>)
  
    * Moving header files shared by driver and firmware to shared directory.
    * Put shared structs/enums in fetch_drivers::shared namespace.
    * Change include of stdint.h cstdint.
    * Put BoardFlags, PanelFlags, and TorsoSensorParams in a struct.
    * Update gitignore to ignore bootloader and firmware.
  
* Merge pull request #1187 <https://github.com/fetchrobotics/fetch_drivers/issues/1187> from chadrockey/1604_fixes
* Contributors: Alexander Moriarty, Andrew Parker, Carl Saldanha, Chad Rockey, Derek King, Eric Relson, Jeff Wilson, Justin Watson, Luc Bettaieb, Niharika Arora, Sarah Elliott
```

## freight_bringup

- No changes
