### PR TITLE
added yapf for ubuntu bionic rosdep/python.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5620,6 +5620,9 @@ yamllint:
     xenial: [yamllint]
     yakkety: [yamllint]
     zesty: [yamllint]
+yapf:
+  ubuntu:
+    bionic: [python-yapf]
 yasm:
   arch: [yasm]
   debian: [yasm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5621,8 +5621,12 @@ yamllint:
     yakkety: [yamllint]
     zesty: [yamllint]
 yapf:
+  arch: [yapf]
+  debian:
+    buster: [yapf]
+    stretch: [yapf]
   ubuntu:
-    bionic: [python-yapf]
+    bionic: [yapf]
 yasm:
   arch: [yasm]
   debian: [yasm]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5480,3 +5480,6 @@ yapf:
       pip:
         packages: [yapf]
     zesty: [yapf]
+    bionic:
+      pip:
+        packages: [yapf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5458,6 +5458,9 @@ yapf:
     stretch: [yapf]
   ubuntu:
     artful: [yapf]
+    bionic:
+      pip:
+        packages: [yapf]
     saucy:
       pip:
         packages: [yapf]
@@ -5480,6 +5483,4 @@ yapf:
       pip:
         packages: [yapf]
     zesty: [yapf]
-    bionic:
-      pip:
-        packages: [yapf]
+

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5458,9 +5458,6 @@ yapf:
     stretch: [yapf]
   ubuntu:
     artful: [yapf]
-    bionic:
-      pip:
-        packages: [yapf]
     saucy:
       pip:
         packages: [yapf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5480,4 +5480,3 @@ yapf:
       pip:
         packages: [yapf]
     zesty: [yapf]
-


### PR DESCRIPTION
rosdep rule for [yapf](https://github.com/google/yapf) on ubuntu 18.04 bionic systems