### PR TITLE
Update 'webots_ros2' reference in 'crystal/distribution.yaml'

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -2185,11 +2185,19 @@ repositories:
       version: ros2
     status: maintained
   webots_ros2:
+    doc:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: crystal
     release:
       tags:
         release: release/crystal/{package}/{version}
-      url: https://github.com/omichel/webots_ros2-release.git
+      url: https://github.com/cyberbotics/webots_ros2-release.git
       version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: crystal
     status: developed
   yaml_cpp_vendor:
     release:


### PR DESCRIPTION
This package was migrated to the https://github.com/cyberbotics organization.