### PR TITLE
Update 'webots_ros' reference in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16245,16 +16245,16 @@ repositories:
   webots_ros:
     doc:
       type: git
-      url: https://github.com/omichel/webots_ros.git
+      url: https://github.com/cyberbotics/webots_ros.git
       version: kinetic
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/omichel/webots_ros-release.git
+      url: https://github.com/cyberbotics/webots_ros-release.git
       version: 2.0.5-1
     source:
       type: git
-      url: https://github.com/omichel/webots_ros.git
+      url: https://github.com/cyberbotics/webots_ros.git
       version: master
     status: developed
   webrtc_ros:


### PR DESCRIPTION
This package was migrated to the https://github.com/cyberbotics organization.