### PR TITLE
Update 'webots_ros' reference in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9565,16 +9565,16 @@ repositories:
   webots_ros:
     doc:
       type: git
-      url: https://github.com/omichel/webots_ros.git
+      url: https://github.com/cyberbotics/webots_ros.git
       version: melodic
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/omichel/webots_ros-release.git
+      url: https://github.com/cyberbotics/webots_ros-release.git
       version: 2.0.5-1
     source:
       type: git
-      url: https://github.com/omichel/webots_ros.git
+      url: https://github.com/cyberbotics/webots_ros.git
       version: melodic
     status: developed
   webrtc_ros:


### PR DESCRIPTION
This package was migrated to the https://github.com/cyberbotics organization.