### PR TITLE
rail_mesh_icp: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6109,7 +6109,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/gt-rail-release/rail_mesh_icp-release.git
-      version: 0.0.1-3
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_mesh_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_mesh_icp` to `0.0.3-1`:

- upstream repository: https://github.com/GT-RAIL/rail_mesh_icp.git
- release repository: https://github.com/gt-rail-release/rail_mesh_icp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-3`

## rail_mesh_icp

```
* fixes to various files for continuous-integration
* fixes to message dependencies
* Contributors: Angel
```
