### PR TITLE
webots_ros2: 0.0.2-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -2190,11 +2190,19 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros2.git
       version: crystal
     release:
+      packages:
+      - webots_ros2
+      - webots_ros2_core
+      - webots_ros2_desktop
+      - webots_ros2_examples
+      - webots_ros2_msgs
+      - webots_ros2_universal_robot
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros2-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/cyberbotics/webots_ros2.git
       version: crystal


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `0.0.2-1`:

  - upstream repository: https://github.com/omichel/webots_ros2.git
  - release repository: https://github.com/omichel/webots_ros2-release.git
  - distro file: `crystal/distribution.yaml`
  - bloom version: `0.8.0`
  - previous version for package: `0.0.1-2`