### PR TITLE
launch: 0.8.5-3 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -748,7 +748,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.8.4-1
+      version: 0.8.5-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.8.5-3`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.4-1`

## launch

```
* Add support for conditions in IncludeLaunchDescription actions (#304 <https://github.com/ros2/launch/issues/304>)
* Contributors: Michel Hidalgo, chapulina
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes
