### PR TITLE
rqt_reconfigure: 1.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1930,6 +1930,11 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
       version: dashing
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_reconfigure

```
* Use a consistent formatting method when logging (#49 <https://github.com/ros-visualization/rqt_reconfigure/issues/49>)
  This will improve logging function compatibility between ROS 1 and
  ROS 2.
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Re-format license headers to conform to ROS templates (#39 <https://github.com/ros-visualization/rqt_reconfigure/issues/39>)
  This change adds a line to the license headers specifying the name of
  the license that follows. It also re-formats the recently added LICENSE
  and CONTRIBUTING.md files to match the templates.
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Rename DynreconfClientWidget => ParamClientWidget (#36 <https://github.com/ros-visualization/rqt_reconfigure/issues/36>)
* Add ament tests
* Add LICENSE and CONTRIBUTING.md (#37 <https://github.com/ros-visualization/rqt_reconfigure/issues/37>)
* Format per linter suggestions and run tests (#35 <https://github.com/ros-visualization/rqt_reconfigure/issues/35>)
* Fix some linter errors and get tests running (#33 <https://github.com/ros-visualization/rqt_reconfigure/issues/33>)
* Pull logging methods into a separate file (#34 <https://github.com/ros-visualization/rqt_reconfigure/issues/34>)
* Update to package.xml format 2 (#32 <https://github.com/ros-visualization/rqt_reconfigure/issues/32>)
* Migration to ROS2
* Contributors: Gonzalo de Pedro, Gonzo, Michel Hidalgo, Scott K Logan, Timon Engelke
```
