### PR TITLE
ament_lint: 0.7.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -166,7 +166,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.7.7-1
+      version: 0.7.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.7.8-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.7-1`
