### PR TITLE
image_transport_plugins: 2.1.0-1 in 'dashing/distribution.yaml…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -690,6 +690,27 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: ros2
     status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/image_transport_plugins-release.git
+      version: 2.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.1.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## compressed_depth_image_transport

```
* Merge pull request #33 <https://github.com/ros-perception/image_transport_plugins/issues/33> from klintan/ros2
  [ROS2] Fixed portability warning for compressed depth plugin.
* fixed portability warning for name
* Contributors: Andreas Klintberg, David Gossow
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

```
* Fix Dashing deprecation warning. (#41 <https://github.com/ros-perception/image_transport_plugins/issues/41>)
  Signed-off-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge pull request #38 <https://github.com/ros-perception/image_transport_plugins/issues/38> from Kapernikov/ros2
  Fix theora plugin wrong path (#37 <https://github.com/ros-perception/image_transport_plugins/issues/37>)
* Fix theora plugin wrong path
* Contributors: David Gossow, Frank Dekervel, Michael Carroll
```
