### PR TITLE
people: 1.3.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1023,7 +1023,7 @@ repositories:
   people:
     doc:
       type: git
-      url: https://github.com/OSUrobotics/people-ros2-release.git
+      url: https://github.com/wg-perception/people.git
       version: ros2
     release:
       packages:
@@ -1035,7 +1035,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/OSUrobotics/people-ros2-release.git
+      url: https://github.com/wg-perception/people.git
       version: ros2
     status: maintained
   pluginlib:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1020,6 +1020,24 @@ repositories:
       url: https://github.com/ros2/pcl_conversions.git
       version: dashing
     status: developed
+  people:
+    doc:
+      type: git
+      url: https://github.com/OSUrobotics/people-ros2-release.git
+      version: ros2
+    release:
+      packages:
+      - people_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/OSUrobotics/people-ros2-release.git
+      version: 1.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/OSUrobotics/people-ros2-release.git
+      version: ros2
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.3.0-1`:

- upstream repository: https://github.com/wg-perception/people
- release repository: https://github.com/OSUrobotics/people-ros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
