### PR TITLE
ecl_lite: 1.0.3-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -454,7 +454,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 1.0.1-1
+      version: 1.0.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `1.0.3-2`:

- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-1`

## ecl_errors

```
* pedantic error message fixes for ecl_compile_time_assert on clang/macosx
* explicit construction for the Error class so surprising things can't happen
* equality operator for the Error class
```

## ecl_time_lite

```
* pedantic error message fixes for const error string methods on clang/macosx
```
