### PR TITLE
add python-jmespath

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1999,6 +1999,11 @@ python-jira-pip:
       packages: [jira]
 python-jmespath:
   ubuntu: [python-jmespath]
+  debian: [python-jmespath]
+  fedora: [python-jmespath]
+  osx:
+    pip:
+      packages: [jmespath]
 python-joblib:
   arch: [python2-joblib]
   debian: [python-joblib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1998,12 +1998,12 @@ python-jira-pip:
     pip:
       packages: [jira]
 python-jmespath:
-  ubuntu: [python-jmespath]
-  debian: [python-jmespath]
+  debian: [python-jmespath] 
   fedora: [python-jmespath]
   osx:
     pip:
       packages: [jmespath]
+  ubuntu: [python-jmespath]
 python-joblib:
   arch: [python2-joblib]
   debian: [python-joblib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1998,7 +1998,7 @@ python-jira-pip:
     pip:
       packages: [jira]
 python-jmespath:
-  debian: [python-jmespath] 
+  debian: [python-jmespath]
   fedora: [python-jmespath]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1997,6 +1997,8 @@ python-jira-pip:
   ubuntu:
     pip:
       packages: [jira]
+python-jmespath:
+  ubuntu: [python-jmespath]
 python-joblib:
   arch: [python2-joblib]
   debian: [python-joblib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1999,7 +1999,7 @@ python-jira-pip:
       packages: [jira]
 python-jmespath:
   debian: [python-jmespath]
-  fedora: [python-jmespath]
+  fedora: [python2-jmespath]
   osx:
     pip:
       packages: [jmespath]


### PR DESCRIPTION
add rosdep rule for python-[jmespath](http://jmespath.org/)
It will be useful when a robot needs to handle some complicated json data. 

This package is available in [pip](https://pypi.org/project/jmespath/) [fedora](https://apps.fedoraproject.org/packages/python2-jmespath) [debian](https://packages.debian.org/stretch/python-jmespath) and [ubuntu](https://packages.ubuntu.com/source/xenial/python-jmespath)