### PR TITLE
ecl_core: 1.0.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -429,7 +429,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `1.0.4-1`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.3-1`
