### PR TITLE
robot_state_publisher: 1.13.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11101,7 +11101,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.13.6-0
+      version: 1.13.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.13.7-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.13.6-0`

## robot_state_publisher

```
* Remove treefksolver completely from the repository. (#100 <https://github.com/ros/robot_state_publisher/issues/100>) (#101 <https://github.com/ros/robot_state_publisher/issues/101>)
* Add Ian as a maintainer for robot_state_publisher (#95 <https://github.com/ros/robot_state_publisher/issues/95>)
* Fixed problem when building static library version (#92 <https://github.com/ros/robot_state_publisher/issues/92>)
* Contributors: Chris Lalancette, Shane Loretz, ivanpauno
```
