### PR TITLE
Switch to melodic-devel branches for robot_state_publisher on Melodic.

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6620,7 +6620,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -6630,7 +6630,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   robot_upstart:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@sloretz FYI