### PR TITLE
rtsprofile: 2.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8062,6 +8062,21 @@ repositories:
       url: https://github.com/gbiggs/rtctree.git
       version: master
     status: maintained
+  rtsprofile:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: release/hydro/rtsprofile
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtsprofile.git
+      version: master
+    status: maintained
   rviz:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8065,8 +8065,8 @@ repositories:
   rtsprofile:
     doc:
       type: git
-      url: https://github.com/tork-a/rtsprofile-release.git
-      version: release/hydro/rtsprofile
+      url: https://github.com/gbiggs/rtsprofile.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsprofile` to `2.0.0-1`:

- upstream repository: https://github.com/gbiggs/rtsprofile.git
- release repository: https://github.com/tork-a/rtsprofile-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
