### PR TITLE
ackermann_msgs: 2.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -52,7 +52,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/ackermann_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_msgs` to `2.0.2-1`:

- upstream repository: https://github.com/ros-drivers/ackermann_msgs.git
- release repository: https://github.com/ros-drivers-gbp/ackermann_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-1`

## ackermann_msgs

```
* missing std msg dependency
* Contributors: Rousseau Vincent
```
