### PR TITLE
robot_statemachine: 1.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11130,7 +11130,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MarcoStb1993/robot_statemachine-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/MarcoStb1993/robot_statemachine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_statemachine` to `1.1.2-1`:

- upstream repository: https://github.com/MarcoStb1993/robot_statemachine.git
- release repository: https://github.com/MarcoStb1993/robot_statemachine-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-1`

## robot_statemachine

- No changes

## rsm_additions

- No changes

## rsm_core

- No changes

## rsm_msgs

```
* Added necessary dependency on geometry_msgs to package.xml
* Contributors: MarcoStb1993
```

## rsm_rqt_plugins

- No changes

## rsm_rviz_plugins

- No changes
