### PR TITLE
rtshell: 3.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8062,6 +8062,21 @@ repositories:
       url: https://github.com/gbiggs/rtctree.git
       version: master
     status: maintained
+  rtshell:
+    doc:
+      type: git
+      url: https://github.com/gbiggs/rtshell.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/rtshell-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/gbiggs/rtshell.git
+      version: master
+    status: maintained
   rtsprofile:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-1`:

- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
