### PR TITLE
power_msgs: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5588,7 +5588,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
-      version: 0.3.0-0
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.4.0-1`:

- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.0-0`

## power_msgs

```
* Merge pull request #10 <https://github.com/fetchrobotics/power_msgs/issues/10> from pavansoundara/battery-dataWe've released a binary version of the drivers which publishes the this version
  Note: will investigate switching both internal and external code to use:
  http://docs.ros.org/api/sensor_msgs/html/msg/BatteryState.html in the future.Adds:
  
    * total_capacity
    * current_capacity
    * battery_voltage
    * supply_voltage
    * charger_voltage
  Removes:
  
    * errors
  
* Contributors: Alex Moriarty, Pavan Soundara
```
