### PR TITLE
Adding ainstein_radar to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -191,6 +191,12 @@ repositories:
       url: https://github.com/RobotnikAutomation/agvs_sim.git
       version: kinetic-devel
     status: maintained
+  ainstein_radar:
+    source:
+      type: git
+      url: https://github.com/AinsteinAI/ainstein_radar.git
+      version: master
+    status: maintained
   amcl3d:
     doc:
       type: git


### PR DESCRIPTION
I'd like ainstein_radar to be indexed and documented on ros.org.