### PR TITLE
Adding crane_x7 to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1233,6 +1233,12 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
       version: kinetic-devel
     status: maintained
+  crane_x7:
+    doc:
+      type: git
+      url: https://github.com/rt-net/crane_x7_ros.git
+      version: master
+    status: developed
   crazyflie:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add crane_x7 for ROS Melodic to be doc'd and indexed.