### PR TITLE
Adding sciurus17 to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8166,6 +8166,12 @@ repositories:
       url: https://github.com/ipa320/schunk_modular_robotics.git
       version: indigo_dev
     status: developed
+  sciurus17:
+    doc:
+      type: git
+      url: https://github.com/rt-net/sciurus17_ros.git
+      version: master
+    status: developed
   sdhlibrary_cpp:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add sciurus17 for ROS Melodic to be doc'd and indexed.