### PR TITLE
py_trees_js: 0.5.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1090,7 +1090,12 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/stonier/py_trees_js-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: release/0.5.x
     status: developed
   py_trees_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.5.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/stonier/py_trees_js-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.0-1`

## py_trees_js

```
* [js] robustness against identical timestamps, #109 <https://github.com/splintered-reality/py_trees_js/pull/109>
* [html] disable scrollbars, #110 <https://github.com/splintered-reality/py_trees_js/pull/110>
* [js] improved window resize handling, #111 <https://github.com/splintered-reality/py_trees_js/pull/111>
  * new public api ``py_trees.canvas.on_window_resize`` and ``py_trees.timeline.on_window_resize``
```
