### PR TITLE
py_trees_ros_viewer: 0.1.3-1 in 'dashing/distribution.yaml' [b…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1149,7 +1149,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_viewer-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_viewer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_viewer` to `0.1.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_viewer.git
- release repository: https://github.com/stonier/py_trees_ros_viewer-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.2-1`

## py_trees_ros_viewer

```
* [html] disable scrollbars, #24 <https://github.com/splintered-reality/py_trees_ros_viewer/pull/24>
* [html] use new 0.5.0 window resizing api ``from py_trees_js``
```
