### PR TITLE
robot_statemachine: 1.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11130,7 +11130,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MarcoStb1993/robot_statemachine-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/MarcoStb1993/robot_statemachine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_statemachine` to `1.1.3-1`:

- upstream repository: https://github.com/MarcoStb1993/robot_statemachine.git
- release repository: https://github.com/MarcoStb1993/robot_statemachine-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.2-1`

## robot_statemachine

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_additions

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_core

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_msgs

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_rqt_plugins

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_rviz_plugins

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```
