### PR TITLE
Add libcunit-dev rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1711,8 +1711,8 @@ libcunit-dev:
   debian: [libcunit1-dev]
   fedora: [CUnit-devel]
   gentoo: [dev-utl/cunit]
-  ubuntu: [libcunit1-dev]
   rhel: [CUnit-devel]
+  ubuntu: [libcunit1-dev]
 libdbus-dev:
   arch: [dbus-core]
   debian: [libdbus-1-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1710,7 +1710,7 @@ libcunit-dev:
   arch: [cunit]
   debian: [libcunit1-dev]
   fedora: [CUnit-devel]
-  gentoo: [dev-utl/cunit]
+  gentoo: [dev-util/cunit]
   rhel: [CUnit-devel]
   ubuntu: [libcunit1-dev]
 libdbus-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1706,6 +1706,13 @@ libcpprest-dev:
     xenial: [libcpprest-dev]
     yakkety: [libcpprest-dev]
     zesty: [libcpprest-dev]
+libcunit-dev:
+  arch: [cunit]
+  debian: [libcunit1-dev]
+  fedora: [CUnit-devel]
+  gentoo: [dev-utl/cunit]
+  ubuntu: [libcunit1-dev]
+  rhel: [CUnit-devel]
 libdbus-dev:
   arch: [dbus-core]
   debian: [libdbus-1-dev]


### PR DESCRIPTION
Arch: https://www.archlinux.org/packages/community/x86_64/cunit/
Debian: https://packages.debian.org/buster/libcunit1-dev (jessie/stretch/buster/bullseye)
Fedora: https://apps.fedoraproject.org/packages/CUnit-devel
Gentoo: https://packages.gentoo.org/packages/dev-util/cunit
Ubuntu: https://packages.ubuntu.com/bionic/libcunit1-dev (xenial/bionic/cosmic/disco/eoan)
RHEL via EPEL: https://apps.fedoraproject.org/packages/CUnit-devel