### PR TITLE
Condense java rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1400,15 +1400,7 @@ java:
   debian:
     jessie: [openjdk-7-jdk]
     wheezy: [openjdk-7-jdk]
-  fedora:
-    '21': [java-1.8.0-openjdk]
-    '22': [java-1.8.0-openjdk]
-    '23': [java-1.8.0-openjdk]
-    '24': [java-1.8.0-openjdk]
-    beefy: [java-1.7.0-openjdk]
-    heisenbug: [java-1.8.0-openjdk, java-1.7.0-openjdk]
-    schrödinger’s: [java-1.8.0-openjdk, java-1.7.0-openjdk]
-    spherical: [java-1.7.0-openjdk]
+  fedora: [java-1.8.0-openjdk]
   freebsd: [openjdk6]
   gentoo: [virtual/jdk]
   ubuntu: [default-jdk]


### PR DESCRIPTION
All supported versions of Fedora use OpenJDK 1.8.0

https://apps.fedoraproject.org/packages/java-1.8.0-openjdk