### PR TITLE
Add python3-boto3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4909,7 +4909,6 @@ python3-boto3:
   opensuse: [python3-boto3]
   ubuntu:
     '*': [python3-boto3]
-    trusty: null
 python3-cairo:
   arch: [python-cairo]
   debian: [python3-cairo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4903,6 +4903,13 @@ python3-backoff-pip:
   ubuntu:
     pip:
       packages: [backoff]
+python3-boto3:
+  debian: [python3-boto3]
+  fedora: [python3-boto3]
+  opensuse: [python3-boto3]
+  ubuntu:
+    '*': [python3-boto3]
+    trusty: null
 python3-cairo:
   arch: [python-cairo]
   debian: [python3-cairo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4907,8 +4907,7 @@ python3-boto3:
   debian: [python3-boto3]
   fedora: [python3-boto3]
   opensuse: [python3-boto3]
-  ubuntu:
-    '*': [python3-boto3]
+  ubuntu: [python3-boto3]
 python3-cairo:
   arch: [python-cairo]
   debian: [python3-cairo]


### PR DESCRIPTION
This will add the python 3 version of boto3. Needed mainly for ROS2 applications since the Python version is 3 by default so they cannot use the existing `python-boto3` key.

[debian](https://packages.debian.org/search?searchon=names&keywords=boto3)
[fedora](https://apps.fedoraproject.org/packages/python3-boto3)
[opensuse](https://software.opensuse.org/package/python3-boto3)
[ubuntu](https://packages.ubuntu.com/bionic/python3-boto3)

Thanks!