### PR TITLE
h264_video_encoder: 1.1.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4157,7 +4157,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/h264_video_encoder-release.git
-      version: 1.1.3-1
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_video_encoder` to `1.1.4-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git
- release repository: https://github.com/aws-gbp/h264_video_encoder-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.3-1`

## h264_video_encoder

```
* increment patch number for bloom release (#34 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/34>)
* Adds h264_encoder_core as exec_depend (#33 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/33>)
  This commit adds h264_encoder_core as an execution dependency. It also puts the dependencies into alphabetic order.
* increment patch version (#31 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/31>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Use standard CMake macros for adding gtest/gmock tests (#25 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/25>)
  * modify h264_video_encoder to use add_rostest_gmock()
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml to be compatible with specifying multiple package names
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Update package.xml for 1.1.2 release
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
* fix issue with uninitialized frame number (#19 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/19>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Add gtest and gmock as test dependencies
* Update package.xml
* Merge pull request #8 <https://github.com/aws-robotics/kinesisvideo-encoder-ros1/issues/8> from ryanewel/master
  increases unit test code coverage
* increases unit test code coverage
* Contributors: AAlon, Abby Xu, M. M, Nick Burek, Ross Desmond, Ryan Newell, ryanewel
```
