### PR TITLE
rxcpp_vendor: 4.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13550,6 +13550,11 @@ repositories:
       type: git
       url: https://github.com/rosin-project/rxcpp_vendor.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rosin-project/rxcpp_vendor-release.git
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/rosin-project/rxcpp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rxcpp_vendor` to `4.1.0-1`:

- upstream repository: https://github.com/rosin-project/rxcpp_vendor.git
- release repository: https://github.com/rosin-project/rxcpp_vendor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rxcpp_vendor

```
* First release (of the wrapper package)
* Contributors: gavanderhoorn
```
