### PR TITLE
Update CycloneDDS snapshots to match with releases

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -340,7 +340,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: b421e1039ffb08eada3a9b75f3c6a581a41962c4
+      version: 1c8c2944ff60544da38fefda5b4e80270e7fec48
     status: developed
   demos:
     doc:
@@ -1427,7 +1427,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/atolab/rmw_cyclonedds.git
-      version: 9ba2508bca559628877df4a41813c46f75b07550
+      version: 888235e96edfa9ca49a5e074407a98ed72843e65
     status: developed
   rmw_fastrtps:
     doc:


### PR DESCRIPTION
These snapshots include recent changes to make the `cyclonedds` package name conform to ROS' best practices and also match up with the released debs, where the package name was already changed.