### PR TITLE
rmw_cyclonedds: 0.4.0-1 in 'dashing/distribution.yaml'

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1423,6 +1423,9 @@ repositories:
     status: developed
   rmw_cyclonedds:
     release:
+      packages:
+      - cyclonedds_cmake_module
+      - rmw_cyclonedds_cpp
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1422,6 +1422,11 @@ repositories:
       version: dashing
     status: developed
   rmw_cyclonedds:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
+      version: 0.4.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.4.0-1`:

- upstream repository: https://github.com/atolab/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`