### PR TITLE
Use a virtual package to install java on Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1400,15 +1400,7 @@ java:
   debian:
     jessie: [openjdk-7-jdk]
     wheezy: [openjdk-7-jdk]
-  fedora:
-    '21': [java-1.8.0-openjdk]
-    '22': [java-1.8.0-openjdk]
-    '23': [java-1.8.0-openjdk]
-    '24': [java-1.8.0-openjdk]
-    beefy: [java-1.7.0-openjdk]
-    heisenbug: [java-1.8.0-openjdk, java-1.7.0-openjdk]
-    schrödinger’s: [java-1.8.0-openjdk, java-1.7.0-openjdk]
-    spherical: [java-1.7.0-openjdk]
+  fedora: [java]
   freebsd: [openjdk6]
   gentoo: [virtual/jdk]
   ubuntu: [default-jdk]


### PR DESCRIPTION
For Fedora 30, only `java-1.8.0-openjdk` seems to provide the resource `java`.

The way this should act in rosdep is that if any installed package provides `java` (such as openjdk or the Oracle-provided RPM), that would satisfy the requirement.

Otherwise, my understanding is that the package which provides the newest version of the resource `java` would be installed.

Closes #22118