### PR TITLE
rosauth: 1.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7065,7 +7065,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/gt-rail-release/rosauth-release.git
-      version: 0.1.7-2
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/GT-RAIL/rosauth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `1.0.1-0`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/gt-rail-release/rosauth-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.7-2`

## rosauth

```
* Fix buffer overrun (#19 <https://github.com/GT-RAIL/rosauth/issues/19>)
* enable Windows build (#25 <https://github.com/GT-RAIL/rosauth/issues/25>)
* chore: Update README, Author, maintainer
* fix: rostest test dependency (#26)
* new: parameters in node namespace (#22)
* new: parameter for allowed_time_delta (#24)
* Industrial CI ROS kinetic, melodic
* Use package format 2
* Contributors: David Kent, Dirk Thomas, Rein Appeldoorn, Russell Toris, Atsushi Watanabe, James Xu
```
