### PR TITLE
[rosdep] python3-nosehtmloutput

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5071,6 +5071,11 @@ python3-nose-yanc:
   debian: [python3-nose-yanc]
   openembedded: [python3-nose-yanc@meta-ros]
   ubuntu: [python3-nose-yanc]
+python3-nosehtmloutput:
+  debian: [python3-nosehtmloutput]
+  gentoo: [dev-python/nosehtmloutput]
+  ubuntu:
+    bionic: [python3-nosehtmloutput]
 python3-numpy:
   debian: [python3-numpy]
   fedora: [python3-numpy]


### PR DESCRIPTION
* Ubuntu: https://launchpad.net/ubuntu/bionic/+package/python3-nosehtmloutput
* Debian: https://packages.debian.org/sid/python3-nosehtmloutput
* Gentoo: https://packages.gentoo.org/packages/dev-python/nosehtmloutput

Doesn't look like fedora has it yet.