### PR TITLE
toposens: 1.2.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14876,7 +14876,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.2.3-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.2-1`

## toposens

- No changes

## toposens_description

- No changes

## toposens_driver

- No changes

## toposens_markers

- No changes

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Outsourced saving of cumulative pointcloud into boost::thread
* Contributors: Christopher Lang
```

## toposens_sync

- No changes
