### PR TITLE
pilz_industrial_motion: 0.4.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5481,7 +5481,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.5-1`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.4-1`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

- No changes

## pilz_msgs

```
* Remove non-ascii symbol from msg/srv/action causing trouble with genpy/python rosbag api
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robot_programming

```
* fix PEP issues
* Contributors: Pilz GmbH and Co. KG
```

## pilz_trajectory_generation

```
* Adapt to changes in pilz_robots
* add static code analyzing (clang-tidy)
* drop deprecated isRobotStateEqual()
* Contributors: Pilz GmbH and Co. KG
```
