### PR TITLE
cartographer_ros: 1.0.9000-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -273,6 +273,25 @@ repositories:
       url: https://github.com/ros2/cartographer.git
       version: ros2
     status: maintained
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: dashing
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer_ros-release.git
+      version: 1.0.9000-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: dashing
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.9000-1`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
