### PR TITLE
diagnostics: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -411,6 +411,25 @@ repositories:
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
       version: ros2
     status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: dashing
+    release:
+      packages:
+      - diagnostic_updater
+      - self_test
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/diagnostics-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: dashing
+    status: developed
   dynamixel_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.0.0-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## diagnostic_updater

```
* Use rclpp timer instead of custom updater logic. (#114 <https://github.com/ros/diagnostics/issues/114>)
* Use std::isfinite since it is supported on all platorms. (#123 <https://github.com/ros/diagnostics/issues/123>)
* Make DiagnosticStatusWrapper no longer implicitly copyable. (#117 <https://github.com/ros/diagnostics/issues/117>)
* Add virtual destructor to task vector class. (#122 <https://github.com/ros/diagnostics/issues/122>)
* Support for node interfaces to allow diagnostics to be used with lifecycle nodes. (#112 <https://github.com/ros/diagnostics/issues/112>)
* Spin on node in diagnostic_updater example to query parameters. (#120 <https://github.com/ros/diagnostics/issues/120>)
* Set diagnostic_updater default period to 1s instead of 1ns. (#110 <https://github.com/ros/diagnostics/issues/110>)
* Make Karsten Knese Maintainer for ROS2 branches #115 <https://github.com/ros/diagnostics/issues/115>
* Migrate diagnostic_updater to ROS2 #102 <https://github.com/ros/diagnostics/issues/102>
* Custom names for FrequencyStatus and TimeStampStatus #86 <https://github.com/ros/diagnostics/issues/86>
* Make FrequencyStatus' name configurable #84 <https://github.com/ros/diagnostics/issues/84>
* Contributors: Austin, Dan Rose, Ian Colwell, Karsten Knese, Nils Bussas, Scott K Logan, VaibhavBhadade
```

## self_test

```
* Migrate self_test to ros2 (#104 <https://github.com/ros/diagnostics/issues/104>)
* Make Karsten Knese maintainer for ros2 branches #115 <https://github.com/ros/diagnostics/issues/115>
* Contributors: Austin, Karsten Knese
```
