### PR TITLE
haros_catkin: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2616,6 +2616,11 @@ repositories:
       type: git
       url: https://github.com/rosin-project/haros_catkin.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rosin-project/haros_catkin-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/rosin-project/haros_catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `haros_catkin` to `0.1.1-1`:

- upstream repository: https://github.com/rosin-project/haros_catkin.git
- release repository: https://github.com/rosin-project/haros_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## haros_catkin

```
* Initial release.
* Contributors: gavanderhoorn, Jonathan Hechtbauer, Nicolas Limpert
```
