### PR TITLE
indoor_localization: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4977,7 +4977,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/inomuh/indoor_localization-release.git
-      version: 0.1.0-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `indoor_localization` to `1.0.0-1`:

- upstream repository: https://github.com/inomuh/indoor_localization.git
- release repository: https://github.com/inomuh/indoor_localization-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-1`

## indoor_localization

```
* the latest version of the scripts (anchor_selection_node.py, positioning_node.py, error_estimation_node.py and kpi_calculation_node.py) are loaded.
* the latest version of the msg files are loaded.
* unit test scripts are loaded.
* localization_params.yaml updated, region_params.yaml is loaded.
* .launch files are updated and new ones are added.
```
