### PR TITLE
ibeo_core: 2.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4707,7 +4707,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/ibeo_core-release.git
-      version: 2.0.2-0
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/astuff/ibeo_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ibeo_core` to `2.0.2-1`:

- upstream repository: https://github.com/astuff/ibeo_core.git
- release repository: https://github.com/astuff/ibeo_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.2-0`

## ibeo_core

```
* Merge pull request #8 <https://github.com/astuff/ibeo_core/issues/8> from ShepelIlya/master
* Deleted redunant conditions & fixed offset in ObjectData2280. It works!
* Contributors: Rinda Gunjala, Шепель Илья Олегович
```
