### PR TITLE
marti_common: 2.10.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6638,7 +6638,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.10.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.9.0-1`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Prevent swri:Subscriber latency calculations if current time is zero (#548 <https://github.com/swri-robotics/marti_common/issues/548>)
* Change way name is created for topic services (#541 <https://github.com/swri-robotics/marti_common/issues/541>)
* Contributors: jgassaway, nick-alton
```

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Support in initialize_origin.py specifying custom ROS topic in parameter (#544 <https://github.com/swri-robotics/marti_common/issues/544>)
* Fix get relative transform (#546 <https://github.com/swri-robotics/marti_common/issues/546>)
* Contributors: Arkady Shapkin, Matthew
```

## swri_yaml_util

- No changes
