### PR TITLE
novatel_gps_driver: 3.9.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4800,7 +4800,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 3.8.0-1
+      version: 3.9.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `3.9.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.8.0-1`

## novatel_gps_driver

```
* Use GPGGA quality to set GPSFix status (#55 <https://github.com/swri-robotics/novatel_gps_driver/issues/55>)
* Publish INSPVAX logs (#54 <https://github.com/swri-robotics/novatel_gps_driver/issues/54>)
* Add GPHDT message (#51 <https://github.com/swri-robotics/novatel_gps_driver/issues/51>)
* Fix ascii header message id in novatel_gps.cpp (#50 <https://github.com/swri-robotics/novatel_gps_driver/issues/50>)
* Correctly convert novatel header flags to bool and add tests for them (#48 <https://github.com/swri-robotics/novatel_gps_driver/issues/48>)
* Add DUALANTENNAHEADING msg (#46 <https://github.com/swri-robotics/novatel_gps_driver/issues/46>)
* Add HEADING2 msg (#43 <https://github.com/swri-robotics/novatel_gps_driver/issues/43>)
* Add BESTXYZ msg (#42 <https://github.com/swri-robotics/novatel_gps_driver/issues/42>)
* Contributors: Marcel Zeilinger, Matthew, Michael McConnell, P. J. Reed
```

## novatel_gps_msgs

```
* Use GPGGA quality to set GPSFix status (#55 <https://github.com/swri-robotics/novatel_gps_driver/issues/55>)
* Add GPHDT message (#51 <https://github.com/swri-robotics/novatel_gps_driver/issues/51>)
* Add DUALANTENNAHEADING msg (#46 <https://github.com/swri-robotics/novatel_gps_driver/issues/46>)
* Add HEADER2 msg (#43 <https://github.com/swri-robotics/novatel_gps_driver/issues/43>)
* Add BESTXYZ msg (#42 <https://github.com/swri-robotics/novatel_gps_driver/issues/42>)
* Contributors: Marcel Zeilinger, Michael McConnell, P. J. Reed
```
