### PR TITLE
mapviz: 1.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6568,7 +6568,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.2.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-1`

## mapviz

- No changes

## mapviz_plugins

```
* Add text to measuring plugin (#640 <https://github.com/swri-robotics/mapviz/issues/640>)
* Add mapviz plug-in for PoseStamped messages. (#641 <https://github.com/swri-robotics/mapviz/issues/641>)
* Fix occupancy grid to load color scheme from configuration. (#642 <https://github.com/swri-robotics/mapviz/issues/642>)
* Restore GL_UNPACK_ALIGNMENT to 4 to prevent corruption of Qt font rendering. (#643 <https://github.com/swri-robotics/mapviz/issues/643>)
* Add ability to show and hide markers by namespace (#636 <https://github.com/swri-robotics/mapviz/issues/636>)
* Fixed layout of MeasuringPlugin (#633 <https://github.com/swri-robotics/mapviz/issues/633>)
* Fixed marker plugin to use swri_transform_util to ensure wgs84 markers work properly (#635 <https://github.com/swri-robotics/mapviz/issues/635>)
* Contributors: Arkady Shapkin, Marc Alban, Matthew, Matthew Grogan, agyoungs
```

## multires_image

```
* Use local_xy_origin for loading tiles of GPSFix not available (#634 <https://github.com/swri-robotics/mapviz/issues/634>)
* Contributors: agyoungs
```

## tile_map

- No changes
