### PR TITLE
Remove ros1_ign package from rosdistro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6779,18 +6779,6 @@ repositories:
       url: https://github.com/ros/ros.git
       version: kinetic-devel
     status: maintained
-  ros1_ign:
-    release:
-      packages:
-      - ros1_ign
-      - ros1_ign_bridge
-      - ros1_ign_gazebo_demos
-      - ros1_ign_image
-      - ros1_ign_point_cloud
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/osrf/ros1_ign-release.git
-      version: 0.7.0-1
   ros_canopen:
     doc:
       type: git


### PR DESCRIPTION
The `ros1_ign` bridge package can not be included into rosdistro since [it depends on ignition software that is not available from Ubuntu or ROS repositories](http://build.ros.org/job/Mbin_uB64__ros1_ign_bridge__ubuntu_bionic_amd64__binary/34/console). We use bloom partially during the release process but end the package creation using `build.osrfoundation.org`.

Accidentally the process ended sending the PR to rosdistro, sorrry about it. This PR removes the key from rosdistro introduced by https://github.com/ros/rosdistro/pull/21908