### PR TITLE
[actionlib] update upstream branch

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -58,7 +58,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/actionlib.git
-      version: indigo-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -68,7 +68,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/actionlib.git
-      version: indigo-devel
+      version: melodic-devel
     status: maintained
   adi_driver:
     doc:


### PR DESCRIPTION
Recently there are some check-ins on `indigo-devel` not compatible with the `melodic-devel` of `realtime_tools` and it causes build break if everything is built from the upstream. I would recommend to use `melodic-devel` instead as the `actionlib` upstream branch.