### PR TITLE
seed_r7_ros_pkg: 0.2.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13708,6 +13708,29 @@ repositories:
       url: https://github.com/ipab-slmc/SDHLibrary-CPP.git
       version: master
     status: maintained
+  seed_r7_ros_pkg:
+    doc:
+      type: git
+      url: https://github.com/seed-solutions/seed_r7_ros_pkg.git
+      version: 0.2.0
+    release:
+      packages:
+      - seed_r7_bringup
+      - seed_r7_description
+      - seed_r7_navigation
+      - seed_r7_robot_interface
+      - seed_r7_ros_controller
+      - seed_r7_typef_moveit_config
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
+      version: 0.2.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/seed-solutions/seed_r7_ros_pkg.git
+      version: 0.2.0
+    status: developed
   seed_smartactuator_sdk:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13712,7 +13712,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/seed-solutions/seed_r7_ros_pkg.git
-      version: 0.2.0
+      version: master
     release:
       packages:
       - seed_r7_bringup
@@ -13729,7 +13729,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/seed-solutions/seed_r7_ros_pkg.git
-      version: 0.2.0
+      version: master
     status: developed
   seed_smartactuator_sdk:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_r7_ros_pkg` to `0.2.0-2`:

- upstream repository: https://github.com/seed-solutions/noid-ros-pkg.git
- release repository: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
