### PR TITLE
ros_mppt: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11968,10 +11968,20 @@ repositories:
       version: master
     status: maintained
   ros_mppt:
+    doc:
+      type: git
+      url: https://github.com/AaronPB/ros_mppt.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AaronPB/ros_mppt-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/AaronPB/ros_mppt.git
       version: master
+    status: maintained
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_mppt` to `0.1.1-1`:

- upstream repository: https://github.com/AaronPB/ros_mppt.git
- release repository: https://github.com/AaronPB/ros_mppt-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros_mppt

```
* First Version
* Contributors: AaronPB, Aarón
```
