### PR TITLE
robot_state_publisher: 2.2.4-1 in 'dashing/distribution.yaml'…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1538,7 +1538,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.2.4-1`:

- upstream repository: https://github.com/ros2/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.2.3-1`

## robot_state_publisher

```
* Remove unused Eigen3 dependency (#27 <https://github.com/ros2/robot_state_publisher/issues/27>) (#29 <https://github.com/ros2/robot_state_publisher/issues/29>)
* Don't export exe as library (#25 <https://github.com/ros2/robot_state_publisher/issues/25>) (#28 <https://github.com/ros2/robot_state_publisher/issues/28>)
* Contributors: Shane Loretz
```
