### PR TITLE
launch: 0.8.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.8.5-3
+      version: 0.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.8.6-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.5-3`

## launch

```
* Address additional syntax issues with Python 3.5. (#328 <https://github.com/ros2/launch/issues/328>)
* Restore support for Python 3.5 (#324 <https://github.com/ros2/launch/issues/324>)
* Contributors: Steven! Ragnarök
```

## launch_testing

```
* Address additional syntax issues with Python 3.5. (#328 <https://github.com/ros2/launch/issues/328>)
* Restore support for Python 3.5 (#324 <https://github.com/ros2/launch/issues/324>)
* Contributors: Steven! Ragnarök
```

## launch_testing_ament_cmake

- No changes
