### PR TITLE
launch_ros: 0.8.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -840,7 +840,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.8.5-1
+      version: 0.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.6-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.5-1`

## launch_ros

```
* Additional fixes for Python 3.5. (#67 <https://github.com/ros2/launch_ros/issues/67>)
* Restore Python 3.5 support. (#65 <https://github.com/ros2/launch_ros/issues/65>)
* Install package marker and manifest. (#62 <https://github.com/ros2/launch_ros/issues/62>) (#63 <https://github.com/ros2/launch_ros/issues/63>)
* Contributors: Dirk Thomas, Steven! Ragnarök
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
