### PR TITLE
geometry2: 0.11.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -685,7 +685,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.11.4-1
+      version: 0.11.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.11.5-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.4-1`

## tf2

- No changes

## tf2_eigen

```
* Use eigen3_cmake_module (#144 <https://github.com/ros2/geometry2/issues/144>) (#153 <https://github.com/ros2/geometry2/issues/153>)
* Contributors: Shane Loretz
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

```
* Use eigen3_cmake_module (#144 <https://github.com/ros2/geometry2/issues/144>) (#153 <https://github.com/ros2/geometry2/issues/153>)
* Contributors: Shane Loretz
```

## tf2_msgs

- No changes

## tf2_ros

```
* Add missing export build dependencies (#135 <https://github.com/ros2/geometry2/issues/135>) (#152 <https://github.com/ros2/geometry2/issues/152>)
* Contributors: Jacob Perron
```

## tf2_sensor_msgs

```
* Use eigen3_cmake_module (#144 <https://github.com/ros2/geometry2/issues/144>) (#153 <https://github.com/ros2/geometry2/issues/153>)
* Added missing header (for tf2::fromMsg) (#126 <https://github.com/ros2/geometry2/issues/126>) (#147 <https://github.com/ros2/geometry2/issues/147>)
* Contributors: Esteve Fernandez, Shane Loretz
```
