### PR TITLE
h264_encoder_core: 2.0.1-1 in 'dashing/distribution.yaml' [blo…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -706,6 +706,21 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: dashing
     status: maintained
+  h264_encoder_core:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/aws-gbp/h264_encoder_core-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
+      version: master
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_encoder_core` to `2.0.1-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
- release repository: https://github.com/aws-gbp/h264_encoder_core-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## h264_encoder_core

```
* increment patch version (#30 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/30>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Add gtest and gmock as test dependencies (#14 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/14>)
  * Add gtest and gmock as test dependencies
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * use the macro in aws_common to find test dependencies for ROS1 or ROS2
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml to be compatible with specifying multiple package names
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml test matrix
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update PACKAGE_NAMES
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Update to use non-legacy ParameterReader API (#9 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/9>)
* Update to use new ParameterReader API (#8 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/8>)
  * fix h264_encoder_test to be compatible with new ParameterReader API
  * increment major version number in package.xml
* Merge pull request #3 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/3> from mm318/bionic_hardware_encoder
  workaround avcodec_find_encoder_by_name() unreliably indicating that h264_omx codec is available
* implementing runtime solution for workaround
* workaround avcodec_find_encoder_by_name() unreliably indicating that h264_omx codec is available
* Contributors: M. M, Miaofei, Ross Desmond
```
