### PR TITLE
cloudwatch_logger: 3.0.0-1 in 'dashing/distribution.yaml' [blo…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -343,6 +343,21 @@ repositories:
       url: https://github.com/aws-robotics/cloudwatch-common.git
       version: master
     status: maintained
+  cloudwatch_logger:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatchlogs-ros2.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/aws-gbp/cloudwatch_logger-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatchlogs-ros2.git
+      version: master
+    status: developed
   common_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_logger` to `3.0.0-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatchlogs-ros2.git
- release repository: https://github.com/aws-gbp/cloudwatch_logger-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cloudwatch_logger

```
* remove changelog for new release (#8 <https://github.com/aws-robotics/cloudwatchlogs-ros2/issues/8>)
* Bump version to 3.0.0, add CHANGELOG and missing dependencies
* add log node unit test (#5 <https://github.com/aws-robotics/cloudwatchlogs-ros2/issues/5>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Add build depend on std_srvs (#4 <https://github.com/aws-robotics/cloudwatchlogs-ros2/issues/4>)
  * Add build depend on std_srvs
  * Add exec depend on std_srvs
* Rename ament_cmake_ros to ament_cmake in CMakeLists.txt
* initial ROS1 to ROS2 conversion
  [WIP] Ros1 conversion
* address PR comments
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* remove unnecessary files
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* add log_node_param_helper unit test
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* correct the information in the README and cleanup the CMakeLists.txt
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* workaround fastrtps typesupport crash
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* fix "ros2 launch" behavior
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* port cloudwatch_logger offline support to ros2
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Convert all code, build files, launch files to ROS2.
* Source from aws-robotics/cloudwatchlogs-ros1 master branch
* Contributors: AAlon, Avishay Alon, Cameron Evans, M. M, Miaofei
```
