### PR TITLE
cloudwatch_metrics_collector: 3.0.0-1 in 'dashing/distribution…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -373,6 +373,21 @@ repositories:
       url: https://github.com/aws-robotics/cloudwatchlogs-ros2.git
       version: master
     status: developed
+  cloudwatch_metrics_collector:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatchmetrics-ros2.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/cloudwatchmetrics-ros2.git
+      version: master
+    status: developed
   common_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_metrics_collector` to `3.0.0-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatchmetrics-ros2.git
- release repository: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cloudwatch_metrics_collector

```
* Bump version to 3.0.0 and add missing dependencies
* Fix default metric options
  - Fix bug where default metric storage directory, file prefix etc were
  being set to the same as logs causing issues when running both
  cloudwatch logs and metrics at the same time.
* Merge pull request #7 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/7> from aws-robotics/rename-launch-file
  Rename launch file from _launch.py to .launch.py
* Rename cloudwatch_metrics_collector_launch.py to cloudwatch_metrics_collector.launch.py
* Add Unit Tests (#6 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/6>)
  * add unit tests
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * Enable travis tests
* Adds launch file (#3 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/3>)
  * Add launch file
* Initial source code migration (#1 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/1>)
  * Initial source code migration
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
  * Adds README and sample configuration
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
  * Adds .rosinstall
  * Remove dependency on parameter reader from metrics collector
  * Fix typo in README
* Contributors: Avishay Alon, M. M, Tim Robinson, ryanewel
```
