### PR TITLE
ros_monitoring_msgs: 2.0.0-1 in 'dashing/distribution.yaml' [b…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1661,6 +1661,21 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: dashing
     status: maintained
+  ros_monitoring_msgs:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/monitoringmessages-ros2.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/monitoringmessages-ros2.git
+      version: master
+    status: developed
   ros_testing:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_monitoring_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/aws-robotics/monitoringmessages-ros2.git
- release repository: https://github.com/aws-gbp/ros_monitoring_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros_monitoring_msgs

```
* Bump version to 2.0.0
* Initial ROS2 migration (#1 <https://github.com/aws-robotics/monitoringmessages-ros2/issues/1>)
  * Initial ROS2 migration
  * Remove message_runtime from package.xml
* Contributors: Avishay Alon, ryanewel
```
