### PR TITLE
tts: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2321,6 +2321,24 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: master
     status: developed
+  tts:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/tts-ros2.git
+      version: master
+    release:
+      packages:
+      - tts
+      - tts_interfaces
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/aws-gbp/tts-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/tts-ros2.git
+      version: master
+    status: developed
   turtlebot3:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tts` to `2.0.0-1`:

- upstream repository: https://github.com/aws-robotics/tts-ros2.git
- release repository: https://github.com/aws-gbp/tts-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## tts

```
* Delete CHANGELOG.rst
* Bump version to 2.0.0 and add changelog
* Add launch dependencies
* Rename python-boto3 to python3-boto3 in package.xml
* Fix imports in tests
* Fix integration test and add graceful shutdown of the server nodes.
* Merge pull request #1 <https://github.com/aws-robotics/tts-ros2/issues/1> from aws-robotics/dev
  initial commit for tts-ros2
* initial commit for tts-ros2
* Contributors: AAlon, Avishay Alon, Yuan "Forrest" Yu, y²
```

## tts_interfaces

```
* Bump version to 2.0.0 and add changelog
* Merge pull request #1 <https://github.com/aws-robotics/tts-ros2/issues/1> from aws-robotics/dev
  initial commit for tts-ros2
* initial commit for tts-ros2
* Contributors: Avishay Alon, Yuan "Forrest" Yu, y²
```
