### PR TITLE
lex_node: 3.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -957,6 +957,24 @@ repositories:
       url: https://github.com/aws-robotics/lex-common.git
       version: master
     status: maintained
+  lex_node:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/lex-ros2.git
+      version: master
+    release:
+      packages:
+      - lex_common_msgs
+      - lex_node
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/aws-gbp/lex_node-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/lex-ros2.git
+      version: master
+    status: developed
   librealsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lex_node` to `3.0.0-1`:

- upstream repository: https://github.com/aws-robotics/lex-ros2.git
- release repository: https://github.com/aws-gbp/lex_node-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## lex_common_msgs

```
* Merge pull request #5 <https://github.com/aws-robotics/lex-ros2/issues/5> from aws-robotics/version-bump
  Bump to version 3.0.0
* Bump to version 3.0.0
* Add missing dependency on ament_lint_auto
* Merge pull request #1 <https://github.com/aws-robotics/lex-ros2/issues/1> from aws-robotics/lex-dev
  Add lex ros2 implementation
* Add lex ros2 implementation
  **Summary**
  Creates readme for how to build lex ros2
  * ament_uncrustify reformat code
  * ament_cpplint formatting changes
  **Tests**
  Unit Tests
* Contributors: AAlon, M M, M. M, Ross Desmond
```

## lex_node

```
* Merge pull request #5 <https://github.com/aws-robotics/lex-ros2/issues/5> from aws-robotics/version-bump
  Bump to version 3.0.0
* Bump to version 3.0.0
* Add launch dependencies
* Allow undeclared parameters
* Disable linting as a temporary measure
* Add missing lint dependencies
* Change ament_cmake_ros to ament_cmake
* Add test depend on ament_cmake_gmock
* Merge pull request #1 <https://github.com/aws-robotics/lex-ros2/issues/1> from aws-robotics/lex-dev
  Add lex ros2 implementation
* Add gmock dependencies and reduce package version
* Remove unnecessary launch file
  Also deletes unnecessary gtest init, gmock init takes care of it.
* Add lex ros2 implementation
  **Summary**
  Creates readme for how to build lex ros2
  * ament_uncrustify reformat code
  * ament_cpplint formatting changes
  **Tests**
  Unit Tests
* Contributors: AAlon, Avishay Alon, M M, M. M, Ross Desmond
```
