### PR TITLE
control_msgs: 2.2.0-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -298,7 +298,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros-gbp/control_msgs-release.git
-      version: 2.1.0-0
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `2.2.0-1`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.0-0`

## control_msgs

```
* generate action interfaces
* Contributors: Mathias Lüdtke
```
