### PR TITLE
control_msgs: 2.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -428,6 +428,21 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: dashing
     status: maintained
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: crystal-devel
+    status: maintained
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `2.2.0-1`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## control_msgs

```
* generate action interfaces
* Contributors: Mathias Lüdtke
```
