### PR TITLE
realtime_tools: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1593,6 +1593,21 @@ repositories:
       url: https://github.com/ros2/realtime_support.git
       version: dashing
     status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: dashing-devel
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.0.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## realtime_tools

```
* Add test_depend ament_cmake_gmock
* Update CI for dashing
* Add sloretz as another author
* Typename and typos in RTPublisher
* Shorter type names
* Port RealtimeServerGoalHandle to ROS 2
* Port RealtimePublisher to ROS 2
  Use test_msgs instead of std_msgs
* Box and buffer work in ROS 2 unchanged
* Port RealtimeClock to ROS 2
* Remove actionlib definitions
* Contributors: Shane Loretz
```
