### PR TITLE
mavros: 0.32.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6737,7 +6737,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.32.1-1
+      version: 0.32.2-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.32.2-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.32.1-1`

## libmavconn

- No changes

## mavros

```
* uncrustify
* Add boolean to check if IMU data has been received
  Follow sensor_msgs/Imu convention when data not present
* Uncrustify the GPS_GLOBAL_ORIGIN handler in global_position
* Fix global origin conversion to ecef (was using amsl where hae was required)
  Summary: Fix global origin conversion to ecef (was using amsl where hae was required)
* moved code to end of function
* added amount of satellites to global_position/raw/
* Contributors: David Jablonski, Nick Steele, Rob Clarke, Robert Clarke
```

## mavros_extras

```
* clean up
* fix obstacle distance plugin
* Contributors: baumanta
```

## mavros_msgs

- No changes

## test_mavros

- No changes
