### PR TITLE
rosbag2: 0.1.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1943,7 +1943,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.1.5-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.4-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_converter_default_plugins

```
* disable fastrtps dependent tests when unavailable (#137 <https://github.com/ros2/rosbag2/issues/137>) (#148 <https://github.com/ros2/rosbag2/issues/148>)
* Contributors: Karsten Knese
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* disable fastrtps dependent tests when unavailable (#137 <https://github.com/ros2/rosbag2/issues/137>) (#148 <https://github.com/ros2/rosbag2/issues/148>)
* Contributors: Karsten Knese
```

## rosbag2_transport

```
* disable some tests for connext (#145 <https://github.com/ros2/rosbag2/issues/145>) (#151 <https://github.com/ros2/rosbag2/issues/151>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* disable plugins/tests which need rmw_fastrtps_cpp if unavailable (#137 <https://github.com/ros2/rosbag2/issues/137>) (#148 <https://github.com/ros2/rosbag2/issues/148>)
  Signed-off-by: ivanpauno <mailto:ivanpauno@ekumenlabs.com>
* Contributors: Karsten Knese
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
