### PR TITLE
hebi_description: 0.1.0-1 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4261,7 +4261,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_description-release.git
-      version: 0.1.0-1      
+      version: 0.1.0-1
     status: developed
   hebiros:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4256,6 +4256,13 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: master
     status: developed
+  hebi_description:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/HebiRobotics/hebi_description-release.git
+      version: 0.1.0-1      
+    status: developed
   hebiros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository hebi_description to 0.1.0-1:

upstream repository: https://github.com/HebiRobotics/hebi_description.git
release repository: https://github.com/HebiRobobitcs/hebi_description-release.git
distro file: kinetic/distribution.yaml
bloom version: 0.8.0
previous version for package: null

## hebi_description
```
* Moved the hebiros_description package contents to new package
* Cleaned up contents and added robots
* Contributors: Matthew Tesch
```