### PR TITLE
hebi_description: 0.1.0-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2664,6 +2664,13 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: master
     status: developed
+  hebi_description:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/HebiRobotics/hebi_description-release.git
+      version: 0.1.0-1
+    status: developed    
   hector_gazebo:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2670,7 +2670,7 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_description-release.git
       version: 0.1.0-1
-    status: developed    
+    status: developed
   hector_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository hebi_description to 0.1.0-1:

upstream repository: https://github.com/HebiRobotics/hebi_description.git
release repository: https://github.com/HebiRobobitcs/hebi_description-release.git
distro file: melodic/distribution.yaml
bloom version: 0.8.0
previous version for package: null

## hebi_description
```
* Moved the hebiros_description package contents to new package
* Cleaned up contents and added robots
* Contributors: Matthew Tesch
```