### PR TITLE
Replace libxerces-c2-dev with libxerces-c-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5503,7 +5503,7 @@ xerces:
   debian: [libxerces-c-dev]
   fedora: [xerces-c]
   gentoo: [dev-libs/xerces-c]
-  ubuntu: [libxerces-c2-dev]
+  ubuntu: [libxerces-c-dev]
 xfont-server:
   debian: [xfs]
   fedora: [libXfont]


### PR DESCRIPTION
libxerces-c2-dev was only existing in trusty. In xenial and bionic
libxerces-c-dev provide libxerves-c3-dev.

Xenial does not contain libxerces-c2-dev at all:
https://packages.ubuntu.com/search?keywords=libxerces&searchon=names&suite=xenial&section=all

Neither does Bionic:
https://packages.ubuntu.com/search?suite=bionic&searchon=names&keywords=libxerces

I cannot imagine that there is any released ROS package using this rule currently? We realized, as we have a dependency in our internal CI pipeline on libxerces which could not be installed.