### PR TITLE
pilz_robots: 0.5.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5541,7 +5541,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.7-1
+      version: 0.5.8-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.8-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.7-1`

## pilz_control

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_testutils

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_hardware_support

```
* add missing transition to STO state machine
* revise STO specification
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_moveit_config

- No changes

## prbt_support

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```
