### PR TITLE
pilz_industrial_motion: 0.4.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5517,7 +5517,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.6-1
+      version: 0.4.7-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.7-1`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.6-1`

## pilz_extensions

```
* Fix clang-tidy issues
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

```
* Fix clang-tidy issues
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## pilz_msgs

- No changes

## pilz_robot_programming

- No changes

## pilz_trajectory_generation

```
* Fix clang-tidy issues
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```
