### PR TITLE
sick_scan: 1.3.22-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8302,7 +8302,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 1.3.21-0
+      version: 1.3.22-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan.git
+      version: master
     status: developed
   sick_tim:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `1.3.22-1`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.3.21-0`
