### PR TITLE
teleop_tools: 1.0.0-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2424,6 +2424,27 @@ repositories:
       url: https://github.com/microROS/system_modes-release.git
       version: 0.1.4-1
     status: developed
+  teleop_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: dashing-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_tools-release.git
+      version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: dashing-devel
+    status: maintained
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.0.0-0`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## joy_teleop

```
* ROS2 port (#35 <https://github.com/ros-teleop/teleop_tools/issues/35>)
  * key_teleop pkg format 3
  * port teleop_tools_msgs
  * key_teleop catch KeyboardInterrupt
  * port mouse_teleop
  * add key_teleop.yaml
  * add xmllint test
  * fix xmllint tests
  * remove useless class KeyTeleop
  * Fixes for dynamic topic joy publishers
  - match_command() now compares button array length to the max
  deadman button index (apples to apples)
  - match_command function now checks if any of the deadman buttons
  are depressed before returning a match
  - properly handle a std_msgs/msg/Empty 'message_value' by not
  attempting to access its value
  - utilizes iter-items to correctly index into the config dict
  for 'axis_mappings''s 'axis' and 'button' values
  - set_member() now splits according to a dash (-) rather than a
  periond (.) to be consistent with ros2 param parsing & example yaml
  - adds the correct name to setup.py for test_key_teleop.py test
  * reduce copy/pasta
* Contributors: Jeremie Deray
```

## key_teleop

```
* ROS2 port (#35 <https://github.com/ros-teleop/teleop_tools/issues/35>)
  * ROS2 port
  * key_teleop pkg format 3
  * port teleop_tools_msgs
  * key_teleop catch KeyboardInterrupt
  * port mouse_teleop
  * add key_teleop.yaml
  * prepare tests
  * add xmllint test
  * fix xmllint tests
  * simplify joy_teleop retrieve_config
  * remove useless class KeyTeleop
  * Fixes for dynamic topic joy publishers
  - match_command() now compares button array length to the max
  deadman button index (apples to apples)
  - match_command function now checks if any of the deadman buttons
  are depressed before returning a match
  - properly handle a std_msgs/msg/Empty 'message_value' by not
  attempting to access its value
  - utilizes iter-items to correctly index into the config dict
  for 'axis_mappings''s 'axis' and 'button' values
  - set_member() now splits according to a dash (-) rather than a
  periond (.) to be consistent with ros2 param parsing & example yaml
  - adds the correct name to setup.py for test_key_teleop.py test
  * reduce copy/pasta
* Contributors: Jeremie Deray
```

## mouse_teleop

```
* ROS2 port (#35 <https://github.com/ros-teleop/teleop_tools/issues/35>)
  * ROS2 port
  * key_teleop pkg format 3
  * port teleop_tools_msgs
  * key_teleop catch KeyboardInterrupt
  * port mouse_teleop
  * add key_teleop.yaml
  * prepare tests
  * add xmllint test
  * fix xmllint tests
  * simplify joy_teleop retrieve_config
  * remove useless class KeyTeleop
  * Fixes for dynamic topic joy publishers
  - match_command() now compares button array length to the max
  deadman button index (apples to apples)
  - match_command function now checks if any of the deadman buttons
  are depressed before returning a match
  - properly handle a std_msgs/msg/Empty 'message_value' by not
  attempting to access its value
  - utilizes iter-items to correctly index into the config dict
  for 'axis_mappings''s 'axis' and 'button' values
  - set_member() now splits according to a dash (-) rather than a
  periond (.) to be consistent with ros2 param parsing & example yaml
  - adds the correct name to setup.py for test_key_teleop.py test
  * reduce copy/pasta
* Contributors: Jeremie Deray
```

## teleop_tools

```
* ROS2 port (#35 <https://github.com/ros-teleop/teleop_tools/issues/35>)
  * ROS2 port
  * key_teleop pkg format 3
  * port teleop_tools_msgs
  * key_teleop catch KeyboardInterrupt
  * port mouse_teleop
  * add key_teleop.yaml
  * prepare tests
  * add xmllint test
  * fix xmllint tests
  * simplify joy_teleop retrieve_config
  * remove useless class KeyTeleop
  * Fixes for dynamic topic joy publishers
  - match_command() now compares button array length to the max
  deadman button index (apples to apples)
  - match_command function now checks if any of the deadman buttons
  are depressed before returning a match
  - properly handle a std_msgs/msg/Empty 'message_value' by not
  attempting to access its value
  - utilizes iter-items to correctly index into the config dict
  for 'axis_mappings''s 'axis' and 'button' values
  - set_member() now splits according to a dash (-) rather than a
  periond (.) to be consistent with ros2 param parsing & example yaml
  - adds the correct name to setup.py for test_key_teleop.py test
  * reduce copy/pasta
* Contributors: Jeremie Deray
```

## teleop_tools_msgs

```
* ROS2 port (#35 <https://github.com/ros-teleop/teleop_tools/issues/35>)
* Contributors: Jeremie Deray
```
