### PR TITLE
cloudwatch_common: 1.1.1-0 in 'dashing/distribution.yaml' [blo…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -352,7 +352,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.1.0-1
+      version: 1.1.1-0
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.1.1-0`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.1.0-1`

## cloudwatch_logs_common, cloudwatch_metrics_common, dataflow_lite, file_management

```
* Disable error on cast-align warning to support ARMhf builds (#41 <https://github.com/aws-robotics/cloudwatch-common/issues/41>)
  * Remove -Wcast-align flag to support ARMhf builds
  *  - bumped versions to 1.1.1
  - restored cast-align, but added as a warning
  - removed unused headers
  * Removed duplicate Werror
```
