### PR TITLE
qpoases_vendor: 3.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6071,6 +6071,21 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git
       version: production-melodic
     status: developed
+  qpoases_vendor:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.ai/qpoases_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/qpoases_vendor-release.git
+      version: 3.2.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.ai/qpoases_vendor.git
+      version: master
+    status: maintained
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpoases_vendor` to `3.2.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.ai/qpoases_vendor.git
- release repository: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/qpoases_vendor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## qpoases_vendor

```
* Fixing schema link for package.xml.
* CI: Adding basic CI script.
* Install in standard package-prefixed include dir.
* Use CMake in qpOASES build and switch to static lib.
* Convert to catkin package
  Signed-off-by: Geoffrey Biggs <mailto:geoff.biggs@tier4.jp>
* Use pure CMake build
* First pass at a vendor package shim for qpOASES
  Signed-off-by: Geoffrey Biggs <mailto:geoff.biggs@tier4.jp>
* Initial commit
* Contributors: Geoffrey Biggs, Joshua Whitley
```
