### PR TITLE
pilz_robots: 0.4.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9365,7 +9365,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.4.11-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.10-1`

## pilz_control

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_testutils

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_hardware_support

```
* add missing transition to STO state machine
* revise STO specification
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```

## prbt_moveit_config

- No changes

## prbt_support

```
* integrate clang-tidy via CMake flag
* Contributors: Pilz GmbH and Co. KG
```
