### PR TITLE
resource_retriever: 1.12.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6376,7 +6376,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.4-0
+      version: 1.12.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.5-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.12.4-0`

## resource_retriever

```
* Update the exec_depend keys for Python 3. (#29 <https://github.com/ros/resource_retriever/issues/29>)
* point to the ros/resource_retriever repository (#28 <https://github.com/ros/resource_retriever/issues/28>)
* append trailing zero to memory buffer, to allow safe use as char* (#27 <https://github.com/ros/resource_retriever/issues/27>)
* Contributors: Chris Lalancette, Mikael Arguedas, Robert Haschke
```
