### PR TITLE
Add python3-lark-parser keys.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5015,6 +5015,9 @@ python3-gnupg:
   gentoo: [dev-python/python-gnupg]
   ubuntu: [python3-gnupg]
 python3-lark-parser:
+  debian:
+    stretch: [python3-lark-parser]
+    buster: [python3-lark-parser]
   fedora:
     '*': [python3-lark-parser]
     '28': null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5016,8 +5016,8 @@ python3-gnupg:
   ubuntu: [python3-gnupg]
 python3-lark-parser:
   debian:
-    stretch: [python3-lark-parser]
     buster: [python3-lark-parser]
+    stretch: [python3-lark-parser]
   fedora:
     '*': [python3-lark-parser]
     '28': null


### PR DESCRIPTION
The ROS bootstrap repo (and now by extension the ROS and ROS 2
repositories) contain these packages for Debian Stretch and Buster.

Proposed as an alternative to #20666 
It isn't a drop-in replacement for that PR as it does not use pip but it does provide the package on all the desired platforms.

We don't have a web index but you can see the packages in the storage pool here:

http://packages.ros.org/ros2/ubuntu/pool/main/l/lark-parser/