### PR TITLE
Add python3-ifcfg keys.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4991,8 +4991,8 @@ python3-flake8:
   ubuntu: [python3-flake8]
 python3-ifcfg:
   debian:
-    stretch: [python3-ifcfg]
     buster: [python3-ifcfg]
+    stretch: [python3-ifcfg]
   ubuntu:
     bionic: [python3-ifcfg]
 python3-gitlab:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5018,6 +5018,8 @@ python3-ifcfg:
   debian:
     buster: [python3-ifcfg]
     stretch: [python3-ifcfg]
+  fedora: [python3-ifcfg]
+  rhel: ['python%{python3_pkgversion}-ifcfg']
   ubuntu:
     bionic: [python3-ifcfg]
 python3-lark-parser:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4989,6 +4989,12 @@ python3-flake8:
   gentoo: [dev-python/flake8]
   openembedded: [python3-flake8@meta-ros]
   ubuntu: [python3-flake8]
+python3-ifcfg:
+  debian:
+    stretch: [python3-ifcfg]
+    buster: [python3-ifcfg]
+  ubuntu:
+    bionic: [python3-ifcfg]
 python3-gitlab:
   debian:
     '*': [python3-gitlab]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4989,12 +4989,6 @@ python3-flake8:
   gentoo: [dev-python/flake8]
   openembedded: [python3-flake8@meta-ros]
   ubuntu: [python3-flake8]
-python3-ifcfg:
-  debian:
-    buster: [python3-ifcfg]
-    stretch: [python3-ifcfg]
-  ubuntu:
-    bionic: [python3-ifcfg]
 python3-gitlab:
   debian:
     '*': [python3-gitlab]
@@ -5020,6 +5014,12 @@ python3-gnupg:
   fedora: [python3-gnupg]
   gentoo: [dev-python/python-gnupg]
   ubuntu: [python3-gnupg]
+python3-ifcfg:
+  debian:
+    buster: [python3-ifcfg]
+    stretch: [python3-ifcfg]
+  ubuntu:
+    bionic: [python3-ifcfg]
 python3-lark-parser:
   fedora:
     '*': [python3-lark-parser]


### PR DESCRIPTION
These are available for the selected platforms via the ROS repositories.

We don't have a web index but you can see the packages in the storage pool here: http://packages.ros.org/ros2/ubuntu/pool/main/p/python-ifcfg/