### PR TITLE
librealsense2: 2.28.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6206,7 +6206,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.25.2-1
+      version: 2.28.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.28.0-2`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.25.2-1`
