### PR TITLE
tts: 1.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14996,6 +14996,9 @@ repositories:
       url: https://github.com/aws-robotics/tts-ros1.git
       version: master
     release:
+      packages:
+      - tts
+      - tts_interfaces
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/tts-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tts` to `1.0.2-1`:

- upstream repository: https://github.com/aws-robotics/tts-ros1.git
- release repository: https://github.com/aws-gbp/tts-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.2-1`
