### PR TITLE
vrx: 1.2.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16170,7 +16170,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.2.2-1
+      version: 1.2.3-2
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx/


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.2.3-2`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.2-1`

## usv_gazebo_plugins

```
* Minor maintenance updates.
* Fix style error.
* Adding a default value for the length_n plugin parameter
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@osrfoundation.org>
```

## vrx_gazebo

```
* Minor maintenance updates.
* Contributors: Carlos Aguero
```

## wamv_description

- No changes

## wamv_gazebo

- No changes

## wave_gazebo

- No changes

## wave_gazebo_plugins

```
* Replace EnableVisualizations() with UserCameraCount().
* Minor maintenance updates.
* Contributors: Carlos Aguero
```
