### PR TITLE
vrx: 1.2.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16170,7 +16170,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.2.3-2
+      version: 1.2.4-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx/


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.2.4-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.3-2`

## usv_gazebo_plugins

- No changes

## vrx_gazebo

```
* Add protobuf-dev as a buildtool depend for vrx_gazebo
* Tweaks: Adding missing line breaks and adjusting perspective file for new topic namespace
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Tully Foote <mailto:tfoote@osrfoundation.org>
```

## wamv_description

- No changes

## wamv_gazebo

- No changes

## wave_gazebo

- No changes

## wave_gazebo_plugins

- No changes
