### PR TITLE
Remove failing packages from Dashing

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -13,7 +13,6 @@ repositories:
       version: 0.0.1
     release:
       packages:
-      - autoware_auto_algorithm
       - autoware_auto_cmake
       - autoware_auto_create_pkg
       - autoware_auto_examples
@@ -21,10 +20,7 @@ repositories:
       - autoware_auto_msgs
       - euclidean_cluster
       - euclidean_cluster_nodes
-      - hungarian_assigner
       - kalman_filter
-      - lidar_utils
-      - motion_model
       - point_cloud_fusion
       - ray_ground_classifier
       - ray_ground_classifier_nodes

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -18,16 +18,6 @@ repositories:
       - autoware_auto_examples
       - autoware_auto_geometry
       - autoware_auto_msgs
-      - euclidean_cluster
-      - euclidean_cluster_nodes
-      - kalman_filter
-      - point_cloud_fusion
-      - ray_ground_classifier
-      - ray_ground_classifier_nodes
-      - velodyne_driver
-      - velodyne_node
-      - voxel_grid
-      - voxel_grid_nodes
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/AutowareAuto/AutowareAuto-release.git


### PR DESCRIPTION
These packages have either never passed or been unable to build due to dependency failures.

The issues have been discussed upstream in https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/issues/116

