### PR TITLE
Remove packages which have never had a passing build.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -821,7 +821,6 @@ repositories:
   micro-ROS-Agent:
     release:
       packages:
-      - micro_ros_agent
       - microxrcedds_agent_cmake_module
       tags:
         release: release/crystal/{package}/{version}


### PR DESCRIPTION
This package has never passed on Crystal.

The issue has been ticketed upstream as https://github.com/micro-ROS/micro-ROS-Agent/issues/16

