### PR TITLE
add keras-rl to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2057,6 +2057,19 @@ python-keras-pip:
   ubuntu:
     pip:
       packages: [keras]
+python-keras-rl-pip:
+  debian:
+    pip:
+      packages: [keras-rl]
+  fedora:
+    pip:
+      packages: [keras-rl]
+  osx:
+    pip:
+      packages: [keras-rl]
+  ubuntu:
+    pip:
+      packages: [keras-rl]
 python-kitchen:
   arch: [python2-kitchen]
   debian: [python-kitchen]


### PR DESCRIPTION
- Adding keras-rl to rosdep. Here is the link to the library: https://github.com/keras-rl/keras-rl
