### PR TITLE
fcl_catkin: 0.5.99-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1898,7 +1898,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.98-1
+      version: 0.5.99-1
     status: developed
   fetch_gazebo:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl_catkin` to `0.5.99-1`:

- upstream repository: https://github.com/wxmerkt/fcl_catkin.git
- release repository: https://github.com/wxmerkt/fcl_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.98-1`

## fcl_catkin

- No changes
