### PR TITLE
rxros: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8199,6 +8199,16 @@ repositories:
       url: https://github.com/rosin-project/rxcpp_vendor.git
       version: master
     status: maintained
+  rxros:
+    release:
+      packages:
+      - rxros
+      - rxros_tf
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rosin-project/rxros-release.git
+      version: 0.1.0-1
+    status: developed
   sainsmart_relay_usb:
     doc:
       type: hg


### PR DESCRIPTION
Increasing version of package(s) in repository `rxros` to `0.1.0-1`:

- upstream repository: https://github.com/rosin-project/rxros.git
- release repository: https://github.com/rosin-project/rxros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rxros

```
* First release of RxROS.
* Contributors: Henrik Larsen, gavanderhoorn
```

## rxros_tf

```
* First release of RxROS TF.
* Contributors: Henrik Larsen, gavanderhoorn
```
