### PR TITLE
jog_control: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5364,7 +5364,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jog_control-release.git
-      version: 0.0.1-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/tork-a/jog_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jog_control` to `0.0.2-1`:

- upstream repository: https://github.com/tork-a/jog_control.git
- release repository: https://github.com/tork-a/jog_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-0`

## jog_control

- No changes

## jog_controller

```
* Add intermittent parameter (#31 <https://github.com/tork-a/jog_control/issues/31> )
  - When this parameter is true, jog motions wait for the end of previous action
* Implemented a twist_to_jogframe controller (#39 <https://github.com/tork-a/jog_control/issues/39> )
  - added optional arg to lauch the spacenav
  - added missing dependency in package.
  - Added Twist to jog frame missing launch file arg
  - Update README.md
  - Fix typos, renamed argument. Mod def scale values
  - Asked modifications for pr.
  - New method to tf from spacenav axis to EEF.
  - Added missing launch file arg to ReadMe
  - clean up of twist script
  - fix to make it work
  - tested joy control using space mouse
  - Change validation message as ROS_ERROR
* Contributors: Alexandre Francoeur, LazyEngineerToBe, Ryosuke Tajima
```

## jog_launch

```
* Add intermittent parameter (#31 <https://github.com/tork-a/jog_control/issues/31> )
  - When this parameter true, jog motions wait for the end of previous action
  - Add i611 files
* Fixed launch files for motoman robots (#35 <https://github.com/tork-a/jog_control/issues/35> )
  - Fixed launch files for motoman robots.
* Contributors: Alexandre Francoeur, LazyEngineerToBe, Ryosuke Tajima
```

## jog_msgs

- No changes
