### PR TITLE
fastcdr: 1.0.11-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -62,6 +62,8 @@ repositories:
       url: https://github.com/ros2-gbp/fastcdr-release.git
       version: 1.0.11-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
       version: v1.0.11

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -55,6 +55,17 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  fastcdr:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/fastcdr-release.git
+      version: 1.0.11-1
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-CDR.git
+      version: v1.0.11
+    status: developed
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `fastcdr` to `1.0.11-1`:

- upstream repository: https://github.com/eProsima/Fast-CDR.git
- release repository: https://github.com/ros2-gbp/fastcdr-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
