### PR TITLE
flexbe: 1.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2132,7 +2132,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.2.2-1`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.1-1`

## flexbe_behavior_engine

- No changes

## flexbe_core

```
* [flexbe_core] Add method to set a custom execute rate for states
* [flexbe_core] Remove unnecessary sleep call in logger (see #79 <https://github.com/team-vigir/flexbe_behavior_engine/issues/79>)
* [flexbe_core] Fix custom rate issues with nested and concurrent states
* Contributors: Philipp Schillinger
```

## flexbe_input

- No changes

## flexbe_mirror

- No changes

## flexbe_msgs

- No changes

## flexbe_onboard

- No changes

## flexbe_states

- No changes

## flexbe_testing

- No changes

## flexbe_widget

- No changes
