### PR TITLE
fastrtps: 1.9.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -68,6 +68,17 @@ repositories:
       url: https://github.com/eProsima/Fast-CDR.git
       version: v1.0.11
     status: developed
+  fastrtps:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/fastrtps-release.git
+      version: 1.9.0-2
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-RTPS.git
+      version: 130e7c7f0c32bd27c543bb823a1b676407eb2656
+    status: developed
   googletest:
     release:
       packages:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -75,6 +75,8 @@ repositories:
       url: https://github.com/ros2-gbp/fastrtps-release.git
       version: 1.9.0-2
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-RTPS.git
       version: 130e7c7f0c32bd27c543bb823a1b676407eb2656


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `1.9.0-2`:

- upstream repository: https://github.com/eProsima/Fast-RTPS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
