### PR TITLE
console_bridge_vendor: 1.2.0-1 in 'eloquent/distribution.yaml'…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -55,6 +55,18 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  console_bridge_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
+      version: 1.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: master
+    status: maintained
   fastcdr:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge_vendor` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/console_bridge_vendor.git
- release repository: https://github.com/ros2-gbp/console_bridge_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
