### PR TITLE
poco_vendor: 1.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -95,6 +95,18 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  poco_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/poco_vendor-release.git
+      version: 1.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/poco_vendor.git
+      version: master
+    status: maintained
   ros_workspace:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `poco_vendor` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/poco_vendor.git
- release repository: https://github.com/ros2-gbp/poco_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
