### PR TITLE
Add rosdep rules for pybind11

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4650,6 +4650,11 @@ pugixml-dev:
   debian: [libpugixml-dev]
   fedora: [pugixml]
   ubuntu: [libpugixml-dev]
+pybind11-dev:
+  arch: [pybind11]
+  debian: [pybind11-dev]
+  fedora: [pybind11-devel]
+  ubuntu: [pybind11-dev]
 python-dev:
   debian: [python-dev]
   fedora: [python2-devel]


### PR DESCRIPTION
Precisely what title says. Added rules for:

- Arch Linux https://www.archlinux.org/packages/?q=pybind11
- Debian https://packages.debian.org/search?keywords=pybind11-dev
- Fedora https://fedora.pkgs.org/30/fedora-x86_64/pybind11-devel-2.2.4-2.fc30.x86_64.rpm.html
- Ubuntu https://packages.ubuntu.com/search?keywords=pybind11-dev