### PR TITLE
Fix branches for catkin_virtualenv

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -641,7 +641,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git
-      version: devel
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -650,7 +650,7 @@ repositories:
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git
-      version: devel
+      version: master
     status: maintained
   class_loader:
     doc:


### PR DESCRIPTION
Following from the errors in https://github.com/ros/rosdistro/pull/22252/files, these branches needed to be fixed.