### PR TITLE
Add python3-docker package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4970,6 +4970,11 @@ python3-django-extra-views:
 python3-djangorestframework:
   debian: [python3-djangorestframework]
   ubuntu: [python3-djangorestframework]
+python3-docker:
+  arch: [python-docker]
+  debian: [python3-docker]
+  fedora: [python3-docker]
+  ubuntu: [python3-docker]
 python3-empy:
   debian:
     buster: [python3-empy]


### PR DESCRIPTION
Python3 API to control docker containers, used to control containerized launch actions https://github.com/aws-robotics/launch-ros-sandbox

Packages:
* Arch https://www.archlinux.org/packages/community/any/python-docker/
* Debian https://packages.debian.org/stretch/python3-docker
* Fedora https://apps.fedoraproject.org/packages/python3-docker
* Ubuntu https://packages.ubuntu.com/bionic/python3-docker