### PR TITLE
add python-jsonpickle

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2010,6 +2010,12 @@ python-joblib:
   fedora: [python-joblib]
   gentoo: [dev-python/joblib]
   ubuntu: [python-joblib]
+python-jsonpickle:
+  arch: [python-jsonpickle]
+  debian: [python-jsonpickle]
+  fedora: [python-jsonpickle]
+  gentoo: [dev_python/jsonpickle]
+  ubuntu: [python-jsonpickle]
 python-jsonpyes-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2014,7 +2014,7 @@ python-jsonpickle:
   arch: [python-jsonpickle]
   debian: [python-jsonpickle]
   fedora: [python-jsonpickle]
-  gentoo: [dev_python/jsonpickle]
+  gentoo: [dev-python/jsonpickle]
   ubuntu: [python-jsonpickle]
 python-jsonpyes-pip:
   debian:


### PR DESCRIPTION
arch: https://www.archlinux.de/packages/community/x86_64/python-jsonpickle
debian: https://packages.debian.org/de/sid/python-jsonpickle
fedora: https://apps.fedoraproject.org/packages/python-jsonpickle
gentoo: https://packages.gentoo.org/packages/dev-python/jsonpickle
ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=jsonpickle&searchon=names
