### PR TITLE
rc_dynamics_api: 0.10.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6288,7 +6288,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_dynamics_api-release.git
-      version: 0.8.0-1
+      version: 0.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_dynamics_api` to `0.10.0-1`:

- upstream repository: https://github.com/roboception/rc_dynamics_api.git
- release repository: https://github.com/roboception-gbp/rc_dynamics_api-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-1`

## rc_dynamics_api

```
* improve exception handling using new NotAvailable
```
