### PR TITLE
tinyxml2_vendor: 0.6.1-1 in 'eloquent/distribution.yaml' [bloo…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -158,5 +158,17 @@ repositories:
       url: https://github.com/ros2/tinyxml_vendor.git
       version: master
     status: maintained
+  tinyxml2_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
+      version: 0.6.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: master
+    status: maintained
 type: distribution
 version: 2

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -146,18 +146,6 @@ repositories:
       url: https://github.com/ros2/tinydir_vendor.git
       version: master
     status: maintained
-  tinyxml_vendor:
-    release:
-      tags:
-        release: release/eloquent/{package}/{version}
-      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
-      version: 0.7.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros2/tinyxml_vendor.git
-      version: master
-    status: maintained
   tinyxml2_vendor:
     release:
       tags:
@@ -168,6 +156,18 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
+      version: master
+    status: maintained
+  tinyxml_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
       version: master
     status: maintained
 type: distribution


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml2_vendor` to `0.6.1-1`:

- upstream repository: https://github.com/ros2/tinyxml2_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
