### PR TITLE
uncrustify_vendor: 1.3.0-1 in 'eloquent/distribution.yaml' [bl…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -170,6 +170,18 @@ repositories:
       url: https://github.com/ros2/tinyxml_vendor.git
       version: master
     status: maintained
+  uncrustify_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
+      version: 1.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: master
+    status: maintained
   urdfdom_headers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uncrustify_vendor` to `1.3.0-1`:

- upstream repository: https://github.com/ament/uncrustify_vendor.git
- release repository: https://github.com/ros2-gbp/uncrustify_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
