### PR TITLE
ros_environment: 2.4.0-1 in 'eloquent/distribution.yaml' [bloo…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -119,6 +119,22 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: eloquent
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_environment-release.git
+      version: 2.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: eloquent
+    status: maintained
   ros_workspace:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `2.4.0-1`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros2-gbp/ros_environment-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
