### PR TITLE
orocos_kinematics_dynamics: 3.2.0-1 in 'eloquent/distribution.…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -107,6 +107,24 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  orocos_kinematics_dynamics:
+    doc:
+      type: git
+      url: https://github.com/ros2/orocos_kinematics_dynamics.git
+      version: ros2
+    release:
+      packages:
+      - orocos_kdl
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
+      version: 3.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/orocos_kinematics_dynamics.git
+      version: ros2
+    status: maintained
   poco_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/orocos_kinematics_dynamics.git
- release repository: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
