### PR TITLE
catkin_virtualenv: 0.5.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -646,7 +646,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.4.1-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.5.1-1`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.1-1`

## catkin_virtualenv

```
* catkin-pkg-modules has disappeared off pypi (#46 <https://github.com/locusrobotics/catkin_virtualenv/issues/46>)
  * catkin-pkg-modules has disappeared off pypi, but catkin-pkg is still there
  * Version all requirements
* Contributors: Paul Bovbel
```
