### PR TITLE
Fix catkin_virtualenv branches

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1245,7 +1245,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git
-      version: devel
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -1254,7 +1254,7 @@ repositories:
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git
-      version: devel
+      version: master
     status: developed
   certifi:
     release:


### PR DESCRIPTION
From https://github.com/ros/rosdistro/pull/22262, forgot about kinetic