### PR TITLE
quaternion_operation: 0.0.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6143,7 +6143,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OUXT-Polaris/quaternion_operation-release.git
-      version: 0.0.3-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `quaternion_operation` to `0.0.3-2`:

- upstream repository: https://github.com/OUXT-Polaris/quaternion_operation.git
- release repository: https://github.com/OUXT-Polaris/quaternion_operation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.3-1`

## quaternion_operation

- No changes
