### PR TITLE
fkie_message_filters: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2089,7 +2089,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fkie-release/message_filters-release.git
-      version: 1.0.0-0
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/fkie/message_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_message_filters` to `1.0.1-1`:

- upstream repository: https://github.com/fkie/message_filters.git
- release repository: https://github.com/fkie-release/message_filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-0`

## fkie_message_filters

```
* Bugfix for ODR violation
* Improve documentation
* Rename helper function for more clarity
* Reword documentation to be a bit more precise
* Contributors: Timo Röhling
```
