### PR TITLE
class_loader: 1.4.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -103,6 +103,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/class_loader-release.git
+      version: 1.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
+    status: maintained
   console_bridge_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `1.4.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## class_loader

```
* Fixed setting AbstractMetaObjectBase base class typeid. (#127 <https://github.com/nuclearsandwich/class_loader/issues/127>)
* Corrected export of class_loader library. (#129 <https://github.com/nuclearsandwich/class_loader/issues/129>)
* Reduced the number of threads spun up in stress test. (#128 <https://github.com/nuclearsandwich/class_loader/issues/128>)
* Contributors: Emerson Knapp, Shane Loretz, bpwilcox
```
