### PR TITLE
osrf_testing_tools_cpp: 1.2.1-1 in 'eloquent/distribution.yaml…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -189,6 +189,25 @@ repositories:
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
       version: ros2
     status: maintained
+  osrf_testing_tools_cpp:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    release:
+      packages:
+      - osrf_testing_tools_cpp
+      - test_osrf_testing_tools_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
+      version: 1.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    status: maintained
   poco_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.2.1-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
