### PR TITLE
osrf_pycommon: 0.1.8-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -208,6 +208,22 @@ repositories:
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
       version: ros2
     status: maintained
+  osrf_pycommon:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_pycommon-release.git
+      version: 0.1.8-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    status: maintained
   osrf_testing_tools_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `0.1.8-2`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## osrf_pycommon

```
* Install package manifest. (#55 <https://github.com/osrf/osrf_pycommon/issues/55>)
  Signed-off-by: Dirk Thomas <mailto:dirk-thomas@users.noreply.github.com>
* Rename ansi_escape_senquences to ansi_escape_sequences keeping backwards compatibility. (#53 <https://github.com/osrf/osrf_pycommon/issues/53>)
* Contributors: Chris Lalancette, Dirk Thomas
```
