### PR TITLE
rviz_visual_tools: 3.8.0-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8178,7 +8178,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 3.7.0-0
+      version: 3.8.0-4
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.8.0-4`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.7.0-0`

## rviz_visual_tools

```
* Windows bring up. (#116 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/116>)
* Change email address (#114 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/114>)
* Fixed publishCylinder namespace (#109 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/109>)
* Remove default arguments to make function calls not ambiguous (#112 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/112>)
  * Remove default arguments to make function calls not ambiguous
  * Remove further default values
  * Add unit tests for publishPath() functions, make sucess return value more stringent
* Initizalize quaternions in demo to avoid warning (#111 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/111>)
* Fix node type in demo launch files (#110 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/110>)
* Only auto-assign one reviewer (#107 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/107>)
* Use LOGNAME for logging re:moveit styel (#106 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/106>)
* Document Github Probot for Auto Assign (#101 <https://github.com/PickNikRobotics/rviz_visual_tools/issues/101>)
* Contributors: Dave Coleman, Sean Yen, Victor Lamoine, d-walsh
```
