### PR TITLE
teleop_tools: 1.0.1-0 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2435,7 +2435,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 1.0.0-0
+      version: 1.0.1-0
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.0.1-0`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.0-0`

## joy_teleop

```
* Fix install rules and dashing changes (#38 <https://github.com/ros-teleop/teleop_tools/issues/38>)
  * fix ament indexing
  * fix package resource files
  * add tk depenndency
  * add check for param index-ability
  * data files are now package agnostic
  Signed-off-by: Ted Kern <mailto:ted.kern@canonical.com>
* Contributors: Ted Kern
```

## key_teleop

```
* Fix install rules and dashing changes (#38 <https://github.com/ros-teleop/teleop_tools/issues/38>)
  * fix ament indexing
  * fix package resource files
  * add tk depenndency
  * add check for param index-ability
  * data files are now package agnostic
  Signed-off-by: Ted Kern <mailto:ted.kern@canonical.com>
* Contributors: Ted Kern
```

## mouse_teleop

```
* Fix install rules and dashing changes (#38 <https://github.com/ros-teleop/teleop_tools/issues/38>)
  * fix ament indexing
  * fix package resource files
  * add tk depenndency
  * add check for param index-ability
  * data files are now package agnostic
  Signed-off-by: Ted Kern <mailto:ted.kern@canonical.com>
* Contributors: Ted Kern
```

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
