### PR TITLE
moveit_sim_controller: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4263,7 +4263,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/moveit_sim_controller-release.git
-      version: 0.1.0-0
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/moveit_sim_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_sim_controller` to `0.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/moveit_sim_controller.git
- release repository: https://github.com/PickNikRobotics/moveit_sim_controller-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-0`

## moveit_sim_controller

```
* Cleanup UR5 example (#2 <https://github.com/PickNikRobotics/moveit_sim_controller/issues/2>)
* Update README
* Add example simulated robot with UR5
* Contributors: Dave Coleman
```
