### PR TITLE
ros_control_boilerplate: 0.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6937,7 +6937,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
-      version: 0.4.1-0
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.5.0-1`:

- upstream repository: https://github.com/PickNikRobotics/ros_control_boilerplate.git
- release repository: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.1-0`

## ros_control_boilerplate

```
* Merge pull request #20 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/20> from ipa-mdl/fix-loop-deadlock
  refactor GenericHWControlLoop to a sleep-based loop
* Merge pull request #19 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/19> from PaulBouchier/kinetic-devel
  change sim_control_mode to 0 (position) so demo works
* Merge pull request #21 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/21> from MohmadAyman/fix_typo
  fixed a typo in readme
* fixed a typo in readme
* refactor GenericHWControlLoop to a sleep-based loop
  using ros:Timer might lead to deadlocks
* initialize desired_update_period_ (renamed from desired_update_freq_)
* Revert "Depend on Eigen3"
  This reverts commit 608cc2fd64739ee56c3fbd5a0ae9d5d26b5684d0.
* change sim_control_mode to 0 (position) so demo works
* Merge pull request #16 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/16> from lucasw/xml-version
  xml version tags for all launch files.
* xml version tags for all launch files.
* Merge pull request #15 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/15> from enricotoi/kinetic-devel
  Fixed a typo in the README.md
* Fixed a typo in the README.md
  rrbot_simulaton.launch -> rrbot_simulation.launch
* Update README.md
* Contributors: Dave Coleman, Lucas Walter, Mathias Lüdtke, Paul Bouchier, enrico toivinen, mohmad ayman
```
