### PR TITLE
rosparam_shortcuts: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7394,7 +7394,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rosparam_shortcuts.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.3.2-1`:

- upstream repository: https://github.com/PickNikRobotics/rosparam_shortcuts.git
- release repository: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.1-1`

## rosparam_shortcuts

```
* Update to new ros_buildfarm workspace directory
* Add get() for geometry_msgs::Pose
* Contributors: Henning Kayser
```
