### PR TITLE
gazebo_ros_pkgs: 3.3.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -742,7 +742,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.3.3-1
+      version: 3.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.3.4-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.3.3-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* fix multi_camera_plugin on windows (#999 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/999>)
* Contributors: Jonathan Noyola
```

## gazebo_ros

```
* Remove ROS-specific arguments before passing to argparse (#994 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/994>)
  This resolves argparse errors when trying to launch the spawn_entity script as a ROS node.
  For example, a launch file like the following wouldn't work without this change:
  <launch>
  <arg name="model_urdf" default="$(find-pkg-share mymodels)/urdf/ball.urdf" />
  <node
  pkg="gazebo_ros"
  exec="spawn_entity.py"
  name="spawner"
  args="-entity foo -file /path/to/my/model/foo.urdf" />
  </launch>
  Signed-off-by: Jacob Perron <mailto:jacob@openrobotics.org>
* [ros2] Remove ported / deprecated (#989 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/989>)
  Signed-off-by: Louise Poubel <mailto:louise@openrobotics.org>
* linter :sweat_smile:
  Signed-off-by: Louise Poubel <mailto:louise@openrobotics.org>
* [ros2] Uncommenting bond option on spawn_entity (wait Ctrl+C then remove entity) (#986 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/986>)
  * Uncommenting bond option on spawn_entity (wait Ctrl+C then remove entity)
  Instead of waiting for a shutdown callback to be created in rclpy,
  we can use the try/except to get the SIGINT signal, then delete the entity.
  * Message formatting
  Signed-off-by: Louise Poubel <mailto:louise@openrobotics.org>
* Contributors: Jacob Perron, Louise Poubel, alexfneves, chapulina
```

## gazebo_ros_pkgs

- No changes
