### PR TITLE
soem: 1.4.0-1 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14088,17 +14088,17 @@ repositories:
   soem:
     doc:
       type: git
-      url: https://github.com/smits/soem.git
+      url: https://github.com/mgruhler/soem.git
       version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/smits/soem-gbp.git
-      version: 1.3.0-0
+      url: https://github.com/mgruhler/soem-gbp.git
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/smits/soem.git
+      url: https://github.com/mgruhler/soem.git
       version: master
     status: maintained
   sophus:


### PR DESCRIPTION
also changes the repo url as this has been moved

Increasing version of package(s) in repository `soem` to `1.4.0-1`:

upstream repository: [mgruhler/soem.git](https://github.com/mgruhler/soem.git)
release repository: [mgruhler/soem-gbp.git](https://github.com/mgruhler/soem-gbp.git)
distro file: `kinetic/distribution.yaml`
bloom version: `0.8.0`
previous version for package: `1.3.0-0`