### PR TITLE
soem: 1.4.0-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8451,7 +8451,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mgruhler/soem-gbp.git
-      version: 1.3.0-0
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.4.0-1`:

upstream repository: [mgruhler/soem.git](https://github.com/mgruhler/soem.git)
release repository: [mgruhler/soem-gbp.git](https://github.com/mgruhler/soem-gbp.git)
distro file: `melodic/distribution.yaml`
bloom version: `0.8.0`
previous version for package: `1.3.0-0`