### PR TITLE
yaml_cpp_vendor: 7.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -375,7 +375,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/yaml_cpp_vendor.git
-      version: dashing
+      version: master
     status: maintained
 type: distribution
 version: 2

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -366,5 +366,16 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  yaml_cpp_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+      version: 7.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/yaml_cpp_vendor.git
+      version: dashing
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `7.0.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## yaml_cpp_vendor

```
* add .dsv file beside custom environment hook (#7 <https://github.com/ros2/yaml_cpp_vendor/issues/7>)
  Signed-off-by: Dirk Thomas <mailto:dirk-thomas@users.noreply.github.com>
* Contributors: Dirk Thomas
```
