### PR TITLE
vrx: 1.2.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16177,7 +16177,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx/


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.2.5-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.4-1`

## usv_gazebo_plugins

```
* merging default into branch
* Changes for code checker
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>
```

## vrx_gazebo

```
* Remove <announce_symbol> parameter.
* moving static docks to waterline
* Use __future__ import
* Adding running_duration parameter to the nav_challenge.xacro.
* Tweak buoyany primative so that 4x4 dock element floats at water line instead of above
* Adding parameters to dock.xacro to for auto. generation of tasks
* adding params to dock xacro for the benefit of automatically generating tasks
* Changes for code checker
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Aguero <mailto:caguero@openrobotics.org>
```

## wamv_description

- No changes

## wamv_gazebo

- No changes

## wave_gazebo

- No changes

## wave_gazebo_plugins

```
* typo
* Fix aspect ration with reflections.
* Style.
* apply reflection / refraction only to camera sensors
* syntax tweak
* removing redundancy in variable initialization
* merging default into branch
* Merged in maintenance (pull request #174)
  Minor maintenance updates
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* Changes for code checker
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, Ian Chen <mailto:ichen@osrfoundation.org>
```
