### PR TITLE
foonathan_memory_vendor: 0.1.0-1 in 'eloquent/distribution.yam…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -176,6 +176,17 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: 130e7c7f0c32bd27c543bb823a1b676407eb2656
     status: developed
+  foonathan_memory_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/eProsima/foonathan_memory_vendor.git
+      version: f3ab481cda60adc18d4172367f16af6076d8fde4
+    status: maintained
   googletest:
     release:
       packages:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -183,6 +183,8 @@ repositories:
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
       version: 0.1.0-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git
       version: f3ab481cda60adc18d4172367f16af6076d8fde4


### PR DESCRIPTION
Increasing version of package(s) in repository `foonathan_memory_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/eProsima/foonathan_memory_vendor.git
- release repository: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
