### PR TITLE
fastrtps: 1.9.0-3 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -168,7 +168,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 1.9.0-2
+      version: 1.9.0-3
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `1.9.0-3`:

- upstream repository: https://github.com/eProsima/Fast-RTPS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.9.0-2`
