### PR TITLE
rtshell: 3.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8151,7 +8151,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
     source:
       type: git
       url: https://github.com/gbiggs/rtshell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-2`:

- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.1-1`
