### PR TITLE
add python3-websocket

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5397,6 +5397,11 @@ python3-venv:
   debian: [python3-venv]
   fedora: [python3-libs]
   ubuntu: [python3-venv]
+python3-websocket:
+  debian: [python3-websocket]
+  fedora: [python3-websocket-client]
+  gentoo: [dev-python/websocket-client]
+  ubuntu: [python3-websocket]
 python3-yaml:
   alpine: [py3-yaml]
   debian: [python3-yaml]


### PR DESCRIPTION
Necessary to release https://github.com/GT-RAIL/async_web_server_cpp for ROS 2 Dashing.

* [Debian](https://packages.debian.org/search?suite=all&searchon=names&keywords=python3-websocket)
* [Fedora](https://apps.fedoraproject.org/packages/python3-websocket-client)
* [Gentoo](https://packages.gentoo.org/packages/dev-python/websocket-client)
* [Ubuntu](https://packages.ubuntu.com/search?suite=all&arch=any&searchon=names&keywords=python3-websocket)