### PR TITLE
rosauth: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1924,6 +1924,22 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  rosauth:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rosauth-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: ros2
+    status: maintained
   rosbag2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `2.0.0-1`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/ros2-gbp/rosauth-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rosauth

```
* Port to ROS 2
```
