### PR TITLE
rosauth: 2.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1933,7 +1933,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosauth-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `2.0.1-1`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/ros2-gbp/rosauth-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-1`

## rosauth

```
* add missing test dependency
```
