### PR TITLE
h264_encoder_core: 2.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -796,7 +796,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/h264_encoder_core-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-encoder-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `h264_encoder_core` to `2.0.2-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-encoder-common.git
- release repository: https://github.com/aws-gbp/h264_encoder_core-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-1`

## h264_encoder_core

```
* Backoff to software encoding if codec isn't available (#35 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/35>)
  * Backoff to software encoding if codec isn't available
  * Remove is_omx_available
  * Update documentation for running on Raspberr Pi
  Signed-off-by: Ryan Newell <mailto:ryanewel@amazon.com>
* Increment version to 2.0.2
* Link libraries only if test target exists
* increment patch version (#30 <https://github.com/aws-robotics/kinesisvideo-encoder-common/issues/30>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>```
