### PR TITLE
health_metric_collector: 3.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -826,7 +826,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/health_metric_collector-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/health-metrics-collector-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `health_metric_collector` to `3.0.1-1`:

- upstream repository: https://github.com/aws-robotics/health-metrics-collector-ros2.git
- release repository: https://github.com/aws-gbp/health_metric_collector-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.0-1`

## health_metric_collector

```
* Bump version to 3.0.1
* Replacing sample_application.launch with an equivalent launch script
* Guard test targets with if(BUILD_TESTING)
* remove changelog for new release
* Add launch dependencies
```
