### PR TITLE
tts: 2.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2629,7 +2629,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/tts-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/tts-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tts` to `2.0.1-1`:

- upstream repository: https://github.com/aws-robotics/tts-ros2.git
- release repository: https://github.com/aws-gbp/tts-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-1`

## tts

```
* Fix voicer and bump version to 2.0.1 (#9 <https://github.com/aws-robotics/tts-ros2/issues/9>)
  * Fix voicer and bump version to 2.0.1
  * Bump version of tts_interfaces to 2.0.1
* Increase wait_for_service timeout in tts_integration.py
* Contributors: AAlon
```

## tts_interfaces

```
* Fix voicer and bump version to 2.0.1 (#9 <https://github.com/aws-robotics/tts-ros2/issues/9>)
  * Fix voicer and bump version to 2.0.1
  * Bump version of tts_interfaces to 2.0.1
* Contributors: AAlon
```
