### PR TITLE
rviz: 1.13.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8181,7 +8181,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.3-0
+      version: 1.13.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.4-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.13.3-0`

## rviz

```
* [feature] Enable rviz -d my_config as shortcut for ~/.rviz/my_config.rviz (#1422 <https://github.com/ros-visualization/rviz/issues/1422>)
* [feature] Added --fullscreen cmdline option (#1413 <https://github.com/ros-visualization/rviz/issues/1413>)
* [feature] RobotModelDisplay: Poll robot_description at 1Hz until found
* [feature] Use assimp to load STL files (#1365 <https://github.com/ros-visualization/rviz/issues/1365>)
* [feature] Added frame-aligned view controller (#1405 <https://github.com/ros-visualization/rviz/issues/1405>)
* [feature] Systematically check parameters of incoming marker messages (#1275 <https://github.com/ros-visualization/rviz/issues/1275>, #1400 <https://github.com/ros-visualization/rviz/issues/1400>)
* [feature] MarkerDisplay: clear statuses on disable()
* [feature] Increase zoom range in orbit view controllers (#1373 <https://github.com/ros-visualization/rviz/issues/1373>)
* [feature] Add shortcut "C" to the Publish Point tool (#1321 <https://github.com/ros-visualization/rviz/issues/1321>)
* [fix] ESC shortcut to leave fullscreen prevents canceling tools from working (#1257 <https://github.com/ros-visualization/rviz/issues/1257>)
* [fix] Fixed color tinting of mesh markers (#1424 <https://github.com/ros-visualization/rviz/issues/1424>)
* [fix] Fixed several issues with Camera and Image display (#1409 <https://github.com/ros-visualization/rviz/issues/1409>)
* [fix] Fixed several issues with view controllers, particularly FPS (#1407 <https://github.com/ros-visualization/rviz/issues/1407>)
* [fix] Fixed (small) memory leak in TFDisplay (#1408 <https://github.com/ros-visualization/rviz/issues/1408>)
* [fix] Fixed memory leak in PointCloud display in case of constant /clock (#1412 <https://github.com/ros-visualization/rviz/issues/1412>)
* [fix] Fixed memory leak in MapDisplay (#1406 <https://github.com/ros-visualization/rviz/issues/1406>)
* [fix] Properly resize RenderWidget on high-DPI displays (#1263 <https://github.com/ros-visualization/rviz/issues/1263>)
* [fix] Fixed opacity of Collada meshes (#1387 <https://github.com/ros-visualization/rviz/issues/1387>)
* [fix] Enable non-ascii chars for MovableText (#1374 <https://github.com/ros-visualization/rviz/issues/1374>)
* [fix] Ignore nan and inf values when normalizing images (#1378 <https://github.com/ros-visualization/rviz/issues/1378>)
* [fix] MovableText: consider full translation vector (#1375 <https://github.com/ros-visualization/rviz/issues/1375>)
* [maintanence] ToolManager: simplify key handling code
* [maintanence] Move sip bindings' build directory into the build space. (#1360 <https://github.com/ros-visualization/rviz/issues/1360>)
* [maintanence] Use std random generators for portability on Windows (#1356 <https://github.com/ros-visualization/rviz/issues/1356>)
* [api] public CovarianceVisual (#1410 <https://github.com/ros-visualization/rviz/issues/1410>)
* [api] Properly override FailedDisplay::save (#1402 <https://github.com/ros-visualization/rviz/issues/1402>)
* [api] Removed extra wrapper MarkerArrayDisplay::handleMarkerArray (#1401 <https://github.com/ros-visualization/rviz/issues/1401>)
* Contributors: Robert Haschke, Daiki Maekawa, Jasper, Jeremie Deray, Mike Purvis, Ryan Lober, Sean Yen, Simon Schmeisser, Victor Lamoine, chapulina
```