### PR TITLE
rosbag2: 0.1.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1967,7 +1967,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.1.6-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.5-1`

## ros2bag

- No changes

## rosbag2

```
* enable address sanitizers only on 64bit machines (#149 <https://github.com/ros2/rosbag2/issues/149>) (#162 <https://github.com/ros2/rosbag2/issues/162>)
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
