### PR TITLE
web_video_server: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2831,6 +2831,22 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/web_video_server-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: ros2
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `1.0.0-1`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/ros2-gbp/web_video_server-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## web_video_server

```
* Port to ROS 2
```
