### PR TITLE
industrial_robot_status_controller: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3004,6 +3004,16 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/industrial_robot_angle_conversions.git
       version: melodic
     status: maintained
+  industrial_robot_status_controller:
+    release:
+      packages:
+      - industrial_robot_status_controller
+      - industrial_robot_status_interface
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
+      version: 0.1.2-1
+    status: maintained
   interactive_marker_proxy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_robot_status_controller` to `0.1.2-1`:

- upstream repository: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
- release repository: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## industrial_robot_status_controller

```
* Fix potential build ordering problem with industrial_msgs pkg. (#4 <https://github.com/gavanderhoorn/industrial_robot_status_controller/issues/4>)
* Contributors: Bianca Homberg
```

## industrial_robot_status_interface

- No changes
