### PR TITLE
odom_frame_publisher: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8482,6 +8482,21 @@ repositories:
       url: https://github.com/xaxxontech/oculusprime_ros.git
       version: master
     status: developed
+  odom_frame_publisher:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/odom_frame_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/odom_frame_publisher-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/odom_frame_publisher.git
+      version: master
+    status: developed
   odva_ethernetip:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `odom_frame_publisher` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/odom_frame_publisher.git
- release repository: https://github.com/OUXT-Polaris/odom_frame_publisher-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## odom_frame_publisher

```
* remove nav_msgs depends
* add CI
* add doxygen comment
* initial commit
* Contributors: Masaya Kataoka
```
