### PR TITLE
Add rosdep rules for python3-bson

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -696,6 +696,14 @@ python-bson:
     pip:
       packages: [bson]
   ubuntu: [python-bson]
+python3-bson:
+  debian: [python3-bson]
+  fedora: [python3-bson]
+  gentoo: [dev-python/pymongo]
+  osx:
+    pip:
+      packages: [bson]
+  ubuntu: [python3-bson]
 python-cairo:
   arch: [python2-cairo]
   debian: [python-cairo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -696,14 +696,6 @@ python-bson:
     pip:
       packages: [bson]
   ubuntu: [python-bson]
-python3-bson:
-  debian: [python3-bson]
-  fedora: [python3-bson]
-  gentoo: [dev-python/pymongo]
-  osx:
-    pip:
-      packages: [bson]
-  ubuntu: [python3-bson]
 python-cairo:
   arch: [python2-cairo]
   debian: [python-cairo]
@@ -4916,6 +4908,14 @@ python3-boto3:
   fedora: [python3-boto3]
   opensuse: [python3-boto3]
   ubuntu: [python3-boto3]
+python3-bson:
+  debian: [python3-bson]
+  fedora: [python3-bson]
+  gentoo: [dev-python/pymongo]
+  osx:
+    pip:
+      packages: [bson]
+  ubuntu: [python3-bson]
 python3-cairo:
   arch: [python-cairo]
   debian: [python3-cairo]


### PR DESCRIPTION
Added rules for:

- [Debian](https://packages.debian.org/search?keywords=python3-bson)
- [Fedora](https://pkgs.org/download/python3-bson)
- [Gentoo](https://packages.gentoo.org/packages/dev-python/pymongo)
- [OSX](https://pypi.org/project/bson/)
- [Ubuntu](https://packages.ubuntu.com/search?keywords=python3-bson)

to match `python-bson` platform coverage. For Gentoo and OSX, the keys are the same as IIUC the Python version being targeted depends on OS configuration and package manager respectively, but I don't have boxes at hand to try this out.