### PR TITLE
Add rosdep rules for python3-tornado

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4423,6 +4423,15 @@ python-tornado:
     pip:
       packages: [tornado]
   ubuntu: [python-tornado]
+python3-tornado:
+  arch: [python-tornado]
+  debian: [python3-tornado]
+  fedora: [python3-tornado]
+  gentoo: [www-servers/tornado]
+  osx:
+    pip:
+      packages: [tornado]
+  ubuntu: [python3-tornado]
 python-tornado-couchdb-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4423,15 +4423,6 @@ python-tornado:
     pip:
       packages: [tornado]
   ubuntu: [python-tornado]
-python3-tornado:
-  arch: [python-tornado]
-  debian: [python3-tornado]
-  fedora: [python3-tornado]
-  gentoo: [www-servers/tornado]
-  osx:
-    pip:
-      packages: [tornado]
-  ubuntu: [python3-tornado]
 python-tornado-couchdb-pip:
   ubuntu:
     pip:
@@ -5366,6 +5357,15 @@ python3-tk:
   debian: [python3-tk]
   fedora: [python3-tkinter]
   ubuntu: [python3-tk]
+python3-tornado:
+  arch: [python-tornado]
+  debian: [python3-tornado]
+  fedora: [python3-tornado]
+  gentoo: [www-servers/tornado]
+  osx:
+    pip:
+      packages: [tornado]
+  ubuntu: [python3-tornado]
 python3-vcstool:
   debian:
     pip:


### PR DESCRIPTION
Added rules for:

- [Debian](https://packages.debian.org/search?keywords=python3-tornado)
- [Fedora](https://pkgs.org/download/python3-tornado)
- [Gentoo](https://packages.gentoo.org/packages/www-servers/tornado)
- [OSX](https://pypi.org/project/tornado/)
- [Ubuntu](https://packages.ubuntu.com/search?keywords=python3-tornado)

to match `python-tornado` platform coverage. For Gentoo and OSX, the keys are the same as IIUC the Python version being targeted depends on OS configuration and package manager respectively, but I don't have boxes at hand to try this out.