### PR TITLE
Add rosdep rules for python3-twisted rules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5392,7 +5392,7 @@ python3-tornado:
   ubuntu: [python3-tornado]
 python3-twisted:
   arch: [python-twisted]
-  debian: [python3-twisted-bin]
+  debian: [python3-twisted]
   fedora: [python3-twisted]
   gentoo: [dev-python/twisted]
   ubuntu: [python3-twisted]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4534,6 +4534,12 @@ python-twisted-web:
   fedora: [python-twisted-web]
   gentoo: [dev-python/twisted]
   ubuntu: [python-twisted-web]
+python3-twisted:
+  arch: [python-twisted]
+  debian: [python3-twisted-bin]
+  fedora: [python3-twisted]
+  gentoo: [dev-python/twisted]
+  ubuntu: [python3-twisted]
 python-twitter:
   debian:
     buster: [python-twitter]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4534,12 +4534,6 @@ python-twisted-web:
   fedora: [python-twisted-web]
   gentoo: [dev-python/twisted]
   ubuntu: [python-twisted-web]
-python3-twisted:
-  arch: [python-twisted]
-  debian: [python3-twisted-bin]
-  fedora: [python3-twisted]
-  gentoo: [dev-python/twisted]
-  ubuntu: [python3-twisted]
 python-twitter:
   debian:
     buster: [python-twitter]
@@ -5396,6 +5390,12 @@ python3-tornado:
     pip:
       packages: [tornado]
   ubuntu: [python3-tornado]
+python3-twisted:
+  arch: [python-twisted]
+  debian: [python3-twisted-bin]
+  fedora: [python3-twisted]
+  gentoo: [dev-python/twisted]
+  ubuntu: [python3-twisted]
 python3-vcstool:
   debian:
     pip:


### PR DESCRIPTION
Added rules for:
- [Arch](https://www.archlinux.org/packages/extra/x86_64/python-twisted/)
- [Debian](https://packages.debian.org/search?keywords=python3-twisted)
- [Fedora](https://pkgs.org/download/python3-twisted)
- [Gentoo](https://packages.gentoo.org/packages/dev-python/twisted)
- [Ubuntu](https://packages.ubuntu.com/search?keywords=python3-twisted)

For Gentoo, the keys are the same as IIUC the Python version being targeted depends on OS configuration but I don't have boxes at hand to try this out.