### PR TITLE
python_cmake_module: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -268,6 +268,17 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: master
     status: maintained
+  python_cmake_module:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/python_cmake_module-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: master
+    status: developed
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_cmake_module` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/python_cmake_module.git
- release repository: https://github.com/ros2-gbp/python_cmake_module-release
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`