### PR TITLE
crop_hull_filter: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2053,6 +2053,21 @@ repositories:
       url: https://github.com/crigroup/criutils.git
       version: master
     status: developed
+  crop_hull_filter:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/crop_hull_filter.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/OUXT-Polaris/crop_hull_filter-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/crop_hull_filter.git
+      version: master
+    status: developed
   csm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `crop_hull_filter` to `0.0.1-1`:

- upstream repository: https://github.com/OUXT-Polaris/crop_hull_filter.git
- release repository: https://github.com/OUXT-Polaris/crop_hull_filter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## crop_hull_filter

```
* add README.md
* add depends
* add .travis.yml
* update install
* add params
* initial commit
* Contributors: Masaya Kataoka
```
