### PR TITLE
Adding niryo_one to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4766,6 +4766,11 @@ repositories:
       url: https://github.com/astuff/network_interface.git
       version: release
     status: developed
+  niryo_one:
+    doc:
+      type: git
+      url: https://github.com/NiryoRobotics/niryo_one_ros.git
+      version: master
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add my repo niryo_one to be indexed and documented on ros.org
niryo_one is a robotic arm made by my company, Niryo. 