### PR TITLE
plotjuggler: 2.3.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9496,7 +9496,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.3.0-1
+      version: 2.3.1-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.3.1-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.3.0-1`

## plotjuggler

```
* Fix #202 <https://github.com/facontidavide/PlotJuggler/issues/202> use_header_stamp not initialized for built-in types
* Merge pull request #200 <https://github.com/facontidavide/PlotJuggler/issues/200> from aeudes/multiple_streamer
  data stream topic plugin
* new color palette
* Allow to have working datastreamtopic plugin in more than one plotjuggler
  instance
* adding covariance to Odometry msg again
* fix issue #187 <https://github.com/facontidavide/PlotJuggler/issues/187>
* Fix segfault when swap plotwidget on archlinux (qt5.12.3).
  This bug is introduced in: 7959e54 Spurious DragLeave fixed?
  And produce a segfault(nullptr) in QCursor::shape() call by
  QBasicDrag::updateCursor(Qt::DropAction) [trigger by plotwidget.cpp:1352
  drag->exec();].
  It seems to me that the change of global application cursor on leave event during drag drop
  operation cause the problem [is it the drop widget duty to reset cursor?].
* minor fixes related to dark theme
* Contributors: Alexandre Eudes, Davide Faconti
```
