### PR TITLE
Add in rosdep key for spdlog.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4965,6 +4965,11 @@ sparsehash:
     xenial: [libsparsehash-dev]
     yakkety: [libsparsehash-dev]
     zesty: [libsparsehash-dev]
+spdlog:
+  debian: [libspdlog-dev]
+  fedora: [spdlog-devel]
+  gentoo: [dev-libs/spdlog]
+  ubuntu: [libspdlog-dev]
 speech-dispatcher:
   debian: [speech-dispatcher]
   fedora: [speech-dispatcher]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -599,6 +599,10 @@ spacenavd:
   osx:
     homebrew:
       packages: [libspnav]
+spdlog:
+  osx:
+    homebrew:
+      packages: [spdlog]
 subversion:
   osx:
     homebrew:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

* Debian: https://packages.debian.org/buster/libspdlog-dev
* Fedora: https://apps.fedoraproject.org/packages/spdlog-devel
* Gentoo: https://packages.gentoo.org/packages/dev-libs/spdlog
* macOS: https://formulae.brew.sh/formula/spdlog
* Ubuntu: https://packages.ubuntu.com/bionic/libspdlog-dev