### PR TITLE
turtlesim: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2718,6 +2718,22 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: dashing-devel
     status: developed
+  turtlesim:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_tutorials-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: dashing-devel
+    status: maintained
   uncrustify_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim` to `1.0.0-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## turtlesim

```
* replace images with ROS 2 turtles (#60 <https://github.com/ros/ros_tutorials/issues/60>)
* add shortcut to quit teleop (#58 <https://github.com/ros/ros_tutorials/issues/58>)
* fix compiler warnings on Windows (#57 <https://github.com/ros/ros_tutorials/issues/57>)
* add support for Windows (#56 <https://github.com/ros/ros_tutorials/issues/56>)
* various fixes for ROS 2 (#55 <https://github.com/ros/ros_tutorials/issues/55>)
* turtlesim for ROS 2 (#53 <https://github.com/ros/ros_tutorials/issues/53>)
```
