### PR TITLE
rcutils: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -320,6 +320,22 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: master
     status: developed
+  rcutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rcutils-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rcutils

```
* Make g_rcutils_log_severity_names public and immutable. (#180 <https://github.com/ros2/rcutils/issues/180>)
* use _WIN32 instead of WIN32 (#179 <https://github.com/ros2/rcutils/issues/179>)
* Revert "check and link against libatomic (#172 <https://github.com/ros2/rcutils/issues/172>)" (#177 <https://github.com/ros2/rcutils/issues/177>)
* check and link against libatomic (#172 <https://github.com/ros2/rcutils/issues/172>)
* Rewrite test_logging_throttle tests: (#167 <https://github.com/ros2/rcutils/issues/167>)
* Disable uncrustify indentation check for macros that use windows  __pragma (#164 <https://github.com/ros2/rcutils/issues/164>)
* Fix armhf warning (#163 <https://github.com/ros2/rcutils/issues/163>)
* Contributors: Christian Rauch, Dirk Thomas, Emerson Knapp, Michel Hidalgo, Shane Loretz, jpsamper2009
```
