### PR TITLE
rcpputils: 0.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -320,6 +320,22 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: master
     status: developed
+  rcpputils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rcpputils-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: master
+    status: maintained
   rcutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rcpputils

```
* find_library: Centralize functionality here (#25 <https://github.com/ros2/rcpputils/issues/25>)
* Implement join() (#20 <https://github.com/ros2/rcpputils/issues/20>)
* Rename test (#21 <https://github.com/ros2/rcpputils/issues/21>)
* use _WIN32 instead of WIN32 (#24 <https://github.com/ros2/rcpputils/issues/24>)
* Update README.md and package.xml (#22 <https://github.com/ros2/rcpputils/issues/22>)
* Fix typo (#23 <https://github.com/ros2/rcpputils/issues/23>)
* type trait rcpputils::is_pointer<T>` (#19 <https://github.com/ros2/rcpputils/issues/19>)
* File extension addition for camera calibration parser (#18 <https://github.com/ros2/rcpputils/issues/18>)
* Add endian helper until C++20 (#16 <https://github.com/ros2/rcpputils/issues/16>)
* use iterators for split (#14 <https://github.com/ros2/rcpputils/issues/14>)
* Add function 'find_and_replace' (#13 <https://github.com/ros2/rcpputils/issues/13>)
* Contributors: Andreas Klintberg, Dirk Thomas, Jacob Perron, Karsten Knese, Michael Carroll, Michel Hidalgo, Tully Foote
```
