### PR TITLE
rosidl: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -383,6 +383,31 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  rosidl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: master
+    release:
+      packages:
+      - rosidl_adapter
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_parser
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: master
+    status: maintained
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rosidl_adapter

```
* Improve parser error messages (#415 <https://github.com/ros2/rosidl/issues/415>)
* support adjacent string literals, use them for multi-line comments (#410 <https://github.com/ros2/rosidl/issues/410>)
* avoid zero length comment when the comment only contains a unit (#411 <https://github.com/ros2/rosidl/issues/411>)
* use latin-1 encoding when reading/writing .idl files, prepend BOM to generated C/C++ files when necessary (#391 <https://github.com/ros2/rosidl/issues/391>)
* fix error msg asserts due to change in pytest (#393 <https://github.com/ros2/rosidl/issues/393>)
* open interface files with utf-8 encoding (#390 <https://github.com/ros2/rosidl/issues/390>)
* Contributors: Dirk Thomas, Jacob Perron, William Woodall
```

## rosidl_cmake

```
* use latin-1 encoding when reading/writing .idl files, prepend BOM to generated C/C++ files when necessary (#391 <https://github.com/ros2/rosidl/issues/391>)
* fix CMake linter warning (#382 <https://github.com/ros2/rosidl/issues/382>)
* Contributors: Dirk Thomas
```

## rosidl_generator_c

```
* [rosidl_generator_c] Updated tests for new msg types from test_interface_files (#398 <https://github.com/ros2/rosidl/issues/398>)
* use latin-1 encoding when reading/writing .idl files, prepend BOM to generated C/C++ files when necessary (#391 <https://github.com/ros2/rosidl/issues/391>)
* Set _FOUND to trick ament_target_dependencies() for test (#396 <https://github.com/ros2/rosidl/issues/396>)
* Contributors: Dirk Thomas, Shane Loretz, Siddharth Kucheria
```

## rosidl_generator_cpp

```
* Update guard against common Windows preprocessor definitions (#401 <https://github.com/ros2/rosidl/issues/401>)
* Update tests for new message types in test_interface_files (#397 <https://github.com/ros2/rosidl/issues/397>)
* use latin-1 encoding when reading/writing .idl files, prepend BOM to generated C/C++ files when necessary (#391 <https://github.com/ros2/rosidl/issues/391>)
* Add emplace_back, move_assignment to BoundedVector (#385 <https://github.com/ros2/rosidl/issues/385>)
* fix cpp generator and introspection ts for long double (#383 <https://github.com/ros2/rosidl/issues/383>)
* Contributors: Dirk Thomas, Jacob Perron, Siddharth Kucheria, cho3
```

## rosidl_parser

```
* support adjacent string literals, use them for multi-line comments (#410 <https://github.com/ros2/rosidl/issues/410>)
* fix parsing empty string literal (#409 <https://github.com/ros2/rosidl/issues/409>)
* add constant for member name in empty structs (#389 <https://github.com/ros2/rosidl/issues/389>)
* Contributors: Dirk Thomas
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* [rosidl_typesupport_introspection_c] Use message namespaced type name as function prefix (#387 <https://github.com/ros2/rosidl/issues/387>)
* fix cpp generator and introspection ts for long double (#383 <https://github.com/ros2/rosidl/issues/383>)
* Contributors: Dirk Thomas, Jacob Perron
```

## rosidl_typesupport_introspection_cpp

```
* fix cpp generator and introspection ts for long double (#383 <https://github.com/ros2/rosidl/issues/383>)
* Contributors: Dirk Thomas
```
