### PR TITLE
pluginlib: 2.4.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -297,6 +297,22 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: maintained
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/pluginlib-release.git
+      version: 2.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    status: maintained
   poco_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `2.4.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## pluginlib

```
* Export tinyxml2 libraries downstream. (#154 <https://github.com/ros/pluginlib/issues/154>)
* Contributors: Esteve Fernandez
```
