### PR TITLE
rosbridge_suite: 1.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2028,7 +2028,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `1.0.2-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-1`

## rosapi

- No changes

## rosbridge_library

```
* use Python 3 dependency keys (#436 <https://github.com/RobotWebTools/rosbridge_suite/issues/436>)
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* use Python 3 dependency keys (#436 <https://github.com/RobotWebTools/rosbridge_suite/issues/436>)
```

## rosbridge_suite

- No changes
