### PR TITLE
rmw: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -368,6 +368,25 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: master
     status: maintained
+  rmw:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: master
+    release:
+      packages:
+      - rmw
+      - rmw_implementation_cmake
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rmw

```
* Added specific return type for non existent node (#182 <https://github.com/ros2/rmw/issues/182>)
* Added function for getting clients by node (#179 <https://github.com/ros2/rmw/issues/179>)
* Added get_actual_qos() feature to subscriptions (#177 <https://github.com/ros2/rmw/issues/177>)
* Added ``RMW_QOS_POLICY_LIVELINESS_UNKNOWN`` enum (#175 <https://github.com/ros2/rmw/issues/175>)
* Contributors: Jacob Perron, M. M, ivanpauno
```

## rmw_implementation_cmake

- No changes
