### PR TITLE
launch: 0.9.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -226,7 +226,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch.git
-      version: eloquent
+      version: master
     release:
       packages:
       - launch
@@ -237,12 +237,12 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch.git
-      version: eloquent
+      version: master
     status: developed
   orocos_kinematics_dynamics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.9.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.9.0-1`

## launch

```
* Fix error in ExecuteProcess parse classmethod (#339 <https://github.com/ros2/launch/issues/339>)
* Add support to ignore fields when parsing ExecuteProcess. (#336 <https://github.com/ros2/launch/issues/336>)
* Make parse_substitution handle zero-width text. (#335 <https://github.com/ros2/launch/issues/335>)
* Fix InvalidLaunchFileError error message. (#333 <https://github.com/ros2/launch/issues/333>)
* Fix default Action describe_conditional_sub_entities() implementation. (#334 <https://github.com/ros2/launch/issues/334>)
* Contributors: Michel Hidalgo, ivanpauno
```

## launch_testing

```
* Optionally remove ready fn arg from generate_test_description (#322 <https://github.com/ros2/launch/issues/322>)
* Contributors: Michel Hidalgo, Peter Baughman
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
