### PR TITLE
python_cmake_module: 0.8.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -326,11 +326,15 @@ repositories:
       version: master
     status: maintained
   python_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: master
     release:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/python_cmake_module-release.git
-      version: 0.8.0-1
+      version: 0.8.0-2
     source:
       type: git
       url: https://github.com/ros2/python_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_cmake_module` to `0.8.0-2`:

- upstream repository: https://github.com/ros2/python_cmake_module.git
- release repository: https://github.com/ros2-gbp/python_cmake_module-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-1`
