### PR TITLE
fanuc: 0.5.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3156,6 +3156,29 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/fanuc.git
       version: indigo
+    release:
+      packages:
+      - fanuc_cr35ia_support
+      - fanuc_cr7ia_support
+      - fanuc_driver
+      - fanuc_lrmate200i_support
+      - fanuc_lrmate200ib_support
+      - fanuc_lrmate200ic_support
+      - fanuc_m10ia_support
+      - fanuc_m16ib_support
+      - fanuc_m20ia_support
+      - fanuc_m20ib_support
+      - fanuc_m430ia_support
+      - fanuc_m6ib_support
+      - fanuc_m710ic_support
+      - fanuc_m900ia_support
+      - fanuc_m900ib_support
+      - fanuc_r1000ia_support
+      - fanuc_resources
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/fanuc-release.git
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.5.0-1`:

- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## fanuc_cr35ia_support

```
* first release of this package.
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* harmonise pkg version numbers (#260 <https://github.com/ros-industrial/fanuc/issues/260>).
* migrate CR-35iA support pkgs from experimental repository (#252 <https://github.com/ros-industrial/fanuc/issues/252>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* use Jade+ xacro 'pi' constant instead of redefining it ourselves (#209 <https://github.com/ros-industrial/fanuc/issues/209>).
* add XML schema processing instruction (#200 <https://github.com/ros-industrial/fanuc/issues/200>).
* migrate to in-order processing of xacros.
* use 'xacro' instead of 'xacro.py' (#195 <https://github.com/ros-industrial/fanuc/issues/195>).
* update colour to match real CR-35iA (#18 <https://github.com/ros-industrial/fanuc_experimental/issues/18>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_cr7ia_support

```
* first release of this package.
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* harmonise pkg version numbers (#260 <https://github.com/ros-industrial/fanuc/issues/260>).
* migrate CR-7iA support pkgs from experimental repository (#252 <https://github.com/ros-industrial/fanuc/issues/252>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
* contributors: dniewinski
```

## fanuc_driver

```
* no changes.
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_lrmate200i_support

```
* first release of this package.
* harmonise pkg version numbers (#260 <https://github.com/ros-industrial/fanuc/issues/260>).
* migrate LR Mate 200i support, moveit and plugin pkgs from experimental repository (#250 <https://github.com/ros-industrial/fanuc/pull/250>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_lrmate200ib_support

```
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_lrmate200ic_support

```
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m10ia_support

```
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m16ib_support

```
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m20ia_support

```
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m20ib_support

```
* first release of this package.
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* migrate M-20iB support and moveit pkgs from experimental repository (#253 <https://github.com/ros-industrial/fanuc/pull/253>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m430ia_support

```
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m6ib_support

```
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m710ic_support

```
* first release of this package.
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* harmonise pkg version numbers (#260 <https://github.com/ros-industrial/fanuc/issues/260>).
* migrate M-710iC support pkgs from experimental repository (#254 <https://github.com/ros-industrial/fanuc/issues/254>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* remove unescaped ampersand from 'robot_ip' arg doc string (#176 <https://github.com/ros-industrial/fanuc/issues/176>).
* add Fanuc M710iC/45M (#42 <https://github.com/ros-industrial/fanuc_experimental/issues/42>).
* fix axis 6 wrong direction in M-710iC definition (#28 <https://github.com/ros-industrial/fanuc_experimental/issues/28>)
* use Jade+ xacro 'pi' constant instead of our own.
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
* contributors: Victor Lamoine
```

## fanuc_m900ia_support

```
* first release of this package.
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* harmonise pkg version numbers (#260 <https://github.com/ros-industrial/fanuc/issues/260>).
* migrate M-900iA support pkgs from experimental repository (#255 <https://github.com/ros-industrial/fanuc/issues/255>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* remove unescaped ampersand from 'robot_ip' arg doc string (#176 <https://github.com/ros-industrial/fanuc/issues/176>).
* use Jade+ xacro 'pi' constant instead of our own.
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_m900ib_support

```
* first release of this package.
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* harmonise pkg version numbers (#260 <https://github.com/ros-industrial/fanuc/issues/260>).
* migrate M-900iB support pkgs from experimental repository (#256 <https://github.com/ros-industrial/fanuc/issues/256>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* remove unescaped ampersand from 'robot_ip' arg doc string (#176 <https://github.com/ros-industrial/fanuc/issues/176>).
* use Jade+ xacro 'pi' constant instead of our own.
* migrate to in-order processing of xacros (supported on Indigo and up).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```

## fanuc_r1000ia_support

```
* first release of this package.
* make ``flange`` parent of ``tool0`` (#271 <https://github.com/ros-industrial/fanuc/issues/271>).
* harmonise pkg version numbers (#260 <https://github.com/ros-industrial/fanuc/issues/260>).
* migrate R-1000iA support, moveit and plugin pkgs from experimental repository (#251 <https://github.com/ros-industrial/fanuc/pull/251>).
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* add 'support level' indicators (#232 <https://github.com/ros-industrial/fanuc/issues/232>).
* use Jade+ xacro 'pi' constant instead of our own.
* migrate to in-order processing of xacros (supported on Indigo and up).
* use ``xacro`` instead of ``xacro.py`` (#195 <https://github.com/ros-industrial/fanuc/issues/195>).
* improve collision mesh of axis 3 (#14 <https://github.com/ros-industrial/fanuc_experimental/issues/14>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
* contributors: Victor Lamoine
```

## fanuc_resources

```
* update xacro xmlns uri (#239 <https://github.com/ros-industrial/fanuc/issues/239>).
* remove deprecated 'common_constants.xacro' (#238 <https://github.com/ros-industrial/fanuc/issues/238>).
* for a complete list of changes see the commit log for 0.5.0 <https://github.com/ros-industrial/fanuc/compare/0.4.4...0.5.0>.
```
