### PR TITLE
um6: 1.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15536,7 +15536,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um6-release.git
-      version: 1.1.2-0
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/um6.git


### PR DESCRIPTION
Increasing version of package(s) in repository `um6` to `1.1.3-1`:

- upstream repository: https://github.com/ros-drivers/um6.git
- release repository: https://github.com/ros-drivers-gbp/um6-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.2-0`

## um6

```
* Disabled using MagneticField message by default.
* Updated to be able to use MagneticField message.
* Updated TravisCI to use Industrial CI for Kinetic and Melodic.
* Contributors: Tony Baltovski
```
