### PR TITLE
launch_ros_sandbox: 0.0.2-4 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1042,12 +1042,13 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/launch_ros_sandbox-release.git
-      version: 0.0.1-1
+      version: 0.0.2-4
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/aws-robotics/launch-ros-sandbox.git
       version: dashing
+    status: developed
   lex_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros_sandbox` to `0.0.2-4`:

- upstream repository: git@github.com:aws-robotics/launch-ros-sandbox.git
- release repository: https://github.com/aws-gbp/launch_ros_sandbox-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-1`
