### PR TITLE
um6: 1.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9230,7 +9230,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um6-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/ros-drivers/um6.git


### PR DESCRIPTION
Increasing version of package(s) in repository `um6` to `1.1.3-1`:

- upstream repository: https://github.com/ros-drivers/um6.git
- release repository: https://github.com/ros-drivers-gbp/um6-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.2-1`

## um6

```
* Disabled using MagneticField message by default.
* Updated to be able to use MagneticField message.
* Updated TravisCI to use Industrial CI for Kinetic and Melodic.
* Contributors: Tony Baltovski
```
