### PR TITLE
Change repo name to urdfdom_py

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -161,7 +161,7 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: kinetic-devel
     status: maintained
-  urdf_parser_py:
+  urdfdom_py:
     source:
       type: git
       url: https://github.com/ros/urdf_parser_py.git


### PR DESCRIPTION
This changes the repo name from `urdf_parser_py` to `urdfdom_py` to match melodic.
The name is used by the blocked releases page to determine which repositories haven't been released yet.

https://github.com/ros/rosdistro/blob/760c688a7a20a80cf4b00b05df64355a4d2c89ab/melodic/distribution.yaml#L9343-L9358