### PR TITLE
rosidl_typesupport_connext: 0.8.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -465,6 +465,26 @@ repositories:
       url: https://github.com/ros2/rosidl_dds.git
       version: master
     status: maintained
+  rosidl_typesupport_connext:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_connext.git
+      version: master
+    release:
+      packages:
+      - connext_cmake_module
+      - rosidl_typesupport_connext_c
+      - rosidl_typesupport_connext_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
+      version: 0.8.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_connext.git
+      version: master
+    status: maintained
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `0.8.0-2`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
