### PR TITLE
ainstein_radar: 1.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -203,7 +203,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ainstein_radar` to `1.0.2-1`:

- upstream repository: https://github.com/AinsteinAI/ainstein_radar.git
- release repository: https://github.com/AinsteinAI/ainstein_radar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-1`

## ainstein_radar

- No changes

## ainstein_radar_drivers

```
* Remove unused includes causing dependency issues
* Contributors: Nick Rotella
```

## ainstein_radar_filters

- No changes

## ainstein_radar_gazebo_plugins

- No changes

## ainstein_radar_msgs

- No changes

## ainstein_radar_rviz_plugins

- No changes
