### PR TITLE
iiwa_stack: 1.4.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4861,6 +4861,20 @@ repositories:
       url: https://github.com/KITrobotics/iirob_filters.git
       version: kinetic-devel
     status: developed
+  iiwa_stack:
+    release:
+      packages:
+      - iiwa_control
+      - iiwa_description
+      - iiwa_gazebo
+      - iiwa_hw
+      - iiwa_moveit
+      - iiwa_msgs
+      - iiwa_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ipa-rwu/iiwa_stack-release.git
+      version: 1.4.1-1
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iiwa_stack` to `1.4.1-1`:

- upstream repository: https://github.com/ipa-rwu/iiwa_stack.git
- release repository: https://github.com/ipa-rwu/iiwa_stack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
