### PR TITLE
rosidl_typesupport_opensplice: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -485,6 +485,26 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_connext.git
       version: master
     status: maintained
+  rosidl_typesupport_opensplice:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+      version: master
+    release:
+      packages:
+      - opensplice_cmake_module
+      - rosidl_typesupport_opensplice_c
+      - rosidl_typesupport_opensplice_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+      version: master
+    status: maintained
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_opensplice` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_opensplice.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
