### PR TITLE
rmw_connext: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -391,6 +391,25 @@ repositories:
       url: https://github.com/ros2/rmw.git
       version: master
     status: maintained
+  rmw_connext:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_connext.git
+      version: master
+    release:
+      packages:
+      - rmw_connext_cpp
+      - rmw_connext_shared_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_connext-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_connext.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rmw_connext_cpp

```
* speed up copy with memcpy (#366 <https://github.com/ros2/rmw_connext/issues/366>)
* Implement get_actual_qos() for subscriptions (#358 <https://github.com/ros2/rmw_connext/issues/358>)
* add missing qos setings in get_actual_qos() (#357 <https://github.com/ros2/rmw_connext/issues/357>)
* Contributors: Jacob Perron, M. M, Neil Puthuff
```

## rmw_connext_shared_cpp

```
* Return specific error when not finding a node name (#365 <https://github.com/ros2/rmw_connext/issues/365>)
* Add function for getting clients by node (#361 <https://github.com/ros2/rmw_connext/issues/361>)
* Use rpputils::find_and_replace instead of std::regex_replace (#359 <https://github.com/ros2/rmw_connext/issues/359>)
* Implement get_actual_qos() for subscriptions (#358 <https://github.com/ros2/rmw_connext/issues/358>)
* Contributors: Jacob Perron, M. M, ivanpauno
```
