### PR TITLE
rmw_fastrtps: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -410,6 +410,26 @@ repositories:
       url: https://github.com/ros2/rmw_connext.git
       version: master
     status: maintained
+  rmw_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: master
+    release:
+      packages:
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: master
+    status: maintained
   rmw_opensplice:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rmw_fastrtps_cpp

```
* Add function for getting clients by node (#293 <https://github.com/ros2/rmw_fastrtps/issues/293>)
* Implement get_actual_qos() for subscriptions (#287 <https://github.com/ros2/rmw_fastrtps/issues/287>)
* Fix error message (#290 <https://github.com/ros2/rmw_fastrtps/issues/290>)
* Contributors: Jacob Perron, M. M
```

## rmw_fastrtps_dynamic_cpp

```
* Add function for getting clients by node (#293 <https://github.com/ros2/rmw_fastrtps/issues/293>)
* Use rcpputils::find_and_replace instead of std::regex_replace (#291 <https://github.com/ros2/rmw_fastrtps/issues/291>)
* Export typesupport_fastrtps package dependencies (#294 <https://github.com/ros2/rmw_fastrtps/issues/294>)
* Implement get_actual_qos() for subscriptions (#287 <https://github.com/ros2/rmw_fastrtps/issues/287>)
* Contributors: Jacob Perron, M. M, kurcha01-arm
```

## rmw_fastrtps_shared_cpp

```
* Correct error message (#320 <https://github.com/ros2/rmw_fastrtps/issues/320>)
* Return specific error code when node is not found (#311 <https://github.com/ros2/rmw_fastrtps/issues/311>)
* Correct linter failure (#318 <https://github.com/ros2/rmw_fastrtps/issues/318>)
* Fix bug in graph API by node (#316 <https://github.com/ros2/rmw_fastrtps/issues/316>)
* fix method name change from 1.8.1->1.9.0 (#302 <https://github.com/ros2/rmw_fastrtps/issues/302>)
* Add missing lock guards for discovered_names and discovered_namespaces (#301 <https://github.com/ros2/rmw_fastrtps/issues/301>)
* Add function for getting clients by node (#293 <https://github.com/ros2/rmw_fastrtps/issues/293>)
* Enable manual_by_node and node liveliness assertion (#298 <https://github.com/ros2/rmw_fastrtps/issues/298>)
* Enable assert liveliness on publisher. (#296 <https://github.com/ros2/rmw_fastrtps/issues/296>)
* Use rcpputils::find_and_replace instead of std::regex_replace (#291 <https://github.com/ros2/rmw_fastrtps/issues/291>)
* Fix a comparison with a sign mismatch (#288 <https://github.com/ros2/rmw_fastrtps/issues/288>)
* Implement get_actual_qos() for subscriptions (#287 <https://github.com/ros2/rmw_fastrtps/issues/287>)
* add missing qos setings in get_actual_qos() (#284 <https://github.com/ros2/rmw_fastrtps/issues/284>)
* Fix ABBA deadlock.
* Contributors: Chris Lalancette, Emerson Knapp, Jacob Perron, M. M, Scott K Logan, William Woodall, ivanpauno
```
