### PR TITLE
xacro: 1.13.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9938,7 +9938,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.3-0
+      version: 1.13.4-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.4-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.13.3-0`

## xacro

```
* [feature] remove xmlns:xacro from processed file (#207 <https://github.com/ros/xacro/issues/207>)
  - Remove all notions of xmlns:xacro from the resulting document.
  - If the root node defines a xacro:targetNamespace attribute,this will become the global xmlns namespace of the resulting document.
* [feature] Add len() to allowed python functions (#208 <https://github.com/ros/xacro/issues/208>)
* [maintanence]
  - --in-order warning: reduce severity level to message
  - fix and cleanup test of cmake extensions
  - adapt run_xacro() to run xacro from PATH
  - simplify import of substition_args
  - remove 'requires' field from setup.py
  - fix Travis config: use new repository key, use xenial/kinetic distro
  - basic README.md
  - fix catkin_lint issue
  - remove duplicate catkin_python_setup() (#206 <https://github.com/ros/xacro/issues/206>)
* Contributors: Robert Haschke, James Xu, Martin Pecka
```
