### PR TITLE
rmw_opensplice: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -410,6 +410,24 @@ repositories:
       url: https://github.com/ros2/rmw_connext.git
       version: master
     status: maintained
+  rmw_opensplice:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_opensplice.git
+      version: master
+    release:
+      packages:
+      - rmw_opensplice_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_opensplice-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_opensplice.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_opensplice` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rmw_opensplice.git
- release repository: https://github.com/ros2-gbp/rmw_opensplice-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
