### PR TITLE
rcl_logging: 0.3.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -340,6 +340,25 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: master
     status: developed
+  rcl_logging:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    release:
+      packages:
+      - rcl_logging_log4cxx
+      - rcl_logging_noop
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 0.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    status: maintained
   rcpputils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `0.3.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rcl_logging_log4cxx

```
* fix package.xml schema violations (#15 <https://github.com/ros2/rcl_logging/issues/15>)
* Contributors: Mikael Arguedas
```

## rcl_logging_noop

```
* remove unused 'dependencies' CMake variable (#16 <https://github.com/ros2/rcl_logging/issues/16>)
* fix package.xml schema violations (#15 <https://github.com/ros2/rcl_logging/issues/15>)
* Contributors: Mikael Arguedas
```
