### PR TITLE
Add rosbag_migration_rule Noetic source entry

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -128,6 +128,12 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: melodic
     status: maintained
+  rosbag_migration_rule:
+    source:
+      type: git
+      url: https://github.com/ros/rosbag_migration_rule.git
+      version: master
+    status: maintained
   rosconsole:
     source:
       test_pull_requests: true


### PR DESCRIPTION
This is blocking a source entry for `common_msgs`, and isn't blocked by any other repos.

http://repositories.ros.org/status_page/blocked_source_entries_noetic.html?s=6&r=1