### PR TITLE
rmw_implementation: 0.8.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -449,6 +449,22 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: master
     status: maintained
+  rmw_implementation:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_implementation-release.git
+      version: 0.8.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: master
+    status: maintained
   rmw_opensplice:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `0.8.0-2`:

- upstream repository: https://github.com/ros2/rmw_implementation
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rmw_implementation

```
* Add function for getting clients by node (#62 <https://github.com/ros2/rmw_implementation/issues/62>)
* add get_actual_qos() feature to subscriptions (#61 <https://github.com/ros2/rmw_implementation/issues/61>)
* Contributors: Jacob Perron, M. M
```
