### PR TITLE
rtt_pcl: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13587,6 +13587,17 @@ repositories:
       url: https://github.com/orocos/rtt_geometry.git
       version: toolchain-2.9
     status: maintained
+  rtt_pcl:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_pcl-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_pcl.git
+      version: master
+    status: maintained
   rtt_ros_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_pcl` to `0.1.0-1`:

- upstream repository: https://github.com/orocos/rtt_pcl.git
- release repository: https://github.com/orocos-gbp/rtt_pcl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rtt_pcl

```
* Merge pull request #1 <https://github.com/orocos/rtt_pcl/issues/1> from achim-k/master
  Add support for point type XYZRGBNormal.
* Add support for point type XYZRGBNormal.
* Added package rtt_pcl
* Initial commit
* Contributors: Achim Krauch, Johannes Meyer
```
