### PR TITLE
rtt_pcl_ros: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13587,6 +13587,17 @@ repositories:
       url: https://github.com/orocos/rtt_geometry.git
       version: toolchain-2.9
     status: maintained
+  rtt_pcl_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/orocos-gbp/rtt_pcl_ros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/orocos/rtt_pcl_ros.git
+      version: master
+    status: maintained
   rtt_ros_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtt_pcl_ros` to `0.1.0-1`:

- upstream repository: https://github.com/orocos/rtt_pcl_ros.git
- release repository: https://github.com/orocos-gbp/rtt_pcl_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rtt_pcl_ros

```
* Added package rtt_pcl_ros
* Initial commit
* Contributors: Johannes Meyer
```
