### PR TITLE
rosidl_runtime_py: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -618,6 +618,22 @@ repositories:
       url: https://github.com/ros2/rosidl_python.git
       version: master
     status: maintained
+  rosidl_runtime_py:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: master
+    status: maintained
   rosidl_typesupport:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rosidl_runtime_py

```
* install resource marker file for package (#2 <https://github.com/ros2/rosidl_runtime_py/issues/2>)
* Update setup.py URLs
* Add contributing and license files
* install package manifest (ros2/rosidl_python#86 <https://github.com/ros2/rosidl_python/issues/86>)
* Rename TestConfig class to Config to avoid pytest warning (ros2/rosidl_python#82 <https://github.com/ros2/rosidl_python/issues/82>)
* fix set_message_fields for numpy array (ros2/rosidl_python#81 <https://github.com/ros2/rosidl_python/issues/81>)
* Fix type name queries for string types. (ros2/rosidl_python#77 <https://github.com/ros2/rosidl_python/issues/77>)
* Require keyword arguments be passed by name (ros2/rosidl_python#80 <https://github.com/ros2/rosidl_python/issues/80>)
* Add utility functions to get interface from identifier
* Make import_message_from_namespaced_type operate on NamespacedType (ros2/rosidl_python#74 <https://github.com/ros2/rosidl_python/issues/74>)
* handle set_message_fields given some non-basic type (ros2/rosidl_python#68 <https://github.com/ros2/rosidl_python/issues/68>)
* Add no_arr and no_str parameters (ros2/rosidl_python#38 <https://github.com/ros2/rosidl_python/issues/38>)
* Contributors: Dirk Thomas, Jacob Perron, Jeremie Deray, Michel Hidalgo, Mikael Arguedas, Vinnam Kim, ivanpauno
```
