### PR TITLE
rcl: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -340,6 +340,27 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: master
     status: developed
+  rcl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: master
+    release:
+      packages:
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: master
+    status: maintained
   rcl_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rcl

```
* Delete rcl_impl_getenv, replaced by rcutils_get_env (#502 <https://github.com/ros2/rcl/issues/502>)
* Parse CLI parameters and YAML files (#508 <https://github.com/ros2/rcl/issues/508>)
* Add specific return code for non existent node (#492 <https://github.com/ros2/rcl/issues/492>)
* Add node name and namespace validation to graph functions (#499 <https://github.com/ros2/rcl/issues/499>)
* Bring back deprecated CLI arguments (#496 <https://github.com/ros2/rcl/issues/496>)
* Polish rcl arguments implementation (#497 <https://github.com/ros2/rcl/issues/497>)
* Uncoment some test_graph test cases after fix in rmw_fastrtps (ros2/rmw_fastrtps#316 <https://github.com/ros2/rmw_fastrtps/issues/316>) (#498 <https://github.com/ros2/rcl/issues/498>)
* Promote special CLI rules to flags (#495 <https://github.com/ros2/rcl/issues/495>)
* Fail fast on invalid ROS arguments (#493 <https://github.com/ros2/rcl/issues/493>)
* Enforce -r/--remap flags. (#491 <https://github.com/ros2/rcl/issues/491>)
* Support parameter overrides and remap rules flags on command line (#483 <https://github.com/ros2/rcl/issues/483>)
* Allow get_node_names to return result in any order (#488 <https://github.com/ros2/rcl/issues/488>)
* rosout init and fini marked as RCL_PUBLIC (#479 <https://github.com/ros2/rcl/issues/479>)
* included header in logging_rosout.c (#478 <https://github.com/ros2/rcl/issues/478>)
* Migrate to '--ros-args ... [--]'-based ROS args extraction (#477 <https://github.com/ros2/rcl/issues/477>)
* Improve security error messages  (#480 <https://github.com/ros2/rcl/issues/480>)
* Add function for getting clients by node (#459 <https://github.com/ros2/rcl/issues/459>)
* Remove special case check for manual_by_node for rmw_fastrtps (#467 <https://github.com/ros2/rcl/issues/467>)
* Fix memory leak of 56 bytes in test_graph
* Change tests to try MANUAL_BY_TOPIC liveliness for FastRTPS (#465 <https://github.com/ros2/rcl/issues/465>)
* Implement get_actual_qos() for subscriptions (#455 <https://github.com/ros2/rcl/issues/455>)
* Log warning when remapping to an invalid node name (#454 <https://github.com/ros2/rcl/issues/454>)
* Use size_t printf format for size_t variable (#453 <https://github.com/ros2/rcl/issues/453>)
* Contributors: Alberto Soragna, Emerson Knapp, Jacob Perron, M. M, Michel Hidalgo, Mikael Arguedas, Víctor Mayoral Vilches, eboasson, ivanpauno
```

## rcl_action

```
* Fix rcl_action test_graph (#504 <https://github.com/ros2/rcl/issues/504>)
* remove unused CMake code (#475 <https://github.com/ros2/rcl/issues/475>)
* Contributors: Mikael Arguedas, ivanpauno
```

## rcl_lifecycle

```
* reset error message before setting a new one, embed the original one (#501 <https://github.com/ros2/rcl/issues/501>)
* Contributors: Dirk Thomas
```

## rcl_yaml_param_parser

```
* Enable incremental parameter yaml file parsing. (#507 <https://github.com/ros2/rcl/issues/507>)
* Support parameter overrides and remap rules flags on command line (#483 <https://github.com/ros2/rcl/issues/483>)
* Increase MAX_STRING_SIZE (#487 <https://github.com/ros2/rcl/issues/487>)
* include actual size in error message (#490 <https://github.com/ros2/rcl/issues/490>)
* Avoid C4703 error on UWP (#282 <https://github.com/ros2/rcl/issues/282>)
* [YAML Parser] Support parameter value parsing (#471 <https://github.com/ros2/rcl/issues/471>)
* [YAML Parser] Depend on rcutils only (#470 <https://github.com/ros2/rcl/issues/470>)
* Accept quoted int or float values as strings (#464 <https://github.com/ros2/rcl/issues/464>)
* Fix memory corruption when maximum number of parameters is exceeded (#456 <https://github.com/ros2/rcl/issues/456>)
* Contributors: Dirk Thomas, Esteve Fernandez, Jacob Perron, Michel Hidalgo, hyunseok-yang, ivanpauno
```
