### PR TITLE
rosidl_typesupport_connext: 0.8.0-3 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -713,12 +713,13 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 0.8.0-2
+      version: 0.8.0-3
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
       version: master
+    status: maintained
   rosidl_typesupport_fastrtps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `0.8.0-3`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-2`
