### PR TITLE
rclcpp: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -440,6 +440,27 @@ repositories:
       url: https://github.com/ros2/rcl_logging.git
       version: master
     status: maintained
+  rclcpp:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: master
+    release:
+      packages:
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rclcpp-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: master
+    status: maintained
   rclpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rclcpp

```
* clean up publisher and subscription creation logic (#867 <https://github.com/ros2/rclcpp/issues/867>)
* Take parameter overrides provided through the CLI. (#865 <https://github.com/ros2/rclcpp/issues/865>)
* add more context to exception message (#858 <https://github.com/ros2/rclcpp/issues/858>)
* remove features and related code which were deprecated in dashing (#852 <https://github.com/ros2/rclcpp/issues/852>)
* check valid timer handler 1st to reduce the time window for scan. (#841 <https://github.com/ros2/rclcpp/issues/841>)
* Add throwing parameter name if parameter is not set (#833 <https://github.com/ros2/rclcpp/issues/833>)
* Fix typo in deprecated warning. (#848 <https://github.com/ros2/rclcpp/issues/848>)
* Fail on invalid and unknown ROS specific arguments (#842 <https://github.com/ros2/rclcpp/issues/842>)
* Force explicit --ros-args in NodeOptions::arguments(). (#845 <https://github.com/ros2/rclcpp/issues/845>)
* Use of -r/--remap flags where appropriate. (#834 <https://github.com/ros2/rclcpp/issues/834>)
* Fix hang with timers in MultiThreadedExecutor (#835 <https://github.com/ros2/rclcpp/issues/835>) (#836 <https://github.com/ros2/rclcpp/issues/836>)
* add mutex in add/remove_node and wait_for_work to protect concurrent use/change of memory_strategy_ (#837 <https://github.com/ros2/rclcpp/issues/837>)
* Crash in callback group pointer vector iterator (#814 <https://github.com/ros2/rclcpp/issues/814>)
* Wrap documentation examples in code blocks (#830 <https://github.com/ros2/rclcpp/issues/830>)
* add callback group as member variable and constructor arg (#811 <https://github.com/ros2/rclcpp/issues/811>)
* Fix get_node_interfaces functions taking a pointer (#821 <https://github.com/ros2/rclcpp/issues/821>)
* Delete unnecessary call for get_node_by_group (#823 <https://github.com/ros2/rclcpp/issues/823>)
* Allow passing logger by const ref (#820 <https://github.com/ros2/rclcpp/issues/820>)
* Explain return value of spin_until_future_complete (#792 <https://github.com/ros2/rclcpp/issues/792>)
* Adapt to '--ros-args ... [--]'-based ROS args extraction (#816 <https://github.com/ros2/rclcpp/issues/816>)
* Add line break after first open paren in multiline function call (#785 <https://github.com/ros2/rclcpp/issues/785>)
* remove mock msgs from rclcpp (#800 <https://github.com/ros2/rclcpp/issues/800>)
* Make TimeSource ignore use_sim_time events coming from other nodes. (#799 <https://github.com/ros2/rclcpp/issues/799>)
* Allow registering multiple on_parameters_set_callback (#772 <https://github.com/ros2/rclcpp/issues/772>)
* Add free function for creating service clients (#788 <https://github.com/ros2/rclcpp/issues/788>)
* Include missing rcl headers in use. (#782 <https://github.com/ros2/rclcpp/issues/782>)
* Switch the NodeParameters lock to recursive. (#781 <https://github.com/ros2/rclcpp/issues/781>)
* changed on_parameter_event qos profile to rmw_qos_profile_parameter_events (#774 <https://github.com/ros2/rclcpp/issues/774>)
* Adding a factory method to create a Duration from seconds (#567 <https://github.com/ros2/rclcpp/issues/567>)
* Fix a comparison with a sign mismatch (#771 <https://github.com/ros2/rclcpp/issues/771>)
* delete superfluous spaces (#770 <https://github.com/ros2/rclcpp/issues/770>)
* Use params from node '/**' from parameter YAML file (#762 <https://github.com/ros2/rclcpp/issues/762>)
* Add ignore override argument to declare parameter (#767 <https://github.com/ros2/rclcpp/issues/767>)
* use default parameter descriptor in parameters interface (#765 <https://github.com/ros2/rclcpp/issues/765>)
* Added support for const member functions (#763 <https://github.com/ros2/rclcpp/issues/763>)
* add get_actual_qos() feature to subscriptions (#754 <https://github.com/ros2/rclcpp/issues/754>)
* Ignore parameters overrides in set parameter methods when allowing undeclared parameters (#756 <https://github.com/ros2/rclcpp/issues/756>)
* Add rclcpp::create_timer() (#757 <https://github.com/ros2/rclcpp/issues/757>)
* checking origin of intra-process msg before taking them (#753 <https://github.com/ros2/rclcpp/issues/753>)
* Contributors: Alberto Soragna, Carl Delsey, Chris Lalancette, Dan Rose, Dirk Thomas, Esteve Fernandez, Guillaume Autran, Jacob Perron, Karsten Knese, Luca Della Vedova, M. M, Michel Hidalgo, Scott K Logan, Shane Loretz, Todd Malsbary, William Woodall, bpwilcox, fujitatomoya, ivanpauno
```

## rclcpp_action

```
* Fix UnknownGoalHandle error string. (#856 <https://github.com/ros2/rclcpp/issues/856>)
* Guard against making multiple result requests for a goal handle (#808 <https://github.com/ros2/rclcpp/issues/808>)
* Add line break after first open paren in multiline function call (#785 <https://github.com/ros2/rclcpp/issues/785>)
* Fix typo in test fixture tear down method name (#787 <https://github.com/ros2/rclcpp/issues/787>)
* Contributors: Chris Lalancette, Dan Rose, Jacob Perron
```

## rclcpp_components

```
* Force explicit --ros-args in NodeOptions::arguments(). (#845 <https://github.com/ros2/rclcpp/issues/845>)
* Use of -r/--remap flags where appropriate. (#834 <https://github.com/ros2/rclcpp/issues/834>)
* Add line break after first open paren in multiline function call (#785 <https://github.com/ros2/rclcpp/issues/785>)
* fix linter issue (#795 <https://github.com/ros2/rclcpp/issues/795>)
* Remove non-package from ament_target_dependencies() (#793 <https://github.com/ros2/rclcpp/issues/793>)
* fix for multiple nodes not being recognized (#790 <https://github.com/ros2/rclcpp/issues/790>)
* Cmake infrastructure for creating components (#784 <https://github.com/ros2/rclcpp/issues/784>)
* Contributors: Dan Rose, Michel Hidalgo, Shane Loretz, Siddharth Kucheria
```

## rclcpp_lifecycle

```
* clean up publisher and subscription creation logic (#867 <https://github.com/ros2/rclcpp/issues/867>)
* reset error message before setting a new one, embed the original one (#854 <https://github.com/ros2/rclcpp/issues/854>)
* remove features and related code which were deprecated in dashing (#852 <https://github.com/ros2/rclcpp/issues/852>)
* Fix typo in deprecated warning. (#848 <https://github.com/ros2/rclcpp/issues/848>)
* Add line break after first open paren in multiline function call (#785 <https://github.com/ros2/rclcpp/issues/785>)
* Fixe error messages not printing to terminal (#777 <https://github.com/ros2/rclcpp/issues/777>)
* Add default value to options in LifecycleNode construnctor. Update API documentation. (#775 <https://github.com/ros2/rclcpp/issues/775>)
* Contributors: Dan Rose, Dirk Thomas, Esteve Fernandez, Luca Della Vedova, William Woodall, Yathartha Tuladhar
```
