### PR TITLE
rclpy: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -440,6 +440,22 @@ repositories:
       url: https://github.com/ros2/rcl_logging.git
       version: master
     status: maintained
+  rclpy:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rclpy-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: master
+    status: maintained
   rcpputils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rclpy

```
* Take parameter overrides provided through the CLI. (#434 <https://github.com/ros2/rclpy/issues/434>)
* Changelog version to master (#410 <https://github.com/ros2/rclpy/issues/410>)
* Remove deprecated QoS functionality (#431 <https://github.com/ros2/rclpy/issues/431>)
* Remove comment (#432 <https://github.com/ros2/rclpy/issues/432>)
* Provide subscription count from Publisher #418 <https://github.com/ros2/rclpy/issues/418> (#429 <https://github.com/ros2/rclpy/issues/429>)
* Raise custom error when node name is not found (#413 <https://github.com/ros2/rclpy/issues/413>)
* Timer uses ROS time by default (#419 <https://github.com/ros2/rclpy/issues/419>)
* Fix _rclpy.c formatting. (#421 <https://github.com/ros2/rclpy/issues/421>)
* Fail on invalid and unknown ROS specific arguments (#415 <https://github.com/ros2/rclpy/issues/415>)
* Force explicit --ros-args in cli args. (#416 <https://github.com/ros2/rclpy/issues/416>)
* Make Future result() and __await__ raise exceptions (#412 <https://github.com/ros2/rclpy/issues/412>)
* Use of -r/--remap flags where appropriate. (#411 <https://github.com/ros2/rclpy/issues/411>)
* Awake waitables on shutdown, check if context is valid (#403 <https://github.com/ros2/rclpy/issues/403>)
* Accept tuples as parameter arrays (#389 <https://github.com/ros2/rclpy/issues/389>)
* Adapt to '--ros-args ... [--]'-based ROS args extraction (#405 <https://github.com/ros2/rclpy/issues/405>)
* Replace 'NULL == ' with ! (#404 <https://github.com/ros2/rclpy/issues/404>)
* Declaring 'use_sim_time' when attaching node to time source. (#396 <https://github.com/ros2/rclpy/issues/396>)
* Adding ignore_override parameter to declare_parameter(s). (#392 <https://github.com/ros2/rclpy/issues/392>)
* fix missing 'raise'
* Adding get_parameters_by_prefix method to Node. (#386 <https://github.com/ros2/rclpy/issues/386>)
* remove whitespace (#385 <https://github.com/ros2/rclpy/issues/385>)
* Added clients by node implementation from rcl (#383 <https://github.com/ros2/rclpy/issues/383>)
* Fix time conversion for a big nanoseconds value (#384 <https://github.com/ros2/rclpy/issues/384>)
* Allowing parameter declaration without a given value. (#382 <https://github.com/ros2/rclpy/issues/382>)
* Make flake8 happy on windows (#381 <https://github.com/ros2/rclpy/issues/381>)
* Rename QoS*Policy enum's to *Policy (#379 <https://github.com/ros2/rclpy/issues/379>)
* Fixing namespace expansion for declare_parameters. (#377 <https://github.com/ros2/rclpy/issues/377>)
* Use params from node '/**' from parameter YAML file (#370 <https://github.com/ros2/rclpy/issues/370>)
* [executors] don't convert a timeout_sec to nsecs (#372 <https://github.com/ros2/rclpy/issues/372>)
* Fix API documentation related to ROS graph methods (#366 <https://github.com/ros2/rclpy/issues/366>)
* Treat warnings as test failures and fix warnings (#365 <https://github.com/ros2/rclpy/issues/365>)
* Refactored _rclpy.rclpy_get_rmw_qos_profile to return dictionary instead of QoSProfile (#364 <https://github.com/ros2/rclpy/issues/364>)
* Contributors: Brian Marchi, Christian Rauch, Daniel Stonier, Daniel Wang, Geno117, Jacob Perron, Juan Ignacio Ubeira, Michel Hidalgo, Scott K Logan, Shane Loretz, Siddharth Kucheria, Vinnam Kim, William Woodall, ivanpauno, suab321321
```
