### PR TITLE
rosbag2: 0.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -699,6 +699,33 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: developed
+  rosbag2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
+    release:
+      packages:
+      - ros2bag
+      - rosbag2
+      - rosbag2_converter_default_plugins
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_test_common
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
+    status: maintained
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros2bag

```
* install resource marker file for package (#167 <https://github.com/ros2/rosbag2/issues/167>)
* install package manifest (#161 <https://github.com/ros2/rosbag2/issues/161>)
* Contributors: Dirk Thomas, Ruffin
```

## rosbag2

```
* enable address sanitizers only on 64bit machines (#149 <https://github.com/ros2/rosbag2/issues/149>)
* Export pluginlib to downstream packages (#113 <https://github.com/ros2/rosbag2/issues/113>)
* Add support for parsing middle module name from type (#128 <https://github.com/ros2/rosbag2/issues/128>)
* Contributors: David Hodo, Esteve Fernandez, Karsten Knese
```

## rosbag2_converter_default_plugins

```
* disable plugins/tests which need rmw_fastrtps_cpp if unavailable (#137 <https://github.com/ros2/rosbag2/issues/137>)
* Contributors: ivanpauno
```

## rosbag2_storage

```
* Fix test failures on armhf (#135 <https://github.com/ros2/rosbag2/issues/135>)
* Export pluginlib to downstream packages (#113 <https://github.com/ros2/rosbag2/issues/113>)
* Contributors: Esteve Fernandez, Prajakta Gokhale
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* disable plugins/tests which need rmw_fastrtps_cpp if unavailable (#137 <https://github.com/ros2/rosbag2/issues/137>)
* Contributors: ivanpauno
```

## rosbag2_transport

```
* fixup after API changes to Subscription in rclcpp (#166 <https://github.com/ros2/rosbag2/issues/166>)
* disable some tests for connext (#145 <https://github.com/ros2/rosbag2/issues/145>)
* disable plugins/tests which need rmw_fastrtps_cpp if unavailable (#137 <https://github.com/ros2/rosbag2/issues/137>)
* Fix test failures on armhf (#135 <https://github.com/ros2/rosbag2/issues/135>)
* Contributors: Karsten Knese, Prajakta Gokhale, William Woodall, ivanpauno
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

```
* install package.xml (#146 <https://github.com/ros2/rosbag2/issues/146>)
* Contributors: Mikael Arguedas
```
