### PR TITLE
eigen3_cmake_module: 0.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -198,6 +198,22 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: maintained
+  eigen3_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: master
+    status: maintained
   fastcdr:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen3_cmake_module` to `0.1.1-1`:

- upstream repository: https://github.com/ros2/eigen3_cmake_module.git
- release repository: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## eigen3_cmake_module

```
* Handle Eigen3 3.3.4 chocolatey package (#3 <https://github.com/ros2/eigen3_cmake_module/issues/3>)
* Update README (#2 <https://github.com/ros2/eigen3_cmake_module/issues/2>)
* Contributors: Marya Belanger, Shane Loretz
```
