### PR TITLE
geometry2: 0.12.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -237,6 +237,31 @@ repositories:
       url: https://github.com/eProsima/foonathan_memory_vendor.git
       version: f3ab481cda60adc18d4172367f16af6076d8fde4
     status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: ros2
+    release:
+      packages:
+      - tf2
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry2-release.git
+      version: 0.12.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: ros2
+    status: maintained
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## tf2

```
* Add pure virtual interface tf2::BufferCoreInterface
* Guard against invalid iterator (#127 <https://github.com/ros2/geometry2/issues/127>)
* Contributors: Jacob Perron
```

## tf2_eigen

```
* Adds toMsg & fromMsg for Eigen Vector3
* Adds additional conversions for tf2, KDL, Eigen
* Use eigen3_cmake_module (#144 <https://github.com/ros2/geometry2/issues/144>)
* Contributors: Ian McMahon, Shane Loretz
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

```
* Adds additional conversions for tf2, KDL, Eigen
* Use eigen3_cmake_module (#144 <https://github.com/ros2/geometry2/issues/144>)
* Contributors: Ian McMahon, Shane Loretz
```

## tf2_msgs

- No changes

## tf2_py

```
* Properly keep references to Python objects.
* Don't use borrowString in time or duration conversions.
* Minor fix to use CMake variable.
* tf2_ros is not built for Python (#99 <https://github.com/ros2/geometry2/issues/99>)
* Contributors: Chris Lalancette, Vinnam Kim
```

## tf2_ros

```
* Simulate work in the acceptedCallback.
* Make Windows Debug to run the correct python executable.
* Make BufferInterface destructor virtual.
* Remove unnecessary and blacklisted actionlib_msgs dependency.
* More test fixes for tf2_ros python.
* class Clock is in clock not timer.
* tf2_ros is not built for Python (#99 <https://github.com/ros2/geometry2/issues/99>)
* Migrate buffer action server to ROS 2
* Add conversion functions for durations
* Make /tf_static use transient_local durability (#160 <https://github.com/ros2/geometry2/issues/160>)
* Force explicit --ros-args in NodeOptions::arguments(). (#162 <https://github.com/ros2/geometry2/issues/162>)
* Use of -r/--remap flags where appropriate. (#159 <https://github.com/ros2/geometry2/issues/159>)
* Include tf2 headers in message_filter.h (#157 <https://github.com/ros2/geometry2/issues/157>)
* Use ament_target_dependencies to ensure correct dependency order (#156 <https://github.com/ros2/geometry2/issues/156>)
* Make sure that TransformListener's node gets a unique name (#129 <https://github.com/ros2/geometry2/issues/129>)
* Fix compiler warning (#148 <https://github.com/ros2/geometry2/issues/148>)
* Do not timeout when waiting for transforms (#146 <https://github.com/ros2/geometry2/issues/146>)
* Fix race between timeout and transform ready callback (#143 <https://github.com/ros2/geometry2/issues/143>)
* Fix high CPU - Use executor to spin and stop node in tf_listener thread (#119 <https://github.com/ros2/geometry2/issues/119>)
* Catch polymorphic exceptions by reference (#138 <https://github.com/ros2/geometry2/issues/138>)
* Add missing export build dependencies (#135 <https://github.com/ros2/geometry2/issues/135>)
* avoid delete-non-virtual-dtor warning (#134 <https://github.com/ros2/geometry2/issues/134>)
* Template tf2_ros::MessageFilter on the buffer type
* Add pure virtual interface tf2_ros::AsyncBufferInterface
* Add pure virtual interface tf2_ros::CreateTimerInterface
* Allow tf2_monitor to be run with ROS command line args (#122 <https://github.com/ros2/geometry2/issues/122>)
* Drop misleading ROS_* logging macros from tf2_monitor (#123 <https://github.com/ros2/geometry2/issues/123>)
* Fix the MessageFilter init order. (#120 <https://github.com/ros2/geometry2/issues/120>)
* Contributors: Chris Lalancette, Dan Rose, Jacob Perron, Karsten Knese, Michel Hidalgo, Scott K Logan, Shane Loretz, Vinnam Kim, bpwilcox, evshary
```

## tf2_sensor_msgs

```
* Use eigen3_cmake_module (#144 <https://github.com/ros2/geometry2/issues/144>)
* Added missing header (for tf2::fromMsg) (#126 <https://github.com/ros2/geometry2/issues/126>)
* Contributors: Esteve Fernandez, Shane Loretz
```
