### PR TITLE
sros2: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -901,6 +901,25 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: master
     status: maintained
+  sros2:
+    doc:
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    release:
+      packages:
+      - sros2
+      - sros2_cmake
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/sros2-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    status: developed
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## sros2

```
* Install an XML catalog so we can look this schema up locally (#158 <https://github.com/ros2/sros2/issues/158>)
  Fixes a failure in test_policy_to_permissions when there's no internet.
* Fix missing resources needed for ament (#160 <https://github.com/ros2/sros2/issues/160>)
* Install package manifest (#159 <https://github.com/ros2/sros2/issues/159>)
* Disable flaky test (#155 <https://github.com/ros2/sros2/issues/155>)
* Add mypy tests to check static typing (#154 <https://github.com/ros2/sros2/issues/154>)
* Topics starting with tilde need a slash right after (#152 <https://github.com/ros2/sros2/issues/152>)
* Update message content to match create_key message
* Create key and cert only once in generate_artifacts
* Fix certificate start date to work regardless of the timezone (#148 <https://github.com/ros2/sros2/issues/148>)
* Use older pytest compatible with Ubuntu Bionic (#145 <https://github.com/ros2/sros2/issues/145>)
* Add request service permissions in generated policies  (#141 <https://github.com/ros2/sros2/issues/141>)
* Replace openssl subprocess calls with Python cryptography library
  * Remove use of subprocess for creating ca key and cert (#126 <https://github.com/ros2/sros2/issues/126>)
  * Obtain S/MIME signature using cryptography library (#129 <https://github.com/ros2/sros2/issues/129>)
  * Migrate permissions S/MIME to cryptography library (#136 <https://github.com/ros2/sros2/issues/136>)
  * Migrate create_key to cryptography library (#138 <https://github.com/ros2/sros2/issues/138>)
  * Remove now obsolete openssl dependency (#140 <https://github.com/ros2/sros2/issues/140>)
* Factor out the hardcoded name 'sros2testCA' into a constant DEFAULT_COMMON_NAME (#134 <https://github.com/ros2/sros2/issues/134>)
* Improve create_key tests (#132 <https://github.com/ros2/sros2/issues/132>)
* Add test for create_key verb (#125 <https://github.com/ros2/sros2/issues/125>)
* Add basic create_keystore test. (#124 <https://github.com/ros2/sros2/issues/124>)
* Add tests for list_keys verb (#123 <https://github.com/ros2/sros2/issues/123>)
* Add tests for generate_policy verb (#122 <https://github.com/ros2/sros2/issues/122>)
* Guard against empty ROS graph when generating policy (#118 <https://github.com/ros2/sros2/issues/118>)
* Guard against invalid key names (#117 <https://github.com/ros2/sros2/issues/117>)
  In particular, guard against keys that only consist of whitespace and '/' characters.
* Contributors: Emerson Knapp, Jacob Perron, Kyle Fazzari, Mikael Arguedas, Peter Baughman, Ruffin, Siddharth Kucheria
```

## sros2_cmake

```
* Fix author, maintainer information in sros2_cmake/package.xml (#156 <https://github.com/ros2/sros2/issues/156>)
* Display sros2 invocation console output (#150 <https://github.com/ros2/sros2/issues/150>)
* Contributors: AAlon, Mikael Arguedas
```
