### PR TITLE
interactive_markers: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -292,6 +292,22 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/interactive_markers-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: ros2
+    status: developed
   launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## interactive_markers

```
* Add missing visibility macros (#51 <https://github.com/ros-visualization/interactive_markers/issues/51>)
* Less verbose logging (#45 <https://github.com/ros-visualization/interactive_markers/issues/45>)
* Rename enums to avoid collisions with MSVC compiler defines (#49 <https://github.com/ros-visualization/interactive_markers/issues/49>)
* Catch polymorphic exceptions by reference (#48 <https://github.com/ros-visualization/interactive_markers/issues/48>)
* Port to ROS 2 (#44)
  
  Style and other aesthetic changes
  
  Use tf2::BufferCoreInterface
  
  Replace 'init' topic with a ROS service
  
  Merge SingleClient logic into InteractiveMarkerClient
  
  Remove notion of server ID
  
  Add feedback publisher to client
  
  Default to C++14 and set stricter compiler flags
  
  Fix Windows compiler warnings
  
  Remove StateMachine class
  
  Fix Clang warnings
* Contributors: David Gossow, Jacob Perron, Scott K Logan
```
