### PR TITLE
urdf: 2.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1022,6 +1022,22 @@ repositories:
       url: https://github.com/ros2/unique_identifier_msgs.git
       version: master
     status: maintained
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: ros2
+    status: maintained
   urdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## urdf

```
* Update to remove unneeded console_bridge dependency. (#4 <https://github.com/ros2/urdf/issues/4>)
* Contributors: Mikael Arguedas
```
