### PR TITLE
kdl_parser: 2.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -292,6 +292,22 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/kdl_parser-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: ros2
+    status: maintained
   launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/kdl_parser.git
- release repository: https://github.com/ros2-gbp/kdl_parser-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## kdl_parser

```
* Fix up missing link tags in some XML files. (#15 <https://github.com/ros2/kdl_parser/issues/15>)
* Contributors: Chris Lalancette
```
