### PR TITLE
realtime_support: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -566,6 +566,25 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: master
     status: maintained
+  realtime_support:
+    doc:
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: master
+    release:
+      packages:
+      - rttest
+      - tlsf_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_support-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: master
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rttest

```
* Switch the latency storage to int64_t (#82 <https://github.com/ros2/realtime_support/issues/82>)
* Only return statistics if they have been calculated (#81 <https://github.com/ros2/realtime_support/issues/81>)
* Remove non-package from ament_target_dependencies() (#79 <https://github.com/ros2/realtime_support/issues/79>)
* Fix armhf build warnings (#78 <https://github.com/ros2/realtime_support/issues/78>)
* Contributors: Chris Lalancette, Prajakta Gokhale, Shane Loretz
```

## tlsf_cpp

- No changes
