### PR TITLE
Added package pmount to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4487,6 +4487,13 @@ pkg-config:
     slackpkg:
       packages: [pkg-config]
   ubuntu: [pkg-config]
+pmount:
+  arch:
+    aur: [pmount]
+  debian: [pmount]
+  fedora: [pmount]
+  gentoo: [sys-apps/pmount]
+  ubuntu: [pmount]
 pocketsphinx-bin:
   debian:
     buster: [pocketsphinx]


### PR DESCRIPTION
We are using pmount/pumount in one of our projects. pmount is a tool to mount/unmount removable drives as normal user.

[arch (AUR)](https://aur.archlinux.org/packages/pmount/)
[debian](https://packages.debian.org/jessie/pmount)
[fedora](https://apps.fedoraproject.org/packages/pmount)
[gentoo](https://packages.gentoo.org/packages/sys-apps/pmount)
[ubuntu](https://packages.ubuntu.com/xenial/pmount)