### PR TITLE
depthimage_to_laserscan: 2.2.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -492,7 +492,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `2.2.2-1`:

- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.2.1-1`

## depthimage_to_laserscan

```
* update code to be consist with new ros2 core (#42 <https://github.com/ros-perception/depthimage_to_laserscan/issues/42>)
* Contributors: Gary Liu
```
