### PR TITLE
vision_opencv: 2.1.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1236,6 +1236,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 2.1.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.1.2-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## cv_bridge

```
* Suppress Boost Python warning. (#279 <https://github.com/ros-perception/vision_opencv/issues/279>)
* silence unused return value warnings (#276 <https://github.com/ros-perception/vision_opencv/issues/276>)
* Contributors: Karsten Knese, Michael Carroll
```

## image_geometry

- No changes

## vision_opencv

- No changes
