### PR TITLE
image_common: 2.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -340,6 +340,26 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_transport
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/image_common-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `2.2.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_transport

- No changes
