### PR TITLE
Adding niryo_one_ros_simulation

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8120,6 +8120,11 @@ repositories:
       url: https://github.com/astuff/network_interface.git
       version: release
     status: maintained
+  niryo_one_simulation:
+    doc:
+      type: git
+      url: https://github.com/NiryoRobotics/niryo_one_ros_simulation.git
+      version: master
   nmea_comms:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4766,10 +4766,10 @@ repositories:
       url: https://github.com/astuff/network_interface.git
       version: release
     status: developed
-  niryo_one:
+  niryo_one_simulation:
     doc:
       type: git
-      url: https://github.com/NiryoRobotics/niryo_one_ros.git
+      url: https://github.com/NiryoRobotics/niryo_one_ros_simulation.git
       version: master
   nmea_comms:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4766,6 +4766,11 @@ repositories:
       url: https://github.com/astuff/network_interface.git
       version: release
     status: developed
+  niryo_one:
+    doc:
+      type: git
+      url: https://github.com/NiryoRobotics/niryo_one_ros.git
+      version: master
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Hi,

I'd like niryo_one_ros_simulation to be indexed and documented on ros.org. 
Niryo one is an educational robotic arm, made by my startup Niryo. 
The stack works for both Kinematic and Melodic distro. 

By thanking you in advance,
Best regards,

Etienne