### PR TITLE
python_qt_binding: 1.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -570,6 +570,22 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: master
     status: developed
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/python_qt_binding-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    status: maintained
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.1-1`:

- upstream repository: git@github.com:ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## python_qt_binding

```
* no warnings for unavailable PySide/Shiboken (#58 <https://github.com/ros-visualization/python_qt_binding/issues/58>)
```
