### PR TITLE
cyclonedds: 0.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -221,6 +221,8 @@ repositories:
       url: https://github.com/ros2-gbp/cyclonedds-release.git
       version: 0.1.0-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: 78fc9c2e8517a34d3a743740a2457e07199234f0

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -214,6 +214,17 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: maintained
+  cyclonedds:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/cyclonedds-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+      version: 78fc9c2e8517a34d3a743740a2457e07199234f0
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.1.0-1`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
