### PR TITLE
launch_ros: 0.9.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -451,6 +451,26 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: master
     status: developed
+  launch_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: master
+    release:
+      packages:
+      - launch_ros
+      - launch_testing_ros
+      - ros2launch
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_ros-release.git
+      version: 0.9.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: master
+    status: developed
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.9.1-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## launch_ros

- No changes

## launch_testing_ros

```
* Make launch_testing_ros examples standalone. (#80 <https://github.com/ros2/launch_ros/issues/80>)
* Contributors: Michel Hidalgo
```

## ros2launch

- No changes
