### PR TITLE
xacro: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2884,6 +2884,22 @@ repositories:
       url: https://github.com/RobotWebTools/web_video_server.git
       version: ros2
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.0-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## xacro

```
* PEP8 cleanup
  - code simplifications
  - avoid empty except
  - sort imports
  - format line breaks
* Code cleanup
  - Removed deprecated options --legacy, --inorder, --check-order, --includes
  - Require all xacro commands to be prefixed with 'xacro:'
  - Added missing copyright notices
  - Removed python2 stuff
* Adapt Travis config to use colcon
* Provide ROS2-based replacement for substition args
* Modified package structure as per ROS2 rules
  - Using ament_cmake
  - Moved source contents from "src/xacro" to "xacro"
  - Modified package.xml and setup.py according to ROS2 requirements
  - Configured completion hook
  - Removed catkin artifacts from cmake extension
* Contributors: vandanamandlik, Jacob Perron, Robert Haschke
```
