### PR TITLE
warehouse_ros_mongo: 0.9.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9741,7 +9741,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros_mongo-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_mongo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `0.9.1-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/ros-gbp/warehouse_ros_mongo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.9.0-1`

## warehouse_ros_mongo

```
* Initialize mongo client only once (#28 <https://github.com/ros-planning/warehouse_ros_mongo/issues/28>)
* Restore mongod python wrapper
* Contributors: Masaki Murooka, Robert Haschke
```
