### PR TITLE
rviz: 1.13.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8238,7 +8238,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.4-1
+      version: 1.13.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.5-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.13.4-1`

## rviz

```
* [fix] ImageDisplay/CameraDisplay: fix status reporting / report frame issues (`#1425 <https://github.com/ros-visualization/rviz/issues/1425>`_)
* [fix] Fix `#1422 <https://github.com/ros-visualization/rviz/issues/1422>`_: update recent config to actual filename
* [fix] ImageDisplayBase/MarkerDisplay: increase subscriber queue size with filter queue size
* [fix] Enable mouse tracking for RenderPanel (`#1433 <https://github.com/ros-visualization/rviz/issues/1433>`_)
* Contributors: Robert Haschke, Simon Schmeisser
```