### PR TITLE
ros_testing: 0.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -946,6 +946,25 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: eloquent
     status: maintained
+  ros_testing:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: master
+    release:
+      packages:
+      - ros2test
+      - ros_testing
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_testing-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: master
+    status: developed
   ros_workspace:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/ros2-gbp/ros_testing-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros2test

```
* install resource marker file for package (#5 <https://github.com/ros2/ros_testing/issues/5>)
* install package manifest (#4 <https://github.com/ros2/ros_testing/issues/4>)
* Move --disable-isolation argument from launch_testing to ros2test (#2 <https://github.com/ros2/ros_testing/issues/2>)
* Contributors: Dirk Thomas, ivanpauno
```

## ros_testing

- No changes
