### PR TITLE
navigation_msgs: 2.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -507,6 +507,25 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: master
     status: maintained
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros2
+    release:
+      packages:
+      - map_msgs
+      - move_base_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/navigation_msgs-release.git
+      version: 2.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros2
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/navigation_msgs
- release repository: https://github.com/ros2-gbp/navigation_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## map_msgs

- No changes

## move_base_msgs

```
* port move_base_msgs to ROS2 actions (#10 <https://github.com/ros-planning/navigation_msgs/issues/10>)
* Contributors: Steven Macenski
```
