### PR TITLE
navigation_msgs: 2.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1192,10 +1192,11 @@ repositories:
     release:
       packages:
       - map_msgs
+      - move_base_msgs
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/navigation_msgs
- release repository: https://github.com/ros2-gbp/navigation_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-1`

## map_msgs

- No changes

## move_base_msgs

```
* port move_base_msgs to ROS2 actions (#10 <https://github.com/ros-planning/navigation_msgs/issues/10>)
* Contributors: Steven Macenski
```
