### PR TITLE
demos: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -227,6 +227,42 @@ repositories:
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: 78fc9c2e8517a34d3a743740a2457e07199234f0
     status: developed
+  demos:
+    doc:
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    release:
+      packages:
+      - action_tutorials_cpp
+      - action_tutorials_interfaces
+      - action_tutorials_py
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
+      - topic_monitor
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/demos-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: master
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## action_tutorials_cpp

```
* Add action tutorials in C++ (#378 <https://github.com/ros2/demos/issues/378>)
* Contributors: Siddharth Kucheria
```

## action_tutorials_interfaces

```
* Move action tutorial interface to a new package, action_tutorials_interfaces (#378 <https://github.com/ros2/demos/issues/378>)
* Contributors: Siddharth Kucheria
```

## action_tutorials_py

```
* Remove non-existing dependency (#384 <https://github.com/ros2/demos/issues/384>)
* Move Python action tutorials to a new package, action_tutorials_py (#378 <https://github.com/ros2/demos/issues/378>)
* Contributors: Mikael Arguedas, Siddharth Kucheria
```

## composition

```
* Add an demo component not inherited from rclcpp::Node (#393 <https://github.com/ros2/demos/issues/393>)
* Contributors: Michael Carroll
```

## demo_nodes_cpp

```
* Adding visibility macros to demos (#381 <https://github.com/ros2/demos/issues/381>)
* Demos using composition (#375 <https://github.com/ros2/demos/issues/375>)
* Contributors: Siddharth Kucheria
```

## demo_nodes_cpp_native

```
* Adding visibility macros to demos (#381 <https://github.com/ros2/demos/issues/381>)
* Check if FastRTPS available in demo_nodes_cpp_native before creating library/executable (#383 <https://github.com/ros2/demos/issues/383>)
* Demos using composition (#375 <https://github.com/ros2/demos/issues/375>)
* Contributors: Siddharth Kucheria
```

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Adding visibility macros to demos (#381 <https://github.com/ros2/demos/issues/381>)
* Demos using composition (#375 <https://github.com/ros2/demos/issues/375>)
* Contributors: Siddharth Kucheria
```

## intra_process_demo

- No changes

## lifecycle

```
* Fix lifecycle_service_client namespace (#369 <https://github.com/ros2/demos/issues/369>)
* Contributors: Cameron Evans
```

## logging_demo

- No changes

## pendulum_control

```
* Fixes to pendulum_control demo (#385)
  
  Add asserts to ensure that the latency is never negative
  
  Switch last_sample to int64_t to match new rttest interface
  
  Allow any number of spaces
  
  Make sure to expect the extra newline for the pendulum_demo
  
  Only publish statistics if they are available.
  
  Remove some unused functions from rtt_executor.hpp
* Fix armhf build warnings (#372 <https://github.com/ros2/demos/issues/372>)
* Contributors: Chris Lalancette, Prajakta Gokhale
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Add interactive quality of service demos (#371 <https://github.com/ros2/demos/issues/371>)
* Contributors: M. M
```

## quality_of_service_demo_py

```
* Fix spelling of pytest marker (#391 <https://github.com/ros2/demos/issues/391>)
* Contributors: Dirk Thomas
```

## topic_monitor

- No changes
