### PR TITLE
rviz: 7.0.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1351,6 +1351,31 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: ros2
+    release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz-release.git
+      version: 7.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: ros2
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `7.0.0-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rviz2

```
* Remove -Werror from defualt compiler options (#420 <https://github.com/ros2/rviz/issues/420>)
* Contributors: Hunter L. Allen
```

## rviz_assimp_vendor

```
* Add .dsv file beside custom environment hook (#466 <https://github.com/ros2/rviz/issues/466>)
* Contributors: Dirk Thomas
```

## rviz_common

```
* Introduce QoS property (#409 <https://github.com/ros2/rviz/issues/409>)
  A container of properties related to QoS settings. Replaces queue size and unreliable properties.
* Migrate InteractiveMarkerDisplay (#457 <https://github.com/ros2/rviz/issues/457>)
* Rename 2d Nav Goal to 2d Goal Pose (#455)
  
  Rename nav pose tool to goal pose tool
  
  Rename topic for goal pose tool from "move_base_simple/goal" to "goal_pose"
* Do not select interactive markers when mousing over them (#451 <https://github.com/ros2/rviz/issues/451>)
* Migrate Interaction Tool (#423 <https://github.com/ros2/rviz/issues/423>)
* Upgrade from Ogre 1.10 to Ogre 1.12.1 (#394 <https://github.com/ros2/rviz/issues/394>)
* Re-enable use of tf message filter (#375 <https://github.com/ros2/rviz/issues/375>)
* Static analysis cleanup for rviz_common (#431 <https://github.com/ros2/rviz/issues/431>)
* Fix deprecation warnings with new Qt (#435 <https://github.com/ros2/rviz/issues/435>)
* FrameTransformer implements tf2::BufferCoreInterface and tf2_ros::AsyncBufferInterface (#422 <https://github.com/ros2/rviz/issues/422>)
* Use geometry_msgs types instead of custom types (#426 <https://github.com/ros2/rviz/issues/426>)
* Remove -Werror from defualt compiler options (#420 <https://github.com/ros2/rviz/issues/420>)
* Use node to create clock used to stamp publications (#407 <https://github.com/ros2/rviz/issues/407>)
* Remove blank lines that latest uncrustify doesn't like (#411 <https://github.com/ros2/rviz/issues/411>)
* Contributors: Emerson Knapp, Hunter L. Allen, Jacob Perron, Martin Idel, Scott K Logan, Shivesh Khaitan, Steven Macenski, William Woodall
```

## rviz_default_plugins

```
* Introduce QoS property (#409 <https://github.com/ros2/rviz/issues/409>)
  A container of properties related to QoS settings. Replaces queue size and unreliable properties.
* Rename interactive marker client enum (#465 <https://github.com/ros2/rviz/issues/465>)
* Migrate InteractiveMarkerDisplay (#457 <https://github.com/ros2/rviz/issues/457>)
* Fix map after upgrade (#459 <https://github.com/ros2/rviz/issues/459>)
* Rename 2d Nav Goal to 2d Goal Pose (#455)
  
  Rename nav pose tool to goal pose tool
  
  Rename topic for goal pose tool from "move_base_simple/goal" to "goal_pose"
* Do not select interactive markers when mousing over them (#451 <https://github.com/ros2/rviz/issues/451>)
* Migrate Interaction Tool (#423 <https://github.com/ros2/rviz/issues/423>)
* Upgrade from Ogre 1.10 to Ogre 1.12.1 (#394 <https://github.com/ros2/rviz/issues/394>)
* Re-enable use of tf message filter (#375 <https://github.com/ros2/rviz/issues/375>)
* Fix map display (#425 <https://github.com/ros2/rviz/issues/425>)
* FrameTransformer implements tf2::BufferCoreInterface and tf2_ros::AsyncBufferInterface (#422 <https://github.com/ros2/rviz/issues/422>)
* Disambiguate "estimate" pose from "goal" pose in log (#427 <https://github.com/ros2/rviz/issues/427>)
* Mojave compatibility (#414 <https://github.com/ros2/rviz/issues/414>)
* Use geometry_msgs types instead of custom types (#426 <https://github.com/ros2/rviz/issues/426>)
* Remove -Werror from defualt compiler options (#420 <https://github.com/ros2/rviz/issues/420>)
* Migrate Wrench Display (#396 <https://github.com/ros2/rviz/issues/396>)
* Contributors: Dan Rose, Hunter L. Allen, Jacob Perron, Karsten Knese, Martin Idel, Shivesh Khaitan, Steven Macenski
```

## rviz_ogre_vendor

```
* Add .dsv file beside custom environment hook (#449 <https://github.com/ros2/rviz/issues/449>)
* Upgrade from Ogre 1.10 to Ogre 1.12.1 (#394 <https://github.com/ros2/rviz/issues/394>)
* Mojave compatibility (#414 <https://github.com/ros2/rviz/issues/414>)
* Contributors: Dirk Thomas, Karsten Knese, Martin Idel
```

## rviz_rendering

```
* Fix map after upgrade (#459 <https://github.com/ros2/rviz/issues/459>)
* Use eigen3_cmake_module (#441 <https://github.com/ros2/rviz/issues/441>)
* Upgrade from Ogre 1.10 to Ogre 1.12.1 (#394 <https://github.com/ros2/rviz/issues/394>)
* Remove -Werror from defualt compiler options (#420 <https://github.com/ros2/rviz/issues/420>)
* Migrate Wrench Display (#396 <https://github.com/ros2/rviz/issues/396>)
* Fix STL loader (#410 <https://github.com/ros2/rviz/issues/410>)
* Contributors: Hunter L. Allen, Martin Idel, Shane Loretz
```

## rviz_rendering_tests

```
* Fix assert in mesh_loader_test (#446 <https://github.com/ros2/rviz/issues/446>)
* Remove non-package from ament_target_dependencies() (#428 <https://github.com/ros2/rviz/issues/428>)
* Remove -Werror from defualt compiler options (#420 <https://github.com/ros2/rviz/issues/420>)
* Fix STL loader (#410 <https://github.com/ros2/rviz/issues/410>)
* Contributors: Hunter L. Allen, Martin Idel, Shane Loretz, Zachary Michaels
```

## rviz_visual_testing_framework

```
* Fix typos in visual testing framework documentation (#416 <https://github.com/ros2/rviz/issues/416>)
* Remove -Werror from defualt compiler options (#420 <https://github.com/ros2/rviz/issues/420>)
* Contributors: Hunter L. Allen, Jacob Perron
```
