### PR TITLE
python_qt_binding: 0.3.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6069,7 +6069,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.5-0
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.3.6-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.5-0`

## python_qt_binding

```
* convert cmake targets to plain libraries (#68 <https://github.com/ros-visualization/python_qt_binding/issues/68>)
* add Python 3 dependency with condition (#75 <https://github.com/ros-visualization/python_qt_binding/issues/75>)
* if present, use the sipconfig suggested sip program (#70 <https://github.com/ros-visualization/python_qt_binding/issues/70>)
* check for Homebrew's PyQt5 install path (#57 <https://github.com/ros-visualization/python_qt_binding/issues/57>)
* modifying sip_configure (#54 <https://github.com/ros-visualization/python_qt_binding/issues/54>)
* replace Qt variable in generated Makefile (#64 <https://github.com/ros-visualization/python_qt_binding/issues/64>)
* fixing trivial accidental string concatenation (#66 <https://github.com/ros-visualization/python_qt_binding/issues/66>)
* Windows: handling build configuration keywords before passed to SIP (#60 <https://github.com/ros-visualization/python_qt_binding/issues/60>)
* cherry-pick windows port from crystal-devel (#61 <https://github.com/ros-visualization/python_qt_binding/issues/61>)
```
