### PR TITLE
python_qt_binding: 1.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -631,7 +631,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.2-1`:

- upstream repository: git@github.com:ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-1`

## python_qt_binding

```
* replace Qt variable in generated Makefile (#64 <https://github.com/ros-visualization/python_qt_binding/issues/64>)
* don't add -l prefix if it already exists (#59 <https://github.com/ros-visualization/python_qt_binding/issues/59>)
* if present, use the sipconfig suggested sip program (#70 <https://github.com/ros-visualization/python_qt_binding/issues/70>)
* replace Qt variable in generated Makefile (#64 <https://github.com/ros-visualization/python_qt_binding/issues/64>) (#67 <https://github.com/ros-visualization/python_qt_binding/issues/67>)
* fixing trivial accidental string concatenation (#66 <https://github.com/ros-visualization/python_qt_binding/issues/66>)
```
