### PR TITLE
qt_gui_core: 0.3.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6190,7 +6190,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.11-0
+      version: 0.3.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.12-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.11-0`

## qt_dotgraph

```
* remove obsolete maintainer (#160 <https://github.com/ros-visualization/qt_gui_core/issues/160>)
* changes for flake8 and ROS2 compatible style changes (#130 <https://github.com/ros-visualization/qt_gui_core/issues/130>)
* autopep8 (#123 <https://github.com/ros-visualization/qt_gui_core/issues/123>)
```

## qt_gui

```
* fix C++ Settings methods allKeys, childGroups, childKeys (#182 <https://github.com/ros-visualization/qt_gui_core/issues/182>)
* add missing QtCore import (#178 <https://github.com/ros-visualization/qt_gui_core/issues/178>)
* fix changing dictionary during iteration (#167 <https://github.com/ros-visualization/qt_gui_core/issues/167>)
* fix typo (#164 <https://github.com/ros-visualization/qt_gui_core/issues/164>)
* remove obsolete maintainer (#160 <https://github.com/ros-visualization/qt_gui_core/issues/160>)
* fix warning message (#143 <https://github.com/ros-visualization/qt_gui_core/issues/143>)
* changes for flake8 and ROS2 compatible style changes (#130 <https://github.com/ros-visualization/qt_gui_core/issues/130>)
* autopep8 (#123 <https://github.com/ros-visualization/qt_gui_core/issues/123>)
```

## qt_gui_app

```
* remove obsolete maintainer (#160 <https://github.com/ros-visualization/qt_gui_core/issues/160>)
* changes for flake8 and ROS2 compatible style changes (#130 <https://github.com/ros-visualization/qt_gui_core/issues/130>)
```

## qt_gui_cpp

```
* [Windows] Add missing DLL exports for qt_gui_cpp (#170 <https://github.com/ros-visualization/qt_gui_core/issues/170>)
* cherry-pick windows port from crystal-devel (#173 <https://github.com/ros-visualization/qt_gui_core/issues/173>)
* remove obsolete maintainer (#160 <https://github.com/ros-visualization/qt_gui_core/issues/160>)
* changes for flake8 and ROS2 compatible style changes (#130 <https://github.com/ros-visualization/qt_gui_core/issues/130>)
* autopep8 (#123 <https://github.com/ros-visualization/qt_gui_core/issues/123>)
```

## qt_gui_py_common

```
* remove obsolete maintainer (#160 <https://github.com/ros-visualization/qt_gui_core/issues/160>)
* changes for flake8 and ROS2 compatible style changes (#130 <https://github.com/ros-visualization/qt_gui_core/issues/130>)
* autopep8 (#123 <https://github.com/ros-visualization/qt_gui_core/issues/123>)
```
