### PR TITLE
qt_gui_core: 1.0.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -638,6 +638,29 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: crystal-devel
     status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/qt_gui_core-release.git
+      version: 1.0.7-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    status: maintained
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.0.7-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## qt_dotgraph

- No changes

## qt_gui

```
* fix C++ Settings methods allKeys, childGroups, childKeys (#182 <https://github.com/ros-visualization/qt_gui_core/issues/182>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
