### PR TITLE
qt_gui_core: 0.3.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6190,7 +6190,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.11-0
+      version: 0.3.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.13-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.11-0`

## qt_dotgraph

```
* add Python 3 dependencies with conditions (#184 <https://github.com/ros-visualization/qt_gui_core/issues/184>)
```

## qt_gui

```
* add Python 3 dependencies with conditions (#184 <https://github.com/ros-visualization/qt_gui_core/issues/184>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

```
* add Python 3 dependencies with conditions (#184 <https://github.com/ros-visualization/qt_gui_core/issues/184>)
```
