### PR TITLE
rqt: 1.0.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1224,6 +1224,28 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: master
     status: maintained
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt-release.git
+      version: 1.0.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.0.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_gui

- No changes

## rqt_gui_cpp

```
* drop unnecessary MOC compilation (#203 <https://github.com/ros-visualization/rqt/issues/203>)
```

## rqt_gui_py

- No changes

## rqt_py_common

```
* use Python debug executable for Windows debug builds (#196 <https://github.com/ros-visualization/rqt/issues/196>)
```
