### PR TITLE
ros_type_introspection: 2.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12210,7 +12210,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/ros_type_introspection-release.git
-      version: 1.3.3-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/facontidavide/ros_type_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `2.0.0-1`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.3.3-1`

## ros_type_introspection

```
* removed abseil
* Merge branch 'master' of https://github.com/facontidavide/ros_type_introspection
* minor changes in the API
* Fix issue #38 <https://github.com/facontidavide/ros_type_introspection/issues/38>
* Contributors: Davide Faconti
```
