### PR TITLE
Added packages python-collada and urdf2webots-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4961,6 +4961,16 @@ python3-catkin-pkg-modules:
   openembedded: [python3-catkin-pkg@meta-ros]
   rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg-modules]
+python3-collada-pip:
+  debian:
+    pip:
+      packages: [pycollada]
+  fedora:
+    pip:
+      packages: [pycollada]
+  ubuntu:
+    pip:
+      packages: [pycollada]
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -969,6 +969,10 @@ python-cobs-pip:
   ubuntu:
     pip:
       packages: [cobs]
+python-collada:
+  debian: [python-collada]
+  fedora: [python-collada]
+  ubuntu: [python-collada]
 python-colorama:
   arch: [python2-colorama]
   debian: [python-colorama]
@@ -2956,10 +2960,6 @@ python-pulsectl-pip:
   ubuntu:
     pip:
       packages: [pulsectl]
-python-collada:
-  debian: [python-collada]
-  fedora: [python-collada]
-  ubuntu: [python-collada]
 python-pyassimp:
   arch: [python2-pyassimp]
   debian: [python-pyassimp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2956,19 +2956,10 @@ python-pulsectl-pip:
   ubuntu:
     pip:
       packages: [pulsectl]
-python-pycollada:
-  debian:
-    pip:
-      packages: [pycollada]
-  fedora:
-    pip:
-      packages: [pycollada]
-  osx:
-    pip:
-      packages: [pycollada]
-  ubuntu:
-    pip:
-      packages: [pycollada]
+python-collada:
+  debian: [python-collada]
+  fedora: [python-collada]
+  ubuntu: [python-collada]
 python-pyassimp:
   arch: [python2-pyassimp]
   debian: [python-pyassimp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -971,7 +971,6 @@ python-cobs-pip:
       packages: [cobs]
 python-collada:
   debian: [python-collada]
-  fedora: [python-collada]
   ubuntu: [python-collada]
 python-colorama:
   arch: [python2-colorama]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2956,6 +2956,19 @@ python-pulsectl-pip:
   ubuntu:
     pip:
       packages: [pulsectl]
+python-pycollada:
+  debian:
+    pip:
+      packages: [pycollada]
+  fedora:
+    pip:
+      packages: [pycollada]
+  osx:
+    pip:
+      packages: [pycollada]
+  ubuntu:
+    pip:
+      packages: [pycollada]
 python-pyassimp:
   arch: [python2-pyassimp]
   debian: [python-pyassimp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5501,6 +5501,16 @@ uavcan-pip:
   ubuntu:
     pip:
       packages: [uavcan]
+urdf2webots-pip:
+  debian:
+    pip:
+      packages: [urdf2webots]
+  fedora:
+    pip:
+      packages: [urdf2webots]
+  ubuntu:
+    pip:
+      packages: [urdf2webots]
 virtualenv:
   debian: [virtualenv]
   fedora: [virtualenv]


### PR DESCRIPTION
I need those two dependencies in my ros package `webots_ros2` (see PR cyberbotics/webots_ros2#28 that is waiting).

The goal is to be able to provide some utilities for ROS2 to be able to convert files between URDF (and XACRO in the furture) and PROTO, to ease the transition from Gazebo to Webots and the other way around so each one can use the simulator he prefers with ROS2 really easily.

Links:
  - **python-collada**
     - **debian**: https://packages.debian.org/search?keywords=python-collada
    - **ubuntu**: https://packages.ubuntu.com/search?keywords=python-collada&searchon=names
  - **python3-collada-pip**
     - **all**: https://pypi.org/project/pycollada/
  - **urdf2webots**
     - **all**: https://pypi.org/project/urdf2webots/