### PR TITLE
joystick_drivers: 2.3.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -446,6 +446,23 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: ros2
     status: developed
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros2/joystick_drivers.git
+      version: dashing
+    release:
+      packages:
+      - joy
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/joystick_drivers-release.git
+      version: 2.3.2-1
+    source:
+      type: git
+      url: https://github.com/ros2/joystick_drivers.git
+      version: dashing
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `2.3.2-1`:

- upstream repository: https://github.com/ros2/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
