### PR TITLE
moveit_pr2: 0.7.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4285,6 +4285,25 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: melodic-devel
     status: maintained
+  moveit_pr2:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_pr2.git
+      version: melodic-devel
+    release:
+      packages:
+      - moveit_pr2
+      - pr2_moveit_config
+      - pr2_moveit_plugins
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_pr2-release.git
+      version: 0.7.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_pr2.git
+      version: melodic-devel
+    status: maintained
   moveit_python:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository moveit_pr2 to 0.7.2-1:

- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: 0.7.1-0

## moveit_pr2
- No changes

## pr2_moveit_config
- No changes

## pr2_moveit_plugins
```
* [maintenance] Fix Travis (`#103 <https://github.com/ros-planning/moveit_pr2/issues/103>`_)
* [maintenance] Adapt IK to newer KDL API (`#101 <https://github.com/ros-planning/moveit_pr2/issues/101>`_)
* Contributors: Kei Okada, Robert Haschke
```