### PR TITLE
jderobot-colortuner: 0.0.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5364,7 +5364,7 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
-  jderobot-colortuner:
+  jderobot_colortuner:
     release:
       packages:
       - jderobot_color_tuner

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5364,6 +5364,14 @@ repositories:
       url: https://github.com/gstavrinos/jaguar-release.git
       version: 0.1.0-0
     status: developed
+  jderobot-colortuner:
+    release:
+      packages:
+      - jderobot_color_tuner
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-2
   jderobot_assets:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot-colortuner` to `0.0.3-2`:

- upstream repository: https://github.com/JdeRobot/ColorTuner.git
- release repository: https://github.com/JdeRobot/ColorTuner-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## jderobot_color_tuner

- No changes
