### PR TITLE
add 'python_version' key to each distribution in the index-v4.yaml

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -8,65 +8,78 @@ distributions:
     distribution_cache: http://repo.ros2.org/rosdistro_cache/ardent-cache.yaml.gz
     distribution_status: end-of-life
     distribution_type: ros2
+    python_version: 3
   bouncy:
     distribution: [bouncy/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/bouncy-cache.yaml.gz
     distribution_status: end-of-life
     distribution_type: ros2
+    python_version: 3
   crystal:
     distribution: [crystal/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz
     distribution_status: active
     distribution_type: ros2
+    python_version: 3
   dashing:
     distribution: [dashing/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/dashing-cache.yaml.gz
     distribution_status: active
     distribution_type: ros2
+    python_version: 3
   eloquent:
     distribution: [eloquent/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/eloquent-cache.yaml.gz
     distribution_status: prerelease
     distribution_type: ros2
+    python_version: 3
   groovy:
     distribution: [groovy/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/groovy-cache.yaml.gz
     distribution_status: end-of-life
     distribution_type: ros1
+    python_version: 2
   hydro:
     distribution: [hydro/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/hydro-cache.yaml.gz
     distribution_status: end-of-life
     distribution_type: ros1
+    python_version: 2
   indigo:
     distribution: [indigo/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/indigo-cache.yaml.gz
     distribution_status: end-of-life
     distribution_type: ros1
+    python_version: 2
   jade:
     distribution: [jade/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/jade-cache.yaml.gz
     distribution_status: end-of-life
     distribution_type: ros1
+    python_version: 2
   kinetic:
     distribution: [kinetic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/kinetic-cache.yaml.gz
     distribution_status: active
     distribution_type: ros1
+    python_version: 2
   lunar:
     distribution: [lunar/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/lunar-cache.yaml.gz
     distribution_status: end-of-life
     distribution_type: ros1
+    python_version: 2
   melodic:
     distribution: [melodic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/melodic-cache.yaml.gz
     distribution_status: active
     distribution_type: ros1
+    python_version: 2
   noetic:
     distribution: [noetic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/noetic-cache.yaml.gz
     distribution_status: prerelease
     distribution_type: ros1
+    python_version: 3
 type: index
 version: 4


### PR DESCRIPTION
Due to [this logic](https://github.com/ros-infrastructure/rosdistro/blob/63663f07d4fc42979cc65df40bde478c41319d1f/src/rosdistro/index.py#L86-L91) in `rosdistro` the extra key won't cause any problems for existing users (see [comment](https://github.com/ros-infrastructure/rosdistro/blob/63663f07d4fc42979cc65df40bde478c41319d1f/src/rosdistro/index.py#L88-L91)).