### PR TITLE
tello_driver: 0.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14748,6 +14748,12 @@ repositories:
       url: https://github.com/methylDragon/teleop_twist_keyboard_cpp.git
       version: master
     status: maintained
+  tello_driver:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/appie-17/tello_driver-release.git
+      version: 0.2.0-1
   tensorflow_ros_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tello_driver` to `0.2.0-1`:

- upstream repository: https://github.com/appie-17/tello_driver.git
- release repository: https://github.com/appie-17/tello_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
