### PR TITLE
turtlesim: 1.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1454,6 +1454,22 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: master
     status: maintained
+  turtlesim:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_tutorials-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: dashing-devel
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim` to `1.0.1-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## turtlesim

```
* fix mimic tutorial node (#65 <https://github.com/ros/ros_tutorials/issues/65>)
* fix syntax error in teleop_turtle_key.cpp on Windows (#66 <https://github.com/ros/ros_tutorials/issues/66>)
* add RotateAbsolute action (#62 <https://github.com/ros/ros_tutorials/issues/62>)
* fix typo in error message (#64 <https://github.com/ros/ros_tutorials/issues/64>)
```
