### PR TITLE
neonavigation_msgs: 0.5.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8095,11 +8095,12 @@ repositories:
       - map_organizer_msgs
       - neonavigation_msgs
       - planner_cspace_msgs
+      - safety_limiter_msgs
       - trajectory_tracker_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_msgs-release.git
-      version: 0.3.1-0
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_msgs` to `0.5.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation_msgs.git
- release repository: https://github.com/at-wat/neonavigation_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.1-0`

## costmap_cspace_msgs

```
* Drop ROS Indigo and Ubuntu Trusty support (#15 <https://github.com/at-wat/neonavigation_msgs/issues/15>)
* Contributors: Atsushi Watanabe
```

## map_organizer_msgs

```
* Drop ROS Indigo and Ubuntu Trusty support (#15 <https://github.com/at-wat/neonavigation_msgs/issues/15>)
* Contributors: Atsushi Watanabe
```

## neonavigation_msgs

```
* Add safety_limiter_msgs package (#16 <https://github.com/at-wat/neonavigation_msgs/issues/16>)
* Contributors: Daiki Maekawa
```

## planner_cspace_msgs

```
* Drop ROS Indigo and Ubuntu Trusty support (#15 <https://github.com/at-wat/neonavigation_msgs/issues/15>)
* Contributors: Atsushi Watanabe
```

## safety_limiter_msgs

```
* Add safety_limiter_msgs package (#16 <https://github.com/at-wat/neonavigation_msgs/issues/16>)
* Contributors: Daiki Maekawa
```

## trajectory_tracker_msgs

```
* Drop ROS Indigo and Ubuntu Trusty support (#15 <https://github.com/at-wat/neonavigation_msgs/issues/15>)
* Contributors: Atsushi Watanabe
```
