### PR TITLE
ros1_bridge: 0.8.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1061,6 +1061,22 @@ repositories:
       url: https://github.com/ros2/robot_state_publisher.git
       version: ros2
     status: maintained
+  ros1_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/ros1_bridge-release.git
+      version: 0.8.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    status: maintained
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.8.0-2`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ros1_bridge

```
* Promote special CLI rules to flags. (#217 <https://github.com/ros2/ros1_bridge/issues/217>)
* Update __log_rosout_disable workaround to use --ros-args. (#216 <https://github.com/ros2/ros1_bridge/issues/216>)
* Clearer instructions for example (#211 <https://github.com/ros2/ros1_bridge/issues/211>)
* add services bridging to parameter_bridge (#176 <https://github.com/ros2/ros1_bridge/issues/176>)
* Contributors: Jose Luis Blanco-Claraco, Michel Hidalgo, cyrilleberger
```
