### PR TITLE
plotjuggler: 2.3.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5708,7 +5708,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.3.3-2
+      version: 2.3.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.3.4-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.3.3-2`

## plotjuggler

```
* I finally did it: plotJuggler "meme edition"
* RosMsgParsers: add cast to be clang compatible (#208 <https://github.com/facontidavide/PlotJuggler/issues/208>)
* Update README.md
* Update FUNDING.yml
* Correct "Github" to "GitHub" (#206 <https://github.com/facontidavide/PlotJuggler/issues/206>)
* Contributors: Dan Katzuv, Davide Faconti, Timon Engelke
```
