### PR TITLE
gps_umd: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4031,7 +4031,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 0.2.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.3.0-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-0`

## gps_common

```
* Switching order of commands to make catkin happy
* Initial attempt at creating an offline bag converter
* Changing ROS_INFO to ROS_DEBUG_THROTTLE as per #15 <https://github.com/pjreed/gps_umd/issues/15>
* Update node name; make appending zone optional; add param for adding zone when going back to navsatfix
* Fix altitude, covariance
* Add reverse_utm_odometry_node
* Contributors: David Anthony, Dheera Venkatraman, P. J. Reed, Tim Clephas, Vikrant Shah, dheera
```

## gps_umd

- No changes

## gpsd_client

- No changes
