### PR TITLE
plotjuggler: 2.3.4-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5708,7 +5708,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.3.3-2
+      version: 2.3.4-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.3.4-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.3.3-2`

## plotjuggler

```
* prepare "meme edition"
* Merge branch 'master' of https://github.com/facontidavide/PlotJuggler
* RosMsgParsers: add cast to be clang compatible (#208)
* Update README.md
* Update FUNDING.yml
* Correct "Github" to "GitHub" (#206)
* 2.3.3
* fix issue with FMT
* Contributors: Dan Katzuv, Davide Faconti, Timon Engelke
```
