### PR TITLE
Update ainstein_radar for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -203,7 +203,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
Manually opening pull request following failure of bloom-release step with the following errors in logfile:

SSLError: ('The read operation timed out',)

[error] Failed to open pull request: SSLError - ('The read operation timed out',)