### PR TITLE
fastcdr: 1.0.11-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -705,7 +705,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/fastcdr-release.git
-      version: 1.0.9-2
+      version: 1.0.11-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastcdr` to `1.0.11-1`:

- upstream repository: https://github.com/eProsima/Fast-CDR.git
- release repository: https://github.com/ros2-gbp/fastcdr-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.9-2`
