### PR TITLE
rqt_publisher: 1.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2335,7 +2335,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.0.5-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.5-1`

## rqt_publisher

```
* fix setting expressions on sequence items (#16 <https://github.com/ros-visualization/rqt_publisher/issues/16>)
```
