### PR TITLE
rcl_logging: 0.3.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -836,10 +836,11 @@ repositories:
       packages:
       - rcl_logging_log4cxx
       - rcl_logging_noop
+      - rcl_logging_spdlog
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.0-1`

## rcl_logging_log4cxx

- No changes

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* Implement a backend logger using spdlog. (#17 <https://github.com/ros2/rcl_logging/issues/17>)
* Contributors: Chris Lalancette
```
