### PR TITLE
rqt_plot: 1.0.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1430,6 +1430,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_msg.git
       version: crystal-devel
     status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_plot-release.git
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    status: maintained
   rqt_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.0.7-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_plot

```
* fix KeyError when curves are removed concurrently (#37 <https://github.com/ros-visualization/rqt_plot/issues/37>)
```
