### PR TITLE
rqt_action: 1.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1405,6 +1405,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_action-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: crystal-devel
+    status: maintained
   rqt_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `1.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_action

```
* updating package.xml to ros2 (#6 <https://github.com/ros-visualization/rqt_action/issues/6>)
* Contributors: Mike Lautman
```
