### PR TITLE
teleop_twist_keyboard: 2.3.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2554,7 +2554,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `2.3.1-1`:

- upstream repository: https://github.com/ros2/teleop_twist_keyboard.git
- release repository: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.3.0-1`

## teleop_twist_keyboard

```
* Stop using deprecated APIs. (#22 <https://github.com/ros2/teleop_twist_keyboard/issues/22>)
* Contributors: Chris Lalancette
```
