### PR TITLE
teleop_twist_keyboard: 2.3.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1615,6 +1615,22 @@ repositories:
       url: https://github.com/ros2/teleop_twist_joy.git
       version: dashing
     status: maintained
+  teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
+      version: 2.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    status: maintained
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `2.3.1-1`:

- upstream repository: https://github.com/ros2/teleop_twist_keyboard.git
- release repository: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## teleop_twist_keyboard

```
* Stop using deprecated APIs. (#22 <https://github.com/ros2/teleop_twist_keyboard/issues/22>)
* Contributors: Chris Lalancette
```
