### PR TITLE
rqt_shell: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1558,6 +1558,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_service_caller.git
       version: crystal-devel
     status: maintained
+  rqt_shell:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_shell-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros2-gbp/rqt_shell-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_shell

```
* Fixing executable (#8 <https://github.com/ros-visualization/rqt_shell/issues/8>)
* Initial port, SimpleShell works (#7 <https://github.com/ros-visualization/rqt_shell/issues/7>)
* Contributors: Mike Lautman, brawner
```
