### PR TITLE
rqt_topic: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1604,6 +1604,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_top.git
       version: crystal-devel
     status: maintained
+  rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_topic-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_topic

```
* removing the spinner from the ros2 port (#11 <https://github.com/ros-visualization/rqt_topic/issues/11>)
* Merge pull request #9 <https://github.com/ros-visualization/rqt_topic/issues/9> from ros-visualization/ros2_port
* Porting to ROS2
* autopep8 (#6 <https://github.com/ros-visualization/rqt_topic/issues/6>)
* Contributors: Mike Lautman, Stephen, brawner
```
