### PR TITLE
roscpp_core: 0.6.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7363,7 +7363,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.12-0
+      version: 0.6.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.13-1`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.6.12-0`

## cpp_common

- No changes

## roscpp_serialization

```
* added cast to uint32_t in roscpp_serialization to fix -Wconversion warning (#113 <https://github.com/ros/roscpp_core/issues/113>)
* roscpp_serialization: replace c-style-casts with static/reinterpret casts (#107 <https://github.com/ros/roscpp_core/issues/107>)
```

## roscpp_traits

- No changes

## rostime

```
* use _WIN32 for platform detection (#110 <https://github.com/ros/roscpp_core/issues/110>)
* Clarified documentation for time validity (#109 <https://github.com/ros/roscpp_core/issues/109>)
* rostime: replace c-style casts with static_casts (#106 <https://github.com/ros/roscpp_core/issues/106>)
```
