### PR TITLE
genpy: 0.6.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2393,7 +2393,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.8-0
+      version: 0.6.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.9-1`:

- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.6.8-0`

## genpy

```
* fix Python 3 buffer handling (#106 <https://github.com/ros/genpy/issues/106>)
* Python 3 compatibility (#104 <https://github.com/ros/genpy/issues/104>)
* fix usage of undefined variables in exception (#105 <https://github.com/ros/genpy/issues/105>)
* convert map iterator to list (#103 <https://github.com/ros/genpy/issues/103>)
* fix negative limit check for signed ints (#102 <https://github.com/ros/genpy/issues/102>)
* failing test case for UTF-8 encoded characters in comments (#95 <https://github.com/ros/genpy/issues/95>)
```
