### PR TITLE
rospack: 2.5.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7487,7 +7487,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.5.3-0
+      version: 2.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.5.4-1`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `2.5.3-0`

## rospack

```
* use condition attributes to specify Python 2 and 3 dependencies (#107 <https://github.com/ros/rospack/issues/107>)
* for fixing potential TOCTOU issue (#104 <https://github.com/ros/rospack/issues/104>)
* fixing mkstemp without securely setting mask/unmask (#106 <https://github.com/ros/rospack/issues/106>)
* fixing code unreachable (#105 <https://github.com/ros/rospack/issues/105>)
```
