### PR TITLE
py_trees_ros_tutorials: 1.0.5-1 in 'dashing/distribution.yaml'…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1441,7 +1441,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_tutorials-release.git
-      version: 1.0.3-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `1.0.5-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/stonier/py_trees_ros_tutorials-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.3-1`

## py_trees_ros_tutorials

```
* [tests] shorten time to send cancel request to avoid accidental success too early
```
