### PR TITLE
rosidl_typesupport_opensplice: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1377,7 +1377,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_opensplice` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_opensplice.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-1`
