### PR TITLE
rviz: 7.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1637,7 +1637,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 7.0.0-2
+      version: 7.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `7.0.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `7.0.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Migrate Axes Display (#429 <https://github.com/ros2/rviz/issues/429>)
* Contributors: Martin Idel
```

## rviz_ogre_vendor

```
* Fix the rviz_ogre_vendor packaging.
* Contributors: Chris Lalancette
```

## rviz_rendering

```
* Migrate Axes Display (#429 <https://github.com/ros2/rviz/issues/429>)
* Contributors: Martin Idel
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
