### PR TITLE
gps_umd: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -830,6 +830,26 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: dashing
     status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    release:
+      packages:
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/gps_umd-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    status: maintained
   h264_encoder_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.0-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## gps_msgs

```
* Support ROS2 (#24 <https://github.com/pjreed/gps_umd/issues/24>)
* Contributors: P. J. Reed
```

## gps_tools

```
* Support ROS2 (#24 <https://github.com/pjreed/gps_umd/issues/24>)
* Contributors: P. J. Reed
```

## gps_umd

```
* Support ROS2 (#24 <https://github.com/pjreed/gps_umd/issues/24>)
* Contributors: P. J. Reed
```

## gpsd_client

```
* Support ROS2 (#24 <https://github.com/pjreed/gps_umd/issues/24>)
* Contributors: P. J. Reed
```
