### PR TITLE
Align eloquent with dashing pr testing

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -203,7 +203,6 @@ repositories:
       url: https://github.com/ros2-gbp/cartographer-release.git
       version: 1.0.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/cartographer.git
       version: ros2
@@ -279,7 +278,6 @@ repositories:
       url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
       version: 1.2.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
       version: eloquent
@@ -574,6 +572,7 @@ repositories:
       url: https://github.com/ros2-gbp/examples-release.git
       version: 0.8.2-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/examples.git
       version: eloquent
@@ -853,7 +852,6 @@ repositories:
       url: https://github.com/ros2-gbp/laser_geometry-release.git
       version: 2.1.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
       version: eloquent
@@ -1003,7 +1001,6 @@ repositories:
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
       version: 2.0.2-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
       version: eloquent
@@ -1087,7 +1084,6 @@ repositories:
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
       version: 0.1.9-2
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
       version: eloquent
@@ -1699,7 +1695,6 @@ repositories:
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
       version: 0.8.1-4
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: eloquent
@@ -1832,7 +1827,6 @@ repositories:
       url: https://github.com/ros2-gbp/ros_environment-release.git
       version: 2.4.1-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_environment.git
       version: eloquent
@@ -2047,7 +2041,6 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
       version: 0.8.4-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
       version: eloquent
@@ -2087,7 +2080,6 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
       version: 0.8.1-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: eloquent
@@ -2534,7 +2526,6 @@ repositories:
       url: https://github.com/ros2-gbp/test_interface_files-release.git
       version: 0.8.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/test_interface_files.git
       version: eloquent
@@ -2558,7 +2549,6 @@ repositories:
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
       version: 0.6.1-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
       version: eloquent
@@ -2570,7 +2560,6 @@ repositories:
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
       version: 0.7.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
       version: eloquent
@@ -2633,7 +2622,6 @@ repositories:
       url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
       version: 1.3.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
       version: eloquent
@@ -2697,7 +2685,6 @@ repositories:
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
       version: 1.0.4-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros/urdfdom_headers.git
       version: eloquent

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -636,7 +636,6 @@ repositories:
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
       version: 0.3.0-1
     source:
-      test_commits: false
       test_pull_requests: true
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -1598,6 +1597,7 @@ repositories:
       url: https://github.com/ros2-gbp/rmw_connext-release.git
       version: 0.8.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_connext.git
       version: eloquent
@@ -1702,6 +1702,7 @@ repositories:
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
       version: 0.8.1-4
     source:
+      test_commits: false
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: eloquent
@@ -2698,7 +2699,6 @@ repositories:
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
       version: 1.0.4-1
     source:
-      test_pull_requests: false
       type: git
       url: https://github.com/ros/urdfdom_headers.git
       version: eloquent

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -203,6 +203,7 @@ repositories:
       url: https://github.com/ros2-gbp/cartographer-release.git
       version: 1.0.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/cartographer.git
       version: ros2
@@ -278,6 +279,7 @@ repositories:
       url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
       version: 1.2.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
       version: eloquent
@@ -634,6 +636,8 @@ repositories:
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
       version: 0.3.0-1
     source:
+      test_commits: false
+      test_pull_requests: true
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git
       version: master
@@ -852,6 +856,7 @@ repositories:
       url: https://github.com/ros2-gbp/laser_geometry-release.git
       version: 2.1.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
       version: eloquent
@@ -906,6 +911,7 @@ repositories:
       version: 1.0.0-1
     source:
       test_abi: true
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
@@ -1001,6 +1007,7 @@ repositories:
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
       version: 2.0.2-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
       version: eloquent
@@ -1084,6 +1091,7 @@ repositories:
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
       version: 0.1.9-2
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
       version: eloquent
@@ -1590,7 +1598,6 @@ repositories:
       url: https://github.com/ros2-gbp/rmw_connext-release.git
       version: 0.8.1-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_connext.git
       version: eloquent
@@ -1827,6 +1834,7 @@ repositories:
       url: https://github.com/ros2-gbp/ros_environment-release.git
       version: 2.4.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_environment.git
       version: eloquent
@@ -2080,6 +2088,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl_typesupport_opensplice-release.git
       version: 0.8.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_opensplice.git
       version: eloquent
@@ -2526,6 +2535,7 @@ repositories:
       url: https://github.com/ros2-gbp/test_interface_files-release.git
       version: 0.8.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/test_interface_files.git
       version: eloquent
@@ -2549,6 +2559,7 @@ repositories:
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
       version: 0.6.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
       version: eloquent
@@ -2560,6 +2571,7 @@ repositories:
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
       version: 0.7.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
       version: eloquent
@@ -2622,6 +2634,7 @@ repositories:
       url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
       version: 1.3.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
       version: eloquent
@@ -2685,6 +2698,7 @@ repositories:
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
       version: 1.0.4-1
     source:
+      test_pull_requests: false
       type: git
       url: https://github.com/ros/urdfdom_headers.git
       version: eloquent
@@ -2767,6 +2781,7 @@ repositories:
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
       version: 7.0.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/yaml_cpp_vendor.git
       version: eloquent


### PR DESCRIPTION
Here is the audit of the current differences:

```
Repo                           D    , E    
cartographer                   False, True
console_bridge_vendor          False, True
examples                       True, False
laser_geometry                 False, True
navigation_msgs                False, True
osrf_pycommon                  False, True
ros1_bridge                    False, True
ros_environment                False, True
rosidl_typesupport_connext     False, True
rosidl_typesupport_opensplice  False, True
test_interface_files           False, True
tinyxml2_vendor                False, True
tinyxml_vendor                 False, True
uncrustify_vendor              False, True
urdfdom_headers                False, True
```