### PR TITLE
ament_cmake: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -34,7 +34,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.7.3-5
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ament/ament_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `0.8.0-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.3-5`
