### PR TITLE
Add some rules for RHEL 8 for existing keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5024,6 +5024,9 @@ python3-flake8:
   fedora: [python3-flake8]
   gentoo: [dev-python/flake8]
   openembedded: [python3-flake8@meta-ros]
+  rhel:
+    '*': ['python%{python3_pkgversion}-flake8']
+    '7': null
   ubuntu: [python3-flake8]
 python3-gitlab:
   debian:
@@ -5232,6 +5235,9 @@ python3-pydot:
   fedora: [python3-pydot]
   gentoo: [dev-python/pydot]
   openembedded: [python3-pydot@meta-ros]
+  rhel:
+    '*': ['python%{python3_pkgversion}-pydot']
+    '7': null
   ubuntu: [python3-pydot]
 python3-pygraphviz:
   alpine: [py3-graphviz]


### PR DESCRIPTION
`python3-flake8`: https://apps.fedoraproject.org/packages/python-flake8
`python3-pydot`: https://apps.fedoraproject.org/packages/python3-pydot