### PR TITLE
mrpt_slam: 0.1.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7517,7 +7517,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
-      version: 0.1.9-0
+      version: 0.1.10-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_slam` to `0.1.10-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_slam.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_slam-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.9-0`

## mrpt_ekf_slam_2d

```
* fix build against mrpt2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_ekf_slam_3d

```
* fix build against mrpt2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_graphslam_2d

```
* fix build against current mrpt2
* fix build against mrpt2
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mrpt_icp_slam_2d

```
* fix build against current mrpt2
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_rbpf_slam

```
* fix build against mrpt2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_slam

- No changes
