### PR TITLE
mrpt_navigation: 0.1.26-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7485,7 +7485,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 0.1.24-0
+      version: 0.1.26-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `0.1.26-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.24-0`

## mrpt_local_obstacles

- No changes

## mrpt_localization

- No changes

## mrpt_map

- No changes

## mrpt_navigation

- No changes

## mrpt_rawlog

```
* mrpt_rawlog: abort if input file does not exist. Fix crash if built against mrpt1.
* remove qtcreator temporary files
* Contributors: Jose Luis Blanco Claraco
```

## mrpt_reactivenav2d

- No changes

## mrpt_tutorials

- No changes
