### PR TITLE
xacro: 2.0.1-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2910,7 +2910,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 2.0.0-1
+      version: 2.0.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.1-2`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-1`

## xacro

```
* Revert requiring that all xacro commands are prefixed with 'xacro:' namespace
  Although this is deprecated since #79 <https://github.com/ros/xacro/issues/79>,
  the corresponding deprecation warning wasn't actually issued.
  Thus, we will accept non-prefixed xacro tags until F-turtle.
* Install to both, bin/xacro and lib/xacro/xacro
* Contributors: Robert Haschke
```
