### PR TITLE
xacro: 2.0.1-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -2215,7 +2215,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.1-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-1`

## xacro

```
* Revert requiring that all xacro commands are prefixed with 'xacro:' namespace
  Although this is deprecated since #79 <https://github.com/ros/xacro/issues/79>,
  the corresponding deprecation warning wasn't actually issued.
  Thus, we will accept non-prefixed xacro tags until F-turtle.
* Install to both, bin/xacro and lib/xacro/xacro
* Contributors: Robert Haschke
```
