### PR TITLE
xacro: 2.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1887,6 +1887,22 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 2.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.1-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## xacro

```
* Revert requiring that all xacro commands are prefixed with 'xacro:' namespace
  Although this is deprecated since #79 <https://github.com/ros/xacro/issues/79>,
  the corresponding deprecation warning wasn't actually issued.
  Thus, we will accept non-prefixed xacro tags until F-turtle.
* Install to both, bin/xacro and lib/xacro/xacro
* Contributors: Robert Haschke
```
