### PR TITLE
moveit_pr2: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4321,7 +4321,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_pr2-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_pr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_pr2` to `0.7.3-1`:

- upstream repository: https://github.com/ros-planning/moveit_pr2.git
- release repository: https://github.com/ros-gbp/moveit_pr2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.2-1`

## moveit_pr2

- No changes

## pr2_moveit_config

- No changes

## pr2_moveit_plugins

```
* [fix] Add missing package: angles
* Contributors: Robert Haschke
```
