### PR TITLE
qb_move: 2.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10346,7 +10346,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_move` to `2.1.3-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbmove-ros.git
- release repository: https://bitbucket.org/qbrobotics/qbmove-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.2-1`

## qb_move

- No changes

## qb_move_control

- No changes

## qb_move_description

```
* Fix initial command and velocity limit for qbmoves
```

## qb_move_hardware_interface

- No changes
