### PR TITLE
rcl_logging: 0.3.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -862,7 +862,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `0.3.2-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.1-1`

## rcl_logging_log4cxx

```
* Enable linters for noop and log4cxx. (#12 <https://github.com/ros2/rcl_logging/issues/12>)
* Contributors: Steven! Ragnarök
```

## rcl_logging_noop

```
* Enable linters for noop and log4cxx. (#12 <https://github.com/ros2/rcl_logging/issues/12>)
* Contributors: Steven! Ragnarök
```

## rcl_logging_spdlog

```
* spdlog is a header-only library, so the exported dep isn't needed. (#19 <https://github.com/ros2/rcl_logging/issues/19>)
* Contributors: Chris Lalancette
```
