### PR TITLE
apriltag_ros: 3.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -170,7 +170,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag_ros-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.1.1-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.1.0-1`

## apriltag_ros

```
* Add support for tagStandard41h12 and tagStandard52h13 (#63 <https://github.com/AprilRobotics/apriltag_ros/issues/63>, #59 <https://github.com/AprilRobotics/apriltag_ros/issues/59>).
* Add gray image input support (#58 <https://github.com/AprilRobotics/apriltag_ros/issues/58>).
* Contributors: Alexander Reimann, Moritz Zimmermann, Samuel Bachmann, Wolfgang Merkt
```
