### PR TITLE
pilz_robots: 0.5.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5672,7 +5672,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.8-1
+      version: 0.5.9-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.9-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.5.8-1`

## pilz_control

```
* Minor fixes
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_testutils

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Add service for getting the global speed override
* Add modbus register for enabling temporary movement
* Add Frame speed monitoring
* Test fixes and improvements
* Contributors: Pilz GmbH and Co. KG
* Add speed observing dependent on operation mode
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* Fix warning by change parent and child of fixed frame
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

```
* Add frame speed monitoring
* Contributors: Pilz GmbH and Co. KG
```
