### PR TITLE
navigation_tutorials: 0.2.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4712,6 +4712,27 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jade-devel
     status: maintained
+  navigation_tutorials:
+    release:
+      packages:
+      - laser_scan_publisher_tutorial
+      - navigation_stage
+      - navigation_tutorials
+      - odometry_publisher_tutorial
+      - point_cloud_publisher_tutorial
+      - robot_setup_tf_tutorial
+      - roomba_stage
+      - simple_navigation_goals_tutorial
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_tutorials-release.git
+      version: 0.2.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation_tutorials.git
+      version: indigo-devel
+    status: maintained
   neonavigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_tutorials` to `0.2.3-1`:

- upstream repository: https://github.com/ros-planning/navigation_tutorials.git
- release repository: https://github.com/ros-gbp/navigation_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
