### PR TITLE
Switch depthimage_to_laserscan branches to dashing-devel.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -487,7 +487,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
-      version: ros2
+      version: dashing-devel
     release:
       tags:
         release: release/dashing/{package}/{version}
@@ -497,7 +497,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
-      version: ros2
+      version: dashing-devel
     status: maintained
   diagnostics:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>