### PR TITLE
catkin: 0.7.19-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -634,7 +634,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.17-0
+      version: 0.7.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.19-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.7.17-0`

## catkin

```
* support for pytest 5.1+ jUnit result files (#1033 <https://github.com/ros/catkin/issues/1033>)
* fix -pthread handling in Debian buster (#1021 <https://github.com/ros/catkin/issues/1021>)
* gmock from source on Debian buster (#1022 <https://github.com/ros/catkin/issues/1022>)
* [windows] update a typo in local_setup.bat.in (#1029 <https://github.com/ros/catkin/issues/1029>)
* fix test when using different Python version (#1028 <https://github.com/ros/catkin/issues/1028>)
* add a blacklist option to make_isolated (#1027 <https://github.com/ros/catkin/issues/1027>)
* use condition attributes to specify Python 2 and 3 dependencies (#1025 <https://github.com/ros/catkin/issues/1025>)
* change relay script to use current Python executable (#1024 <https://github.com/ros/catkin/issues/1024>)
* remove executable bit and shebang line (#1023 <https://github.com/ros/catkin/issues/1023>)
* correctly set gtest 1.8 root directory (#1014 <https://github.com/ros/catkin/issues/1014>)
* fix interface targets that do not have libraries (#1013 <https://github.com/ros/catkin/issues/1013>)
* fix catkin_make on Windows (#1020 <https://github.com/ros/catkin/issues/1020>)
* prefix install target with project name (#1019 <https://github.com/ros/catkin/issues/1019>)
* [Windows][kinetic-devel] fix build issues with specific build type (#1015 <https://github.com/ros/catkin/issues/1015>)
* fix Python 3 version used by travis (#1016 <https://github.com/ros/catkin/issues/1016>)
```
