### PR TITLE
ros2cli: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1125,7 +1125,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/ros2cli.git
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.1-1`
