### PR TITLE
Switch crystal robot_state_publisher src/doc to original repo.

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1370,7 +1370,7 @@ repositories:
   robot_state_publisher:
     doc:
       type: git
-      url: https://github.com/ros2/robot_state_publisher.git
+      url: https://github.com/ros/robot_state_publisher.git
       version: crystal
     release:
       tags:
@@ -1380,7 +1380,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/robot_state_publisher.git
+      url: https://github.com/ros/robot_state_publisher.git
       version: crystal
     status: developed
   ros1_bridge:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>