### PR TITLE
Switch dashing robot_state_publisher to original repo.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1842,7 +1842,7 @@ repositories:
   robot_state_publisher:
     doc:
       type: git
-      url: https://github.com/ros2/robot_state_publisher.git
+      url: https://github.com/ros/robot_state_publisher.git
       version: dashing
     release:
       tags:
@@ -1852,7 +1852,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/robot_state_publisher.git
+      url: https://github.com/ros/robot_state_publisher.git
       version: dashing
     status: maintained
   ros1_bridge:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>