### PR TITLE
Switch eloquent robot_state_publisher to original repo.

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1071,7 +1071,7 @@ repositories:
   robot_state_publisher:
     doc:
       type: git
-      url: https://github.com/ros2/robot_state_publisher.git
+      url: https://github.com/ros/robot_state_publisher.git
       version: ros2
     release:
       tags:
@@ -1081,7 +1081,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/robot_state_publisher.git
+      url: https://github.com/ros/robot_state_publisher.git
       version: ros2
     status: maintained
   ros1_bridge:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>