### PR TITLE
astuff_sensor_msgs: 3.0.0-2 in 'dashing/distribution.yaml' [bl…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -223,6 +223,32 @@ repositories:
       url: https://github.com/christianrauch/apriltag_ros.git
       version: master
     status: developed
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: dashing-devel
+    release:
+      packages:
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
+      - pacmod_msgs
+      - radar_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/astuff/astuff_sensor_msgs-release.git
+      version: 3.0.0-2
+    source:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: dashing-devel
+    status: developed
   async_web_server_cpp:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `3.0.0-2`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## delphi_esr_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## delphi_mrr_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## delphi_srr_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## derived_object_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## ibeo_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## kartech_linear_actuator_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## mobileye_560_660_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## neobotix_usboard_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## pacmod_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## radar_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```
