### PR TITLE
automotive_autonomy_msgs: 3.0.0-1 in 'dashing/distribution.yam…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -230,6 +230,24 @@ repositories:
       url: https://github.com/ros2-gbp/async_web_server_cpp-release.git
       version: 1.0.0-1
     status: unmaintained
+  automotive_autonomy_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: dashing-devel
+    release:
+      packages:
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/astuff/automotive_autonomy_msgs-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: dashing-devel
+    status: developed
   aws_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.0-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## automotive_navigation_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Ported to ROS2 Dashing.
* Contributors: Joshua Whitley
```
