### PR TITLE
py_trees_ros: 1.2.1-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1496,7 +1496,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 1.2.0-1
+      version: 1.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `1.2.1-2`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.0-1`

## py_trees_ros

```
* [trees] bugfix KeyError on publication of missing keys, #118 <https://github.com/splintered-reality/py_trees_ros/pull/118>
* [utilities] a ros myargv stipper, a'la ROS1 style, until something is available upstream
```
