### PR TITLE
Added zenity rosdep rule.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5687,6 +5687,12 @@ zbar:
   fedora: [zbar-devel]
   gentoo: [media-gfx/zbar]
   ubuntu: [libzbar-dev]
+zenity:
+  arch: [zenity]
+  debian: [zenity]
+  fedora: [zenity]
+  gentoo: [gnome-extra/zenity]
+  ubuntu: [zenity]
 zeromq3:
   arch: [zeromq]
   debian: [libzmq5]


### PR DESCRIPTION
A tool for displaying graphical dialogs and querying the user.

https://www.archlinux.org/packages/extra/x86_64/zenity/
https://packages.gentoo.org/packages/gnome-extra/zenity
https://apps.fedoraproject.org/packages/zenity
https://packages.debian.org/buster/zenity
https://packages.ubuntu.com/disco/zenity