### PR TITLE
py_trees_ros_interfaces: 1.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -765,6 +765,21 @@ repositories:
       url: https://github.com/splintered-reality/py_trees.git
       version: release/1.3.x
     status: developed
+  py_trees_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: release/1.2.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros_interfaces-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: release/1.2.x
+    status: developed
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `1.2.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces.git
- release repository: https://github.com/stonier/py_trees_ros_interfaces-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
