### PR TITLE
py_trees_js: 0.5.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -785,6 +785,21 @@ repositories:
       url: https://github.com/splintered-reality/py_trees.git
       version: release/1.3.x
     status: developed
+  py_trees_js:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: release/0.5.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/py_trees_js-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: release/0.5.x
+    status: developed
   py_trees_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.5.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/stonier/py_trees_js-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## py_trees_js

```
* [js] robustness against identical timestamps, #109 <https://github.com/splintered-reality/py_trees_js/pull/109>
* [html] disable scrollbars, #110 <https://github.com/splintered-reality/py_trees_js/pull/110>
* [js] improved window resize handling, #111 <https://github.com/splintered-reality/py_trees_js/pull/111>
  * new public api ``py_trees.canvas.on_window_resize`` and ``py_trees.timeline.on_window_resize``
```
