### PR TITLE
Adding rt_usb_9axisimu_driver to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13441,6 +13441,16 @@ repositories:
       url: https://github.com/robosavvy/rsv_balance_simulator.git
       version: master
     status: maintained
+  rt_usb_9axisimu_driver:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: master
+    status: developed
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add rt_usb_9axisimu_driver for ROS Kinetic to be doc'd and indexed.