### PR TITLE
mavros: 0.33.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6831,7 +6831,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.32.2-1
+      version: 0.33.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.33.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.32.2-1`

## libmavconn

```
* libmavconn: simplify parse_buffer, and fix dropped_packets and parse_error counters
  Currently the dropped_packets & parse_error counters are always published as 0 in mavros_diag.cpp.
  This seems to be caused by using the wrong status struct.
  Seems like mavros was editing m_status after mavlink_frame_char_buffer. This struct
  seems to be the parsing state, and looks like it shouldn't be modified by the caller (for example
  status->parse_error is zeroed out in the end of mavlink_frame_char_buffer).
  Also, the crc & signature checks done in mavros seems redundant.
  r_mavlink_status seems to be the struct that holds the mavlink connection information, therefore I
  changed get_status to return it instead.
  This fixes #1285 <https://github.com/mavlink/mavros/issues/1285>.
* Contributors: Koby Aizer
```

## mavros

```
* Add vtol transition service
* CleanUp
* Update frame name in px4_config to match ROS standards
* Enable publishing multiple static tfs at once, publish standard static tfs
* moving ACK_TIMEOUT_DEFAULT out of class
* cog: Update all generated code
* mavros/src/plugins/command.cpp: one more style fix
* mavros/src/plugins/command.cpp: style fixes
* mavros/src/plugins/command.cpp: command_ack_timeout ms -> s
* mavros/src/plugins/command.cpp: command_ack_timeout_ms int -> double
* mavros/src/plugins/command.cpp: uncrustify
* mavros/src/plugins/command.cpp: parameter for command's ack timeout
  Sometimes commands take more time than default 5 seconds. Due to a low bandwidth
  of UART and a high rate of some mavlink streams. To eliminate this problem it's
  better to provide the parameter to configure the command's ack timeout.
* added manual flag to mavros/state
* Use GeoPoseStamped messages
* Fix build
* Add callback for SET_POSITION_TARGET_GLBOAL_INT
* Contributors: David Jablonski, Jaeyoung-Lim, Sergei Zobov, Vladimir Ermakov, kamilritz
```

## mavros_extras

```
* CleanUp
* Odom Plugin, enforcing ROS convetion, less options but clearer to use
* Fix service namespace with new nodehandle
* Add mount configure service
* use header.stamp to fill mavlink msg field time_usec
* use cog for copy
* adapt message and plugin after mavlink message merge
* rename message and adjust fields
* add component id to mavros message to distinguish ROS msgs from different systems
* component_status message and plugin draft
* Contributors: Jaeyoung-Lim, baumanta, kamilritz
```

## mavros_msgs

```
* Add vtol transition service
* Apply comments
* Add mount configure service message
* cog: Update all generated code
* added manual flag to mavros/state
* use header.stamp to fill mavlink msg field time_usec
* use cog for copy
* adapt message and plugin after mavlink message merge
* rename message and adjust fields
* add component id to mavros message to distinguish ROS msgs from different systems
* component_status message and plugin draft
* Contributors: David Jablonski, Jaeyoung-Lim, Vladimir Ermakov, baumanta
```

## test_mavros

- No changes
