### PR TITLE
avt_vimba_camera: 0.0.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -728,8 +728,8 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/srv/avt_vimba_camera-release.git
-      version: 0.0.10-0
+      url: https://github.com/astuff/avt_vimba_camera-release.git
+      version: 0.0.11-1
     source:
       type: git
       url: https://github.com/srv/avt_vimba_camera.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -723,7 +723,7 @@ repositories:
   avt_vimba_camera:
     doc:
       type: git
-      url: https://github.com/srv/avt_vimba_camera.git
+      url: https://github.com/astuff/avt_vimba_camera.git
       version: kinetic
     release:
       tags:
@@ -732,7 +732,7 @@ repositories:
       version: 0.0.11-1
     source:
       type: git
-      url: https://github.com/srv/avt_vimba_camera.git
+      url: https://github.com/astuff/avt_vimba_camera.git
       version: kinetic
     status: maintained
   aws_common:


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.11-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.10-0`

## avt_vimba_camera

```
* Merge pull request #35 <https://github.com/astuff/avt_vimba_camera/issues/35> from willcbaker/feature/nodelet
  Feature/nodelet
* Update nodelet launch files
* Add nodelet
* Fix #31 <https://github.com/astuff/avt_vimba_camera/issues/31>
* Merge pull request #30 <https://github.com/astuff/avt_vimba_camera/issues/30> from chewwt/armv8
  add support for armv8
* add support for armv8
* Change frame observer to shared ptr
* Contributors: Miquel Massot, Will Baker, ruth
```
