### PR TITLE
osrf_pycommon: 0.1.9-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -716,7 +716,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 0.1.8-2
+      version: 0.1.9-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `0.1.9-2`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.1.8-2`

## osrf_pycommon

```
* install resource marker file for package (#56 <https://github.com/osrf/osrf_pycommon/pull/56>)
```
