### PR TITLE
navigation2: 0.2.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1270,6 +1270,7 @@ repositories:
       - nav2_navfn_planner
       - nav2_recoveries
       - nav2_rviz_plugins
+      - nav2_system_tests
       - nav2_util
       - nav2_voxel_grid
       - nav2_world_model
@@ -1279,7 +1280,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.2.5-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.4-1`
