### PR TITLE
Add python3-pyaudio

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5218,6 +5218,16 @@ python3-psutil:
   rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
+python3-pyaudio:
+  arch: [python-pyaudio]
+  debian: [python3-pyaudio]
+  fedora: [python3-pyaudio]
+  gentoo: [dev-python/pyaudio]
+  osx:
+    pip:
+      packages: [pyaudio]
+  rhel: ['python%{python3_pkgversion}-pyaudio']
+  ubuntu: [python3-pyaudio]
 python3-pycodestyle:
   arch: [python-pycodestyle]
   debian: [python3-pycodestyle]


### PR DESCRIPTION
Add python3-pyaudio for all recent ubuntu distributions. Keep python-pyaudio as is.

This is necessary for the ROS2 branch of https://github.com/aws-robotics/aws-robomaker-sample-application-voiceinteraction/tree/ros2 

Package details: https://packages.ubuntu.com/bionic/python3-pyaudio