### PR TITLE
move_base_flex: 0.2.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4252,7 +4252,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.2.5-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.4-1`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Update goal pose on replanning, so the feedback remains consistent
* Fix: Reset oscillation timer after executing a recovery behavior
* Remove debug log messages
* Do not pass boost functions to abstract server to (de)activate costmaps.
  Run instead abstract methods (possibly) overridden in the costmap server,
  all costmap-related handling refactored to a new CostmapWrapper class
* On controller execution, check that local costmap is current
* On move_base action, use MoveBaseResult constant to fill outcome in case of oscilation
```

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* Add clear_on_shutdown functionality
* Do not pass boost functions to abstract server to (de)activate costmaps.
  Run instead abstract methods (possibly) overridden in the costmap server,
  all costmap-related handling refactored to a new CostmapWrapper class
* On controller execution, check that local costmap is current
```

## mbf_msgs

- No changes

## mbf_simple_nav

- No changes

## mbf_utility

- No changes

## move_base_flex

- No changes
