### PR TITLE
ecl_lite: 1.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -639,10 +639,9 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
       version: 1.0.3-2
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_lite.git
-      version: devel
+      version: release/1.0.x
     status: maintained
   ecl_tools:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -295,6 +295,31 @@ repositories:
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
       version: dashing-devel
     status: maintained
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.0.x
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 1.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: devel
+    status: maintained
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `1.0.3-1`:

- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## ecl_errors

```
* pedantic error message fixes for ecl_compile_time_assert on clang/macosx
* explicit construction for the Error class so surprising things can't happen
* equality operator for the Error class
```

## ecl_time_lite

```
* pedantic error message fixes for const error string methods on clang/macosx
```
