### PR TITLE
rclpy: 0.7.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1682,7 +1682,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.7.7-1
+      version: 0.7.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.7.8-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.7-1`

## rclpy

```
* Updated to accept tuples as parameter arrays. (#442 <https://github.com/ros2/rclpy/issues/442>)
* Fixed uncaught exception from user execute callback in Action Server. (#439 <https://github.com/ros2/rclpy/issues/439>)
  Fixes #296 <https://github.com/ros2/rclpy/issues/296>.
* Contributors: Christian Rauch, Jacob Perron, Steven! Ragnarök
```
