### PR TITLE
plotjuggler: 2.3.5-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5741,7 +5741,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.3.4-2
+      version: 2.3.5-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.3.5-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.3.4-2`

## plotjuggler

```
* remember the size of the splitter
* fix inveted XY
* Contributors: Davide Faconti
* remember last splashscreen
* Update README.md
* Update appimage_howto.md
* fix warning
* meme fixed
* Contributors: Davide Faconti
```
