### PR TITLE
rclcpp: 0.7.11-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1667,7 +1667,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.7.10-1
+      version: 0.7.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.7.11-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.10-1`

## rclcpp

```
* Fix get_node_*_interface functions taking a pointer (#870 <https://github.com/ros2/rclcpp/pull/870>).
* Fix hang with timers in MultiThreadedExecutor (#869 <https://github.com/ros2/rclcpp/pull/869>).
* Contributors: Todd Malsbary, ivanpauno
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
