### PR TITLE
Add python3-networkmanager

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2427,7 +2427,14 @@ python-networkmanager:
     buster: [python-networkmanager]
     jessie: [python-networkmanager]
     stretch: [python-networkmanager]
-  ubuntu: [python-networkmanager]
+  ubuntu: 
+    '*': [python-networkmanager]
+    artful_python3: [python3-networkmanager]
+    bionic_python3: [python3-networkmanager]
+    cosmic_python3: [python3-networkmanager]
+    xenial_python3: [python3-networkmanager]
+    yakkety_python3: [python3-networkmanager]
+    zesty_python3: [python3-networkmanager]
 python-networkx:
   arch: [python2-networkx]
   debian: [python-networkx]


### PR DESCRIPTION
Add python3-networkmanager for all recent ubuntu distributions. Keep python-networkmanager as is.

This is necessary to manipulate the NetworkManager service from ROS2 python nodes.

Package details: https://packages.ubuntu.com/bionic/python3-networkmanager