### PR TITLE
ament_package: 0.8.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -135,7 +135,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/ament/ament_package.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.8.3-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.2-1`
