### PR TITLE
ros_workspace: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1241,7 +1241,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 0.7.1-2
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `0.8.0-1`:

- upstream repository: https://github.com/nuclearsandwich/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.1-2`

## ros_workspace

```
* Added .dsv file generation for PYTHONPATH. (#16 <https://github.com/ros2/ros_workspace/issues/16>)
* Added support for ament_package installed with setup.py develop. (#15 <https://github.com/ros2/ros_workspace/issues/15>)
* Contributors: Dirk Thomas
```
