### PR TITLE
launch: 0.8.7-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1085,7 +1085,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.8.6-1
+      version: 0.8.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.8.7-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.6-1`

## launch

```
* install package marker and manifest (#323 <https://github.com/ros2/launch/issues/323>) (#343 <https://github.com/ros2/launch/issues/343>)
  Signed-off-by: Dirk Thomas <mailto:dirk-thomas@users.noreply.github.com>
  (cherry picked from commit 4eb26874260bab821863d28e52fbcecd25553f07)
* Avoid registering atexit on windows (#297 <https://github.com/ros2/launch/issues/297>) (#329 <https://github.com/ros2/launch/issues/329>)
  Signed-off-by: ivanpauno <mailto:ivanpauno@ekumenlabs.com>
* Contributors: Dirk Thomas, ivanpauno
```

## launch_testing

```
* install package manifest (#330 <https://github.com/ros2/launch/issues/330>) (#344 <https://github.com/ros2/launch/issues/344>)
  Signed-off-by: Dirk Thomas <mailto:dirk-thomas@users.noreply.github.com>
  (cherry picked from commit 81edb5f43a81ade32e5271caa19c38756f52dac2)
* Contributors: Dirk Thomas
```

## launch_testing_ament_cmake

- No changes
