### PR TITLE
uwsim_bullet: 2.82.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9555,6 +9555,16 @@ repositories:
       url: https://github.com/uuvsimulator/uuv_simulator.git
       version: master
     status: developed
+  uwsim_bullet:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
+      version: 2.82.1-1
+    source:
+      type: git
+      url: https://github.com/uji-ros-pkg/uwsim_bullet.git
+      version: melodic-devel
   vapor_master:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_bullet` to `2.82.1-1`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_bullet.git
- release repository: https://github.com/uji-ros-pkg/uwsim_bullet-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
