### PR TITLE
uwsim_osgocean: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9615,6 +9615,12 @@ repositories:
       type: git
       url: https://github.com/uji-ros-pkg/uwsim_bullet.git
       version: melodic-devel
+  uwsim_osgocean:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
+      version: 1.0.3-1
   vapor_master:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgocean` to `1.0.3-1`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgocean.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
