### PR TITLE
visualization_osg: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9710,6 +9710,17 @@ repositories:
       url: https://github.com/lagadic/visp-release.git
       version: 3.2.0-1
     status: maintained
+  visualization_osg:
+    release:
+      packages:
+      - osg_interactive_markers
+      - osg_markers
+      - osg_utils
+      - visualization_osg
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/visualization_osg-release.git
+      version: 1.0.2-1
   visualization_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_osg` to `1.0.2-1`:

- upstream repository: https://github.com/uji-ros-pkg/visualization_osg.git
- release repository: https://github.com/uji-ros-pkg/visualization_osg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## osg_interactive_markers

```
* Changed return type to object, as osg was internally creating a copy (temporary reference return)
* Now mesh interactive markers autoscale to mesh size.
* Contributors: perezsolerj
```

## osg_markers

```
* Fixed return to temporary object, marker was returning references to copied objects
* Fixed some issues with color in markers
* Now mesh interactive markers autoscale to mesh size.
* Contributors: perezsolerj
```

## osg_utils

- No changes

## visualization_osg

- No changes
