### PR TITLE
tello_driver: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14753,7 +14753,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/appie-17/tello_driver-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/appie-17/tello_driver.git
+      version: 0.3.0
+    status: developed
   tensorflow_ros_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tello_driver` to `0.3.0-1`:

- upstream repository: https://github.com/appie-17/tello_driver.git
- release repository: https://github.com/appie-17/tello_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-1`

## tello_driver

```
* Merge branch 'development' of https://github.com/appie-17/tello_driver into development
* CMake configuration include functional tello_driver for ROS repo
* Update README.md
* Fix installation clone from branche develop-0.7.0
* Gamepad_node fix flattrim to square, altitude and attitude limit params
* Manual takeoff topic
* Revert unfinished features
* Addition of gamepad_teleop_node.py and joy node
* Contributors: appie-17
```
