### PR TITLE
py_trees_ros: 1.2.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1498,10 +1498,9 @@ repositories:
       url: https://github.com/stonier/py_trees_ros-release.git
       version: 1.2.1-2
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/splintered-reality/py_trees_ros.git
-      version: devel
+      version: release/1.2.x
     status: developed
   py_trees_ros_interfaces:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -800,6 +800,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_js.git
       version: release/0.5.x
     status: developed
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/1.2.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros-release.git
+      version: 1.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: devel
+    status: developed
   py_trees_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `1.2.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## py_trees_ros

```
* [trees] bugfix KeyError on publication of missing keys, #118 <https://github.com/splintered-reality/py_trees_ros/pull/118>
* [utilities] a ros myargv stipper, a'la ROS1 style, until something is available upstream
```
