### PR TITLE
sophus: 1.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1709,6 +1709,21 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: ros2
     status: maintained
+  sophus:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.1-eloquent
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.1-eloquent
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.1.0-1`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
