### PR TITLE
Add rosdep rules for python-mysql.connector

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5129,6 +5129,11 @@ python3-mypy:
   fedora: [python3-mypy]
   gentoo: [dev-python/mypy]
   ubuntu: [python3-mypy]
+python3-mysql.connector:
+  arch: [python-mysql-connector]
+  debian: [python3-mysql.connector]
+  fedora: [mysql-connector-python3]
+  ubuntu: [python3-mysql-connector]
 python3-netifaces:
   debian: [python3-netifaces]
   fedora: [python3-netifaces]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2328,6 +2328,10 @@ python-multicast:
     pip: [py-multicast]
   ubuntu:
     pip: [py-multicast]
+python-mysql.connector:
+  arch: [python2-mysql-connector]
+  debian: [python-mysql.connector]
+  ubuntu: [python-mysql.connector]
 python-mysqldb:
   debian: [python-mysqldb]
   fedora: [python-mysql]


### PR DESCRIPTION
Add rosdep rules for Python2 and Python3 packages for mysql connector