### PR TITLE
camera_info_manager_py: 0.2.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -527,6 +527,13 @@ repositories:
       type: git
       url: https://github.com/ros-perception/calibration.git
       version: hydro
+  camera_info_manager_py:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/appie-17/camera_info_manager_py-release.git
+      version: 0.2.3-1
+    status: maintained
   camera_umd:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `0.2.3-1`:

- upstream repository: https://github.com/ros-perception/camera_info_manager_py.git
- release repository: https://github.com/appie-17/camera_info_manager_py-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## camera_info_manager_py

- No changes
