### PR TITLE
tello_driver: 0.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14753,7 +14753,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/appie-17/tello_driver-release.git
-      version: 0.2.0-1
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/appie-17/tello_driver.git
+      version: development
+    status: developed
   tensorflow_ros_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tello_driver` to `0.3.1-1`:

- upstream repository: https://github.com/appie-17/tello_driver.git
- release repository: https://github.com/appie-17/tello_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-1`
