### PR TITLE
rr_openrover_stack: 0.7.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13396,7 +13396,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
-      version: 0.7.2-1
+      version: 0.7.3-2
     status: maintained
   rr_swiftnav_piksi:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_stack` to `0.7.3-2`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_stack.git
- release repository: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.2-1`

## rr_control_input_manager

- No changes

## rr_openrover_driver

```
* Migrating all usage of tf to tf2
* Simplified rover data messages and only publish rate-based data in legacy mode
```

## rr_openrover_driver_msgs

- No changes

## rr_openrover_stack

```
* Migrating all usage of tf to tf2
* Simplified rover data messages and only publish rate-based data in legacy mode
```
