### PR TITLE
tracetools_analysis: 0.2.0-1 in 'dashing/distribution.yaml' [b…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2739,10 +2739,13 @@ repositories:
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
       version: master
     release:
+      packages:
+      - ros2trace_analysis
+      - tracetools_analysis
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `0.2.0-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-1`

## ros2trace_analysis

```
* Add ros2trace_analysis command and process/convert verbs
* Contributors: Christophe Bedard
```

## tracetools_analysis

```
* Improve UX
* Add flag for process command to force re-conversion of trace directory
* Make process command convert directory if necessary
* Make output file name optional for convert command
* Remove references to "pickle" file and simply use "output" file
* Display Processor progress on stdout
* Add sample data, notebook, and launch file
* Add data model util functions
* Add profiling and CPU time event handlers
* Refactor and extend analysis architecture
* Contributors: Christophe Bedard
```
