### PR TITLE
Autoware.Auto: 0.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -13,15 +13,35 @@ repositories:
       version: 0.0.1
     release:
       packages:
+      - autoware_auto_algorithm
       - autoware_auto_cmake
       - autoware_auto_create_pkg
       - autoware_auto_examples
       - autoware_auto_geometry
+      - autoware_auto_helper_functions
       - autoware_auto_msgs
+      - euclidean_cluster
+      - euclidean_cluster_nodes
+      - hungarian_assigner
+      - kalman_filter
+      - lidar_utils
+      - localization_common
+      - localization_nodes
+      - motion_model
+      - ndt
+      - optimization
+      - point_cloud_fusion
+      - ray_ground_classifier
+      - ray_ground_classifier_nodes
+      - serial_driver
+      - velodyne_driver
+      - velodyne_node
+      - voxel_grid
+      - voxel_grid_nodes
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/AutowareAuto/AutowareAuto-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `Autoware.Auto` to `0.0.2-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto.git
- release repository: https://gitlab.com/AutowareAuto/AutowareAuto-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-1`
