### PR TITLE
launch_ros: 0.8.7-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1125,7 +1125,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.8.6-1
+      version: 0.8.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.7-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.6-1`

## launch_ros

- No changes

## launch_testing_ros

```
* Install package manifest. (#71 <https://github.com/ros2/launch_ros/issues/71>) (#86 <https://github.com/ros2/launch_ros/issues/86>)
* Contributors: Dirk Thomas
```

## ros2launch

```
* Install resource marker file for package. (#78 <https://github.com/ros2/launch_ros/issues/78>) (#87 <https://github.com/ros2/launch_ros/issues/87>)
* Contributors: Dirk Thomas
```
