### PR TITLE
pcl_conversions: 2.0.0-1 in 'eloquent/distribution.yaml' [bloo…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -742,6 +742,21 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: maintained
+  pcl_conversions:
+    doc:
+      type: git
+      url: https://github.com/ros2/pcl_conversions.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/pcl_conversions-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/pcl_conversions.git
+      version: ros2
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/pcl_conversions.git
- release repository: https://github.com/ros2-gbp/pcl_conversions-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
