### PR TITLE
variants: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1932,6 +1932,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    release:
+      packages:
+      - desktop
+      - ros_base
+      - ros_core
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.8.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
