### PR TITLE
fsrobo_r: 0.7.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3615,6 +3615,29 @@ repositories:
       url: https://github.com/paulbovbel/frontier_exploration.git
       version: indigo-devel
     status: maintained
+  fsrobo_r:
+    doc:
+      type: git
+      url: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
+      version: master
+    release:
+      packages:
+      - fsrobo_r
+      - fsrobo_r_bringup
+      - fsrobo_r_description
+      - fsrobo_r_driver
+      - fsrobo_r_moveit_config
+      - fsrobo_r_msgs
+      - fsrobo_r_trajectory_filters
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/FUJISOFT-Robotics/fsrobo_r-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
+      version: master
+    status: developed
   ftm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fsrobo_r` to `0.7.0-1`:

- upstream repository: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
- release repository: https://github.com/FUJISOFT-Robotics/fsrobo_r-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## fsrobo_r

```
* first public release
```

## fsrobo_r_bringup

```
* first public release
```

## fsrobo_r_description

```
* first public release
```

## fsrobo_r_driver

```
* first public release
```

## fsrobo_r_moveit_config

```
* first public release
```

## fsrobo_r_msgs

```
* first public release
```

## fsrobo_r_trajectory_filters

```
* first public release
```
