### PR TITLE
navigation_experimental: 0.2.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7992,7 +7992,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_experimental-release.git
-      version: 0.2.1-0
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.2.2-1`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.1-0`

## assisted_teleop

```
* assisted_teleop: Rename library laser_scan_filters
  This fixes a name clash with the package laser_filters.
  Fixes #42 <https://github.com/ros-planning/navigation_experimental/issues/42> .
* Add READMEs
* Contributors: Martin Günther
```

## goal_passer

```
* Add READMEs
* Contributors: Martin Günther
```

## navigation_experimental

- No changes

## pose_base_controller

```
* Add READMEs
* Contributors: Martin Günther
```

## pose_follower

```
* Add dynamic reconfigure to pose_follower (#40 <https://github.com/ros-planning/navigation_experimental/issues/40>)
  Similar to the other available local planners, this commit adds dynamic reconfigure to pose_follower. In addition to this, the collision_planner parameters (used for detecting illegal trajectory) have been moved to the PoseFollower/collision_planner namespace.
  Major ROS API changes:
  * all internal TrajectoryPlannerROS parameters moved into the collision_planner namespace
  * all internal TrajectoryPlannerROS publishers (cost_cloud, global_plan, local_plan) moved into the collision_planner namespace
  * there is still a global_plan topic without namespace, which is now only published by the pose_follower itself and no longer shared with the internal TrajectoryPlannerROS.
* unused publisher removed (#41 <https://github.com/ros-planning/navigation_experimental/issues/41>)
* Add READMEs
* Contributors: Martin Günther, Pavel Shumejko
```

## sbpl_lattice_planner

```
* Add READMEs
* Contributors: Martin Günther
```

## sbpl_recovery

```
* Add READMEs
* Contributors: Martin Günther
```

## twist_recovery

```
* Add READMEs
* Contributors: Martin Günther
```
