### PR TITLE
ros2_tracing: 0.2.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2002,7 +2002,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 0.2.0-1
+      version: 0.2.8-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.2.8-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-1`

## tracetools

```
* Add overload of get_symbols as a fallback
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools_read

```
* Add is_trace_directory() util function
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Re-order args for trace command
* Contributors: Christophe Bedard
```
