### PR TITLE
Follow launch_ros_sandbox release repo move

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1135,17 +1135,17 @@ repositories:
   launch_ros_sandbox:
     doc:
       type: git
-      url: https://github.com/aws-robotics/launch-ros-sandbox.git
+      url: https://github.com/ros-security/launch_ros_sandbox.git
       version: dashing
     release:
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/aws-gbp/launch_ros_sandbox-release.git
+      url: https://github.com/ros-security/launch_ros_sandbox-release.git
       version: 0.0.2-4
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/aws-robotics/launch-ros-sandbox.git
+      url: https://github.com/ros-security/launch_ros_sandbox.git
       version: dashing
     status: developed
   lex_common:


### PR DESCRIPTION
launch_ros_sandbox is now living in the ros-security organization.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>