### PR TITLE
qpoases_vendor: 3.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6240,7 +6240,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/qpoases_vendor-release.git
-      version: 3.2.0-2
+      version: 3.2.1-1
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.ai/qpoases_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpoases_vendor` to `3.2.1-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.ai/qpoases_vendor.git
- release repository: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/qpoases_vendor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.2.0-2`

## qpoases_vendor

```
* Adding missing dependency on subversion.
* Contributors: Joshua Whitley
```
