### PR TITLE
rosbag_editor: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12262,6 +12262,21 @@ repositories:
       url: https://github.com/GT-RAIL/rosauth.git
       version: develop
     status: maintained
+  rosbag_editor:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/rosbag_editor.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/facontidavide/rosbag_editor-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/rosbag_editor.git
+      version: master
+    status: developed
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_editor` to `0.3.0-1`:

- upstream repository: https://github.com/facontidavide/rosbag_editor.git
- release repository: https://github.com/facontidavide/rosbag_editor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rosbag_editor

- No changes
