### PR TITLE
Adding swarm_functions to documentation index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14552,6 +14552,11 @@ repositories:
       url: https://github.com/SvenzvaRobotics/svenzva_ros.git
       version: master
     status: developed
+  swarm_functions:
+    doc:
+      type: git
+      url: https://github.com/cpswarm/swarm_functions
+      version: master
   swri_console:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14555,7 +14555,7 @@ repositories:
   swarm_functions:
     doc:
       type: git
-      url: https://github.com/cpswarm/swarm_functions
+      url: https://github.com/cpswarm/swarm_functions.git
       version: master
   swri_console:
     doc:


### PR DESCRIPTION
I'd like swarm_functions to be indexed and documented on ros.org.