### PR TITLE
cross_compile: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -500,6 +500,17 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: crystal-devel
     status: maintained
+  cross_compile:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros-tooling/cross_compile-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-tooling/cross_compile.git
+      version: dashing-devel
+    status: developed
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `cross_compile` to `0.1.0-1`:

- upstream repository: https://github.com/ros-tooling/cross_compile.git
- release repository: https://github.com/ros-tooling/cross_compile-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
