### PR TITLE
ament_download: 0.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -115,10 +115,6 @@ repositories:
       version: dashing
     status: developed
   ament_download:
-    doc:
-      type: git
-      url: https://github.com/samsung-ros/ament_download
-      version: ros2
     release:
       tags:
         release: release/dashing/{package}/{version}

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -114,6 +114,17 @@ repositories:
       url: https://github.com/ros2/ament_cmake_ros.git
       version: dashing
     status: developed
+  ament_download:
+    doc:
+      type: git
+      url: https://github.com/samsung-ros/ament_download
+      version: ros2
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/samsung-ros/ament_download-release.git
+      version: 0.0.1-1
+    status: maintained
   ament_index:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_download` to `0.0.1-1`:

- upstream repository: https://github.com/samsung-ros/ament_download
- release repository: https://github.com/samsung-ros/ament_download-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
