### PR TITLE
dccomms_ros_pkgs: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1381,6 +1381,15 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git
       version: master
     status: developed
+  dccomms_ros_pkgs:
+    release:
+      packages:
+      - dccomms_ros
+      - dccomms_ros_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/dcentelles/dccomms_ros_pkgs-release.git
+      version: 0.0.1-1
   ddynamic_reconfigure:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dccomms_ros_pkgs` to `0.0.1-1`:

- upstream repository: https://github.com/dcentelles/dccomms_ros_pkgs.git
- release repository: https://github.com/dcentelles/dccomms_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
