### PR TITLE
rqt_launchtree: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7872,6 +7872,13 @@ repositories:
       url: https://github.com/ros-visualization/rqt_launch.git
       version: master
     status: maintained
+  rqt_launchtree:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pschillinger/rqt_launchtree-release.git
+      version: 0.2.0-1
+    status: maintained
   rqt_logger_level:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launchtree` to `0.2.0-1`:

- upstream repository: https://github.com/pschillinger/rqt_launchtree.git
- release repository: https://github.com/pschillinger/rqt_launchtree-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rqt_launchtree

```
* Merge branch '130s-impr/save_status' into kinetic
* Store pkg name instead of index and also remember launch args
* Save and restore last pkg and launch file (address #4 <https://github.com/pschillinger/rqt_launchtree/issues/4>).
* Hide old properties if new file is loaded
* Adapted changes of pyqt5
* Contributors: Isaac I.Y. Saito, Philipp Schillinger
```
