### PR TITLE
ros2_tracing: 0.2.9-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1180,6 +1180,28 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_tracing:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: master
+    release:
+      packages:
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
+      version: 0.2.9-1
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: master
+    status: developed
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.2.9-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## tracetools

```
* Set symbols visibility to public for util functions
* Contributors: Christophe Bedard, Ingo Lütkebohle
```
