### PR TITLE
cross_compile: 0.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -505,7 +505,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-tooling/cross_compile-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/cross_compile.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cross_compile` to `0.1.1-1`:

- upstream repository: https://github.com/ros-tooling/cross_compile.git
- release repository: https://github.com/ros-tooling/cross_compile-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-1`

## cross_compile

```
* Remove non-portable use of USER environment variable (#25 <https://github.com/ros-tooling/cross_compile/issues/25>)
* Add travis configuration to build master and PRs (#23 <https://github.com/ros-tooling/cross_compile/issues/23>)
* Contributors: Emerson Knapp, Prajakta Gokhale
```
