### PR TITLE
rosbag_fancy: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7271,6 +7271,15 @@ repositories:
       version: develop
     status: maintained
   rosbag_fancy:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosbag_fancy.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/xqms/rosbag_fancy-release.git
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_fancy` to `0.1.0-1`:

- upstream repository: https://github.com/xqms/rosbag_fancy
- release repository: https://github.com/xqms/rosbag_fancy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rosbag_fancy

```
* Initial release
* Contributors: Jan Quenzel, Max Schwarz
```
