### PR TITLE
add boost rules for disco/eoan, collapse global boost rules fo…

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -301,24 +301,12 @@ boost:
     slackpkg:
       packages: [boost]
   ubuntu:
-    artful: [libboost-all-dev]
-    bionic: [libboost-all-dev]
+    '*': [libboost-all-dev]
     lucid: [libboost1.40-all-dev]
     maverick: [libboost1.42-all-dev]
     natty: [libboost1.42-all-dev]
     oneiric: [libboost1.46-all-dev]
-    precise: [libboost-all-dev]
-    quantal: [libboost-all-dev]
-    raring: [libboost-all-dev]
-    saucy: [libboost-all-dev]
-    trusty: [libboost-all-dev]
     trusty_python3: [libboost-all-dev]
-    utopic: [libboost-all-dev]
-    vivid: [libboost-all-dev]
-    wily: [libboost-all-dev]
-    xenial: [libboost-all-dev]
-    yakkety: [libboost-all-dev]
-    zesty: [libboost-all-dev]
 box2d-dev:
   arch: [box2d]
   debian: [libbox2d-dev]
@@ -1586,6 +1574,8 @@ libboost-program-options:
   fedora: [boost-program-options]
   ubuntu:
     bionic: [libboost-program-options1.65.1]
+    disco: [libboost-program-options1.67.0]
+    eoan: [libboost-program-options1.67.0]
     trusty: [libboost-program-options1.55.0]
     xenial: [libboost-program-options1.58.0]
 libboost-program-options-dev:
@@ -1606,6 +1596,8 @@ libboost-random:
   fedora: [boost-random]
   ubuntu:
     bionic: [libboost-random1.65.1]
+    disco: [libboost-random1.67.0]
+    eoan: [libboost-random1.67.0]
     precise: [libboost-random1.46.1]
     trusty: [libboost-random1.54.0]
 libboost-random-dev:


### PR DESCRIPTION
boost rules needed to compile ROS2 and the turtlebot3_demo on eoan

[libboost-program-options](https://packages.ubuntu.com/eoan/libboost-program-options1.67.0)
[libboost-random](https://packages.ubuntu.com/eoan/libboost-random1.67.0)
[libboost-all-dev](https://packages.ubuntu.com/eoan/libboost-all-dev)

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>