### PR TITLE
Update eol distro list

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,1 @@
-eol_distro_names = ['groovy', 'hydro', 'jade']
+eol_distro_names = ['ardent', 'bouncy', 'groovy', 'hydro', 'indigo', 'jade', 'lunar']

--- a/scripts/add_devel_repo.py
+++ b/scripts/add_devel_repo.py
@@ -9,7 +9,7 @@ from sort_yaml import sort_yaml_data
 
 
 def add_devel_repository(yaml_file, name, vcs_type, url, version=None):
-    data = yaml.load(open(yaml_file, 'r'))
+    data = yaml.safe_load(open(yaml_file, 'r'))
     if data['type'] == 'gbp':
         add_devel_repository_fuerte(yaml_file, data, name, vcs_type, url, version)
         return

--- a/scripts/add_release_repo.py
+++ b/scripts/add_release_repo.py
@@ -9,7 +9,7 @@ from sort_yaml import sort_yaml_data
 
 
 def add_release_repository(yaml_file, name, url, version):
-    data = yaml.load(open(yaml_file, 'r'))
+    data = yaml.safe_load(open(yaml_file, 'r'))
     if data['type'] == 'gbp':
         add_release_repository_fuerte(yaml_file, data, name, url, version)
         return

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -45,7 +45,7 @@ def create_default_sources():
     filepath = os.path.join(basedir, 'index.yaml')
     with open(filepath) as f:
         content = f.read()
-    index = yaml.load(content)
+    index = yaml.safe_load(content)
     for distro in index['distributions']:
         distfile = 'file://' + basedir + '/' + distro + '/distribution.yaml'
         print('loading %s' % distfile)
@@ -68,7 +68,7 @@ def create_default_sources():
         filepath = os.path.join(basedir, 'rosdep', filename)
         with open(filepath) as f:
             content = f.read()
-        rosdep_data = yaml.load(content)
+        rosdep_data = yaml.safe_load(content)
         tag = 'osx' if 'osx-' in filepath else ''
         sources.append(CachedDataSource('yaml', 'file://' + filepath, [tag], rosdep_data))
     return sources
@@ -125,7 +125,7 @@ def main(infile):
         filepath = os.path.join(os.getcwd(), filename)
         with open(filepath) as f:
             content = f.read()
-        rosdep_data = yaml.load(content)
+        rosdep_data = yaml.safe_load(content)
         # osx-homebrew uses osx tag
         tag = 'osx' if 'osx-' in filepath else ''
         model = CachedDataSource('yaml', 'file://' + filepath, [tag], rosdep_data)

--- a/scripts/check_rosdistro.py
+++ b/scripts/check_rosdistro.py
@@ -143,7 +143,7 @@ def main(fname):
     my_assert.clean = True
 
     try:
-        ydict = yaml.load(buf)
+        ydict = yaml.safe_load(buf)
     except Exception as e:
         print_err("could not build the dict: %s" % (str(e)))
         my_assert(False)

--- a/scripts/clean_rosdep_yaml.py
+++ b/scripts/clean_rosdep_yaml.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     with open(args.infile) as f:
-        iny = yaml.load(f.read())
+        iny = yaml.safe_load(f.read())
 
     buf = ''
     for a in sorted(iny):

--- a/scripts/sort_yaml.py
+++ b/scripts/sort_yaml.py
@@ -8,7 +8,7 @@ import yaml
 
 
 def sort_yaml(yaml_file):
-    data = yaml.load(open(yaml_file, 'r'))
+    data = yaml.safe_load(open(yaml_file, 'r'))
     if 'version' in data:
         print('This script does not support the new rosdistro yaml files', file=sys.stderr)
         sys.exit(1)

--- a/scripts/yaml2rosinstall.py
+++ b/scripts/yaml2rosinstall.py
@@ -8,7 +8,7 @@ import yaml
 
 
 def convert_yaml_to_rosinstall(yaml_file, rosinstall_file):
-    data = yaml.load(open(yaml_file, 'r'))
+    data = yaml.safe_load(open(yaml_file, 'r'))
     data = convert_yaml_data_to_rosinstall_data(data)
     with open(rosinstall_file, 'w') as out_file:
         yaml.dump(data, out_file, default_flow_style=False)


### PR DESCRIPTION
When testing eoan rosdep PRs, noticed a bunch of warnings and long test times:
- warnings due to YAML load being unsafe addressed in https://github.com/ros/rosdistro/commit/3c648ae8e8edbd9791f01f4d1edbc35f7b009b82
- long time was due to EOL distro, particularly topologically ordering all indigo packages, EOL distro list updated in https://github.com/ros/rosdistro/commit/a34566a93e1f5ed840922617923e7144c10b660d:
  - this reduce job time by ~40%
  - make CI fail when changes to EOL distribution fils are made (PR like https://github.com/ros/rosdistro/pull/21672 will now fail travis)