### PR TITLE
px4_msgs: 1.0.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10101,6 +10101,13 @@ repositories:
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
       version: 0.1.2-0
     status: maintained
+  px4_msgs:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/PX4/px4_msgs-release.git
+      version: 1.0.0-3
+    status: developed
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `px4_msgs` to `1.0.0-3`:

- upstream repository: https://github.com/PX4/px4_msgs.git
- release repository: https://github.com/PX4/px4_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## px4_msgs

```
* First release of px4_msgs for ROS (1) distros
* Contributors: Nuno Marques, PX4 Build Bot, PX4BuildBot, TSC21
```
