### PR TITLE
px4_msgs: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6041,6 +6041,13 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/prosilica_gige_sdk.git
       version: hydro-devel
+  px4_msgs:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PX4/px4_msgs-release.git
+      version: 1.0.0-1
+    status: developed
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `px4_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/PX4/px4_msgs.git
- release repository: https://github.com/PX4/px4_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## px4_msgs

```
* First release of px4_msgs for ROS (1) distros
* Contributors: Nuno Marques, PX4 Build Bot, PX4BuildBot, TSC21
```
