### PR TITLE
px4_msgs: 2.0.0-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1058,6 +1058,13 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: crystal
     status: developed
+  px4_msgs:
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/PX4/px4_msgs2-release.git
+      version: 2.0.0-1
+    status: developed
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `px4_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/PX4/px4_msgs.git
- release repository: https://github.com/PX4/px4_msgs2-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## px4_msgs

```
* First release of px4_msgs to ROS 2 distros
* Contributors: Nuno Marques, PX4 Build Bot, PX4BuildBot, TSC21
```
