### PR TITLE
tracetools_analysis: 0.2.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1855,6 +1855,24 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: master
     status: maintained
+  tracetools_analysis:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: master
+    release:
+      packages:
+      - ros2trace_analysis
+      - tracetools_analysis
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: master
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `0.2.1-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
