### PR TITLE
mcl_3dl: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4034,7 +4034,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.1.6-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.5-1`

## mcl_3dl

```
* Clear odometry integration error on global localization (#257 <https://github.com/at-wat/mcl_3dl/issues/257>)
* Accelerate CI and prerelease test (#254 <https://github.com/at-wat/mcl_3dl/issues/254>)
* Contributors: Atsushi Watanabe
```
