### PR TITLE
neonavigation: 0.5.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8100,7 +8100,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.4.3-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.5.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.3-1`

## costmap_cspace

```
* costmap_cspace: fix unknown handling (#392 <https://github.com/at-wat/neonavigation/issues/392>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

```
* joystick_interrupt: publish twist soon after simulator starts (#389 <https://github.com/at-wat/neonavigation/issues/389>)
* Contributors: Naotaka Hatao
```

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

```
* planner_cspace: publish internally used maps as OccupancyGrid (#396 <https://github.com/at-wat/neonavigation/issues/396>)
* costmap_cspace: fix unknown handling (#392 <https://github.com/at-wat/neonavigation/issues/392>)
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: fix debug output test stability (#399 <https://github.com/at-wat/neonavigation/issues/399>)
* planner_cspace: publish internally used maps as OccupancyGrid (#396 <https://github.com/at-wat/neonavigation/issues/396>)
* planner_cspace: clear hysteresis if new obstacle is on the previous path (#393 <https://github.com/at-wat/neonavigation/issues/393>)
* planner_cspace: fix remember_updates feature (#391 <https://github.com/at-wat/neonavigation/issues/391>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* safety_limiter: remove debug output (#385 <https://github.com/at-wat/neonavigation/issues/385>)
* safety_limiter: status broadcasting from safety_limiter node (#383 <https://github.com/at-wat/neonavigation/issues/383>)
* Contributors: Atsushi Watanabe, Daiki Maekawa
```

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: track interpolated rotation (#394 <https://github.com/at-wat/neonavigation/issues/394>)
* Contributors: Atsushi Watanabe
```
