### PR TITLE
add ament_virtualenv

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -136,8 +136,8 @@ repositories:
       version: master
     release:
       packages:
-      - ament_cmake_virtualenv
       - ament_virtualenv
+      - ament_cmake_virtualenv
       - test_ament_virtualenv
       tags:
         release: release/crystal/{package}/{version}

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -136,8 +136,8 @@ repositories:
       version: master
     release:
       packages:
-      - ament_virtualenv
       - ament_cmake_virtualenv
+      - ament_virtualenv
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,6 +129,25 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: crystal
     status: maintained
+  ament_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    release:
+      packages:
+      - ament_virtualenv
+      - ament_cmake_virtualenv
+      - test_ament_virtualenv
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/esol-community/ament_virtualenv-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    status: developed
   angles:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,6 +129,21 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: crystal
     status: maintained
+  ament_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    release:
+      tags:
+        release: release/crystal/{package}/{version}
+      url: https://github.com/esol-community/ament_virtualenv-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    status: developed
   angles:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -129,25 +129,6 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: crystal
     status: maintained
-  ament_virtualenv:
-    doc:
-      type: git
-      url: https://github.com/esol-community/ament_virtualenv.git
-      version: master
-    release:
-      packages:
-      - ament_virtualenv
-      - ament_cmake_virtualenv
-      - test_ament_virtualenv
-      tags:
-        release: release/crystal/{package}/{version}
-      url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.1-0
-    source:
-      type: git
-      url: https://github.com/esol-community/ament_virtualenv.git
-      version: master
-    status: developed
   angles:
     doc:
       type: git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -135,6 +135,10 @@ repositories:
       url: https://github.com/esol-community/ament_virtualenv.git
       version: master
     release:
+      packages:
+      - ament_cmake_virtualenv
+      - ament_virtualenv
+      - test_ament_virtualenv
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -138,11 +138,10 @@ repositories:
       packages:
       - ament_virtualenv
       - ament_cmake_virtualenv
-      - test_ament_virtualenv
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -201,8 +201,8 @@ repositories:
       version: master
     release:
       packages:
-      - ament_virtualenv
       - ament_cmake_virtualenv
+      - ament_virtualenv
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -207,7 +207,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -200,6 +200,10 @@ repositories:
       url: https://github.com/esol-community/ament_virtualenv.git
       version: master
     release:
+      packages:
+      - ament_cmake_virtualenv
+      - ament_virtualenv
+      - test_ament_virtualenv
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -194,6 +194,21 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: dashing
     status: developed
+  ament_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/esol-community/ament_virtualenv-release.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    status: developed
   angles:
     doc:
       type: git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -206,7 +206,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -201,8 +201,8 @@ repositories:
       version: master
     release:
       packages:
-      - ament_cmake_virtualenv
       - ament_virtualenv
+      - ament_cmake_virtualenv
       - test_ament_virtualenv
       tags:
         release: release/dashing/{package}/{version}

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -203,11 +203,10 @@ repositories:
       packages:
       - ament_virtualenv
       - ament_cmake_virtualenv
-      - test_ament_virtualenv
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git


### PR DESCRIPTION
_The bloom release process failed trying to create an oauth token, so this PR was created manually.
I hope it is acceptable. Please let me know if there are anything I should do differently._

`ament_virtualenv` provides a mechanism to export python library requirements in a `requirements.txt` file.
It is a port of [`catkin_virtualenv`](https://github.com/locusrobotics/catkin_virtualenv) for `ament`.

Included packages:
* `ament_virtualenv` : Python package for creating the virtual environment (for `ament_python`)
* `ament_cmake_virtualenv` : Cmake package to use `ament_virtualenv` with `ament_cmake` as build tool.
* `test_ament_virtualenv` : Package using `ament_virtualenv`. Used as a test and usage example.