### PR TITLE
system_modes: 0.1.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1847,6 +1847,16 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: master
     status: developed
+  system_modes:
+    release:
+      packages:
+      - system_modes
+      - system_modes_examples
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/microROS/system_modes-release.git
+      version: 0.1.5-1
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.1.5-1`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
