### PR TITLE
Add python3-babeltrace rules for RHEL and Fedora

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4909,6 +4909,8 @@ python3:
   ubuntu: [python3-dev]
 python3-babeltrace:
   debian: [python3-babeltrace]
+  fedora: [python3-babeltrace]
+  rhel: ['python%{python3_pkgversion}-babeltrace']
   ubuntu: [python3-babeltrace]
 python3-backoff-pip:
   arch:


### PR DESCRIPTION
Package DB showing the package is in Fedora and EPEL (6 + 7)
https://apps.fedoraproject.org/packages/python3-babeltrace

This package isn't available in EPEL 8 yet, but if/when it does become available, it is extremely unlikely that the package name would change from what it was in EPEL 6, EPEL 7 and Fedora. Therefore, I didn't create a separate rule to disclude EPEL 8 from the RHEL rule.