### PR TITLE
sick_scan2: 0.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2616,6 +2616,12 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: dashing
     status: maintained
+  sick_scan2:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/SICKAG/sick_scan2-release.git
+      version: 0.1.1-1
   slam_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan2` to `0.1.1-1`:

- upstream repository: https://github.com/SICKAG/sick_scan2.git
- release repository: https://github.com/SICKAG/sick_scan2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
