### PR TITLE
Debian stretch kernel key is now version 11, so update it here.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3900,7 +3900,7 @@ linux-headers-generic:
   arch: [linux-headers]
   debian:
     jessie: [linux-headers-3.16.0-4-all]
-    stretch: [linux-headers-4.9.0-3-all]
+    stretch: [linux-headers-4.9.0-11-all]
     wheezy: [linux-headers-3.2.0-4-all]
   fedora: [kernel-headers, kernel-devel]
   gentoo: [sys-kernel/linux-headers]


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>