### PR TITLE
rqt_reconfigure: 0.5.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13205,7 +13205,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.4.10-0
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.5.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.10-0`

## rqt_reconfigure

```
* Use a consistent formatting method when logging (#49 <https://github.com/ros-visualization/rqt_reconfigure/issues/49>)
  This will improve logging function compatibility between ROS 1 and
  ROS 2.
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Superficial changes to align ROS 1 and ROS 2 branches (#47 <https://github.com/ros-visualization/rqt_reconfigure/issues/47>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Add explicit PyYAML dependency (#45 <https://github.com/ros-visualization/rqt_reconfigure/issues/45>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Another round of license formatting alignment (#43 <https://github.com/ros-visualization/rqt_reconfigure/issues/43>)
  This change removes a superfluous license specification in license
  headers and makes the formatting in the test files' headers the same as
  the source files'.
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Re-format license headers to conform to ROS templates (#39 <https://github.com/ros-visualization/rqt_reconfigure/issues/39>)
  This change adds a line to the license headers specifying the name of
  the license that follows. It also re-formats the recently added LICENSE
  and CONTRIBUTING.md files to match the templates.
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Rename DynreconfClientWidget => ParamClientWidget (#36 <https://github.com/ros-visualization/rqt_reconfigure/issues/36>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Add LICENSE and CONTRIBUTING.md (#37 <https://github.com/ros-visualization/rqt_reconfigure/issues/37>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Format per linter suggestions and run tests (#35 <https://github.com/ros-visualization/rqt_reconfigure/issues/35>)
* Reproduce python2 behavior in NoneType comparison (#30 <https://github.com/ros-visualization/rqt_reconfigure/issues/30>)
* Fix some linter errors and get tests running (#33 <https://github.com/ros-visualization/rqt_reconfigure/issues/33>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Pull logging methods into a separate file (#34 <https://github.com/ros-visualization/rqt_reconfigure/issues/34>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Update to package.xml format 2 (#32 <https://github.com/ros-visualization/rqt_reconfigure/issues/32>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Contributors: Scott K Logan, Timon Engelke
```
