### PR TITLE
Add python-astor-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -457,6 +457,19 @@ python-argparse:
     maverick: [python-argparse]
     natty: [python-argparse]
     oneiric: [python-argparse]
+python-astor-pip:
+  debian:
+    pip:
+      packages: [astor]
+  fedora:
+    pip:
+      packages: [astor]
+  osx:
+    pip:
+      packages: [astor]
+  ubuntu:
+    pip:
+      packages: [astor]
 python-attrs:
   debian: [python-attr]
   fedora: [python2-attrs]


### PR DESCRIPTION
Source https://pypi.org/project/astor/
Extra tools for working with the python AST library