### PR TITLE
Adding mongodb_store to documentation index for distro

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7507,6 +7507,10 @@ repositories:
       url: https://github.com/HumaRobotics/modbus.git
       version: master
   mongodb_store:
+    doc:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: hydro-devel
     release:
       packages:
       - libmongocxx_ros


### PR DESCRIPTION
The doc tag was missing for older releases, and since this is the first page on the wiki it's a bit annoying! 