### PR TITLE
Use crystal branch for image_transport_plugins

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -677,7 +677,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: crystal
     release:
       packages:
       - compressed_depth_image_transport
@@ -692,7 +692,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: ros2
+      version: crystal
     status: maintained
   joystick_drivers:
     doc:


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>