### PR TITLE
geometry2: 0.12.1-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -487,6 +487,7 @@ repositories:
       version: ros2
     release:
       packages:
+      - geometry2
       - tf2
       - tf2_eigen
       - tf2_geometry_msgs
@@ -498,7 +499,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.12.0-1
+      version: 0.12.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.12.1-2`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.12.0-1`

## geometry2

```
* Port geometry2 metapackage to ROS 2 to be able to use it in variants (#184 <https://github.com/ros2/geometry2/issues/184>)
* Contributors: Mikael Arguedas
```

## tf2

```
* Overwrite TimeCacheInterface type with a current input (#151 <https://github.com/ros2/geometry2/issues/151>)
* [tf2] Use ament_target_dependencies where possible
* Restore conversion via message traits (#167 <https://github.com/ros2/geometry2/issues/167>)
* Contributors: Jacob Perron, Michael Carroll, Vinnam Kim
```

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* Remove template specialization for toMsg functions (#179 <https://github.com/ros2/geometry2/issues/179>)
* Use smart pointers for global buffer variables in tests
* Don't assume quaternions init to all zeros
* Contributors: Jacob Perron, Josh Langsfeld
```

## tf2_kdl

```
* Restore conversion via message traits (#167 <https://github.com/ros2/geometry2/issues/167>)
* Don't assume quaternions init to all zeros
* Contributors: Josh Langsfeld, Michael Carroll
```

## tf2_msgs

- No changes

## tf2_py

```
* Quiet the cast-function-type warning on GCC 8.
* Contributors: Chris Lalancette
```

## tf2_ros

```
* Add convenience methods using rclcpp time types (#180 <https://github.com/ros2/geometry2/issues/180>)
* Don't assume quaternions init to all zeros
* Make BufferClient destructor virtual
* Contributors: Josh Langsfeld, Shane Loretz, Thomas Moulard
```

## tf2_sensor_msgs

```
* Use smart pointers for global buffer variables in tests
* Contributors: Josh Langsfeld
```
