### PR TITLE
rosidl_runtime_py: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1462,7 +1462,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rosidl_runtime_py

```
* Fix get_interfaces() implementation. (#4 <https://github.com/ros2/rosidl_runtime_py/issues/4>)
* Add functions for getting interface names and paths (#3 <https://github.com/ros2/rosidl_runtime_py/issues/3>)
* Contributors: Jacob Perron, Michel Hidalgo
```
