### PR TITLE
rcutils: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1073,7 +1073,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rcutils

```
* Specify working directory for filesystem test (#185 <https://github.com/ros2/rcutils/issues/185>)
* Make use of time source type for throttling logs (#183 <https://github.com/ros2/rcutils/issues/183>)
* Remove ready_fn - will be replaced by ReadyToTest() (#184 <https://github.com/ros2/rcutils/issues/184>)
* Contributors: Brian Marchi, Dan Rose, Peter Baughman
```
