### PR TITLE
foonathan_memory_vendor: 0.3.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -450,7 +450,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
-      version: 0.1.0-1
+      version: 0.3.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `foonathan_memory_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/eProsima/foonathan_memory_vendor.git
- release repository: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-1`
