### PR TITLE
demos: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -272,7 +272,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.8.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

```
* Update setup.py versions
* Contributors: Jacob Perron
```

## composition

```
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* Contributors: Peter Baughman
```

## demo_nodes_cpp

```
* rename return functions for loaned messages (#403 <https://github.com/ros2/demos/issues/403>)
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* remove intra-process manager impl (#382 <https://github.com/ros2/demos/issues/382>)
* zero copy api (#394 <https://github.com/ros2/demos/issues/394>)
* Remove command line parsing from C++ demos (#401 <https://github.com/ros2/demos/issues/401>)
* Need to specify NodeOption explicitly to allow declaration. (#389 <https://github.com/ros2/demos/issues/389>)
* Contributors: Alberto Soragna, Jacob Perron, Karsten Knese, Peter Baughman, tomoya
```

## demo_nodes_cpp_native

```
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* Contributors: Peter Baughman
```

## demo_nodes_py

```
* Prevent argparse from parsing ROS args in Python demo nodes. (#396 <https://github.com/ros2/demos/issues/396>)
* Update setup.py versions
* Contributors: Jacob Perron, Michel Hidalgo
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Fix burguer mode parameter typo in help text (#406 <https://github.com/ros2/demos/issues/406>)
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* [image_tools] Use ROS parameters instead of regular CLI arguments (#398 <https://github.com/ros2/demos/issues/398>)
* Contributors: Brian Marchi, Jacob Perron, Peter Baughman
```

## intra_process_demo

```
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* Contributors: Peter Baughman
```

## lifecycle

```
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* Contributors: Peter Baughman
```

## logging_demo

```
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* Fix logging demo test (#400 <https://github.com/ros2/demos/issues/400>)
* Contributors: Michel Hidalgo, Peter Baughman
```

## pendulum_control

```
* Replace ready_fn with ReadyToTest action (#404 <https://github.com/ros2/demos/issues/404>)
* Contributors: Peter Baughman
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* get_actual_qos() now returns a rclcpp::QoS (#395 <https://github.com/ros2/demos/issues/395>)
* Contributors: William Woodall
```

## quality_of_service_demo_py

```
* Update setup.py versions
* Contributors: Jacob Perron
```

## topic_monitor

```
* Update setup.py versions
* Contributors: Jacob Perron
```
