### PR TITLE
rosidl: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1391,7 +1391,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rosidl_adapter

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

```
* Add is_message trait in support of tf2 conversions (#412 <https://github.com/ros2/rosidl/issues/412>)
* Contributors: Michael Carroll
```

## rosidl_parser

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Add init and fini function for creating introspection messages (#416 <https://github.com/ros2/rosidl/issues/416>)
* Contributors: Karsten Knese
```

## rosidl_typesupport_introspection_cpp

```
* Add init and fini function for creating introspection messages (#416 <https://github.com/ros2/rosidl/issues/416>)
* Contributors: Karsten Knese
```
