### PR TITLE
robot_state_publisher: 2.3.0-3 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1219,7 +1219,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.3.0-1
+      version: 2.3.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.3.0-3`:

- upstream repository: https://github.com/ros2/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.3.0-1`

## robot_state_publisher

```
* Install include directories (#31 <https://github.com/ros2/robot_state_publisher/issues/31>)
* Publish URDF string on startup (#24 <https://github.com/ros2/robot_state_publisher/issues/24>)
* Contributors: Patrick Beeson, Poh Zhi-Ee, Shane Loretz
```
