### PR TITLE
rosidl_python: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1446,7 +1446,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rosidl_generator_py

```
* Enable tests for 'char' type fields (#91 <https://github.com/ros2/rosidl_python/issues/91>)
* Refactor tests (#89 <https://github.com/ros2/rosidl_python/issues/89>)
* Contributors: Jacob Perron
```
