### PR TITLE
examples: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -403,6 +403,7 @@ repositories:
       - examples_rclcpp_minimal_service
       - examples_rclcpp_minimal_subscriber
       - examples_rclcpp_minimal_timer
+      - examples_rclcpp_multithreaded_executor
       - examples_rclpy_executors
       - examples_rclpy_minimal_action_client
       - examples_rclpy_minimal_action_server
@@ -413,7 +414,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ros2/examples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `examples` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/examples.git
- release repository: https://github.com/ros2-gbp/examples-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## examples_rclcpp_minimal_action_client

- No changes

## examples_rclcpp_minimal_action_server

- No changes

## examples_rclcpp_minimal_client

- No changes

## examples_rclcpp_minimal_composition

- No changes

## examples_rclcpp_minimal_publisher

- No changes

## examples_rclcpp_minimal_service

- No changes

## examples_rclcpp_minimal_subscriber

- No changes

## examples_rclcpp_minimal_timer

- No changes

## examples_rclcpp_multithreaded_executor

```
* Implemented Multithreaded Executor example (#251 <https://github.com/ros2/examples/issues/251>)
* Contributors: jhdcs
```

## examples_rclpy_executors

- No changes

## examples_rclpy_minimal_action_client

- No changes

## examples_rclpy_minimal_action_server

- No changes

## examples_rclpy_minimal_client

```
* future.result() raises if it fails (#253 <https://github.com/ros2/examples/issues/253>)
* Contributors: Shane Loretz
```

## examples_rclpy_minimal_publisher

- No changes

## examples_rclpy_minimal_service

- No changes

## examples_rclpy_minimal_subscriber

- No changes
