### PR TITLE
teleop_twist_joy: 2.2.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1873,7 +1873,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.2.2-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.2.1-1`

## teleop_twist_joy

```
* Export interfaces for Shared Lib on Windows.
* Make teleop_twist_joy composable.
* Reenable cppcheck.
* Rename teleop_twist_joy.h to teleop_twist_joy.hpp
* Get some basic tests running (#10 <https://github.com/ros2/teleop_twist_joy/issues/10>)
* Port config and launch to ROS 2 (#11 <https://github.com/ros2/teleop_twist_joy/issues/11>)
* Contributors: Chris Lalancette, Scott K Logan, seanyen
```
