### PR TITLE
rcl: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -960,7 +960,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rcl

```
* Remove the prototype from rcl_impl_getenv. (#525 <https://github.com/ros2/rcl/issues/525>)
* Use return_loaned_message_from (#523 <https://github.com/ros2/rcl/issues/523>)
* Avoid ready_fn and self.proc_info (#522 <https://github.com/ros2/rcl/issues/522>)
* Add localhost option to node creation (#520 <https://github.com/ros2/rcl/issues/520>)
* Add initial instrumentation (#473 <https://github.com/ros2/rcl/issues/473>)
* Zero copy api (#506 <https://github.com/ros2/rcl/issues/506>)
* Don't create rosout publisher instance unless required. (#514 <https://github.com/ros2/rcl/issues/514>)
* Handle zero non-ROS specific args properly in rcl_remove_ros_arguments (#518 <https://github.com/ros2/rcl/issues/518>)
* Update rcl_node_init docstring (#517 <https://github.com/ros2/rcl/issues/517>)
* Remove vestigial references to rcl_ok() (#516 <https://github.com/ros2/rcl/issues/516>)
* Add mechanism to pass rmw impl specific payloads during pub/sub creation (#513 <https://github.com/ros2/rcl/issues/513>)
* Contributors: Brian Marchi, Chris Lalancette, Ingo Lütkebohle, Jacob Perron, Karsten Knese, Michel Hidalgo, Peter Baughman, William Woodall, tomoya
```

## rcl_action

```
* Correct action server documentation (#519 <https://github.com/ros2/rcl/issues/519>)
* Add mechanism to pass rmw impl specific payloads during pub/sub creation (#513 <https://github.com/ros2/rcl/issues/513>)
* Contributors: Jacob Perron, William Woodall
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Specify test working directory (#529 <https://github.com/ros2/rcl/issues/529>)
* Remove the maximum string size. (#524 <https://github.com/ros2/rcl/issues/524>)
* Contributors: Chris Lalancette, Dan Rose
```
