### PR TITLE
rosidl_typesupport_connext: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1501,7 +1501,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## connext_cmake_module

- No changes

## rosidl_typesupport_connext_c

```
* Connext 6 compatibility (#37 <https://github.com/ros2/rosidl_typesupport_connext/issues/37>)
* Contributors: Dirk Thomas
```

## rosidl_typesupport_connext_cpp

```
* Connext 6 compatibility (#37 <https://github.com/ros2/rosidl_typesupport_connext/issues/37>)
* Contributors: Dirk Thomas
```
