### PR TITLE
launch: 0.9.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -641,7 +641,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.1-1`

## launch

- No changes

## launch_testing

```
* Support launch test reruns when using pytest (#348 <https://github.com/ros2/launch/issues/348>)
* Support CLI commands testing (#279 <https://github.com/ros2/launch/issues/279>)
* Contributors: Michel Hidalgo
```

## launch_testing_ament_cmake

```
* Use ament_cmake_copyright (#349 <https://github.com/ros2/launch/issues/349>)
* Contributors: Dan Rose
```

## launch_xml

```
* install resource marker file for packages (#341 <https://github.com/ros2/launch/issues/341>)
* Contributors: Dirk Thomas
```

## launch_yaml

```
* install resource marker file for packages (#341 <https://github.com/ros2/launch/issues/341>)
* Contributors: Dirk Thomas
```
