### PR TITLE
launch_ros: 0.9.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -661,7 +661,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.1-1`

## launch_ros

```
* Fix launch_ros.actions.Node parsing function (#83 <https://github.com/ros2/launch_ros/issues/83>)
* Add support for launching nodes not in a package (#82 <https://github.com/ros2/launch_ros/issues/82>)
* Contributors: Michel Hidalgo
```

## launch_testing_ros

```
* Remove self.proc_output and ready_fn (#90 <https://github.com/ros2/launch_ros/issues/90>)
* Add support for launching nodes not in a package (#82 <https://github.com/ros2/launch_ros/issues/82>)
* Contributors: Michel Hidalgo, Peter Baughman
```

## ros2launch

- No changes
