### PR TITLE
image_common: 2.2.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -528,11 +528,12 @@ repositories:
       packages:
       - camera_calibration_parsers
       - camera_info_manager
+      - image_common
       - image_transport
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `2.2.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.2.0-1`

## camera_calibration_parsers

```
* ROS2 Using the filesystem helper in rcpputils (#133 <https://github.com/ros-perception/image_common/issues/133>)
* [Windows][ros2] Avoid build break for Visual Studio 2019 v16.3 (#135 <https://github.com/ros-perception/image_common/issues/135>)
* Contributors: Andreas Klintberg, Sean Yen
```

## camera_info_manager

```
* Fix abort criteria for setCameraInfoService callback (#132 <https://github.com/ros-perception/image_common/issues/132>)
* Contributors: Joseph Schornak
```

## image_common

```
* [ros2] image_common metapackage (#129 <https://github.com/ros-perception/image_common/issues/129>)
* Contributors: chapulina
```

## image_transport

```
* add missing set header (#140 <https://github.com/ros-perception/image_common/issues/140>)
* Contributors: Mikael Arguedas
```
