### PR TITLE
image_transport_plugins: 2.2.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -553,7 +553,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.2.1-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.2.0-1`

## compressed_depth_image_transport

- No changes

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

```
* Remove dependency to ${PROJECT_NAME} (#46 <https://github.com/ros-perception/image_transport_plugins/issues/46>)
* Contributors: Gaël Écorchard
```
