### PR TITLE
turtlesim: 1.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1991,7 +1991,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim` to `1.0.2-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.1-1`

## turtlesim

```
* separate background color from drawn paths, trigger repaint on parameter changes (#75 <https://github.com/ros/ros_tutorials/issues/75>)
* add descriptor information for background color parameters (#73 <https://github.com/ros/ros_tutorials/issues/73>)
* Fix Windows compiler warning (#69 <https://github.com/ros/ros_tutorials/issues/69>)
* Change log messages to use 'goal' instead of 'action' (#67 <https://github.com/ros/ros_tutorials/issues/67>)
* Contributors: Dirk Thomas, Jacob Perron
```
