### PR TITLE
vision_opencv: 2.1.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2108,7 +2108,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.1.3-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.1.2-1`

## cv_bridge

```
* populate array.array directly instead of converting to and from a string (#305 <https://github.com/ros-perception/vision_opencv/issues/305>)
* include Boost to fix Windows build (#290 <https://github.com/ros-perception/vision_opencv/issues/290>)
* Export interfaces for Win32 Shared Lib (#301 <https://github.com/ros-perception/vision_opencv/issues/301>)
* Contributors: Dirk Thomas, Jonathan Noyola, Sean Yen
```

## image_geometry

- No changes

## vision_opencv

- No changes
