### PR TITLE
rqt_graph: 1.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1613,7 +1613,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.0.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.2-1`

## rqt_graph

```
* Add topic edges for the Nodes Only view mode. (#35 <https://github.com/ros-visualization/rqt_graph/issues/35>)
* Fix node not found during refresh when namespace is not empty (#34 <https://github.com/ros-visualization/rqt_graph/issues/34>)
* Contributors: Dirk Thomas, Michel Hidalgo, Xavier BROQUERE
```
