### PR TITLE
rclpy: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1045,7 +1045,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rclpy

```
* Fix the unicode test string for opensplice rmw implementation (#447 <https://github.com/ros2/rclpy/issues/447>)
* Expand test timeout to deflake rmw_connext (#449 <https://github.com/ros2/rclpy/issues/449>)
* Support array parameter types (#444 <https://github.com/ros2/rclpy/issues/444>)
* Make use of Clock class for throttling logs (#441 <https://github.com/ros2/rclpy/issues/441>)
* Drop rclpy test_remove_ros_args_empty test case. (#445 <https://github.com/ros2/rclpy/issues/445>)
* Add Rate (#443 <https://github.com/ros2/rclpy/issues/443>)
* Action server: catch exception from user execute callback (#437 <https://github.com/ros2/rclpy/issues/437>)
* Make cppcheck happy (#438 <https://github.com/ros2/rclpy/issues/438>)
* Contributors: Brian Marchi, Jacob Perron, Michael Carroll, Michel Hidalgo, Shane Loretz
```
