### PR TITLE
rmw_fastrtps: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1192,7 +1192,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rmw_fastrtps_cpp

```
* use return_loaned_message_from (#334 <https://github.com/ros2/rmw_fastrtps/issues/334>)
* Restrict traffic to localhost only if env var is provided (#331 <https://github.com/ros2/rmw_fastrtps/issues/331>)
* Zero copy api (#322 <https://github.com/ros2/rmw_fastrtps/issues/322>)
* update signature for added pub/sub options (#329 <https://github.com/ros2/rmw_fastrtps/issues/329>)
* Contributors: Brian Marchi, Karsten Knese, William Woodall
```

## rmw_fastrtps_dynamic_cpp

```
* use return_loaned_message_from (#334 <https://github.com/ros2/rmw_fastrtps/issues/334>)
* Restrict traffic to localhost only if env var is provided (#331 <https://github.com/ros2/rmw_fastrtps/issues/331>)
* Zero copy api (#322 <https://github.com/ros2/rmw_fastrtps/issues/322>)
* update signature for added pub/sub options (#329 <https://github.com/ros2/rmw_fastrtps/issues/329>)
* Contributors: Brian Marchi, Karsten Knese, William Woodall
```

## rmw_fastrtps_shared_cpp

```
* Restrict traffic to localhost only if env var is provided (#331 <https://github.com/ros2/rmw_fastrtps/issues/331>)
* Added new functions which can be used to get rmw_qos_profile_t from WriterQos and ReaderQos (#328 <https://github.com/ros2/rmw_fastrtps/issues/328>)
* Renamed dds_qos_to_rmw_qos to dds_attributes_to_rmw_qos (#330 <https://github.com/ros2/rmw_fastrtps/issues/330>)
* Contributors: Brian Marchi, jaisontj
```
