### PR TITLE
rmw_connext: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1172,7 +1172,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rmw_connext_cpp

```
* CMAKE_SOURCE_DIR -> CMAKE_CURRENT_SOURCE_DIR (#378 <https://github.com/ros2/rmw_connext/issues/378>)
* use return_loaned_message_from (#376 <https://github.com/ros2/rmw_connext/issues/376>)
* Support localhost only communication (#373 <https://github.com/ros2/rmw_connext/issues/373>)
* Zero copy api (#367 <https://github.com/ros2/rmw_connext/issues/367>)
* update logic / patches to optionally support Connext 6 (#374 <https://github.com/ros2/rmw_connext/issues/374>)
* assert that unmodified lines in the patch match the input (#371 <https://github.com/ros2/rmw_connext/issues/371>)
* supress invalid syntax warning for macro call (#370 <https://github.com/ros2/rmw_connext/issues/370>)
* Fix build error (#369 <https://github.com/ros2/rmw_connext/issues/369>)
* update signature for added pub/sub options (#368 <https://github.com/ros2/rmw_connext/issues/368>)
* Contributors: Brian Marchi, Dan Rose, Dirk Thomas, Karsten Knese, William Woodall, ivanpauno
```

## rmw_connext_shared_cpp

```
* Support localhost only communication (#373 <https://github.com/ros2/rmw_connext/issues/373>)
* update logic / patches to optionally support Connext 6 (#374 <https://github.com/ros2/rmw_connext/issues/374>)
* Contributors: Brian Marchi, Dirk Thomas
```
