### PR TITLE
cyclonedds: 0.1.0-3 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -255,13 +255,13 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.1.0-1
+      version: 0.1.0-3
     source:
       test_commits: false
       test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: 78fc9c2e8517a34d3a743740a2457e07199234f0
+      version: 76fa68808682a15dd8aff26da20622ac574fa1a1
     status: developed
   demos:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.1.0-3`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-1`
