### PR TITLE
interactive_markers: 2.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -592,7 +592,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.0.1-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.0-1`

## interactive_markers

```
* Fix test flakes by waiting for pub/sub discovery (#55 <https://github.com/ros-visualization/interactive_markers/issues/55>)
* Add parameters for QoS of update and feedback topics (#54 <https://github.com/ros-visualization/interactive_markers/issues/54>)
* Port Python implementation to ROS 2 (#53 <https://github.com/ros-visualization/interactive_markers/issues/53>)
  * Move Python files to their own directory
  * Install Python via ament_cmake_python
  * Make Python implementation ROS 2 compatible
  * Use docstrings
  * Minor refactor of callback logic
  * Guard against None values and KeyError's
  * Change insert() signature to take keyword arguments
  * Rename variables for clarity (e.g. 'cb' -> 'callback')
  * Fix PEP 257 errors
  * Remove unused setup.py
  * Enable flake8 tests and fix errors
  * Improve performance
  * Clear pending updates after applying all of them
  * Don't rely on user to apply any pose updates
  * Expose QoSProfile a parameter
  * Add Python implementation dependencies to package.xml
* Contributors: Jacob Perron
```
