### PR TITLE
rmw_opensplice: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1226,7 +1226,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_opensplice-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_opensplice` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rmw_opensplice.git
- release repository: https://github.com/ros2-gbp/rmw_opensplice-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rmw_opensplice_cpp

```
* use return_loaned_message_from (#290 <https://github.com/ros2/rmw_opensplice/issues/290>)
* Add localhost parameter to create node function (#288 <https://github.com/ros2/rmw_opensplice/issues/288>)
* zero copy api for opensplice (#285 <https://github.com/ros2/rmw_opensplice/issues/285>)
* Change PrismTech -> ADLINK (#287 <https://github.com/ros2/rmw_opensplice/issues/287>)
* Fix build error (#286 <https://github.com/ros2/rmw_opensplice/issues/286>)
* update signature for added pub/sub options (#284 <https://github.com/ros2/rmw_opensplice/issues/284>)
* Contributors: Brian Marchi, Dan Rose, Karsten Knese, William Woodall, ivanpauno
```
