### PR TITLE
rmw: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1153,7 +1153,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## rmw

```
* Use return_loaned_message_from (#192 <https://github.com/ros2/rmw/issues/192>)
* Add function to enable localhost communication only from env var (#190 <https://github.com/ros2/rmw/issues/190>)
* Zero copy api (#185 <https://github.com/ros2/rmw/issues/185>)
* Add call to bump dev version to the upcoming version 0.8.1 (#191 <https://github.com/ros2/rmw/issues/191>)
* Add pub/sub option structures to support rmw specific payload feature (#187 <https://github.com/ros2/rmw/issues/187>)
* Contributors: Brian Marchi, Dirk Thomas, Karsten Knese, William Woodall
```

## rmw_implementation_cmake

- No changes
