### PR TITLE
rviz: 7.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1824,7 +1824,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 7.0.1-1
+      version: 7.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `7.0.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `7.0.1-1`

## rviz2

```
* Remove ROS arguments before passing to QApplication (#474 <https://github.com/ros2/rviz/issues/474>)
* Contributors: Jacob Perron
```

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Use clock from context in markers (#472 <https://github.com/ros2/rviz/issues/472>)
* Contributors: Martin Idel
```

## rviz_ogre_vendor

```
* Switch back to patch instead of git apply (#470 <https://github.com/ros2/rviz/issues/470>)
* Remove OGRE_BUILD_COMPONENT_SAMPLES cmake arg.
* Contributors: Chris Lalancette
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
