### PR TITLE
ros1_bridge: 0.8.1-3 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1258,7 +1258,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.8.1-1
+      version: 0.8.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.8.1-3`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## ros1_bridge

```
* fix showing duplicate keys in --print-pairs (#225 <https://github.com/ros2/ros1_bridge/issues/225>)
* fix bridging builtin_interfaces Duration and Time (#224 <https://github.com/ros2/ros1_bridge/issues/224>)
* Don't use features that will be deprecated (#222 <https://github.com/ros2/ros1_bridge/issues/222>)
* Contributors: Dirk Thomas, Peter Baughman
```
