### PR TITLE
rmw_implementation: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1208,7 +1208,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 0.8.0-4
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rmw_implementation
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-4`

## rmw_implementation

```
* use return_loaned_message_from (#76 <https://github.com/ros2/rmw_implementation/issues/76>)
* Add localhost boolean parameter to create node function (#75 <https://github.com/ros2/rmw_implementation/issues/75>)
* Zero copy api (#69 <https://github.com/ros2/rmw_implementation/issues/69>)
* Add Python API for RMW implementation lookups (#73 <https://github.com/ros2/rmw_implementation/issues/73>)
* update signature for added pub/sub options (#74 <https://github.com/ros2/rmw_implementation/issues/74>)
* remove unneeded line from CMakeLists (#70 <https://github.com/ros2/rmw_implementation/issues/70>)
* Make middleware selection more independent of build-time package availability (#67 <https://github.com/ros2/rmw_implementation/issues/67>)
* Contributors: Brian Marchi, Dan Rose, Karsten Knese, Michel Hidalgo, William Woodall
```
