### PR TITLE
rosbag2: 0.2.1-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1389,7 +1389,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.2.0-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.1-2`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.0-1`

## ros2bag

```
* Fix flake8 errors and add missing lint tests. (#194 <https://github.com/ros2/rosbag2/issues/194>)
* Import rosbag2_transport Python module on demand. (#190 <https://github.com/ros2/rosbag2/issues/190>)
* Contributors: Michel Hidalgo, Thomas Moulard
```

## rosbag2

```
* Add get_identifier to base io-interfaces for support in bagfile splitting (#183 <https://github.com/ros2/rosbag2/issues/183>)
* Add bagfile splitting support to storage_options (#182 <https://github.com/ros2/rosbag2/issues/182>)
* Support for zero copy API (#168 <https://github.com/ros2/rosbag2/issues/168>)
* Change storage interfaces for bagfile splitting feature (#170 <https://github.com/ros2/rosbag2/issues/170>)
* Contributors: Karsten Knese, Zachary Michaels
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

```
* Add get_identifier to base io-interfaces for support in bagfile splitting (#183 <https://github.com/ros2/rosbag2/issues/183>)
* Add bagfile splitting support to storage_options (#182 <https://github.com/ros2/rosbag2/issues/182>)
* Change storage interfaces for bagfile splitting feature (#170 <https://github.com/ros2/rosbag2/issues/170>)
* Contributors: Zachary Michaels
```

## rosbag2_storage_default_plugins

```
* Add get_identifier to storage io-interface for support in bagfile splitting. (#183 <https://github.com/ros2/rosbag2/issues/183>)
* Change storage interfaces for bagfile splitting feature (#170 <https://github.com/ros2/rosbag2/issues/170>)
* Add error checking on SqliteWrapper deconstructor. (#169 <https://github.com/ros2/rosbag2/issues/169>)
* Contributors: Zachary Michaels
```

## rosbag2_test_common

```
* Disable parameter event publishers on test nodes. (#180 <https://github.com/ros2/rosbag2/issues/180>)
* Fix API for new Intra-Process communication. (#143 <https://github.com/ros2/rosbag2/issues/143>)
* Contributors: Alberto Soragna, Dan Rose
```

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Disable parameter event publishers on test nodes. (#180 <https://github.com/ros2/rosbag2/issues/180>)
* Narrow down tests for topic discovery. (#178 <https://github.com/ros2/rosbag2/issues/178>)
* Fix API for new Intra-Process communication. (#143 <https://github.com/ros2/rosbag2/issues/143>)
* Add dependency on python_cmake_module. (#188 <https://github.com/ros2/rosbag2/issues/188>)
* Add bagfile splitting support to storage_options. (#182 <https://github.com/ros2/rosbag2/issues/182>)
* Fix the test failure of wrong messages count. (#165 <https://github.com/ros2/rosbag2/issues/165>)
* Support for zero-copy message transport. (#168 <https://github.com/ros2/rosbag2/issues/168>)
* Contributors: Alberto Soragna, ChenYing Kuo, Dan Rose, Karsten Knese, Mikael Arguedas, Zachary Michaels
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
