### PR TITLE
launch: 0.9.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -664,7 +664,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.9.3-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.2-1`

## launch

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

```
* add missing test dependency (#350 <https://github.com/ros2/launch/issues/350>)
  Signed-off-by: Dirk Thomas <mailto:dirk-thomas@users.noreply.github.com>
* Contributors: Dirk Thomas
```

## launch_xml

- No changes

## launch_yaml

- No changes
