### PR TITLE
grid_map: 1.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2605,7 +2605,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/anybotics/grid_map-release.git
-      version: 1.6.1-0
+      version: 1.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.6.2-1`:

- upstream repository: https://github.com/anybotics/grid_map.git
- release repository: https://github.com/anybotics/grid_map-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.6.1-0`

## grid_map

- No changes

## grid_map_core

```
* Implements a grid map transformation from one map frame to another map frame given the transform between the frames.
  Authors:
  Co-authored-by: fabianje <mailto:fabian.jenelten@mavt.ethz.ch>
* Contributors: fabianje
```

## grid_map_costmap_2d

- No changes

## grid_map_cv

- No changes

## grid_map_demos

- No changes

## grid_map_filters

```
* Update MinInRadiusFilter.cpp
* Contributors: Sascha Wirges
```

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

- No changes

## grid_map_rviz_plugin

- No changes

## grid_map_sdf

- No changes

## grid_map_visualization

- No changes
