### PR TITLE
rmw_cyclonedds: 0.4.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1179,6 +1179,25 @@ repositories:
       url: https://github.com/ros2/rmw_connext.git
       version: master
     status: maintained
+  rmw_cyclonedds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: master
+    release:
+      packages:
+      - cyclonedds_cmake_module
+      - rmw_cyclonedds_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
+      version: 0.4.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: master
+    status: developed
   rmw_fastrtps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.4.1-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## cyclonedds_cmake_module

```
* Use rosdep (#32 <https://github.com/ros2/rmw_cyclonedds/issues/32>)
* Contributors: Dan Rose
```

## rmw_cyclonedds_cpp

```
* rename return functions
* Solve the lint issue.
* Add already obsoleted loaned message interfaces
* zero copy api for cyclonedds
* Use right event info for RMW_EVENT_LIVELINESS_LOST
* unbreak Dashing build after #50 <https://github.com/ros2/rmw_cyclonedds/issues/50>
* Add compilation guards for RMW compatibility
* update signature for added pub/sub options
* Remove dead string serialization code (#41 <https://github.com/ros2/rmw_cyclonedds/issues/41>)
* Use RMW_RET_NODE_NAME_NON_EXISTENT only if defined
* Code improvements in ser/deser code wrt passing data size (#39 <https://github.com/ros2/rmw_cyclonedds/issues/39>)
* Return NODE_NAME_NON_EXISTENT instead of ERROR.
* Address uncrustify linter violation
* Validation in deserializer (#36 <https://github.com/ros2/rmw_cyclonedds/issues/36>)
* make cyclonedds vender package play nice with colcon (#34 <https://github.com/ros2/rmw_cyclonedds/issues/34>)
* Address CMake and uncrustify linter violations
* Fix "type punning" warning in printing floats (#33 <https://github.com/ros2/rmw_cyclonedds/issues/33>)
* Use rosdep (#32 <https://github.com/ros2/rmw_cyclonedds/issues/32>)
* Implemented byte-swapping in deserializer (#31 <https://github.com/ros2/rmw_cyclonedds/issues/31>)
* Optional reporting of late messages
* Multi-domain support
* Add support for printing messages to DDSI trace
* Contributors: Brian Marchi, Dan Rose, Erik Boasson, Karsten Knese, Scott K Logan, dennis-adlink, eboasson, evshary
```
