### PR TITLE
add python3-pytest-timeout

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5299,6 +5299,11 @@ python3-pytest-mock:
   gentoo: [dev-python/pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
+python3-pytest-timeout:
+  debian: [python3-pytest-timeout]
+  fedora: [python3-pytest-timeout]
+  gentoo: [dev-python/pytest-timeout]
+  ubuntu: [python3-pytest-timeout]
 python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]


### PR DESCRIPTION
[debian](https://packages.debian.org/buster/python3-pytest-timeout)
[fedora](https://fedora.pkgs.org/30/fedora-x86_64/python3-pytest-timeout-1.3.3-2.fc30.noarch.rpm.html)
[gentoo](https://packages.gentoo.org/packages/dev-python/pytest-timeout)
[ubuntu](https://packages.ubuntu.com/eoan/python3-pytest-timeout)

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>