### PR TITLE
eigenpy: 1.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1754,7 +1754,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 1.5.1-2
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
### Important notes

This changes the package from a catkin wrapper to a proper third-party released library per the REP. This requires changing dependent projects from `find_package(catkin REQUIRED COMPONENTS eigenpy)` to use `find_package(PkgConfig) ; pkg_check_modules(eigenpy REQUIRED eigenpy)`. 

I have opened such a PR for MoveIt and Exotica; the two projects currently depending on eigenpy. As thus, we need to coordinate a MoveIt release after this eigenpy release in the same sync cycle (cc: @v4hn).

### Regular bloom notes

Increasing version of package(s) in repository `eigenpy` to `1.6.2-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.5.1-2`
