### PR TITLE
eigenpy: 1.6.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2962,7 +2962,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 1.5.1-1
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
**Same note as in https://github.com/ros/rosdistro/pull/22797 applies here**

Increasing version of package(s) in repository `eigenpy` to `1.6.2-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.5.1-1`
