### PR TITLE
rosbag_editor: 0.4.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12311,7 +12311,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/rosbag_editor-release.git
-      version: 0.3.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/facontidavide/rosbag_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_editor` to `0.4.1-1`:

- upstream repository: https://github.com/facontidavide/rosbag_editor.git
- release repository: https://github.com/facontidavide/rosbag_editor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.0-1`
