### PR TITLE
rqt_reconfigure: 0.5.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8071,7 +8071,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.5.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.0-1`

## rqt_reconfigure

```
* Reproduce python2 behavior in NoneType comparison (#60 <https://github.com/ros-visualization/rqt_reconfigure/issues/60>)
  Re-applied after the behavior was regressed in
  e55cfa1c9b2ba1ec97626bc330d6e97f3237f795
* Contributors: Scott K Logan, Timon Engelke
```
