### PR TITLE
foonathan_memory_vendor: 0.3.0-1 in 'dashing/distribution.yaml…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -830,6 +830,18 @@ repositories:
         release: release/dashing/{package}/{version}
       url: https://github.com/boschresearch/fmilibrary_vendor-release.git
       version: 0.1.0-1
+  foonathan_memory_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
+      version: 0.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/eProsima/foonathan_memory_vendor.git
+      version: master
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `foonathan_memory_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/eProsima/foonathan_memory_vendor.git
- release repository: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
