### PR TITLE
Update source for foonathan_memory_vendor and enable tests.

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -473,11 +473,9 @@ repositories:
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
       version: 0.3.0-1
     source:
-      test_commits: false
-      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git
-      version: f3ab481cda60adc18d4172367f16af6076d8fde4
+      version: master
     status: maintained
   gazebo_ros_pkgs:
     doc:


### PR DESCRIPTION
foonathan_memory_vendor should be compatible with Dev and PR jobs on master.