### PR TITLE
costmap_converter: 0.0.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1223,7 +1223,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.9-0
+      version: 0.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.10-1`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.9-0`

## costmap_converter

```
* Runtime improvements for CostmapToPolygonsDBSMCCH (#12 <https://github.com/rst-tu-dortmund/costmap_converter/issues/12>)
  * Grid lookup for regionQuery
  * use a grid structure for looking up nearest neighbors
  * parameters in a struct
  * guard the parameters by drawing a copy from dynamic reconfigure
  * Adding some test cases for regionQuery and dbScan
  * Avoid computing sqrt at the end of convexHull2
  * Add doxygen comments for the neighbor lookup
  * Change the param read to one liners
  * Add test on empty map for dbScan
* Contributors: Rainer Kümmerle
```
