### PR TITLE
tello_driver: 0.3.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14829,7 +14829,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/appie-17/tello_driver-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       type: git
       url: https://github.com/appie-17/tello_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tello_driver` to `0.3.1-2`:

- upstream repository: https://github.com/appie-17/tello_driver.git
- release repository: https://github.com/appie-17/tello_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.1-1`
