### PR TITLE
costmap_converter: 0.0.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1223,7 +1223,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.9-0
+      version: 0.0.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.11-1`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.9-0`

## costmap_converter

```
* rostest integration to avoid running a roscore separately for unit testing
* Contributors: Christoph Rösmann
```
