### PR TITLE
rosbag_editor: 0.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7286,7 +7286,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/rosbag_editor-release.git
-      version: 0.3.0-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/facontidavide/rosbag_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_editor` to `0.4.2-1`:

- upstream repository: https://github.com/facontidavide/rosbag_editor.git
- release repository: https://github.com/facontidavide/rosbag_editor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.0-1`

## rosbag_editor

```
* downgrade to c++11
* Contributors: Davide Faconti
```
