### PR TITLE
turtlesim_dash_tutorial: 1.0.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9209,6 +9209,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: melodic-devel
     status: developed
+  turtlesim_dash_tutorial:
+    doc:
+      type: git
+      url: https://github.com/banerjs/turtlesim_dash_tutorial.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/banerjs-ros-release/turtlesim_dash_tutorial-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/banerjs/turtlesim_dash_tutorial.git
+      version: melodic-devel
+    status: maintained
   tuw_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim_dash_tutorial` to `1.0.0-2`:

- upstream repository: https://github.com/banerjs/turtlesim_dash_tutorial.git
- release repository: https://github.com/banerjs-ros-release/turtlesim_dash_tutorial-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## turtlesim_dash_tutorial

```
* Add a travis build
* Better documentation
* Feedback the results from the server
* Flesh out the client connection to the shape server. Also add requirements.txt
* Added in polling via JS
* Completed the pose plot
* Create a skeleton of the app and the internal class
* Create the package
* Contributors: Siddhartha Banerjee
```
