### PR TITLE
px4_msgs: 2.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -850,7 +850,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/PX4/px4_msgs2-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     status: developed
   py_trees:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `px4_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/PX4/px4_msgs.git
- release repository: https://github.com/PX4/px4_msgs2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.0-1`

## px4_msgs

```
* Update message definitions
* Add a dependency on ros_environment
* CI: bump container tags to 2019-10-24
* Contributors: PX4 BuildBot, TSC21, Tully Foote
```
