### PR TITLE
fmilibrary_vendor: 0.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -466,6 +466,12 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: 130e7c7f0c32bd27c543bb823a1b676407eb2656
     status: developed
+  fmilibrary_vendor:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/boschresearch/fmilibrary_vendor-release.git
+      version: 0.1.1-1
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `0.1.1-1`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/boschresearch/fmilibrary_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## fmilibrary_vendor

```
* Added build status badges.
```
