### PR TITLE
network_autoconfig: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8207,6 +8207,21 @@ repositories:
       url: https://github.com/UTNuclearRoboticsPublic/netft_utils.git
       version: master
     status: maintained
+  network_autoconfig:
+    doc:
+      type: git
+      url: https://github.com/LucidOne/network_autoconfig.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/LucidOne-release/network_autoconfig.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/LucidOne/network_autoconfig.git
+      version: master
+    status: developed
   network_interface:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_autoconfig` to `0.1.1-1`:

- upstream repository: https://github.com/LucidOne/network_autoconfig.git
- release repository: https://github.com/LucidOne-release/network_autoconfig.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## network_autoconfig

```
* Documentation updates
```
