### PR TITLE
turtlebot_loadout_kha1: 0.1.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15470,6 +15470,17 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_interactions.git
       version: indigo
     status: maintained
+  turtlebot_loadout_kha1:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/TurtleBot-Mfg-release/turtlebot_loadout_kha1.git
+      version: 0.1.0-3
+    source:
+      type: git
+      url: https://github.com/TurtleBot-Mfg/turtlebot_loadout_kha1.git
+      version: master
+    status: developed
   turtlebot_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_loadout_kha1` to `0.1.0-3`:

- upstream repository: https://github.com/TurtleBot-Mfg/turtlebot_loadout_kha1.git
- release repository: https://github.com/TurtleBot-Mfg-release/turtlebot_loadout_kha1.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## turtlebot_loadout_kha1

```
* Initial Release
```
