### PR TITLE
turtlebot_loadout_kha1: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9209,6 +9209,17 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: melodic-devel
     status: developed
+  turtlebot_loadout_kha1:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/TurtleBot-Mfg-release/turtlebot_loadout_kha1.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/TurtleBot-Mfg/turtlebot_loadout_kha1.git
+      version: master
+    status: developed
   tuw_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_loadout_kha1` to `0.1.0-1`:

- upstream repository: https://github.com/TurtleBot-Mfg/turtlebot_loadout_kha1.git
- release repository: https://github.com/TurtleBot-Mfg-release/turtlebot_loadout_kha1.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## turtlebot_loadout_kha1

```
* Initial Release
```
