### PR TITLE
network_autoconfig: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4823,6 +4823,21 @@ repositories:
       url: https://github.com/nerian-vision/nerian_stereo.git
       version: master
     status: developed
+  network_autoconfig:
+    doc:
+      type: git
+      url: https://github.com/LucidOne/network_autoconfig.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/LucidOne-release/network_autoconfig.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/LucidOne/network_autoconfig.git
+      version: master
+    status: developed
   network_interface:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_autoconfig` to `0.1.1-1`:

- upstream repository: https://github.com/LucidOne/network_autoconfig.git
- release repository: https://github.com/LucidOne-release/network_autoconfig.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## network_autoconfig

```
* Documentation updates
```
