### PR TITLE
py_trees_js: 0.5.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -876,7 +876,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_js-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.5.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/stonier/py_trees_js-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.0-1`

## py_trees_js

```
* [js] performance improvements, #120 <https://github.com/splintered-reality/py_trees_js/pull/120>
* [js] highlighted links, #115 <https://github.com/splintered-reality/py_trees_js/pull/115>
* [js] orthogonal link connections, for better visualisation
* [qt] capture screenshots, #114 <https://github.com/splintered-reality/py_trees_js/pull/114>
```
