### PR TITLE
py_trees_ros_tutorials: 1.0.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1598,10 +1598,9 @@ repositories:
       url: https://github.com/stonier/py_trees_ros_tutorials-release.git
       version: 1.0.5-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
-      version: devel
+      version: release/1.0.x
     status: developed
   py_trees_ros_viewer:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -961,6 +961,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: release/1.2.x
     status: developed
+  py_trees_ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros_tutorials-release.git
+      version: 1.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    status: developed
   py_trees_ros_viewer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `1.0.6-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/stonier/py_trees_ros_tutorials-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
