### PR TITLE
py_trees_ros_viewer: 0.1.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -913,6 +913,21 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: release/1.2.x
     status: developed
+  py_trees_ros_viewer:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: release/0.1.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros_viewer-release.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: release/0.1.x
+    status: developed
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_viewer` to `0.1.4-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_viewer.git
- release repository: https://github.com/stonier/py_trees_ros_viewer-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## py_trees_ros_viewer

```
* [infra] update to make use of usability / performance improvements in ``py_trees_js v0.5.1``
```
