### PR TITLE
ecl_core: 1.0.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -652,10 +652,9 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_core-release.git
       version: 1.0.4-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_core.git
-      version: devel
+      version: release/1.0.x
     status: maintained
   ecl_lite:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -315,6 +315,48 @@ repositories:
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
       version: dashing-devel
     status: maintained
+  ecl_core:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.0.x
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_core-release.git
+      version: 1.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: devel
+    status: maintained
   ecl_lite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `1.0.4-1`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
