### PR TITLE
rosmon: 2.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7538,7 +7538,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.2.0-1`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.1-1`

## rosmon

- No changes

## rosmon_core

```
* ui: adjust "faded" crashed color
  This makes the selected node more visible if it is a crashed one.
* terminal: new input system that hides known escape codes
  The old system would pass through all escape codes and generate
  *additional* SK_* events whenever a complete escape code was recognized.
  The new system hides those events, but will yield incomplete escape codes
  after a timeout (this is useful for supporting the escape key itself).
* ui: line wrap for node output
* node_monitor: Log manual start/stop actions
* colored log output from rosmon itself
* improved support for running under tmux and screen
* UI modernization (PR: #99) with new colors, redesigned status bar
* Interactive node search (PR: #97)
* Add restart count to ROS diagnostics (PR: #96)
* monitor: make updateStats() rate-independent (Issue: #95)
* Contributors: Max Schwarz, Tim Clephas
```

## rosmon_msgs

- No changes

## rqt_rosmon

```
* rqt_rosmon: use std::sort() instead of qSort()
  qSort() is deprecated in newer Qt versions.
* rqt_rosmon: node_model: fix dataChanged() column indices
  Column indices are end-inclusive, so we should give COL_COUNT-1. This
  fixes an issue where the table view would not update on new data.
* Contributors: Max Schwarz
```
