### PR TITLE
ainstein_radar: 1.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -203,7 +203,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 1.0.3-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ainstein_radar` to `1.1.0-1`:

- upstream repository: https://github.com/AinsteinAI/ainstein_radar.git
- release repository: https://github.com/AinsteinAI/ainstein_radar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.3-1`

## ainstein_radar

```
* Minor fixes to package XML formatting
  Fixed the package XML file formatting and added missing content to
  conform to the suggested style guidelines.
* Contributors: Nick Rotella
```

## ainstein_radar_drivers

```
* Minor fixes to package XML formatting
  Fixed the package XML file formatting and added missing content to
  conform to the suggested style guidelines.
* Add simple T79 (ZOI) configuration GUI
  Added a simple Tk-based configuration GUI for the non-BSD T79 firmware
  (ZOI or Zone Of Interest firmware).  This GUI allows setting the
  "Nonvolatile Radar Parameters Command" which includes CAN ID, baudrate,
  and self start behavior.
* Add K79-3D nodelet
  Added a nodelet for K79-3D to enable zero-copy message passing within
  the same nodelet manager.  Also added a launch file for testing this
  nodelet. Tested on hardware and working.
* Add non-BSD T79 node for ZOI firmware/deprecate BSD
  Added a new interface and node for the new ZOI (Zone of Interest) T79
  firmware and deprecated the old T79 BSD interface and node by moving
  them as needed. Both tested and working, however nodelets are not yet
  available due to runtime issues involving the virtual base class.
  The new T79 node allows setting the zone of interest (min/max range,
  min/max azimuth angle) via ROS dynamic reconfigure GUI. The new node
  also supports up to 10 radars at once, specifying the CAN ID of each
  as a fixed node parameter. To set the CAN ID for a radar, currently
  this must be done outside ROS. A service call may implement this soon.
* Bug fix in K79-3D interface, working in parking lot
  Fixed a few bugs in the parsing of K79-3D data packets which caused the
  data to be interpreted incorrectly resulting in nonphysical range and
  angles. Tested in the parking lot and seems to be working properly.
* Contributors: Nick Rotella
```

## ainstein_radar_filters

```
* Minor, add radar SNR as laserscan intensities
* Refactor pointcloud and laserscan converters
  Refactored the radar to pointcloud and laserscan conversion class and
  nodes in order to remove deprecated functionality and keep topic names
  consistent between them. The laserscan converter still has filtering
  based on the min/max angle/range parameters which should be removed and
  these parameters should be set from a radar sensor info message similar
  to camera info.
* Minor fixes to package XML formatting
  Fixed the package XML file formatting and added missing content to
  conform to the suggested style guidelines.
* Expose radar target array to point cloud conversion
  Exposed a function from ainstein_radar_filters which converts from the
  RadarTargetArray message type to the custom PCL point cloud type which
  includes radar data by making it static.  This was needed for new
  tools which need easy access to a polar-to-cartesian function. It may
  make more sense to pull out such conversions and put them in utility
  class somewhere else.
  Note that the only change to CMakeLists required to expose the header
  from this package to any package which imports it was to add an
  INCLUDE_DIRS line in the catkin_Package() function of this package.
* Add param for fixed frame to point cloud converter
  Add an optional fixed frame parameter for the radar target array to
  point cloud converted which takes in the name of the fixed frame,
  otherwise defaulting to map. Previously, map was hardcoded.
* Refactor redundant radar to pointcloud class
  Refactored the old, redundant radar to pointcloud converter class and
  associated node/lets to a radar speed filter class, preserving the
  projected speed filtering functionality. Tested on K79 data and working
  with mock zero speed command, should test further with nonzero GPS
  speed.
  There is still deprecated functionality in this class for testing the
  radar rotated which should be removed at some point as this was only
  experimental.
* Use custom PCL radar point for data converter class
  Switched from using the normal pcl::PointXYZ type to the custom radar
  specific ainstein_radar_filters::PointRadarTarget type in the radar to
  point cloud conversion class. Tested on radar data and verified that it
  allows coloring clouds according to additional radar-specific fields eg
  range, speed, etc. This permits using existing point cloud-based filter
  node/lets to filter based on radar parameters, deprecating eg the range
  filter class in this repo.
  Also removed a debug printout from the rviz plugin class.
* Contributors: Nick Rotella
```

## ainstein_radar_gazebo_plugins

```
* Minor fixes to package XML formatting
  Fixed the package XML file formatting and added missing content to
  conform to the suggested style guidelines.
* Contributors: Nick Rotella
```

## ainstein_radar_msgs

```
* Minor fixes to package XML formatting
  Fixed the package XML file formatting and added missing content to
  conform to the suggested style guidelines.
* Contributors: Nick Rotella
```

## ainstein_radar_rviz_plugins

```
* Minor fixes to package XML formatting
  Fixed the package XML file formatting and added missing content to
  conform to the suggested style guidelines.
* Use custom PCL radar point for data converter class
  Switched from using the normal pcl::PointXYZ type to the custom radar
  specific ainstein_radar_filters::PointRadarTarget type in the radar to
  point cloud conversion class. Tested on radar data and verified that it
  allows coloring clouds according to additional radar-specific fields eg
  range, speed, etc. This permits using existing point cloud-based filter
  node/lets to filter based on radar parameters, deprecating eg the range
  filter class in this repo.
  Also removed a debug printout from the rviz plugin class.
* Ensure RadarTargetArray visual cleared on hide
  Fixed bug so that the RadarTargetDisplay visuals get cleared when the
  display for them is hidden. Still fails to work sometimes, maybe there
  is a race condition - return to this later.
* Contributors: Nick Rotella
```
