### PR TITLE
robot_systemd: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11342,6 +11342,21 @@ repositories:
       url: https://github.com/MarcoStb1993/robot_statemachine.git
       version: master
     status: maintained
+  robot_systemd:
+    doc:
+      type: git
+      url: https://github.com/LucidOne/robot_systemd.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/LucidOne-release/robot_systemd.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/LucidOne/robot_systemd.git
+      version: master
+    status: developed
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_systemd` to `0.1.1-1`:

- upstream repository: https://github.com/LucidOne/robot_systemd.git
- release repository: https://github.com/LucidOne-release/robot_systemd.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## robot_systemd

```
* Added env-hook for environment
* Added documentation
```
