### PR TITLE
um7: 0.0.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15764,7 +15764,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/um7-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/ros-drivers/um7.git


### PR DESCRIPTION
Increasing version of package(s) in repository `um7` to `0.0.6-1`:

- upstream repository: https://github.com/ros-drivers/um7
- release repository: https://github.com/ros-drivers-gbp/um7-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.5-1`

## um7

```
* Fix error of mag topic not publish
* Contributors: Nicolas SIMON
```
