### PR TITLE
rail_mesh_icp: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6361,7 +6361,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/gt-rail-release/rail_mesh_icp-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/GT-RAIL/rail_mesh_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rail_mesh_icp` to `0.0.4-1`:

- upstream repository: https://github.com/GT-RAIL/rail_mesh_icp.git
- release repository: https://github.com/gt-rail-release/rail_mesh_icp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.3-1`

## rail_mesh_icp

```
* Merge pull request #1 <https://github.com/GT-RAIL/rail_mesh_icp/issues/1> from clalancette/fix-race
* Make the template_matcher_node depend on generated messages to avoid
  race condition on slow platforms.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Angel Andres Daruna, Chris Lalancette
```
