### PR TITLE
plotjuggler: 2.3.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9618,7 +9618,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.3.6-2
+      version: 2.3.7-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.3.7-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.3.6-2`

## plotjuggler

```
* Dont take invisible curve into account for axis limit computation (#185 <https://github.com/facontidavide/PlotJuggler/issues/185>)
* consistent line width
* do not close() a rosbag unless you accepted the dialog
* important bug fix: stop playback when loading new data
* fix bug in TopicPublisher
* do complete reset of globals in custom functions
* apply changes discussed in #220 <https://github.com/facontidavide/PlotJuggler/issues/220>
* Merge branch 'master' of github.com:facontidavide/PlotJuggler
* cherry picking bug fix from #220 <https://github.com/facontidavide/PlotJuggler/issues/220> : update custom functions
  Thanks @aeudes
* Fix F10 is ambiguous (#219 <https://github.com/facontidavide/PlotJuggler/issues/219>)
* fix compilation and add feature #218 <https://github.com/facontidavide/PlotJuggler/issues/218>
* qwt updated
* appImage instructions updated
* Contributors: Davide Faconti, alexandre eudes
```
