### PR TITLE
add python-pydrive-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -242,16 +242,16 @@ pydocstyle:
 pydrive-pip:
   debian:
     pip:
-     packages: [PyDrive]
+      packages: [PyDrive]
   fedora:
     pip:
-     packages: [PyDrive]
+      packages: [PyDrive]
   osx:
     pip:
-     packages: [PyDrive]
+      packages: [PyDrive]
   ubuntu:
     pip:
-     packages: [PyDrive]
+      packages: [PyDrive]
 pyflakes3:
   debian: [pyflakes3]
   fedora: [python3-pyflakes]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -239,6 +239,19 @@ pydocstyle:
   gentoo: [dev-python/pydocstyle]
   openembedded: ['${PYTHON_PN}-pydocstyle@meta-ros']
   ubuntu: [pydocstyle]
+pydrive-pip:
+  debian:
+    pip:
+     packages: [PyDrive]
+  fedora:
+    pip:
+     packages: [PyDrive]
+  osx:
+    pip:
+     packages: [PyDrive]
+  ubuntu:
+    pip:
+     packages: [PyDrive]
 pyflakes3:
   debian: [pyflakes3]
   fedora: [python3-pyflakes]


### PR DESCRIPTION
I add `PyDrive` install via `pip` with this PR.
PyPi: https://pypi.org/project/PyDrive/