### PR TITLE
behaviotree_cpp_v3: 3.1.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -933,7 +933,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
-      version: 3.0.7-0
+      version: 3.1.0-3
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviotree_cpp_v3` to `3.1.0-3`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.0.7-0`

## behaviortree_cpp_v3

```
* Error message corrected
* fix windows and mingw compilation (?)
* Merge pull request #70 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/70> from Masadow/patch-3
  Added 32bits compilation configuration for msvc
* make Tree non copyable
* fix #114 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/114>
* Merge branch 'master' of https://github.com/BehaviorTree/BehaviorTree.CPP
* critical bug fix affecting AsyncActionNode
  When a Tree is copied, all the thread related to AsyncActionNode where
  invoked.
  As a consequence, they are never executed, despite the fact that the
  value RUNNING is returned.
* Fix issue #109 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/109>
* fix #111 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/111>
* Merge pull request #108 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/108> from daniel-serrano/add-RobMoSys-acknowledgement
  Add robmosys acknowledgement
* Add robomosys acknowledgement as requested
* Add robomosys acknowledgement as requested
* added more comments (issue #102 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/102>)
* Update README.md
* Add files via upload
* Merge pull request #96 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/96> from LoyVanBeek/patch-1
  Fix typo
* Update tutorial_04_sequence_star.md
* fix compilation
* removing backward_cpp
  Motivation: backward_cpp is SUPER useful, but it is a library to use at
  the application level. It makes no sense to add it at the library level.
* Merge pull request #95 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/95> from LoyVanBeek/patch-1
  Remove 0 in front of http://... URL to publication
* Remove 0 in front of http://... URL to publication
  Hopefully, this makes the link correctly click-able when rendered to HTML
* fix issue #84 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/84> (Directories)
* add infinite loop to Repeat and Retry (issue #80 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/80>)
* fix unit test
* issue #82 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/82>
* fix issue #82 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/82>
* Added 32bits compilation configuration for msvc
* Contributors: Daniel Serrano, Davide Facont, Davide Faconti, Jimmy Delas, Loy
```
