### PR TITLE
oxford_gps_eth: 1.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9079,7 +9079,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 1.0.0-0
+      version: 1.1.1-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `1.1.1-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.0-0`

## oxford_gps_eth

```
* Install Python script
* Add missing rospy dependency
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```
