### PR TITLE
kinesis_video_streamer: 3.1.0-1 in 'dashing/distribution.yaml'…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1103,7 +1103,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
-      version: 3.0.0-2
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinesis_video_streamer` to `3.1.0-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-ros2.git
- release repository: https://github.com/aws-gbp/kinesis_video_streamer-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.0-2`

## kinesis_video_msgs

```
* Bump version to 3.1.0
* Fix author, maintainer information for kinesis_video_msgs
* Contributors: AAlon, ryanewel
```

## kinesis_video_streamer

```
* Bump version number to 3.1.0
* Add ability to set AWS Region and stream name via launch parameters (#20 <https://github.com/aws-robotics/kinesisvideo-ros2/issues/20>)
  * add ability to override aws_region and stream_name via launch parameters
  * add ability to override rekognition_data_stream via launch parameters
  * address feedback in the pull request
  * conditionally override rekognition_data_stream, so that sample_config.yaml does not need to be modified
* Contributors: M. M, ryanewel
```
