### PR TITLE
lex_node: 3.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1203,7 +1203,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/lex_node-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lex_node` to `3.1.0-1`:

- upstream repository: https://github.com/aws-robotics/lex-ros2.git
- release repository: https://github.com/aws-gbp/lex_node-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.0-1`

## lex_common_msgs

```
* 3.1.0
* Contributors: ryanewel
```

## lex_node

```
* Merge pull request #9 <https://github.com/aws-robotics/lex-ros2/issues/9> from aws-robotics/bump-version
  3.1.0
* 3.1.0
* Merge pull request #8 <https://github.com/aws-robotics/lex-ros2/issues/8> from aws-robotics/add-region-userid
  Allow setting region or user_id from env var or param
* Allow setting region or user_id from env var or param
  - Allow launching this node with a specific aws region or user_id by
  setting ROS_AWS_REGION or LEX_USER_ID or passing them as parameters to
  the launch file.
* Merge pull request #7 <https://github.com/aws-robotics/lex-ros2/issues/7> from aws-robotics/allow-config-change
  Allow specifying config_file and node_name
* Make logging stream to stdout in code instead of env var
  - This is how the ros2/demos samples ensure that logs stream to stdout
  instead of buffering. Doing it this way will be more reliable than
  setting the env var in the launch file.
* Allow specifying config_file and node_name
  - Add parameters to allow the user of this node to specify their own
  config file and node name.
* Contributors: Tim Robinson
```
