### PR TITLE
rmw_cyclonedds: 0.4.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1252,7 +1252,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.4.2-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.1-1`

## cyclonedds_cmake_module

- No changes

## rmw_cyclonedds_cpp

```
* Suppress a syntax error identified by cppcheck 1.89 (#59 <https://github.com/ros2/rmw_cyclonedds/issues/59>)
  Signed-off-by: Scott K Logan <mailto:logans@cottsay.net>
* Make RMW version acceptable to MSVC (#58 <https://github.com/ros2/rmw_cyclonedds/issues/58>)
  GCC and Clang support the ternary operator in macros, MSVC does not.
  Signed-off-by: Erik Boasson <mailto:eb@ilities.com>
* skip compilation of rmw_cyclonedds when cyclone dds is not found (#56 <https://github.com/ros2/rmw_cyclonedds/issues/56>)
  * skip compilation of rmw_cyclonedds when cyclone dds is not found
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
  * proper case and company name
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
  * linters
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
  * change ADLINK to Eclipse
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* remove executive flags from source code files
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* Contributors: Karsten Knese, Scott K Logan, eboasson
```
