### PR TITLE
py_trees: 1.3.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -909,7 +909,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 1.3.0-2
+      version: 1.3.3-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `1.3.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.0-2`

## py_trees

```
* [blackboard] client ``Blackboard.unregister_key()`` method
```
