### PR TITLE
Add multiple packages to documentation index for indigo and kinetic

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -585,16 +585,6 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_halcon_bridge.git
       version: master
-  asr_ism:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_ism.git
-      version: master
-  asr_ism_visualizations:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_ism_visualizations.git
-      version: master
   asr_ivt:
     doc:
       type: git
@@ -614,16 +604,6 @@ repositories:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_kinematic_chain_optimizer.git
-      version: master
-  asr_lib_ism:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_lib_ism.git
-      version: master
-  asr_lib_pose_prediction_ism:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_lib_pose_prediction_ism.git
       version: master
   asr_mild_base_driving:
     doc:
@@ -675,30 +655,10 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_object_database.git
       version: master
-  asr_psm:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_psm.git
-      version: master
-  asr_psm_visualizations:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_psm_visualizations.git
-      version: master
   asr_rapidxml:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
-      version: master
-  asr_relation_graph_generator:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_relation_graph_generator.git
-      version: master
-  asr_resources_for_psm:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_resources_for_psm.git
       version: master
   asr_resources_for_vision:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -585,6 +585,16 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_halcon_bridge.git
       version: master
+  asr_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism.git
+      version: master
+  asr_ism_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism_visualizations.git
+      version: master
   asr_ivt:
     doc:
       type: git
@@ -604,6 +614,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_kinematic_chain_optimizer.git
+      version: master
+  asr_lib_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_ism.git
+      version: master
+  asr_lib_pose_prediction_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_pose_prediction_ism.git
       version: master
   asr_mild_base_driving:
     doc:
@@ -655,10 +675,30 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_object_database.git
       version: master
+  asr_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm.git
+      version: master
+  asr_psm_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm_visualizations.git
+      version: master
   asr_rapidxml:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
+  asr_relation_graph_generator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_relation_graph_generator.git
+      version: master
+  asr_resources_for_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_psm.git
       version: master
   asr_resources_for_vision:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -415,6 +415,16 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_halcon_bridge.git
       version: master
+  asr_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism.git
+      version: master
+  asr_ism_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism_visualizations.git
+      version: master
   asr_ivt:
     doc:
       type: git
@@ -434,6 +444,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_kinematic_chain_optimizer.git
+      version: master
+  asr_lib_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_ism.git
+      version: master
+  asr_lib_pose_prediction_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_pose_prediction_ism.git
       version: master
   asr_mild_base_driving:
     doc:
@@ -485,10 +505,30 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_object_database.git
       version: master
+  asr_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm.git
+      version: master
+  asr_psm_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm_visualizations.git
+      version: master
   asr_rapidxml:
     doc:
       type: git
       url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
+  asr_relation_graph_generator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_relation_graph_generator.git
+      version: master
+  asr_resources_for_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_psm.git
       version: master
   asr_resources_for_vision:
     doc:


### PR DESCRIPTION
Adding new packages to indigo and kinetic documentation index:
- asr_ism
- asr_ism_visualizations
- asr_lib_ism
- asr_lib_pose_prediction_ism
- asr_psm
- asr_psm_visualizations
- asr_relation_graph_generator
- asr_resources_for_psm