### PR TITLE
seed_smartactuator_sdk: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8492,6 +8492,22 @@ repositories:
       url: https://github.com/ipab-slmc/SDHLibrary-CPP.git
       version: master
     status: maintained
+  seed_smartactuator_sdk:
+    doc:
+      type: git
+      url: https://github.com/seed-solutions/seed_smartactuator_sdk.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
+      version: 0.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/seed-solutions/seed_smartactuator_sdk.git
+      version: master
+    status: developed
   serial:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_smartactuator_sdk` to `0.0.4-1`:

- upstream repository: https://github.com/seed-solutions/seed_smartactuator_sdk.git
- release repository: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
