### PR TITLE
libmynteye: 0.2.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6279,10 +6279,12 @@ repositories:
       url: https://github.com/harjeb/libmynteye.git
       version: master
     release:
+      packages:
+      - ros_mynteye
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/harjeb/libmynteye-release.git
-      version: 0.1.3-0
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libmynteye` to `0.2.2-1`:

- upstream repository: https://github.com/harjeb/libmynteye.git
- release repository: https://github.com/harjeb/libmynteye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.3-0`

## ros_mynteye

```
* rename package
```
