### PR TITLE
cpswarm_msgs: 1.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2037,7 +2037,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cpswarm/cpswarm_msgs-release.git
-      version: 1.1.0-0
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2032,17 +2032,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/cpswarm/cpswarm_msgs.git
-      version: 1.1.0
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cpswarm/cpswarm_msgs-release.git
-      version: 1.1.0-1
+      version: 1.1.0-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/cpswarm/cpswarm_msgs.git
-      version: 1.1.0
+      version: kinetic-devel
     status: developed
   crane_x7:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2028,6 +2028,22 @@ repositories:
       url: https://github.com/clearpathrobotics/cpr_multimaster_tools.git
       version: kinetic-devel
     status: developed
+  cpswarm_msgs:
+    doc:
+      type: git
+      url: https://github.com/cpswarm/cpswarm_msgs.git
+      version: 1.1.0
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/cpswarm/cpswarm_msgs-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cpswarm/cpswarm_msgs.git
+      version: 1.1.0
+    status: developed
   crane_x7:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpswarm_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/cpswarm/cpswarm_msgs.git
- release repository: https://github.com/cpswarm/cpswarm_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## cpswarm_msgs

```
* Added: State event
* Added: Area division event
* Added: Target action
* Changed: Use stamped pose for actions
* Removed: Assigned CPS from tracking action
* Added: Valid flag for get waypoint service
* Fixed: Rename service files according to ROS best practices
* Contributors: Micha Sende
```
