### PR TITLE
ros_canopen: 0.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7000,7 +7000,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.8.2-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## can_msgs

- No changes

## canopen_402

```
* enable rosconsole_bridge bindings
* switch to new logging macros
* Contributors: Mathias Lüdtke
```

## canopen_chain_node

```
* rename to logWarning to fix build on Debian stretch
* log the result of all services in RosChain
* enable rosconsole_bridge bindings
* switch to new logging macros
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* implemented LayerStatus::equals<>()
* added support for SYNC counter in SimpleSyncLayer (#349 <https://github.com/ipa-mdl/ros_canopen/issues/349>)
* enable rosconsole_bridge bindings
* switch to new logging macros
* add logging based on console_bridge
* removed implicit Header operator
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

- No changes

## ros_canopen

- No changes

## socketcan_bridge

```
* fix roslint errors in socketcan_bridge
* run roslint as part of run_tests
* enable rosconsole_bridge bindings
* Contributors: Mathias Lüdtke
```

## socketcan_interface

```
* enable rosconsole_bridge bindings
* switch to new logging macros
* add logging based on console_bridge
* handle extended frame strings like candump
* implement Frame::fullid()
* removed implicit Header operator
* move stream operators into can namespace
* Contributors: Mathias Lüdtke
```
