### PR TITLE
ros_canopen: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2071,6 +2071,19 @@ repositories:
       url: https://github.com/ros2/ros2cli.git
       version: dashing
     status: developed
+  ros_canopen:
+    release:
+      packages:
+      - can_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: dashing-devel
+    status: developed
   ros_environment:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `2.0.0-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## can_msgs

```
* port can_msgs to ROS2
* Contributors: Joshua Whitley, Mathias Lüdtke
```
