### PR TITLE
swarm_functions: 1.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14642,7 +14642,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/cpswarm/swarm_functions.git
-      version: master
+      version: kinetic-devel
     release:
       packages:
       - area_division

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14643,6 +14643,25 @@ repositories:
       type: git
       url: https://github.com/cpswarm/swarm_functions.git
       version: master
+    release:
+      packages:
+      - area_division
+      - coverage_path
+      - kinematics_exchanger
+      - state_exchanger
+      - swarm_functions
+      - target_monitor
+      - task_allocation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/cpswarm/swarm_functions-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cpswarm/swarm_functions.git
+      version: kinetic-devel
+    status: developed
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swarm_functions` to `1.1.0-1`:

- upstream repository: https://github.com/cpswarm/swarm_functions.git
- release repository: https://github.com/cpswarm/swarm_functions-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## area_division

```
* Initial release of area_division
* Contributors: Micha Sende
```

## coverage_path

```
* Initial release of coverage_path
* Contributors: Micha Sende
```

## kinematics_exchanger

```
* Changed: Renamed package swarm_kinematics_exchanger to kinematics_exchanger
* Contributors: Micha Sende
```

## state_exchanger

```
* Initial release of state_exchanger
* Contributors: Micha Sende
```

## swarm_functions

```
* Added: Package area_division
* Added: Package coverage_path
* Added: Package state_exchanger
* Added: Package target_monitor
* Changed: Renamed package swarm_kinematics_exchanger to kinematics_exchanger
* Fixed task_allocation: Use frame ID in messages
* Changed task_allocation: Use latched topics
```

## target_monitor

```
* Initial release of target_monitor
* Contributors: Micha Sende
```

## task_allocation

```
* Fixed: Use frame ID in messages
* Changed: Use latched topics
* Contributors: Micha Sende
```
