### PR TITLE
fmi_adapter_ros2: 0.1.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -508,6 +508,24 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: 130e7c7f0c32bd27c543bb823a1b676407eb2656
     status: developed
+  fmi_adapter_ros2:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: eloquent
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
+      version: 0.1.6-1
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: eloquent
+    status: developed
   fmilibrary_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.6-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/boschresearch/fmi_adapter_ros2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## fmi_adapter

```
* Release for ROS 2 Eloquent.
* Changed build files for use of fmilibrary_vendor package.
```

## fmi_adapter_examples

```
* Release for ROS 2 Eloquent.
```
