### PR TITLE
ros_canopen: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1399,6 +1399,19 @@ repositories:
       url: https://github.com/ros2/ros2cli.git
       version: master
     status: maintained
+  ros_canopen:
+    release:
+      packages:
+      - can_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: dashing-devel
+    status: developed
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `2.0.0-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## can_msgs

```
* port can_msgs to ROS2
* Contributors: Joshua Whitley, Mathias Lüdtke
```
