### PR TITLE
added inertial_sense_ros to melodic distribution.yaml

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3098,6 +3098,11 @@ repositories:
       url: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
       version: master
     status: maintained
+  inertial_sense_ros:
+    doc:
+      type: git
+      url: https://github.com/inertialsense/inertial_sense_ros.git
+      version: master
   interactive_marker_proxy:
     doc:
       type: git


### PR DESCRIPTION
I did this once before and got a comment from @tfoote for licensing, but I was to slow to fix it. I added licensing to the README and added license.txt  

Hope that covers all the bases!