### PR TITLE
dataspeed_ulc_ros: 0.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1338,7 +1338,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_ulc_ros` to `0.0.5-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.4-1`

## dataspeed_ulc

- No changes

## dataspeed_ulc_can

```
* Updates scale factor on linear accel and decel limit CAN signals
* Adds README to document the ROS node interface
* Contributors: Micho Radovnikovich
```

## dataspeed_ulc_msgs

- No changes
