### PR TITLE
Add python3-setuptools-scm rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5437,6 +5437,17 @@ python3-setuptools:
   openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-setuptools]
+python3-setuptools-scm:
+  arch: [python-setuptools-scm]
+  debian: [python-setuptools-scm]
+  fedora: [python3-setuptools_scm]
+  gentoo: [dev-python/setuptools_scm]
+  macports: ['py%{python3_pkgversion}-setuptools_scm']
+  osx:
+    pip:
+      packages: [setuptools-scm]
+  rhel: ['python%{python3_pkgversion}-setuptools_scm']
+  ubuntu: [python3-setuptools-scm]
 python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip]


### PR DESCRIPTION
Signed-off-by: Thomas Moulard <tmoulard@amazon.com>

Distro information using [`whohas`](https://unix.stackexchange.com/questions/62355/is-there-a-tool-website-to-compare-package-status-in-different-linux-distributio):
```
$ whohas setuptools-scm
Fink        setuptools-scm-py27                    3.1.0-1                                                      http://pdb.finkproject.org/pdb/package.php/setuptools-scm-py27
Fink        setuptools-scm-py34                    3.1.0-1                                                      http://pdb.finkproject.org/pdb/package.php/setuptools-scm-py34
Fink        setuptools-scm-py35                    3.1.0-1                                                      http://pdb.finkproject.org/pdb/package.php/setuptools-scm-py35
Fink        setuptools-scm-py36                    3.1.0-1                                                      http://pdb.finkproject.org/pdb/package.php/setuptools-scm-py36
Fink        setuptools-scm-py37                    3.1.0-1                                                      http://pdb.finkproject.org/pdb/package.php/setuptools-scm-py37
Ubuntu      pypy-setuptools-scm                    1.15.6-1           13K             all                       http://packages.ubuntu.com/bionic/pypy-setuptools-scm
Ubuntu      pypy-setuptools-scm                    3.0.6-1            18K             all                       http://packages.ubuntu.com/cosmic/pypy-setuptools-scm
Ubuntu      pypy-setuptools-scm                    3.2.0-1            19K             all                       http://packages.ubuntu.com/disco/pypy-setuptools-scm
Ubuntu      pypy-setuptools-scm                    3.3.3-2            19K             all                       http://packages.ubuntu.com/eoan/pypy-setuptools-scm
Ubuntu      python-setuptools-scm                  1.10.1-2ubuntu1    11K             all                       http://packages.ubuntu.com/xenial/python-setuptools-scm
Ubuntu      python-setuptools-scm                  1.15.6-1           13K             all                       http://packages.ubuntu.com/bionic/python-setuptools-scm
Ubuntu      python-setuptools-scm                  3.0.6-1            19K             all                       http://packages.ubuntu.com/cosmic/python-setuptools-scm
Ubuntu      python-setuptools-scm                  3.2.0-1            19K             all                       http://packages.ubuntu.com/disco/python-setuptools-scm
Ubuntu      python-setuptools-scm                  3.3.3-2            19K             all                       http://packages.ubuntu.com/eoan/python-setuptools-scm
Ubuntu      python3-setuptools-scm                 1.10.1-2ubuntu1    11K             all                       http://packages.ubuntu.com/xenial/python3-setuptools-scm
Ubuntu      python3-setuptools-scm                 1.15.6-1           13K             all                       http://packages.ubuntu.com/bionic/python3-setuptools-scm
Ubuntu      python3-setuptools-scm                 3.0.6-1            18K             all                       http://packages.ubuntu.com/cosmic/python3-setuptools-scm
Ubuntu      python3-setuptools-scm                 3.2.0-1            19K             all                       http://packages.ubuntu.com/disco/python3-setuptools-scm
Ubuntu      python3-setuptools-scm                 3.3.3-2            19K             all                       http://packages.ubuntu.com/eoan/python3-setuptools-scm
Ubuntu      python3-setuptools-scm-git-archive     1.0-1              3K              all                       http://packages.ubuntu.com/cosmic/python3-setuptools-scm-git-archive
Ubuntu      python3-setuptools-scm-git-archive     1.0-2              3K              all                       http://packages.ubuntu.com/disco/python3-setuptools-scm-git-archive
Ubuntu      python3-setuptools-scm-git-archive     1.1-2              4K              all                       http://packages.ubuntu.com/eoan/python3-setuptools-scm-git-archive
Debian      pypy-setuptools-scm                    3.2.0-1~bpo9+1     24K             all                       http://packages.debian.org/stretch-backports/pypy-setuptools-scm
Debian      pypy-setuptools-scm                    3.2.0-1            24K             all                       http://packages.debian.org/buster/pypy-setuptools-scm
Debian      pypy-setuptools-scm                    3.3.3-2            24K             all                       http://packages.debian.org/bullseye/pypy-setuptools-scm
Debian      pypy-setuptools-scm                    3.3.3-2            24K             all                       http://packages.debian.org/sid/pypy-setuptools-scm
Debian      python-setuptools-scm                  1.15.0-1           15K             all                       http://packages.debian.org/stretch/python-setuptools-scm
Debian      python-setuptools-scm                  3.2.0-1~bpo9+1     24K             all                       http://packages.debian.org/stretch-backports/python-setuptools-scm
Debian      python-setuptools-scm                  3.2.0-1            24K             all                       http://packages.debian.org/buster/python-setuptools-scm
Debian      python-setuptools-scm                  3.3.3-2            24K             all                       http://packages.debian.org/bullseye/python-setuptools-scm
Debian      python-setuptools-scm                  3.3.3-2            24K             all                       http://packages.debian.org/sid/python-setuptools-scm
Debian      python3-setuptools-scm                 1.15.0-1           15K             all                       http://packages.debian.org/stretch/python3-setuptools-scm
Debian      python3-setuptools-scm                 3.2.0-1~bpo9+1     24K             all                       http://packages.debian.org/stretch-backports/python3-setuptools-scm
Debian      python3-setuptools-scm                 3.2.0-1            24K             all                       http://packages.debian.org/buster/python3-setuptools-scm
Debian      python3-setuptools-scm                 3.3.3-2            24K             all                       http://packages.debian.org/bullseye/python3-setuptools-scm
Debian      python3-setuptools-scm                 3.3.3-2            24K             all                       http://packages.debian.org/sid/python3-setuptools-scm
Debian      python3-setuptools-scm-git-archive     1.0-2              3K              all                       http://packages.debian.org/buster/python3-setuptools-scm-git-archive
Debian      python3-setuptools-scm-git-archive     1.1-2              4K              all                       http://packages.debian.org/bullseye/python3-setuptools-scm-git-archive
Debian      python3-setuptools-scm-git-archive     1.1-2              4K              all                       http://packages.debian.org/sid/python3-setuptools-scm-git-archive
Gentoo      setuptools-git                         1.2                                                          http://packages.gentoo.org/package/dev-python/setuptools-git 
Gentoo      setuptools-git                         1.0-r1000                                                    http://packages.gentoo.org/package/dev-python/setuptools-git 
Gentoo      setuptools                             9999                                                         http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             9999                                                         http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             41.5.1                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             41.5.0                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             41.4.0                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             41.2.0                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             41.1.0                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             40.6.3                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             36.7.2                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             18.2-r1000                                                   http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             12.0.1                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools                             0.8-r1                                                       http://packages.gentoo.org/package/dev-python/setuptools 
Gentoo      setuptools-markdown                    0.2                                                          http://packages.gentoo.org/package/dev-python/setuptools-markdown 
Gentoo      pbr                                    5.4.3                                                        http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    5.1.3                                                        http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    5.1.1                                                        http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    4.2.0-r2                                                     http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    4.2.0-r1                                                     http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    4.1.1                                                        http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    3.1.1                                                        http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    1.10.0-r1                                                    http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    0.11.0-r1000                                                 http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    0.8.2-r1                                                     http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    0.8.2-r1                                                     http://packages.gentoo.org/package/dev-python/pbr 
Gentoo      pbr                                    0.8.0                                                        http://packages.gentoo.org/package/dev-python/pbr 
```

Other distros I checked that `whohas` does not report:

- MacPorts: https://www.macports.org/ports.php?by=name&substr=setuptools_scm
- Arch: https://www.archlinux.org/packages/?sort=&q=python-setuptools-scm&maintainer=&flagged=
- RHEL: https://access.redhat.com/downloads/content/python3-setuptools_scm/1.15.7-4.el8/noarch/fd431d51/package
- Fedora: https://apps.fedoraproject.org/packages/python3-setuptools_scm

OpenEmbedded does not package this software AFAIK, so I didn't add a key for it.