### PR TITLE
cob_calibration_data: 0.6.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -804,7 +804,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.12-1
+      version: 0.6.13-1
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.13-1`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.12-1`

## cob_calibration_data

```
* Merge pull request #157 <https://github.com/ipa320/cob_calibration_data/issues/157> from floweisshardt/migrate/travis_com
  migrate to travis-ci.com
* migrate to travis-ci.com
* Merge pull request #156 <https://github.com/ipa320/cob_calibration_data/issues/156> from fmessmer/add_cob4-24
  add cob4-24
* transfer mojin calibration to cob calibration for cob4-24
* add cob4-24
* Merge pull request #155 <https://github.com/ipa320/cob_calibration_data/issues/155> from HannesBachter/update_cob4-3
  update xacro for cob4-3
* update xacro for cob4-3
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, floweisshardt, fmessmer, hyb
```
