### PR TITLE
cob_extern: 0.6.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -960,7 +960,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.13-1
+      version: 0.6.14-1
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.14-1`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.13-1`

## cob_extern

- No changes

## libdlib

- No changes

## libntcan

- No changes

## libpcan

```
* Merge pull request #100 <https://github.com/ipa320/cob_extern/issues/100> from christian-rauch/rm_dep_header
  remove dependency on linux-headers-generic
* remove dependency on linux-headers-generic
  rosdep key 'linux-headers-generic' will always install the "standard" kernel headers. On Ubuntu LTS, where kernels are updated with point
  releases, this will depend on the old kernel header files, while a newer kernel image might be booted.
* Contributors: Christian Rauch, Felix Messmer
```

## libphidgets

- No changes

## opengm

- No changes
