### PR TITLE
cob_supported_robots: 0.6.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1080,7 +1080,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.12-1
+      version: 0.6.13-1
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.13-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.12-1`

## cob_supported_robots

```
* Merge pull request #23 <https://github.com/ipa320/cob_supported_robots/issues/23> from floweisshardt/migrate/travis_com
  migrate to travis-ci.com
* migrate to travis-ci.com
* Merge pull request #22 <https://github.com/ipa320/cob_supported_robots/issues/22> from fmessmer/add_cob4-24
  add cob4-24
* add cob4-24
* Contributors: Benjamin Maidel, Florian Weisshardt, floweisshardt, fmessmer
```
