### PR TITLE
cob_common: 0.7.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1482,7 +1482,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.1-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.0-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

```
* Merge pull request #274 <https://github.com/ipa320/cob_common/issues/274> from LoyVanBeek/feature/usb-cam-model
  Put in true dimensions of usb-camera according to datasheet
* Put in true dimensions of usb-camera according to datasheet
* Merge pull request #272 <https://github.com/ipa320/cob_common/issues/272> from fmessmer/copy_pg70_description
  copy schunk_pg70
* fix simulated camera_info topic name of d435
* fake inertia for pg70
* copy schunk_pg70
* Contributors: Felix Messmer, Florian Weisshardt, Loy van Beek, fmessmer
```

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

- No changes
