### PR TITLE
cob_robots: 0.7.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1731,7 +1731,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.2-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.1-1`

## cob_bringup

```
* Merge pull request #788 <https://github.com/ipa320/cob_robots/issues/788> from HannesBachter/add_cob4-24
  Add cob4 24
* use internal sync for arms and grippers
* move grippers to t3
* Merge pull request #786 <https://github.com/ipa320/cob_robots/issues/786> from fmessmer/add_cob4-24
  [WIP] add cob4 24
* Merge pull request #24 <https://github.com/ipa320/cob_robots/issues/24> from HannesBachter/add_cob4-24
  fix gripper
* fix gripper can, driver, ...
* configure external sync for arm and pg70 on same can bus
* add cob4-24
* Merge pull request #783 <https://github.com/ipa320/cob_robots/issues/783> from HannesBachter/update_cob4-3
  update cob4-3 to regular cob base
* update cob4-3 to regular cob base
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer, hyb
```

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

```
* Merge pull request #788 <https://github.com/ipa320/cob_robots/issues/788> from HannesBachter/add_cob4-24
  Add cob4 24
* add default acc and vel for grippers
* Merge pull request #786 <https://github.com/ipa320/cob_robots/issues/786> from fmessmer/add_cob4-24
  [WIP] add cob4 24
* Merge pull request #24 <https://github.com/ipa320/cob_robots/issues/24> from HannesBachter/add_cob4-24
  fix gripper
* fix gripper can, driver, ...
* add cob4-24
* Merge pull request #783 <https://github.com/ipa320/cob_robots/issues/783> from HannesBachter/update_cob4-3
  update cob4-3 to regular cob base
* update cob4-3 to regular cob base
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer, hyb
```

## cob_hardware_config

```
* Merge pull request #786 <https://github.com/ipa320/cob_robots/issues/786> from fmessmer/add_cob4-24
  [WIP] add cob4 24
* Merge pull request #24 <https://github.com/ipa320/cob_robots/issues/24> from HannesBachter/add_cob4-24
  fix gripper
* fix gripper can, driver, ...
* fix velocity filter and costmap config
* add cob4-24
* Merge pull request #785 <https://github.com/ipa320/cob_robots/issues/785> from HannesBachter/calibrate_cob4-3
  correct typo for fl FDM
* correct typo for fl FDM
* Merge pull request #784 <https://github.com/ipa320/cob_robots/issues/784> from HannesBachter/calibrate_cob4-3
  Calibrate cob4 3
* harmonize config appearance
* calibrate cob4-3 base
* Merge pull request #783 <https://github.com/ipa320/cob_robots/issues/783> from HannesBachter/update_cob4-3
  update cob4-3 to regular cob base
* update cob4-3 to regular cob base
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer, hyb
```

## cob_moveit_config

```
* Merge pull request #786 <https://github.com/ipa320/cob_robots/issues/786> from fmessmer/add_cob4-24
  [WIP] add cob4 24
* add cob4-24
* Merge pull request #783 <https://github.com/ipa320/cob_robots/issues/783> from HannesBachter/update_cob4-3
  update cob4-3 to regular cob base
* update cob4-3 to regular cob base
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer, hyb
```

## cob_robots

- No changes
