### PR TITLE
cob_simulation: 0.7.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1747,12 +1747,13 @@ repositories:
       - cob_bringup_sim
       - cob_gazebo
       - cob_gazebo_objects
+      - cob_gazebo_tools
       - cob_gazebo_worlds
       - cob_simulation
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.7.1-2
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.1-2`

## cob_bringup_sim

```
* Merge pull request #172 <https://github.com/ipa320/cob_simulation/issues/172> from fmessmer/cob_gazebo_tools
  new package cob_gazebo_tools
* move scripts to cob_gazebo_tools
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo

- No changes

## cob_gazebo_objects

- No changes

## cob_gazebo_tools

```
* add CHANGELOG for cob_gazebo_tools
* Merge pull request #172 <https://github.com/ipa320/cob_simulation/issues/172> from fmessmer/cob_gazebo_tools
  new package cob_gazebo_tools
* move scripts to cob_gazebo_tools
* add new package cob_gazebo_tools
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_worlds

- No changes

## cob_simulation

```
* Merge pull request #172 <https://github.com/ipa320/cob_simulation/issues/172> from fmessmer/cob_gazebo_tools
  new package cob_gazebo_tools
* add new package cob_gazebo_tools
* Contributors: Felix Messmer, fmessmer
```
