### PR TITLE
py_trees: 1.4.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -929,7 +929,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
-      version: release/1.3.x
+      version: release/1.4.x
     release:
       tags:
         release: release/eloquent/{package}/{version}
@@ -938,7 +938,7 @@ repositories:
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
-      version: release/1.3.x
+      version: release/1.4.x
     status: developed
   py_trees_js:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -934,7 +934,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 1.3.3-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `1.4.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.3-1`
