### PR TITLE
cob_control: 0.8.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -874,6 +874,7 @@ repositories:
       - cob_control_msgs
       - cob_footprint_observer
       - cob_frame_tracker
+      - cob_hardware_emulation
       - cob_model_identifier
       - cob_obstacle_distance
       - cob_omni_drive_controller
@@ -883,7 +884,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.1-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

```
* Merge pull request #213 <https://github.com/ipa320/cob_control/issues/213> from fmessmer/emulator
  [melodic] add cob_hardware_emulation
* add cob_hardware_emulation to meta package
```

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

```
* Merge branch 'kinetic_dev' of github.com:ipa320/cob_control into melodic_dev
* add CHANGELOG for cob_hardware_emulation
* Merge pull request #221 <https://github.com/ipa320/cob_control/issues/221> from fmessmer/post_vacation_qa
  [WIP] post vacation qa
* fix missing dependencies
* Merge pull request #218 <https://github.com/ipa320/cob_control/issues/218> from floweisshardt/fix/emulator
  catch zero division if two trajectory points have the same time_from_start
* catch zero division if two trajectory points have the same time_from_start
* Merge pull request #217 <https://github.com/ipa320/cob_control/issues/217> from floweisshardt/emulator
  initialpose from yaml file for base emulator
* initialpose from yaml file for base emulator
* Merge pull request #216 <https://github.com/ipa320/cob_control/issues/216> from benmaidel/feature/base_emulation_initialpose
  add initialpose to emulation_base
* Merge pull request #215 <https://github.com/ipa320/cob_control/issues/215> from lindemeier/feature/1238-joint-trajectory-controller-emulator-linear-interpolation
  Feature/1238 joint trajectory controller emulator linear interpolation
* 1238 Setting joint velocity and effort to zero after eaching final trajectory point
* reset odom on initialpose
* syntax fixes
* 1238 added  service reset
* 1238 joint velocities added
* 1238 adding preempt polling
  1238 readme adjusted and small improvements
* add initialpose to emulation_base
* 1238 linear interpolation of joint states sampling the given trajectory
  1238 lerping start and goal works
  1238 Fixed error in lerp
  1238 using only local time segments for computing the interpolation weight
  1238 added more comments
* 1238 replacing timer with rospy loop rate
  + publishing joint_states with 10Hz controlled by loop rate instead of timer
* Merge pull request #214 <https://github.com/ipa320/cob_control/issues/214> from floweisshardt/feature/emulator_base
  emulator base can be used with real navigation
* migrate tf to tf2
* emulator base can be used with real navigation
* Merge pull request #212 <https://github.com/ipa320/cob_control/issues/212> from floweisshardt/emulator
  initial version of move_base emulator
* review comments
* initial version of move_base emulator
* Merge pull request #211 <https://github.com/ipa320/cob_control/issues/211> from ipa320/emulator
  add hardware_emulation package
* add hardware_emulation package
* Contributors: Benjamin Maidel, Felix Messmer, Florian Weisshardt, Thomas Lindemeier, floweisshardt, fmessmer
```

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
