### PR TITLE
laser_filters: 1.8.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3636,7 +3636,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.7-1
+      version: 1.8.8-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.8-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.8.7-1`

## laser_filters

```
* Merge pull request #83 <https://github.com/ros-perception/laser_filters/issues/83> from remco-r/indigo-devel
  [fix] when high fidelity true added laser_max_range_ to projection
* [fix] when high fidelity true added laser_max_range_ to projection
* Merge pull request #79 <https://github.com/ros-perception/laser_filters/issues/79> from Jailander/indigo-devel
  Adding invert filter parameter to BOX filter
* Merge pull request #80 <https://github.com/ros-perception/laser_filters/issues/80> from k-okada/indigo-devel
  Add scan blob filters
* add scan blob filters
* Merge pull request #72 <https://github.com/ros-perception/laser_filters/issues/72> from ms-iot/windows_port_tests_fix
  [Windows][indigo] Use ${GTEST_LIBRARIES} for more portable gtest library linkage.
* Adding invert filter parameter to BOX filter
* Remove extra changes.
* windows bring up
* Contributors: Jonathan Binney, Kei Okada, Remco, Sean Yen, jailander
```
