### PR TITLE
cob_command_tools: 0.6.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.14-1
+      version: 0.6.15-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.15-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.14-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

```
* Merge pull request #258 <https://github.com/ipa320/cob_command_tools/issues/258> from floweisshardt/fix/error_print
  fix syntax error in cob_dashboard error print
* fix syntax error in cob_dashboard error print
* Merge pull request #251 <https://github.com/ipa320/cob_command_tools/issues/251> from HannesBachter/fix/batt_tooltip
  fix format of battery minutes
* fix format of battery minutes
* Contributors: Felix Messmer, floweisshardt, mailto:robot@cob4-99
```

## cob_helper_tools

```
* Merge pull request #253 <https://github.com/ipa320/cob_command_tools/issues/253> from benmaidel/fix/visualize_nav_goals
  visualize nav_goals improvements
* improvements:
  - add every nav_goal to a separate namespace (enable/disable visual)
  - fix scaling for Arrow marker
* Contributors: Benjamin Maidel, Florian Weisshardt
```

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #255 <https://github.com/ipa320/cob_command_tools/issues/255> from floweisshardt/fix/wlan_monitor
  more verbose error message for wlan monitor
* more verbose error message for wlan monitor
* Merge pull request #254 <https://github.com/ipa320/cob_command_tools/issues/254> from floweisshardt/remove_terminal_spam
  remove terminal spam
* remove terminal spam
* Contributors: Florian Weisshardt, floweisshardt
```

## cob_script_server

```
* Merge pull request #261 <https://github.com/ipa320/cob_command_tools/issues/261> from fmessmer/fix/travis
  fix/travis
* disable test
* Merge pull request #256 <https://github.com/ipa320/cob_command_tools/issues/256> from floweisshardt/fix/joint_order
  fix joint order in sss
* fix joint order
* Merge pull request #250 <https://github.com/ipa320/cob_command_tools/issues/250> from HannesBachter/feature/move_rel
  Feature/move rel
* fix ah handling and dependency
* return move_traj action_handle
* calculate poses for multiple movements
* add urdf, cleanup and return in error case
* check parameters
* move rel with check of joint limits
* Contributors: Felix Messmer, Florian Weisshardt, floweisshardt, fmessmer, hyb, mailto:robot@mrl-a
```

## cob_teleop

```
* Merge pull request #252 <https://github.com/ipa320/cob_command_tools/issues/252> from benmaidel/feature/dock_undock
  added docking/undocking feature to teleop
* added docking/undocking feature to teleop
* Contributors: Benjamin Maidel, Felix Messmer
```

## generic_throttle

- No changes

## service_tools

- No changes
