### PR TITLE
rosmon: 2.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7602,7 +7602,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.2.1-1`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.2.0-1`

## rosmon

- No changes

## rosmon_core

```
* correctly terminate execvp() arguments (issue: #102, PR: #103).
  Curiously, this bug has remained hidden until now.
* Contributors: Max Schwarz
```

## rosmon_msgs

- No changes

## rqt_rosmon

- No changes
