### PR TITLE
cloudwatch_common: 1.1.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -416,7 +416,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.1.1-0
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.1.2-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.1.1-0`

## cloudwatch_logs_common

```
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Nick Burek
```

## cloudwatch_metrics_common

```
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Nick Burek
```

## dataflow_lite

```
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Nick Burek
```

## file_management

```
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Fixes a bug where we did not null check the result of getting the HOM… (#43 <https://github.com/aws-robotics/cloudwatch-common/issues/43>)
  Fixes a bug where we did not null check the result of getting the HOME env variable and also switches to create_directories instead of create_directory so that it doesn't SIGABRT when asked to create multiple levels of a directory.
* Contributors: Nick Burek
```
