### PR TITLE
linux_networking: 1.0.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3870,11 +3870,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pr2-gbp/linux_networking-release.git
-      version: 1.0.13-2
+      version: 1.0.16-1
     source:
       type: git
       url: https://github.com/pr2/linux_networking.git
       version: melodic-devel
+    status: unmaintained
   lms1xx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linux_networking` to `1.0.16-1`:

- upstream repository: https://github.com/PR2/linux_networking.git
- release repository: https://github.com/pr2-gbp/linux_networking-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.13-2`

## access_point_control

- No changes

## asmach

- No changes

## asmach_tutorials

- No changes

## ddwrt_access_point

- No changes

## hostapd_access_point

- No changes

## ieee80211_channels

- No changes

## linksys_access_point

- No changes

## linux_networking

- No changes

## multi_interface_roam

```
* Merge pull request #4 <https://github.com/pr2/linux_networking/issues/4> from k-okada/add_travis
  update travis.yml
* rm *.pyc
* add python-twisted-core to multi_interface_roam to pass the test
* Contributors: Kei Okada
```

## network_control_tests

- No changes

## network_detector

- No changes

## network_monitor_udp

```
* ROS-melodic .debs for network_monitor_udp incomplete (#3 <https://github.com/pr2/linux_networking/issues/3>)
  * update melodic-devel to include appropriate files
  - python modules were missing (needed setup.py and catkin_python_setup) from .deb
  - python executables were missing (needed catkin_install_python) from .deb
  - python package roslib is deprecated; rostime now lives in rospy
  - compiled binaries and .launch file were missing from from .deb
* Contributors: David Feil-Seifer, bk-mtg
```

## network_traffic_control

- No changes
