### PR TITLE
robot_body_filter: 1.1.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6780,7 +6780,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/robot_body_filter-release.git
-      version: 1.1.4-1
+      version: 1.1.5-1
     source:
       type: git
       url: https://github.com/peci1/robot_body_filter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_body_filter` to `1.1.5-1`:

- upstream repository: https://github.com/peci1/robot_body_filter
- release repository: https://github.com/peci1/robot_body_filter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.1.4-1`

## robot_body_filter

```
* refactor(RobotBodyFilter): Made frames/sensor parameter optional (#2 <https://github.com/peci1/robot_body_filter/issues/2>)
  The sensor frame will now be derived from the incoming sensor messages.
  This way, messages from different sensors can be processed and the
  filter can be configured without any knowledge of the sensor.
* Improved readme.
* Reorganized the readme.
* Added support for non-uniform scaling of collision meshes.
* Contributors: Martin Pecka, Rein Appeldoorn
```
