### PR TITLE
urdfdom_py: 0.4.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9563,7 +9563,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.4.1-1
+      version: 0.4.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.4.1-2`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.1-1`

## urdfdom_py

```
* Python 3 fixes (#38 <https://github.com/ros/urdf_parser_py/issues/38> #43 <https://github.com/ros/urdf_parser_py/issues/43> #48 <https://github.com/ros/urdf_parser_py/issues/48>)
* Remove old example test (#37 <https://github.com/ros/urdf_parser_py/issues/37>)
* Contributors: Chris Lalancette, Eric Cousineau, Markus Grimm, Timon Engelke
```
