### PR TITLE
demos: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -299,7 +299,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Don't redefine add_dependencies (#408 <https://github.com/ros2/demos/issues/408>)
* Contributors: Dan Rose
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

```
* Remove unnecessary dependency on ros2run (#413 <https://github.com/ros2/demos/issues/413>)
* Contributors: Michel Hidalgo
```

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

```
* Remove unnecessary dependency on ros2run (#413 <https://github.com/ros2/demos/issues/413>)
* Contributors: Michel Hidalgo
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes
