### PR TITLE
rosidl_runtime_py: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1619,7 +1619,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rosidl_runtime_py

```
* Add .gitignore (#5 <https://github.com/ros2/rosidl_runtime_py/issues/5>)
* Do not remove interface namespaces (#6 <https://github.com/ros2/rosidl_runtime_py/issues/6>)
* Contributors: Gaël Écorchard, Jacob Perron
```
