### PR TITLE
launch: 0.9.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -735,7 +735,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.3-1
+      version: 0.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.9.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.3-1`

## launch

```
* Fix ExecuteProcess.get_sub_entities() implementation. (#353 <https://github.com/ros2/launch/issues/353>)
* Contributors: Michel Hidalgo
```

## launch_testing

```
* Fix a small typo in the launch_testing README. (#351 <https://github.com/ros2/launch/issues/351>)
* Contributors: Chris Lalancette
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
