### PR TITLE
swri_profiler: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8893,6 +8893,25 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  swri_profiler:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: master
+    release:
+      packages:
+      - swri_profiler
+      - swri_profiler_msgs
+      - swri_profiler_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: master
+    status: developed
   talos_robot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.2.0-1`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## swri_profiler

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Install Python scripts & HTML files
* Contributors: P. J. Reed
```

## swri_profiler_msgs

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Contributors: P. J. Reed
```

## swri_profiler_tools

```
* Update maintainers
* Make master build on both Indigo and Kinetic
* Fix deps, cmakelist and localPos() to get working on indigo
* Contributors: Matthew Bries, P. J. Reed
```
