### PR TITLE
robot_indicator: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11222,6 +11222,21 @@ repositories:
       url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
       version: 0.5.2-0
     status: maintained
+  robot_indicator:
+    doc:
+      type: git
+      url: https://github.com/LucidOne/robot_indicator.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/LucidOne-release/robot_indicator.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/LucidOne/robot_indicator.git
+      version: master
+    status: developed
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_indicator` to `0.1.1-1`:

- upstream repository: https://github.com/LucidOne/robot_indicator.git
- release repository: https://github.com/LucidOne-release/robot_indicator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## robot_indicator

```
* Improved documentation
* Added desktop autostart
```
