### PR TITLE
robot_indicator: 0.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11231,7 +11231,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LucidOne-release/robot_indicator.git
-      version: 0.1.1-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/LucidOne/robot_indicator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_indicator` to `0.1.3-1`:

- upstream repository: https://github.com/LucidOne/robot_indicator.git
- release repository: https://github.com/LucidOne-release/robot_indicator.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.1-1`

## robot_indicator

```
* Install scripts/robot_indicator_launch
* fixed error logging
```
