### PR TITLE
cob_simulation: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1088,6 +1088,25 @@ repositories:
       url: https://github.com/ipa320/cob_robots.git
       version: kinetic_dev
     status: maintained
+  cob_simulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_gazebo_objects
+      - cob_gazebo_tools
+      - cob_gazebo_worlds
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_simulation-release.git
+      version: 0.7.3-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: kinetic_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## cob_gazebo_objects

- No changes

## cob_gazebo_tools

```
* add CHANGELOG for cob_gazebo_tools
* Merge pull request #172 <https://github.com/ipa320/cob_simulation/issues/172> from fmessmer/cob_gazebo_tools
  new package cob_gazebo_tools
* move scripts to cob_gazebo_tools
* add new package cob_gazebo_tools
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_worlds

- No changes
