### PR TITLE
cis_camera: 0.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1345,7 +1345,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tork-a/cis_camera.git
-      version: 0.0.2
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -1355,7 +1355,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/tork-a/cis_camera.git
-      version: 0.0.2
+      version: master
     status: developed
   class_loader:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1341,6 +1341,22 @@ repositories:
       url: https://github.com/Playfish/cht10_node.git
       version: master
     status: maintained
+  cis_camera:
+    doc:
+      type: git
+      url: https://github.com/tork-a/cis_camera.git
+      version: 0.0.2
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tork-a/cis_camera-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/tork-a/cis_camera.git
+      version: 0.0.2
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cis_camera` to `0.0.2-1`:

- upstream repository: https://github.com/tork-a/cis_camera.git
- release repository: https://github.com/tork-a/cis_camera-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
