### PR TITLE
cis_camera: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -681,7 +681,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tork-a/cis_camera.git
-      version: 0.0.2
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -691,7 +691,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/tork-a/cis_camera.git
-      version: 0.0.2
+      version: master
     status: developed
   class_loader:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -677,6 +677,22 @@ repositories:
       url: https://github.com/locusrobotics/catkin_virtualenv.git
       version: master
     status: maintained
+  cis_camera:
+    doc:
+      type: git
+      url: https://github.com/tork-a/cis_camera.git
+      version: 0.0.2
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/cis_camera-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/tork-a/cis_camera.git
+      version: 0.0.2
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cis_camera` to `0.0.2-1`:

- upstream repository: https://github.com/tork-a/cis_camera.git
- release repository: https://github.com/tork-a/cis_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
