### PR TITLE
dccomms_ros_pkgs: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1396,7 +1396,13 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/dcentelles/dccomms_ros_pkgs-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dcentelles/dccomms_ros_pkgs.git
+      version: master
+    status: developed
   ddynamic_reconfigure:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dccomms_ros_pkgs` to `0.0.2-1`:

- upstream repository: https://github.com/dcentelles/dccomms_ros_pkgs.git
- release repository: https://github.com/dcentelles/dccomms_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.1-1`
