### PR TITLE
ubiquity_motor: 0.10.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9471,6 +9471,21 @@ repositories:
       url: https://github.com/osrf/uav_testing.git
       version: master
     status: maintained
+  ubiquity_motor:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: 0.10.0
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
+      version: 0.10.0-1
+    source:
+      type: git
+      url: https://github.com/UbiquityRobotics/ubiquity_motor.git
+      version: kinetic-devel
+    status: developed
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubiquity_motor` to `0.10.0-1`:

- upstream repository: https://github.com/UbiquityRobotics/ubiquity_motor.git
- release repository: https://github.com/UbiquityRobotics-release/ubiquity_motor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ubiquity_motor

```
* Support for higher resolution odometry (firmware v35+ required)
* Tool to verify odometry consistency
* Support for target velocity term in the PID (firmware v35+ required)
* Firmware update script now supports local firmware files
* Firmware update script can use different serial port
* Support for reading motor controller version from I2C
* Safer E-STOP behavior (MCB 5.0+)
* Publishing the state of the estop switch
* Improved documentation
* Improvements to the testing scripts
* Contributors: Alexander Sergeenko, David Crawley, Mark Johnston, Rohan Agrawal
```
