### PR TITLE
plotjuggler: 2.4.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9645,7 +9645,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.3.7-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.4.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.3.7-1`

## plotjuggler

```
* Tree view  (#226 <https://github.com/facontidavide/PlotJuggler/issues/226>)
* fix issue #225 <https://github.com/facontidavide/PlotJuggler/issues/225>
* add version number of the layout syntax
* fix issue #222 <https://github.com/facontidavide/PlotJuggler/issues/222>
* more readable plugin names
* fix issue #221 <https://github.com/facontidavide/PlotJuggler/issues/221>
* Merge branch 'master' of github.com:facontidavide/PlotJuggler
* minor bug fix
* Contributors: Davide Faconti
```
