### PR TITLE
uwsim_osgocean: 1.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9742,7 +9742,13 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uji-ros-pkg/uwsim_osgocean.git
+      version: melodic-devel
+    status: maintained
   uwsim_osgworks:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgocean` to `1.0.4-1`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgocean.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgocean-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.3-1`
