### PR TITLE
uwsim_osgworks: 3.0.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9748,7 +9748,13 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
-      version: 3.0.3-1
+      version: 3.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uji-ros-pkg/uwsim_osgworks.git
+      version: melodic-devel
+    status: maintained
   vapor_master:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgworks` to `3.0.3-2`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgworks.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgworks-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.3-1`
