### PR TITLE
uwsim_osgbullet: 3.0.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9736,7 +9736,13 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uji-ros-pkg/uwsim_osgbullet-release.git
-      version: 3.0.1-1
+      version: 3.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uji-ros-pkg/uwsim_osgbullet.git
+      version: melodic-devel
+    status: maintained
   uwsim_osgocean:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwsim_osgbullet` to `3.0.1-3`:

- upstream repository: https://github.com/uji-ros-pkg/uwsim_osgbullet.git
- release repository: https://github.com/uji-ros-pkg/uwsim_osgbullet-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.1-1`
