### PR TITLE
mongodb_store: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4279,7 +4279,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.5.1-2
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.5.2-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.5.1-2`

## mongodb_log

```
* back to system mongo
* Contributors: Ferenc Balint-Benczedi, Nick Hawes, Shingo Kitagawa, Volker Gabler
```

## mongodb_store

```
* added python-future to package.xml, which got lost in previous commit for some reasons ...
* corrected typo
* removed flags for most of files for simplicity, also included future.utils, may introduce undesireable dependency though
* resolved python2 backward compatibility issues
  not thouroughly checked though
  Added python version checks, where needed.
  Changes not adjusted to version:
  - print always with brackets
  - excepti XXX, e ==> except XXX as e
  as there is no problem with python2 to best of my knowledge
* adjusted python funtions for python3
* add dependency to package xml
* back to system mongo
* Contributors: Ferenc Balint-Benczedi, Nick Hawes, Shingo Kitagawa, Volker Gabler, vgab
```

## mongodb_store_msgs

```
* Contributors: Nick Hawes, Shingo Kitagawa, Volker Gabler
```
