### PR TITLE
swri_profiler: 0.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8914,7 +8914,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
-      version: 0.2.0-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.2.2-1`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.0-1`

## swri_profiler

```
* Update catkin dependencies for swri_profiler_tools
* Enable c++11 support
* Contributors: P. J. Reed
```

## swri_profiler_msgs

- No changes

## swri_profiler_tools

```
* Enable c++11 support
* Update catkin dependencies for swri_profiler_tools
* Contributors: P. J. Reed
```
