### PR TITLE
marti_common: 3.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1259,7 +1259,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1261,6 +1261,7 @@ repositories:
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
       version: 3.0.2-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/marti_common.git
       version: dashing-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.0.2-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.0.1-1`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Comment out ament_cmake_gtest (#555 <https://github.com/pjreed/marti_common/issues/555>)
* Contributors: P. J. Reed
```
