### PR TITLE
underwater_simulation: 1.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9522,6 +9522,21 @@ repositories:
       url: https://github.com/ros-drivers/um7.git
       version: indigo-devel
     status: maintained
+  underwater_simulation:
+    release:
+      packages:
+      - underwater_sensor_msgs
+      - underwater_vehicle_dynamics
+      - uwsim
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
+      version: 1.4.2-1
+    source:
+      type: git
+      url: https://github.com/uji-ros-pkg/underwater_simulation.git
+      version: melodic-devel
+    status: developed
   unique_identifier:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `underwater_simulation` to `1.4.2-1`:

- upstream repository: https://github.com/uji-ros-pkg/underwater_simulation.git
- release repository: https://github.com/uji-ros-pkg/underwater_simulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
