### PR TITLE
Centos updates

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4982,6 +4982,8 @@ spdlog:
   debian: [libspdlog-dev]
   fedora: [spdlog-devel]
   gentoo: [dev-libs/spdlog]
+  rhel:
+    '7': [spdlog-devel]
   ubuntu: [libspdlog-dev]
 speech-dispatcher:
   debian: [speech-dispatcher]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5340,7 +5340,9 @@ python3-pytest-mock:
   debian: [python3-pytest-mock]
   fedora: [python3-pytest-mock]
   gentoo: [dev-python/pytest-mock]
-  rhel: ['python%{python3_pkgversion}-pytest-mock']
+  rhel:
+    '*': ['python%{python3_pkgversion}-pytest-mock']
+    '7': null
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:
   debian: [python3-pytest-timeout]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5162,6 +5162,7 @@ python3-netifaces:
   debian: [python3-netifaces]
   fedora: [python3-netifaces]
   gentoo: [dev-python/netifaces]
+  rhel: ['python%{python3_pkgversion}-netifaces']
   ubuntu: [python3-netifaces]
 python3-nose:
   debian: [python3-nose]


### PR DESCRIPTION
- spdlog: https://apps.fedoraproject.org/packages/spdlog-devel
- python3-netifaces: In RHEL 8 AppStream and EPEL 7: https://apps.fedoraproject.org/packages/python3-netifaces
- python3-pytest-mock: In EPEL 8, but not 7

As usual, there is no authoritative web database for RHEL/CentOS packages, and sometimes EPEL source name collisions prevent packages from showing up on apps.fedoraproject.org/packages.