### PR TITLE
mavros: 0.33.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4075,7 +4075,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.33.0-1
+      version: 0.33.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.33.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.33.0-1`

## libmavconn

```
* resolved merge conflict
* Contributors: David Jablonski
```

## mavros

```
* Add mutex
* Initialize type mask
* Handle frame with StaticTF
* Handle different frames
* Set yaw rate from message inputs
* Add setpoint trajectory reset interface
* Fix trajectory timestamp
* Address comments
* Pass reference with oneshot timers
* Set typemasks correctly
* Address more style comments
* Address style comments
* Visualize desired trajectory
* Handle end of trajectory correctly
* Remove message handlers
* Add setpoint_trajectory plugin template
* resolved merge conflict
* Contributors: David Jablonski, Jaeyoung-Lim
```

## mavros_extras

```
* Merge pull request #1297 <https://github.com/mavlink/mavros/issues/1297> from dayjaby/feature/mount_orientation
  adding mount orientation to mount_control plugin
* landing_target: Fix cartesian to displacement bug
  I think these four conditionals are buggy:
  The first is    (x and y) > 0
  and should be   (x > 0) and (y > 0)
  (This one actually works the way it's written.)
  The second is   (x < 0 and y) > 0
  and should be   (x < 0) and (y > 0)
  The third is    (x and y) < 0
  and should be   (x < 0) and (y < 0)
  The fourth is   (x < 0 and y) < 0
  and should be   (x > 0) and (y < 0)
* obstacle distance plugin: Add ROS param for mavlink frame
  Makes it possible to specify the 'frame' field in the MAVLink
  OBSTACLE_DISTANCE message sent by this plugin. Previously the
  frame was not defined, which means it defaulted to MAV_FRAME_GLOBAL.
  (See https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE)
  The default frame is therefore still MAV_FRAME_GLOBAL.
* resolved merge conflict
* adding mount orientation to mount_control plugin
* Contributors: David Jablonski, Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_msgs

```
* resolved merge conflict
* Contributors: David Jablonski
```

## test_mavros

```
* resolved merge conflict
* Contributors: David Jablonski
```
