### PR TITLE
swri_profiler: 0.2.2-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14763,7 +14763,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
-      version: 0.1.0-0
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/swri-robotics/swri_profiler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.2.2-2`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-0`

## swri_profiler

```
* Update catkin dependencies for swri_profiler_tools
* Enable c++11 support
* Contributors: P. J. Reed
```

## swri_profiler_msgs

- No changes

## swri_profiler_tools

```
* Enable c++11 support
* Update catkin dependencies for swri_profiler_tools
* Contributors: P. J. Reed
```
