### PR TITLE
behaviortree_cpp_v3: 3.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -159,11 +159,19 @@ repositories:
       version: ros2
     status: maintained
   behaviortree_cpp_v3:
+    doc:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: ros2-dev
     release:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
+    source:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: ros2-dev
     status: developed
   cartographer:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v3` to `3.1.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.1.0-1`

## behaviortree_cpp_v3

```
* fix samples compilation (hopefully)
* Contributors: Davide Faconti
```
