### PR TITLE
move tracetools repository

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16326,7 +16326,7 @@ repositories:
   tracetools:
     doc:
       type: git
-       url: https://github.com/bosch-robotics-cr/tracetools.git
+      url: https://github.com/bosch-robotics-cr/tracetools.git
       version: devel
     release:
       tags:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16323,21 +16323,6 @@ repositories:
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: master
     status: developed
-  tracetools:
-    doc:
-      type: git
-      url: https://github.com/boschresearch/ros1_tracetools.git
-      version: devel
-    release:
-      tags:
-        release: release/indigo/{package}/{version}
-      url: https://github.com/boschresearch/ros1-tracetools-release.git
-      version: 0.1.0-1
-    source:
-      type: git
-      url: https://github.com/boschresearch/ros1_tracetools.git
-      version: devel
-    status: developed
   transform_graph:
     doc:
       type: git

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16326,16 +16326,16 @@ repositories:
   tracetools:
     doc:
       type: git
-      url: https://github.com/bosch-robotics-cr/tracetools.git
+      url: https://github.com/boschresearch/ros1_tracetools.git
       version: devel
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/bosch-robotics-cr/tracetools-release.git
+      url: https://github.com/boschresearch/ros1-tracetools-release.git
       version: 0.1.0-1
     source:
       type: git
-      url: https://github.com/bosch-robotics-cr/tracetools.git
+      url: https://github.com/boschresearch/ros1_tracetools.git
       version: devel
     status: developed
   transform_graph:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16326,16 +16326,16 @@ repositories:
   tracetools:
     doc:
       type: git
-      url: https://github.com/boschresearch/ros1_tracetools.git
+       url: https://github.com/bosch-robotics-cr/tracetools.git
       version: devel
     release:
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/boschresearch/ros1-tracetools-release.git
+      url: https://github.com/bosch-robotics-cr/tracetools-release.git
       version: 0.1.0-1
     source:
       type: git
-      url: https://github.com/boschresearch/ros1_tracetools.git
+      url: https://github.com/bosch-robotics-cr/tracetools.git
       version: devel
     status: developed
   transform_graph:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -16323,6 +16323,21 @@ repositories:
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: master
     status: developed
+  tracetools:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/ros1_tracetools.git
+      version: devel
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/boschresearch/ros1-tracetools-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/boschresearch/ros1_tracetools.git
+      version: devel
+    status: developed
   transform_graph:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15323,16 +15323,16 @@ repositories:
   tracetools:
     doc:
       type: git
-      url: https://github.com/bosch-robotics-cr/tracetools.git
+      url: https://github.com/boschresearch/ros1_tracetools.git
       version: devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/bosch-robotics-cr/tracetools-release.git
+      url: https://github.com/boschresearch/ros1-tracetools-release.git
       version: 0.2.1-0
     source:
       type: git
-      url: https://github.com/bosch-robotics-cr/tracetools.git
+      url: https://github.com/boschresearch/ros1_tracetools.git
       version: devel
     status: developed
   tts:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9190,7 +9190,7 @@ repositories:
   tracetools:
     doc:
       type: git
-      url: https://github.com/boschresearch/ros1_tracetools
+      url: https://github.com/boschresearch/ros1_tracetools.git
       version: devel
     release:
       tags:
@@ -9199,7 +9199,7 @@ repositories:
       version: 0.2.1-1
     source:
       type: git
-      url: https://github.com/boschresearch/ros1_tracetools
+      url: https://github.com/boschresearch/ros1_tracetools.git
       version: devel
     status: developed
   tts:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9190,16 +9190,16 @@ repositories:
   tracetools:
     doc:
       type: git
-      url: https://github.com/bosch-robotics-cr/tracetools.git
+      url: https://github.com/boschresearch/ros1_tracetools
       version: devel
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/bosch-robotics-cr/tracetools-release.git
+      url: https://github.com/boschresearch/ros1-tracetools-release.git
       version: 0.2.1-1
     source:
       type: git
-      url: https://github.com/bosch-robotics-cr/tracetools.git
+      url: https://github.com/boschresearch/ros1_tracetools
       version: devel
     status: developed
   tts:


### PR DESCRIPTION
We've moved the organizations root URL. Otherwise things are unchanged.