### PR TITLE
Add devilspie2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -571,6 +571,11 @@ debhelper:
 debtree:
   debian: [debtree]
   ubuntu: [debtree]
+devilspie2:
+  arch: [devilspie2]
+  debian: [devilspie2]
+  gentoo: [x11-misc/devilspie2]
+  ubuntu: [devilspie2]
 devscripts:
   debian: [devscripts]
   fedora: [devscripts]


### PR DESCRIPTION
Tool for automating window placement on an Xorg desktop.

Arch: https://aur.archlinux.org/packages/devilspie2/
Debian: https://packages.debian.org/jessie/devilspie2
Gentoo: https://packages.gentoo.org/packages/x11-misc/devilspie2
Ubuntu: https://packages.ubuntu.com/xenial/devilspie2