### PR TITLE
ainstein_radar: 2.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -120,6 +120,19 @@ repositories:
       version: master
     status: maintained
   ainstein_radar:
+    release:
+      packages:
+      - ainstein_radar
+      - ainstein_radar_drivers
+      - ainstein_radar_filters
+      - ainstein_radar_gazebo_plugins
+      - ainstein_radar_msgs
+      - ainstein_radar_rviz_plugins
+      - ainstein_radar_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/AinsteinAI/ainstein_radar-release.git
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ainstein_radar` to `2.0.1-1`:

- upstream repository: https://github.com/AinsteinAI/ainstein_radar.git
- release repository: https://github.com/AinsteinAI/ainstein_radar-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ainstein_radar

- No changes

## ainstein_radar_drivers

- No changes

## ainstein_radar_filters

- No changes

## ainstein_radar_gazebo_plugins

- No changes

## ainstein_radar_msgs

- No changes

## ainstein_radar_rviz_plugins

- No changes

## ainstein_radar_tools

```
* Add vision_msgs as ainstein_radar_tools dependency
* Contributors: Nick Rotella
```
