### PR TITLE
gazebo_ros_pkgs: 3.4.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -573,7 +573,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.4.2-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.4.1-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Merge branch 'ros2' into eloquent
* [ros2] Add remapping tag (#1011 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1011>)
  * add --ros-args and a remapping element for ros arguments
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
  * keep backward compatibility
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
  * update docs and world file accordingly
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
  * remap all the things :fist_raised:
  Signed-off-by: Louise Poubel <mailto:louise@openrobotics.org>
* generate a .dsv file for the environment hook
* Contributors: Dirk Thomas, Louise Poubel, Mikael Arguedas
```

## gazebo_ros

```
* Merge branch 'ros2' into eloquent
* Remove ROS-specific arguments before passing to argparse (#994 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/994>) (#1013 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1013>)
  This resolves argparse errors when trying to launch the spawn_entity script as a ROS node.
  For example, a launch file like the following wouldn't work without this change:
  <launch>
  <arg name="model_urdf" default="$(find-pkg-share mymodels)/urdf/ball.urdf" />
  <node
  pkg="gazebo_ros"
  exec="spawn_entity.py"
  name="spawner"
  args="-entity foo -file /path/to/my/model/foo.urdf" />
  </launch>
  Signed-off-by: Jacob Perron <mailto:jacob@openrobotics.org>
* [ros2] Add remapping tag (#1011 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1011>)
  * add --ros-args and a remapping element for ros arguments
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
  * keep backward compatibility
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
  * update docs and world file accordingly
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
  * remap all the things :fist_raised:
  Signed-off-by: Louise Poubel <mailto:louise@openrobotics.org>
* catch const ref to fix -Wcatch-value warnings (#1012 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1012>)
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
* Contributors: Jacob Perron, Louise Poubel, Mikael Arguedas
```

## gazebo_ros_pkgs

```
* Merge branch 'ros2' into eloquent
* Remove TODO in package.xml (#1010 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1010>)
  As I understand, listing execution dependencies is the correct way to form a metapackage.
  Signed-off-by: Jacob Perron <mailto:jacob@openrobotics.org>
* Contributors: Jacob Perron, Louise Poubel
```
