### PR TITLE
tinydir_vendor: 1.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2082,7 +2082,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/tinydir_vendor-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinydir_vendor` to `1.1.1-1`:

- upstream repository: https://github.com/ros2/tinydir_vendor.git
- release repository: https://github.com/ros2-gbp/tinydir_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.1.0-1`
