### PR TITLE
rcutils: 0.8.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1206,7 +1206,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.8.3-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.2-1`

## rcutils

```
* Fix uninitialized handle error (#187 <https://github.com/ros2/rcutils/issues/187>)
* Use Win32 wrapper around 64 bit atomic operations (#186 <https://github.com/ros2/rcutils/issues/186>)
* Contributors: Sean Kelly
```
