### PR TITLE
mavros: 0.33.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6942,7 +6942,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.33.0-1
+      version: 0.33.3-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.33.3-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.33.0-1`

## libmavconn

- No changes

## mavros

```
* package: fix 6fa58e59 - main package depends on trajectory_msgs, not extras
* Contributors: Vladimir Ermakov
```

## mavros_extras

```
* package: fix 6fa58e59 - main package depends on trajectory_msgs, not extras
* Contributors: Vladimir Ermakov
```

## mavros_msgs

- No changes

## test_mavros

- No changes
