### PR TITLE
libmynteye: 0.2.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6360,7 +6360,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/harjeb/libmynteye-release.git
-      version: 0.2.3-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libmynteye` to `0.2.5-1`:

- upstream repository: https://github.com/harjeb/libmynteye.git
- release repository: https://github.com/harjeb/libmynteye-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.3-1`

## mynt_eye_ros_wrapper

```
* fix cmake path
```
