### PR TITLE
realtime_support: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1225,7 +1225,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rttest

- No changes

## tlsf_cpp

```
* Fix clang thread safety warning (#86 <https://github.com/ros2/realtime_support/issues/86>)
* disable intra process test until intra process manager fixed up (#84 <https://github.com/ros2/realtime_support/issues/84>)
* Contributors: Anas Abou Allaban, William Woodall
```
