### PR TITLE
rmw_cyclonedds: 0.4.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1301,7 +1301,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.4.3-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.2-1`

## cyclonedds_cmake_module

- No changes

## rmw_cyclonedds_cpp

```
* Address "Precondition not met" on rmw_create_node (#65 <https://github.com/ros2/rmw_cyclonedds/issues/65>) (#66 <https://github.com/ros2/rmw_cyclonedds/issues/66>)
* Fix dashing breakage (#64 <https://github.com/ros2/rmw_cyclonedds/issues/64>)
* Support localhost-only communications (#60 <https://github.com/ros2/rmw_cyclonedds/issues/60>)
* Contributors: eboasson
```
