### PR TITLE
depthimage_to_laserscan: 2.2.5-1 in 'dashing/distribution.yaml…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -574,7 +574,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.2.2-1
+      version: 2.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `2.2.5-1`:

- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.2.2-1`

## depthimage_to_laserscan

```
* Update the README.md to describe the topics and parameters.
* Add in a launch file for composable node.
* Rename launch file to conform to recommendations.
* Remove unnecessary Depth.cfg.
* Make depthimage_to_laserscan composable.
* Rename header files to .hpp
* Style cleanup.
* Contributors: Chris Lalancette
```
