### PR TITLE
sros2: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2012,7 +2012,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## sros2

```
* add profile for lifecycle nodes (#146 <https://github.com/ros2/sros2/issues/146>)
* Cleanup changelog
* Update version in setup.py
* Contributors: Jacob Perron, Mikael Arguedas
```

## sros2_cmake

- No changes
