### PR TITLE
network_autoconfig: 0.1.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4944,7 +4944,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LucidOne-release/network_autoconfig.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/LucidOne/network_autoconfig.git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_autoconfig` to `0.1.1-2`:

- upstream repository: https://github.com/LucidOne/network_autoconfig.git
- release repository: https://github.com/LucidOne-release/network_autoconfig.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.1-1`

## network_autoconfig

```
* Documentation updates
```
