### PR TITLE
rclpy: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1174,7 +1174,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rclpy

```
* Explicitly destroy a node's objects before the node. (#456 <https://github.com/ros2/rclpy/issues/456>)
* Get proper parameters with prefixes without dot separator. (#455 <https://github.com/ros2/rclpy/issues/455>)
* Fix import to use builtin_interfaces.msg (#453 <https://github.com/ros2/rclpy/issues/453>)
* Add missing exec depend on rcl_interfaces (#452 <https://github.com/ros2/rclpy/issues/452>)
* Contributors: Brian Marchi, Dirk Thomas, Steven! Ragnarök
```
