### PR TITLE
robot_systemd: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6992,6 +6992,21 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: melodic-devel
     status: maintained
+  robot_systemd:
+    doc:
+      type: git
+      url: https://github.com/LucidOne/robot_systemd.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/LucidOne-Release/robot_systemd.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/LucidOne/robot_systemd.git
+      version: master
+    status: developed
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_systemd` to `0.1.2-1`:

- upstream repository: https://github.com/LucidOne/robot_systemd.git
- release repository: https://github.com/LucidOne-Release/robot_systemd.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## robot_systemd

```
* Removed pre-emptive conflict
* Added TasksMax=infinity
* Added KillSignal=SIGINT
* Added documentation
```
