### PR TITLE
variants: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2252,7 +2252,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## desktop

- No changes

## ros_base

```
* Replaced tf2* by geometry2. (#19 <https://github.com/ros2/variants/issues/19>)
* Contributors: Mikael Arguedas
```

## ros_core

```
* Added ros2interface to ros_core variant. (#20 <https://github.com/ros2/variants/issues/20>)
* Contributors: Shane Loretz
```
