### PR TITLE
rosbag2: 0.2.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1531,7 +1531,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.2.1-2
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.2-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.1-2`

## ros2bag

- No changes

## rosbag2

```
* (API) Generate bagfile metadata in Writer (#184 <https://github.com/ros2/rosbag2/issues/184>)
* Contributors: Zachary Michaels
```

## rosbag2_converter_default_plugins

```
* (API) Generate bagfile metadata in Writer (#184 <https://github.com/ros2/rosbag2/issues/184>)
* Contributors: Zachary Michaels
```

## rosbag2_storage

```
* (API) Generate bagfile metadata in Writer (#184 <https://github.com/ros2/rosbag2/issues/184>)
* Contributors: Zachary Michaels
```

## rosbag2_storage_default_plugins

```
* (API) Generate bagfile metadata in Writer (#184 <https://github.com/ros2/rosbag2/issues/184>)
* Contributors: Zachary Michaels
```

## rosbag2_test_common

```
* (API) Generate bagfile metadata in Writer (#184 <https://github.com/ros2/rosbag2/issues/184>)
* Contributors: Zachary Michaels
```

## rosbag2_tests

```
* (API) Generate bagfile metadata in Writer (#184 <https://github.com/ros2/rosbag2/issues/184>)
* Contributors: Zachary Michaels
```

## rosbag2_transport

```
* (API) Generate bagfile metadata in Writer (#184 <https://github.com/ros2/rosbag2/issues/184>)
* Contributors: Zachary Michaels
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
