### PR TITLE
robot_indicator: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6887,6 +6887,21 @@ repositories:
       url: https://github.com/fetchrobotics/robot_controllers.git
       version: melodic-devel
     status: maintained
+  robot_indicator:
+    doc:
+      type: git
+      url: https://github.com/LucidOne/robot_indicator.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/LucidOne-release/robot_indicator.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/LucidOne/robot_indicator.git
+      version: master
+    status: developed
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_indicator` to `0.1.3-1`:

- upstream repository: https://github.com/LucidOne/robot_indicator.git
- release repository: https://github.com/LucidOne-release/robot_indicator.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## robot_indicator

```
* Install scripts/robot_indicator_launch
* fixed error logging
```
