### PR TITLE
orocos_kinematics_dynamics: 3.2.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -827,7 +827,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kinematics_dynamics` to `3.2.1-1`:

- upstream repository: https://github.com/ros2/orocos_kinematics_dynamics.git
- release repository: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.2.0-1`
