### PR TITLE
added selectors2-pip library

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3873,6 +3873,22 @@ python-seaborn:
     trusty:
       pip:
         packages: [seaborn]
+python-selectors2-pip:
+  arch:
+    pip:
+      packages: [selectors2]
+  debian:
+    pip:
+      packages: [selectors2]
+  fedora:
+    pip:
+      packages: [selectors2]
+  osx:
+    pip:
+      packages: [selectors2]
+  ubuntu:
+    pip:
+      packages: [selectors2]
 python-selenium-pip:
   debian:
     pip:
@@ -5543,22 +5559,6 @@ rpy2:
   debian: [python-rpy2]
   gentoo: [=dev-python/rpy-2*]
   ubuntu: [python-rpy2]
-selectors2-pip:
-  arch:
-    pip:
-      packages: [selectors2]
-  debian:
-    pip:
-      packages: [selectors2]
-  fedora:
-    pip:
-      packages: [selectors2]
-  osx:
-    pip:
-      packages: [selectors2]
-  ubuntu:
-    pip:
-      packages: [selectors2]
 sphinxcontrib-bibtex-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5543,6 +5543,22 @@ rpy2:
   debian: [python-rpy2]
   gentoo: [=dev-python/rpy-2*]
   ubuntu: [python-rpy2]
+selectors2-pip:
+  arch:
+    pip:
+      packages: [selectors2]
+  debian:
+    pip:
+      packages: [selectors2]
+  fedora:
+    pip:
+      packages: [selectors2]
+  osx:
+    pip:
+      packages: [selectors2]
+  ubuntu:
+    pip:
+      packages: [selectors2]
 sphinxcontrib-bibtex-pip:
   debian:
     pip:


### PR DESCRIPTION

Added the selectors2 pip library which is a port of the python3 selectors library to python2.

See the project on [Pypi](https://pypi.org/project/selectors2/)
> Backported, durable, and portable selectors designed to replace the standard library selectors module.