### PR TITLE
rqt_topic: 1.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1943,7 +1943,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.0-1`

## rqt_topic

```
* set qos_profile (#14 <https://github.com/ros-visualization/rqt_topic/issues/14>)
```
