### PR TITLE
novatel_gps_driver: 4.0.0-1 in 'dashing/distribution.yaml' [bl…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1398,6 +1398,25 @@ repositories:
       url: https://github.com/ros-drivers/nmea_msgs.git
       version: ros2
     status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
+      version: 4.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    status: developed
   object_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.0.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## novatel_gps_driver

```
* ROS2 Dashing support (#61 <https://github.com/pjreed/novatel_gps_driver/issues/61>)
* Contributors: P. J. Reed
```

## novatel_gps_msgs

```
* ROS2 Dashing support (#61 <https://github.com/pjreed/novatel_gps_driver/issues/61>)
* Contributors: P. J. Reed
```
