### PR TITLE
marti_common: 2.11.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4052,7 +4052,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/marti_common.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4054,6 +4054,7 @@ repositories:
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
       version: 2.11.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/marti_common.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.11.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.10.0-1`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Fix incorrect type for strings in dynamic params (#553 <https://github.com/pjreed/marti_common/issues/553>)
* Contributors: jgassaway
```

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Add a nodelet that transforms ObstacleArrays
* Install gps_transform_publisher node (#551 <https://github.com/pjreed/marti_common/issues/551>)
* Contributors: Matthew, P. J. Reed
```

## swri_yaml_util

- No changes
