### PR TITLE
rmw_implementation: 0.8.2-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1337,7 +1337,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 0.8.1-1
+      version: 0.8.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `0.8.2-2`:

- upstream repository: https://github.com/ros2/rmw_implementation
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rmw_implementation

```
* Add support for Cyclone DDS. (#71 <https://github.com/ros2/rmw_implementation/issues/71>)
* Contributors: Ruffin
```
