### PR TITLE
ainstein_radar: 2.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -200,10 +200,11 @@ repositories:
       - ainstein_radar_gazebo_plugins
       - ainstein_radar_msgs
       - ainstein_radar_rviz_plugins
+      - ainstein_radar_tools
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 1.1.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ainstein_radar` to `2.0.1-1`:

- upstream repository: https://github.com/AinsteinAI/ainstein_radar.git
- release repository: https://github.com/AinsteinAI/ainstein_radar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.1.0-1`

## ainstein_radar

- No changes

## ainstein_radar_drivers

- No changes

## ainstein_radar_filters

- No changes

## ainstein_radar_gazebo_plugins

- No changes

## ainstein_radar_msgs

- No changes

## ainstein_radar_rviz_plugins

- No changes

## ainstein_radar_tools

```
* Add vision_msgs as ainstein_radar_tools dependency
* Contributors: Nick Rotella
```
