### PR TITLE
seed_r7_ros_pkg: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14110,14 +14110,16 @@ repositories:
       packages:
       - seed_r7_bringup
       - seed_r7_description
+      - seed_r7_moveit_config
       - seed_r7_navigation
       - seed_r7_robot_interface
       - seed_r7_ros_controller
+      - seed_r7_samples
       - seed_r7_typef_moveit_config
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
-      version: 0.2.0-2
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_r7_ros_pkg` to `0.3.0-1`:

- upstream repository: https://github.com/seed-solutions/noid-ros-pkg.git
- release repository: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.0-2`

## seed_r7_moveit_config

```
* Merge branch 'sasabot-master'
* Merge branch 'master' of https://github.com/sasabot/seed_r7_ros_pkg into sasabot-master
* remove robot-specific hard-coding in seed_r7_ros_pkg
* Contributors: Kazuhiro Sasabuchi, hi-kondo
```

## seed_r7_samples

```
* Merge pull request #47 <https://github.com/seed-solutions/seed_r7_ros_pkg/issues/47> from y-shiigi/demo
  add Moveit! sample
* add install at CMakeList.txt
* fix typo
* add samples
* Contributors: hi-kondo, y-shiigi
```

## seed_r7_typef_moveit_config

```
* Merge branch 'sasabot-master'
* Merge branch 'master' of https://github.com/sasabot/seed_r7_ros_pkg into sasabot-master
* Update package.xml
* lowercase file names, move csv locations, remove hard-coded data size
* Contributors: Kazuhiro Sasabuchi, hi-kondo
```
