### PR TITLE
sick_scan: 1.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8681,7 +8681,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 1.3.22-1
+      version: 1.4.2-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `1.4.2-1`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.22-1`

## sick_scan

```
* fixed timing issues with MRS6124
* added launch info for lms4xxx
* added LMS 4xxx support
* tim_7xxS dependencys included
* Adding info for 7xxS-Launch-file
* safety scanner added
* added dependency for thrusty
* added information about TIM 7xx launch
* IMU Support, scan freq. and angle. resolution settings added
* TiM7xx integrated
* typical startup sequence
* added lms1xx hires mode
* added support for high ang. resolution for LMS 1xx
* added pointcloud chopping
* Issue resolve handling added
* Pointcloud splitting prepared
* added timing documentation
* cartographer support improved
* improved IMU support
* Update google_cartographer.md
* added Networktiming PLL
* improved performance, start of tim7xx integration
* Contributors: Michael Lehning
```
