### PR TITLE
leuze_ros_drivers: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6295,7 +6295,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa-led/leuze_ros_drivers-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://gitlab.cc-asp.fraunhofer.de/led/leuze_ros_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leuze_ros_drivers` to `1.0.1-1`:

- upstream repository: https://gitlab.cc-asp.fraunhofer.de/led/leuze_ros_drivers.git
- release repository: https://github.com/ipa-led/leuze_ros_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.0-2`

## leuze_bringup

- No changes

## leuze_description

- No changes

## leuze_msgs

- No changes

## leuze_phidget_driver

- No changes

## leuze_ros_drivers

- No changes

## leuze_rsl_driver

```
* Fixed dependency on angles
* Contributors: kut
```
