### PR TITLE
leuze_ros_drivers: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3785,6 +3785,25 @@ repositories:
       version: hydro
     status: developed
     status_description: Slow development
+  leuze_ros_drivers:
+    release:
+      packages:
+      - leuze_bringup
+      - leuze_description
+      - leuze_msgs
+      - leuze_phidget_driver
+      - leuze_ros_drivers
+      - leuze_rsl_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa-led/leuze_ros_drivers-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://gitlab.cc-asp.fraunhofer.de/led/leuze_ros_drivers.git
+      version: master
+    status: maintained
   lex_common:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3799,7 +3799,6 @@ repositories:
       url: https://github.com/ipa-led/leuze_ros_drivers-release.git
       version: 1.0.1-1
     source:
-      test_pull_requests: true
       type: git
       url: https://gitlab.cc-asp.fraunhofer.de/led/leuze_ros_drivers.git
       version: master


### PR DESCRIPTION
Increasing version of package(s) in repository `leuze_ros_drivers` to `1.0.1-1`:

- upstream repository: https://gitlab.cc-asp.fraunhofer.de/led/leuze_ros_drivers.git
- release repository: https://github.com/ipa-led/leuze_ros_drivers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## leuze_bringup

- No changes

## leuze_description

- No changes

## leuze_msgs

- No changes

## leuze_phidget_driver

- No changes

## leuze_ros_drivers

- No changes

## leuze_rsl_driver

```
* Fixed dependency on angles
* Contributors: kut
```
