### PR TITLE
cyclonedds: 0.1.0-6 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -270,13 +270,13 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.1.0-5
+      version: 0.1.0-6
     source:
       test_commits: false
       test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: 76fa68808682a15dd8aff26da20622ac574fa1a1
+      version: b6b0c2535585dafd794478e0778ed15c71a7afbb
     status: developed
   demos:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.1.0-6`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-5`
