### PR TITLE
[dashing][eloquent] Fixed the source branch for BehaviorTree.CPP

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -341,7 +341,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: ros2-dev
+      version: ros2-devel
     release:
       tags:
         release: release/dashing/{package}/{version}
@@ -350,7 +350,7 @@ repositories:
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: ros2-dev
+      version: ros2-devel
     status: developed
   cartographer:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -162,7 +162,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: ros2-dev
+      version: ros2-devel
     release:
       tags:
         release: release/eloquent/{package}/{version}
@@ -171,7 +171,7 @@ repositories:
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: ros2-dev
+      version: ros2-devel
     status: developed
   cartographer:
     doc:


### PR DESCRIPTION
The source branch of [`BehaviorTree.CPP`](https://github.com/BehaviorTree/BehaviorTree.CPP) seems to be out-of-dated.