### PR TITLE
rqt_robot_steering: 0.5.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8260,7 +8260,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_steering-release.git
-      version: 0.5.9-0
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `0.5.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros-gbp/rqt_robot_steering-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.9-0`

## rqt_robot_steering

```
* minor cleanup (#6 <https://github.com/ros-visualization/rqt_robot_steering/issues/6>)
* add Python 3 conditional dependencies (#5 <https://github.com/ros-visualization/rqt_robot_steering/issues/5>)
* style: format code to conform to the PEP8 style (#3 <https://github.com/ros-visualization/rqt_robot_steering/issues/3>)
```
