### PR TITLE
navigation: 1.16.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4752,7 +4752,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.16.2-0
+      version: 1.16.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.16.3-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.16.2-0`

## amcl

```
* Merge branch 'melodic-devel' into layer_clear_area-melodic
* Fix typo in amcl_laser model header (#918 <https://github.com/ros-planning/navigation/issues/918>)
* Merge pull request #849 <https://github.com/ros-planning/navigation/issues/849> from seanyen/amcl_windows_fix
  [Windows][melodic] AMCL Windows build bring up.
* revert unrelated changes.
* AMCL windows build bring up.
  * Add HAVE_UNISTD and HAVE_DRAND48 and portable_utils.hpp for better cross compiling.
  * Variable length array is not supported in MSVC, conditionally disable it.
  * Fix install location for shared lib and executables on Windows.
  * Use isfinite for better cross compiling.
* feat: AMCL Diagnostics (#807 <https://github.com/ros-planning/navigation/issues/807>)
  Diagnostic task that monitors the estimated standard deviation of the filter.
  By: reinzor <mailto:reinzor@gmail.com>
* fix typo for parameter beam_skip_error_threshold but bandaged for other users in AMCL (#790 <https://github.com/ros-planning/navigation/issues/790>)
  * fix typo but bandage for other users
* Merge pull request #785 <https://github.com/ros-planning/navigation/issues/785> from mintar/amcl_c++11
  amcl: Add compile option C++11
* amcl: Set C++ standard 11 if not set
  This is required to build the melodic-devel branch of the navigation
  stack on kinetic. Melodic sets CMAKE_CXX_STANDARD=14, but kinetic
  doesn't set that variable at all.
* Contributors: Hadi Tabatabaee, Martin Günther, Michael Ferguson, Rein Appeldoorn, Sean Yen, Steven Macenski
```

## base_local_planner

```
* Merge branch 'melodic-devel' into layer_clear_area-melodic
* Provide different negative values for unknown and out-of-map costs (#833 <https://github.com/ros-planning/navigation/issues/833>)
* Merge pull request #857 <https://github.com/ros-planning/navigation/issues/857> from jspricke/add_include
  Add missing header
* Add missing header
* [kinetic] Fix for adjusting plan resolution (#819 <https://github.com/ros-planning/navigation/issues/819>)
  * Fix for adjusting plan resolution
  * Simpler math expression
* Contributors: David V. Lu!!, Jochen Sprickerhof, Jorge Santos Simón, Michael Ferguson, Steven Macenski
```

## carrot_planner

- No changes

## clear_costmap_recovery

```
* Merge pull request #877 <https://github.com/ros-planning/navigation/issues/877> from SteveMacenski/layer_clear_area-melodic
  [melodic] moving clearing area method to costmap_layer so other applications can clear other types.
* Merge branch 'melodic-devel' into layer_clear_area-melodic
* Add force_updating and affected_maps parameters to tailor clear costmaps recovey (#838 <https://github.com/ros-planning/navigation/issues/838>)
  behavior
* clear area in layer for melodic
* Contributors: Jorge Santos Simón, Michael Ferguson, Steven Macenski, stevemacenski
```

## costmap_2d

```
* Merge pull request #877 <https://github.com/ros-planning/navigation/issues/877> from SteveMacenski/layer_clear_area-melodic
  [melodic] moving clearing area method to costmap_layer so other applications can clear other types.
* Merge branch 'melodic-devel' into layer_clear_area-melodic
* Drop Parameter Magic (#893 <https://github.com/ros-planning/navigation/issues/893>)
* Fixes #782 <https://github.com/ros-planning/navigation/issues/782> (#892 <https://github.com/ros-planning/navigation/issues/892>)
* Costmap_2d plugin universal parameters and pre-hydro warnings (#738 <https://github.com/ros-planning/navigation/issues/738>)
  * Comment and description clarification
  * Renamed resetOldParameters to loadOldParameters
  * Upscaled pre-hydro parameter info message to warning and added costmap-name
  * Warn user when static_map or map_type is set but not used while plugins are used
  * Added function that copies parent parameters inside each layer (makes it possible to set a global inflation_radius)
  * use parameter magic
* Changed logic for when to resize layered costmap in static layer (#792 <https://github.com/ros-planning/navigation/issues/792>)
  * Changed logic for when to resize layered costmap in static layer
  -Now the master layered costmap should no longer get resized when
  isSizeLocked returns true
  * Fixing format for if loop
* clear area in layer for melodic
* [kinetic] Fix Bounds Bug (plus test) (#871 <https://github.com/ros-planning/navigation/issues/871>) (#875 <https://github.com/ros-planning/navigation/issues/875>)
  * fix map bounds bug
  * Add test
* Fix install (#855 <https://github.com/ros-planning/navigation/issues/855>)
* Add additional linked libraries (#803 <https://github.com/ros-planning/navigation/issues/803>)
* Contributors: David V. Lu!!, Martin Ganeff, Michael Ferguson, Steven Macenski, stevemacenski
```

## dwa_local_planner

```
* Set footprint before in place rotation continuation (#829 <https://github.com/ros-planning/navigation/issues/829>) (#861 <https://github.com/ros-planning/navigation/issues/861>)
  * Make sure to call setFootprint() before an in-place rotation
  * Change to const reference
  * Remove footprint from findBestPath
* Contributors: David V. Lu!!
```

## fake_localization

```
* Merge pull request #831 <https://github.com/ros-planning/navigation/issues/831> from ros-planning/feature/remove_slashes
  [melodic] Remove leading slashes from default frame_id parameters
* Remove leading slashes from default frame_id parameters
* Fix for #805 <https://github.com/ros-planning/navigation/issues/805> (#813 <https://github.com/ros-planning/navigation/issues/813>)
* Contributors: David V. Lu, David V. Lu!!, Michael Ferguson
```

## global_planner

```
* Remove unused visualize_potential (#866 <https://github.com/ros-planning/navigation/issues/866>)
* remove unused costmap_pub_frequency (#858 <https://github.com/ros-planning/navigation/issues/858>)
* Fix #845 <https://github.com/ros-planning/navigation/issues/845> (#846 <https://github.com/ros-planning/navigation/issues/846>)
* Merge pull request #831 <https://github.com/ros-planning/navigation/issues/831> from ros-planning/feature/remove_slashes
  [melodic] Remove leading slashes from default frame_id parameters
* Remove leading slashes from default frame_id parameters
* Contributors: David V. Lu, David V. Lu!!, Michael Ferguson, Stepan Kostusiev
```

## map_server

```
* Merge branch 'melodic-devel' into layer_clear_area-melodic
* Merge pull request #850 <https://github.com/ros-planning/navigation/issues/850> from seanyen/map_server_windows_fix
  [Windows][melodic] map_server Windows build bring up
* map_server Windows build bring up
  * Fix install location for Windows build. (On Windows build, shared library uses RUNTIME location, but not LIBRARY)
  * Use boost::filesystem::path to handle path logic and remove the libgen.h dependency for better cross platform.
  * Fix gtest hard-coded and add YAML library dir in CMakeList.txt.
* Contributors: Michael Ferguson, Sean Yen, Steven Macenski
```

## move_base

```
* Merge branch 'melodic-devel' into layer_clear_area-melodic
* Added publishZeroVelocity() before starting planner (#751 <https://github.com/ros-planning/navigation/issues/751>)
  Edit for Issue #750 <https://github.com/ros-planning/navigation/issues/750>
* Merge pull request #831 <https://github.com/ros-planning/navigation/issues/831> from ros-planning/feature/remove_slashes
  [melodic] Remove leading slashes from default frame_id parameters
* Remove leading slashes from default frame_id parameters
* Contributors: David V. Lu, Michael Ferguson, SUNIL SULANIA, Steven Macenski
```

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

```
* Merge pull request #831 <https://github.com/ros-planning/navigation/issues/831> from ros-planning/feature/remove_slashes
  [melodic] Remove leading slashes from default frame_id parameters
* Remove leading slashes from default frame_id parameters
* Merge pull request #789 <https://github.com/ros-planning/navigation/issues/789> from ipa-fez/fix/astar_const_melodic
  Remove const from create_nav_plan_astar
* remove const from create_nav_plan_astar
* Contributors: David V. Lu, Felix, Michael Ferguson
```

## navigation

- No changes

## rotate_recovery

```
* Merge branch 'melodic-devel' into layer_clear_area-melodic
* Cherry pick #914 <https://github.com/ros-planning/navigation/issues/914> (#919 <https://github.com/ros-planning/navigation/issues/919>)
* Contributors: David V. Lu!!, Steven Macenski
```

## voxel_grid

- No changes
