### PR TITLE
navigation: 1.14.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8081,7 +8081,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.4-0
+      version: 1.14.5-1
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.14.5-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.14.4-0`

## amcl

```
* fix typo for parameter beam_skip_error_threshold but bandaged for other users in AMCL (#790 <https://github.com/ros-planning/navigation/issues/790>)
  * fix typo but bandage for other users
* Contributors: Steven Macenski
```

## base_local_planner

```
* ROS_DEBUG prints incorrect gen_id & incorrect namespace for /latch_xy_goal_tolerance (#862 <https://github.com/ros-planning/navigation/issues/862>)
  * gen_id also increments when the critic's scale is set to 0
  * Moved the latch_xy_goal_tolerance parameter from global namespace to the planner's namespace.
  * latch_xy_goal_tolerance  parameter is searched in node_handle's namespace as well as in global namespace, for people who relied on the old configuration
* Provide different negative values for unknown and out-of-map costs (#833 <https://github.com/ros-planning/navigation/issues/833>)
* [kinetic] Fix for adjusting plan resolution (#819 <https://github.com/ros-planning/navigation/issues/819>)
  * Fix for adjusting plan resolution
  * Simpler math expression
* Contributors: David V. Lu!!, Jorge Santos Simón, Veera Ragav
```

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

```
* Changed logic for when to resize layered costmap in static layer (#792 <https://github.com/ros-planning/navigation/issues/792>)
  * Changed logic for when to resize layered costmap in static layer
  -Now the master layered costmap should no longer get resized when
  isSizeLocked returns true
  * Fixing format for if loop
* [kinetic] Fix Bounds Bug (plus test) (#871 <https://github.com/ros-planning/navigation/issues/871>)
  * fix map bounds bug
  * Add test
* Remove twice calculation of time_diff (#863 <https://github.com/ros-planning/navigation/issues/863>)
* Merge pull request #841 <https://github.com/ros-planning/navigation/issues/841> from DLu/feature/fix_install
  [kinetic] Fix install
* Fix install
* Add additional linked libraries (#800 <https://github.com/ros-planning/navigation/issues/800>)
* Contributors: David V. Lu, David V. Lu!!, Michael Ferguson, Stepan Kostusiev
```

## dwa_local_planner

```
* ROS_DEBUG prints incorrect gen_id & incorrect namespace for /latch_xy_goal_tolerance (#862 <https://github.com/ros-planning/navigation/issues/862>)
  * gen_id also increments when the critic's scale is set to 0
  * Moved the latch_xy_goal_tolerance parameter from global namespace to the planner's namespace.
  * latch_xy_goal_tolerance  parameter is searched in node_handle's namespace as well as in global namespace, for people who relied on the old configuration
* Set footprint before in place rotation continuation (#829 <https://github.com/ros-planning/navigation/issues/829>)
  * Make sure to call setFootprint() before an in-place rotation
  * Change to const reference
  * Remove footprint from findBestPath
* Contributors: Marcel Soler, Veera Ragav
```

## fake_localization

```
* Fix for #805 <https://github.com/ros-planning/navigation/issues/805> (#813 <https://github.com/ros-planning/navigation/issues/813>)
* Contributors: David V. Lu!!
```

## global_planner

```
* Remove unused costmap_pub_freq (#864 <https://github.com/ros-planning/navigation/issues/864>)
* Merge pull request #865 <https://github.com/ros-planning/navigation/issues/865> from IronClimber/remove-visualize-potential
  [kinetic] Remove unused visualize_potential_
* Remove unused visualize_potential_
* Fix #845 <https://github.com/ros-planning/navigation/issues/845> (#846 <https://github.com/ros-planning/navigation/issues/846>)
* Merge pull request #821 <https://github.com/ros-planning/navigation/issues/821> from ros-planning/fix739kinetic
  PR #739 <https://github.com/ros-planning/navigation/issues/739> for Kinetic
* feat(orientation_filter): Added additional orientation filter options (#739 <https://github.com/ros-planning/navigation/issues/739>)
  * feat(orientation_filter): Added additional orientation filter options
  Enables plan references with different orientations for omni-base
  controllers. The following options are added:
  - Backward (backward path traversal, pose points to previous point)
  - Leftward (lateral path traversal in the positive y direction)
  - Rightward (lateral path traversal in the negative y direction)
  * Updated orientation filter option description
  * Added window size parameter to orientation filter
  Previously, the orientation was calculated using the current and the
  next point. However, when the path is somewhat jumpy, this results in
  poor orientations. By adding this parameter and altering the orientation
  calculation, the calculated orientation can be smoothened along the path
  by taking into account a larger window. The orientation of index point i
  will be calculated using the positions of i - window_size and i +
  window_size.
* Contributors: David V. Lu!!, Michael Ferguson, Rein Appeldoorn, Stepan Kostusiev
```

## map_server

- No changes

## move_base

- No changes

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## robot_pose_ekf

- No changes

## rotate_recovery

```
* Rotate Recovery Refactor (#914 <https://github.com/ros-planning/navigation/issues/914>)
* Contributors: David V. Lu!!
```

## voxel_grid

- No changes
