### PR TITLE
camera_info_manager_py: 0.2.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -546,6 +546,21 @@ repositories:
       type: git
       url: https://github.com/ros-perception/calibration.git
       version: hydro
+  camera_info_manager_py:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/camera_info_manager_py-release.git
+      version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/camera_info_manager_py.git
+      version: master
+    status: unmaintained
   camera_umd:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `0.2.3-1`:

- upstream repository: https://github.com/ros-perception/camera_info_manager_py.git
- release repository: https://github.com/ros-gbp/camera_info_manager_py-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## camera_info_manager_py

- No changes
