### PR TITLE
ros2_tracing: 0.2.10-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1410,7 +1410,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 0.2.9-1
+      version: 0.2.10-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.2.10-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.9-1`

## ros2trace

```
* Make printing list of enabled events more readable
* Contributors: Christophe Bedard
```

## tracetools

```
* Add new rclcpp_subscription_init tracepoint to support new intra-process comms
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Update tests after new intra-process communications
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Make printing list of enabled events more readable
* Add new rclcpp_subscription_init tracepoint to default ROS events list
* Contributors: Christophe Bedard
```
