### PR TITLE
fsrobo_r: 0.7.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3745,7 +3745,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/FUJISOFT-Robotics/fsrobo_r-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/FUJISOFT-Robotics/fsrobo_r.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fsrobo_r` to `0.7.1-1`:

- upstream repository: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
- release repository: https://github.com/FUJISOFT-Robotics/fsrobo_r-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.0-1`

## fsrobo_r

- No changes

## fsrobo_r_bringup

```
* Use KDL as default kinematics
```

## fsrobo_r_description

- No changes

## fsrobo_r_driver

```
* Improve performance
```

## fsrobo_r_moveit_config

```
* Use KDL as default kinematics
* Fix max velocity and acceleration
```

## fsrobo_r_msgs

- No changes

## fsrobo_r_trajectory_filters

- No changes
