### PR TITLE
fsrobo_r: 0.7.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2365,6 +2365,29 @@ repositories:
       url: https://github.com/frankaemika/franka_ros.git
       version: melodic-devel
     status: developed
+  fsrobo_r:
+    doc:
+      type: git
+      url: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
+      version: master
+    release:
+      packages:
+      - fsrobo_r
+      - fsrobo_r_bringup
+      - fsrobo_r_description
+      - fsrobo_r_driver
+      - fsrobo_r_moveit_config
+      - fsrobo_r_msgs
+      - fsrobo_r_trajectory_filters
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/FUJISOFT-Robotics/fsrobo_r-release.git
+      version: 0.7.1-1
+    source:
+      type: git
+      url: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
+      version: master
+    status: developed
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fsrobo_r` to `0.7.1-1`:

- upstream repository: https://github.com/FUJISOFT-Robotics/fsrobo_r.git
- release repository: https://github.com/FUJISOFT-Robotics/fsrobo_r-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## fsrobo_r

- No changes

## fsrobo_r_bringup

```
* Use KDL as default kinematics
```

## fsrobo_r_description

- No changes

## fsrobo_r_driver

```
* Improve performance
```

## fsrobo_r_moveit_config

```
* Use KDL as default kinematics
* Fix max velocity and acceleration
```

## fsrobo_r_msgs

- No changes

## fsrobo_r_trajectory_filters

- No changes
