### PR TITLE
toposens: 1.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15340,7 +15340,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.2.3-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `1.3.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.3-1`

## toposens

- No changes

## toposens_description

```
* Added robot description for visualizing single sensor
* Added Collada file for TS3 visualization
* Contributors: Sebastian Dengler
```

## toposens_driver

- No changes

## toposens_markers

```
* Using robot description instead of markers for sensor visualization
* Contributors: Sebastian Dengler
```

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Using robot description instead of markers for sensor visualization
* Made topic name to listen for TsScans a launch argument
* Fixed bug of crashing ts_cloud_node due to access conflicts in Logging class
* Contributors: Sebastian Dengler
```

## toposens_sync

- No changes
