### PR TITLE
wireless-tools

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5443,6 +5443,11 @@ wget:
   macports: [wget]
   opensuse: [wget]
   ubuntu: [wget]
+wireless-tools:
+  debian: [wireless-tools]
+  fedora: [wireless-tools]
+  gentoo: [net-wireless/wireless-tools]
+  ubuntu: [wireless-tools]
 wkhtmltopdf:
   arch: [wkhtmltopdf]
   debian: [wkhtmltopdf]


### PR DESCRIPTION
Required for `wireless_monitor` https://github.com/ros-drivers/linux_peripheral_interfaces/pull/17