### PR TITLE
novatel_gps_driver: 4.0.2-1 in 'dashing/distribution.yaml' [bl…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1410,7 +1410,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.0.2-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `4.0.1-1`

## novatel_gps_driver

```
* Add dependency on tf2_geometry_msgs (#67 <https://github.com/swri-robotics/novatel_gps_driver/issues/67>)
* Contributors: P. J. Reed
```

## novatel_gps_msgs

- No changes
