### PR TITLE
rosbag2: 0.2.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1532,7 +1532,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.3-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.2-1`

## ros2bag

```
* Add CLI option to expose option for bagfile splitting (#203 <https://github.com/ros2/rosbag2/issues/203>)
* Contributors: Karsten Knese, Prajakta Gokhale
```

## rosbag2

```
* Enhance rosbag reader capabilities to read split bag files. (#206 <https://github.com/ros2/rosbag2/issues/206>)
* Modular Reader/Writer API. (#205 <https://github.com/ros2/rosbag2/issues/205>)
* Enhance rosbag writer capabilities to split bag files. (#185 <https://github.com/ros2/rosbag2/issues/185>)
* Contributors: Karsten Knese, Zachary Michaels
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

```
* Enhance rosbag writer capabilities to split bag files. (#185 <https://github.com/ros2/rosbag2/issues/185>)
* Contributors: Zachary Michaels
```

## rosbag2_storage_default_plugins

```
* Enhance rosbag writer capabilities to split bag files. (#185 <https://github.com/ros2/rosbag2/issues/185>)
* Contributors: Zachary Michaels
```

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* Enhance rosbag writer capabilities to split bag files. (#185 <https://github.com/ros2/rosbag2/issues/185>)
* Contributors: Zachary Michaels
```

## rosbag2_transport

```
* Add CLI option to expose bagfile splitting. (#203 <https://github.com/ros2/rosbag2/issues/203>)
* Delay subscriber asynchronous creation for opensplice in test_rosbag2_node. (#196 <https://github.com/ros2/rosbag2/issues/196>)
* Modular Reader/Writer API. (#205 <https://github.com/ros2/rosbag2/issues/205>)
* Contributors: Brian Marchi, Karsten Knese, Prajakta Gokhale
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
