### PR TITLE
geometry2: 0.12.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -599,7 +599,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.12.1-2
+      version: 0.12.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.12.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.12.1-2`

## geometry2

- No changes

## tf2

```
* Fix up -Wcast-qual warning (#193 <https://github.com/ros2/geometry2/issues/193>) (#197 <https://github.com/ros2/geometry2/issues/197>)
* Contributors: Chris Lalancette
```

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Fix tf2_monitor subscriptions QoS settings. (#196 <https://github.com/ros2/geometry2/issues/196>)
* Contributors: Michel Hidalgo
```

## tf2_sensor_msgs

- No changes
