### PR TITLE
seed_r7_ros_pkg: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14119,7 +14119,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
-      version: 0.3.0-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_r7_ros_pkg` to `0.3.2-1`:

- upstream repository: https://github.com/seed-solutions/noid-ros-pkg.git
- release repository: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.0-1`

## seed_r7_navigation

```
* Merge pull request #53 <https://github.com/seed-solutions/seed_r7_ros_pkg/issues/53> from hi-kondo/new-master
  added typef to CMakeLists of seed_r7_interface
* added install tag to seed_r7_navigation
* Merge branch 'new-master' of https://github.com/hi-kondo/seed_r7_ros_pkg into new-master
* depends bug fixed
* Merge branch 'master' into new-master
* Contributors: hi-kondo
```

## seed_r7_samples

```
* Merge branch 'new-master' of https://github.com/hi-kondo/seed_r7_ros_pkg into new-master
* Merge branch 'master' into new-master
* Contributors: hi-kondo
```
