### PR TITLE
geometry2: 0.12.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -599,7 +599,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.12.2-1
+      version: 0.12.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.12.3-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.12.2-1`

## geometry2

- No changes

## tf2

```
* Provide more available error messaging for nonexistent and invalid frames in canTransform (#187 <https://github.com/ros2/geometry2/issues/187>)
* Contributors: Emerson Knapp
```

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* Remove unused setup.py files (#190 <https://github.com/ros2/geometry2/issues/190>)
* Contributors: Vasilii Artemev
```

## tf2_kdl

```
* Remove unused setup.py files (#190 <https://github.com/ros2/geometry2/issues/190>)
* Contributors: Vasilii Artemev
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Remove unused setup.py files (#190 <https://github.com/ros2/geometry2/issues/190>)
* Print out the name of the signalFailure reason instead of just its enum value (#186 <https://github.com/ros2/geometry2/issues/186>)
* Contributors: Emerson Knapp, Vasilii Artemev
```

## tf2_sensor_msgs

```
* Remove unused setup.py files (#190 <https://github.com/ros2/geometry2/issues/190>)
* Contributors: Vasilii Artemev
```
