### PR TITLE
rclcpp: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1158,7 +1158,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rclcpp

```
* Updated tracing logic to match changes in rclcpp's intra-process system (#918 <https://github.com/ros2/rclcpp/issues/918>)
* Fixed a bug that prevented the ``shutdown_on_sigint`` option to not work correctly (#850 <https://github.com/ros2/rclcpp/issues/850>)
* Added support for STREAM logging macros (#926 <https://github.com/ros2/rclcpp/issues/926>)
* Relaxed multithreaded test constraint (#907 <https://github.com/ros2/rclcpp/issues/907>)
* Contributors: Anas Abou Allaban, Christophe Bedard, Dirk Thomas, alexfneves
```

## rclcpp_action

```
* Increased a timeout for the ``test_client`` tests. (#917 <https://github.com/ros2/rclcpp/issues/917>)
* Contributors: Michel Hidalgo
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
