### PR TITLE
rosbag2_bag_v2: 0.0.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1539,6 +1539,25 @@ repositories:
       url: https://github.com/ros2/rosbag2.git
       version: master
     status: maintained
+  rosbag2_bag_v2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    release:
+      packages:
+      - ros1_rosbag_storage_vendor
+      - rosbag2_bag_v2_plugins
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
+      version: 0.0.7-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    status: developed
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_bag_v2` to `0.0.7-1`:

- upstream repository: https://github.com/ros2/rosbag2_bag_v2.git
- release repository: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ros1_rosbag_storage_vendor

- No changes

## rosbag2_bag_v2_plugins

```
* Update interfaces to eloquent API. (#8 <https://github.com/ros2/rosbag2_bag_v2/issues/8>)
* Implement changes in IO interfaces. (#7 <https://github.com/ros2/rosbag2_bag_v2/issues/7>)
* Contributors: Zachary Michaels
```
