### PR TITLE
rosbag2: 0.2.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1532,7 +1532,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.4-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.3-1`

## ros2bag

- No changes

## rosbag2

```
* Load metadata from storage if no yaml file is found. (#210 <https://github.com/ros2/rosbag2/issues/210>)
* Contributors: Karsten Knese
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes
