### PR TITLE
code_coverage: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1906,7 +1906,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mikeferguson/code_coverage-gbp.git
-      version: 0.2.4-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/mikeferguson/code_coverage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.3.0-1`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.4-1`

## code_coverage

```
* update target name in readme
* Merge pull request #15 <https://github.com/mikeferguson/code_coverage/issues/15> from rhaschke/master
  Simplify + clarify usage
* add link to original source
* simplify usage
  - automatically include(CodeCoverage)
  - clarify that APPEND_COVERAGE_COMPILER_FLAGS() needs to be called before defining any target
* Merge pull request #13 <https://github.com/mikeferguson/code_coverage/issues/13> from leunMar/fix/usage_docu
  Fix example of add_code_coverage() in README.md
* Fix example of add_code_coverage() in README.md
* Contributors: Immanuel Martini, Michael Ferguson, Robert Haschke
```
