### PR TITLE
ifopt: 2.0.7-1 in 'lunar/distribution.yaml' [bloom]

### DIFF
--- a/lunar/distribution.yaml
+++ b/lunar/distribution.yaml
@@ -1597,7 +1597,7 @@ repositories:
       tags:
         release: release/lunar/{package}/{version}
       url: https://github.com/ethz-adrl/ifopt-release.git
-      version: 2.0.6-0
+      version: 2.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifopt` to `2.0.7-1`:

- upstream repository: https://github.com/ethz-adrl/ifopt.git
- release repository: https://github.com/ethz-adrl/ifopt-release.git
- distro file: `lunar/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.6-0`

## ifopt

```
* Create function to get the time statistics and the return code from the optimization solver. (#40 <https://github.com/ethz-adrl/ifopt/issues/40>)
* Contributors: viviansuzano
```
