### PR TITLE
py_trees: 2.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -937,7 +937,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
-      version: release/1.4.x
+      version: release/2.0.x
     release:
       tags:
         release: release/eloquent/{package}/{version}
@@ -946,7 +946,7 @@ repositories:
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
-      version: release/1.4.x
+      version: release/2.0.x
     status: developed
   py_trees_js:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -942,7 +942,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 1.4.1-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.0.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.4.1-1`

## py_trees

```
* [blackboard] static methods have a namespace too (root), use absolute names, #261 <https://github.com/splintered-reality/py_trees/pull/261>
* [blackboard] do not register keys on the client when xclusive write aborts the process, #261 <https://github.com/splintered-reality/py_trees/pull/261>
```
