### PR TITLE
geometry2: 0.12.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -587,6 +587,7 @@ repositories:
       version: ros2
     release:
       packages:
+      - examples_tf2_py
       - geometry2
       - tf2
       - tf2_eigen
@@ -599,7 +600,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.12.3-1
+      version: 0.12.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.12.4-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.12.3-1`

## examples_tf2_py

```
* Add Python examples for tf2_ros (#161 <https://github.com/ros2/geometry2/issues/161>)
```

## geometry2

- No changes

## tf2

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes
