### PR TITLE
ainstein_radar: 2.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -132,7 +132,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ainstein_radar` to `2.0.2-1`:

- upstream repository: https://github.com/AinsteinAI/ainstein_radar.git
- release repository: https://github.com/AinsteinAI/ainstein_radar-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.1-1`

## ainstein_radar

- No changes

## ainstein_radar_drivers

```
* Minor, remove temporary file
* Minor, fix SRD-D1 output data topic name
* Contributors: Nick Rotella
```

## ainstein_radar_filters

```
* Minor, fix header exports breaking bloom build
* Rename input/output radar topics
  Renamed all instances of radardata_in and radardata_out to radar_in and
  radar_out to conform with other packages.
* Fix laser scan converter params, remove deprecated
  Fixed the min/max range for the laserscan converted to be 0.0 and 100.0
  respectively by default so that the filtering by range doesn't affect
  most radars by default. These paremeters are required by the laserscan
  message and should instead be set from the RadarInfo message, to be
  done soon. Also removed some deprecated code.
* Remove deprecated file and code from pcl converter
  Removed an old file for testing the pointcloud (pcl) converter class
  and removed old code from the pointcloud converted class which was
  previously used to filter targets based on relative speed.
* Contributors: Nick Rotella
```

## ainstein_radar_gazebo_plugins

- No changes

## ainstein_radar_msgs

- No changes

## ainstein_radar_rviz_plugins

- No changes

## ainstein_radar_tools

```
* Use RadarInfo for sizing validation 2d bounding box
  Changed the radar-camera validation node, which draws 2d bounding boxes
  on the input image corresponding to the radar sensor's specifications,
  to use the actual RadarInfo message assumed to be published by any
  radar which publishes data. Needs testing on hardware.
* Separate radar camera validation class from node
* Rename radar camera test node, update launch files
  Renamed the radar camera "test" node to rdara camera "validation" and
  updated launch files for T79 and added one for K79. Testing again with
  K79 to verify this still works and get screenshots for wiki tutorials.
  In the future, should separate radar camera validation class from the
  node for portability, same as radar camera fusion class/node setup.
* Contributors: Nick Rotella
```
