### PR TITLE
ublox: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9578,6 +9578,26 @@ repositories:
       url: https://github.com/UbiquityRobotics/ubiquity_motor.git
       version: kinetic-devel
     status: developed
+  ublox:
+    doc:
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: master
+    release:
+      packages:
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/KumarRobotics/ublox-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: master
+    status: maintained
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `1.2.0-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/KumarRobotics/ublox-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ublox

- No changes

## ublox_gps

```
* Add support for ZED-F9P new RELPOSNED message and provide heading output
  Fix whitespacing...
  Add RELPOSNED9 message to compile
* Fix for corrupted diagnostics messages
  Before the diagnostic structs were copied, but the pointers in FrequencyStatusParams still pointed to the old/freed objects.
* Show TMODE3 diagnostics OK if disabled
  Since there is no default for TMODE3 this is a deliberate choice
* added simple (remote) logger node for raw data stream logging
* updated raw data stream logging
  + moved all global/node functions to new class RawDataStreamPa
  (raw_data_pa .h/.c)
  + changed messagetype to uint8-multiarray
  (string can not handle non-characters)
* fix #52 <https://github.com/KumarRobotics/ublox/issues/52>
* FIX: overflow bug when the nano field of the NavPVT message (which is signed and can be negative) is assigned to the nsec value of a ros time stamp (which is unsigned)
* deactivated config checks for base parts, if config_on_startup is false
* Added flag config_on_startup to deactivate configuration of ublox.
* fixes to raw data stream
  + moving write_callback_ before the read_callback_, to avoid buffer copying
  (write_callback_ == publishing ros messages and writing to file)
  + publishing empty ros message during config phase to force instantiation
  of publisher
* renamed new topic and internal variables for raw data stream
  + from raw_data_xxx to raw_data_stream_xxx
  + this is to avoid confusion with the RawDataProduct
* updated debug message for measurement rate
  (added "hz" and "cycles" as units)
* TUC-ProAut: added raw data output
  (publishing ros messages and storing to file)
* boost::posix_time::seconds constructor requires integer argument
* Add TIM product and M8U functionality as well as the TIM-TM2 message (#27 <https://github.com/KumarRobotics/ublox/issues/27>)
* Initialize set_usb_ to false by default
* Set serial port to raw mode, needed for Boost versions < 1.66.0
* Minor fixes for very old devices
* Fix potential segfault when printing Inf messages
  The Inf message strings are not null terminated, so we need to construct
  the string of the correct size from the vector of bytes instead of just
  printing using %s.
* In AsyncWorker::doClose(), close the stream instead of just cancelling operations
* Cleanup + modernize to make compatible with C++11
* Fix compilation with newer GCC and Boost
  As of now, doesn't compile with C++11 or later.
* added clear params arg
* updated config files
* added save and load configuration parameters and functions. changed how GNSS is configured & reset.
* added raw data product class and structs for frequency diagnostics
* Contributors: Chao Qu, Evan Flynn, Ferry Schoenmakers, Kartik Mohta, Michael Stoll, Peter Weissig, Stewart Worrall, Tim Clephas, Veronica Lane
```

## ublox_msgs

```
* Add support for ZED-F9P new RELPOSNED message and provide heading output
  Fix whitespacing...
  Add RELPOSNED9 message to compile
* Add TIM product and M8U functionality as well as the TIM-TM2 message (#27 <https://github.com/KumarRobotics/ublox/issues/27>)
* comment cleanup
* added MonHW message for Firmware 6.
* fixed incorrect message id
* Contributors: Evan Flynn, Ferry Schoenmakers, Veronica Lane
```

## ublox_serialization

- No changes
