### PR TITLE
universal_robot: 1.2.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15985,7 +15985,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.2.5-0
+      version: 1.2.6-1
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.2.6-1`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.5-0`

## universal_robot

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch
```

## universal_robots

- No changes

## ur10_e_moveit_config

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch
```

## ur10_moveit_config

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch, Qiang Qiu
```

## ur3_e_moveit_config

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch
```

## ur3_moveit_config

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch, Qiang Qiu
```

## ur5_e_moveit_config

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch
```

## ur5_moveit_config

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch, Qiang Qiu
```

## ur_bringup

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch, Qiang Qiu
```

## ur_description

```
* Add optional safety_controller tags to all joints in xacro macros (#437 <https://github.com/ros-industrial/universal_robot/issues/437>)
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Corrected dimensions and positions of inertias (#426 <https://github.com/ros-industrial/universal_robot/issues/426>)
* Add description view launch files for all descriptions to easily check them (#435 <https://github.com/ros-industrial/universal_robot/issues/435>)
* Contributors: Felix Mauch, JeremyZoss, Miguel Prada, Qiang Qiu, gavanderhoorn
```

## ur_driver

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch
```

## ur_e_description

```
* Add optional safety_controller tags to all joints in xacro macros (#437 <https://github.com/ros-industrial/universal_robot/issues/437>)
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Corrected dimensions and positions of inertias (#426 <https://github.com/ros-industrial/universal_robot/issues/426>)
* Add description view launch files for all descriptions to easily check them (#435 <https://github.com/ros-industrial/universal_robot/issues/435>)
* Contributors: Felix Mauch, JeremyZoss, gavanderhoorn, ipa-nhg
```

## ur_e_gazebo

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Load the JointGroupPositionController so jog commands can be sent (#422 <https://github.com/ros-industrial/universal_robot/issues/422>)
* Contributors: AndyZe, Felix Mauch
```

## ur_gazebo

```
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Load the JointGroupPositionController so jog commands can be sent (#422 <https://github.com/ros-industrial/universal_robot/issues/422>)
* Contributors: AndyZe, Felix Mauch, Qiang Qiu
```

## ur_kinematics

```
* Simplify FK equations (#372 <https://github.com/ros-industrial/universal_robot/issues/372>)
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch, Levi Armstrong, Qiang Qiu
```

## ur_msgs

```
* Added a service to set the speed slider position (#454 <https://github.com/ros-industrial/universal_robot/issues/454>)
* Added a domain field to Analog.msg (#450 <https://github.com/ros-industrial/universal_robot/issues/450>)
* Migrated all package.xml files to format=2 (#439 <https://github.com/ros-industrial/universal_robot/issues/439>)
* Contributors: Felix Mauch
```
