### PR TITLE
tracetools_analysis: 0.2.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2176,7 +2176,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `0.2.2-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.1-1`

## ros2trace_analysis

```
* Add flag for hiding processing results with the process verb
* Contributors: Christophe Bedard
```

## tracetools_analysis

```
* Update ROS 2 handler and data model after new tracepoint
* Fix timestamp column conversion util method
* Contributors: Christophe Bedard
```
