### PR TITLE
Add realtime_tools noetic source entry

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -224,6 +224,12 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  realtime_tools:
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: melodic-devel
+    status: maintained
   resource_retriever:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Add Noetic source entry for `realtime_tools`. It seems to build fine on Buster using Python 3.

@bmagyar is `melodic-devel` the right branch, or will `realtime_tools` get a new branch for Noetic?