### PR TITLE
Add control_msgs Noetic source entry

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -58,6 +58,12 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: jade-devel
     status: maintained
+  control_msgs:
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: kinetic-devel
+    status: maintained
   dynamic_reconfigure:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Add Noetic source entry for control_msgs. It seems to build fine on Buster using Python 3.

@bmagyar is kinetic-devel the right branch, or will control_msgs get a new branch for Noetic?