### PR TITLE
Add four_wheel_steering_msgs Noetic source entry

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -79,6 +79,12 @@ repositories:
       url: https://github.com/ros/filters.git
       version: lunar-devel
     status: maintained
+  four_wheel_steering_msgs:
+    source:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: master
+    status: maintained
   gencpp:
     source:
       type: git


### PR DESCRIPTION
Add Noetic source entry for four_wheel_steering_msgs. It seems to build fine on Buster using Python 3.

@vincentrou is master the right branch, or will four_wheel_steering_msgs get a new branch for Noetic?