### PR TITLE
Add urdf_geometry_parser Noetic source entry

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -414,6 +414,12 @@ repositories:
       url: https://github.com/ros/urdf.git
       version: melodic-devel
     status: maintained
+  urdf_geometry_parser:
+    source:
+      type: git
+      url: https://github.com/ros-controls/urdf_geometry_parser.git
+      version: kinetic-devel
+    status: developed
   urdfdom_py:
     source:
       type: git


### PR DESCRIPTION
Add Noetic source entry for `urdf_geometry_parser`. It seems to build fine on Buster using Python 3.

@vincentrou @bmagyar is kinetic-devel the right branch, or will `urdf_geometry_parser` get a new branch for Noetic?