### PR TITLE
Add pcl_msgs noetic source entry

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -191,6 +191,13 @@ repositories:
       url: https://github.com/tfoote/orocos_kinematics_dynamics.git
       version: python3_support
     status: maintained
+  pcl_msgs:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: indigo-devel
+    status: maintained
   pluginlib:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Add Noetic source entry for `pcl_msgs`. It seems to build fine on Buster using Python 3.

@LucidOne @paulbovbel is `indigo-devel` the right branch, or will `pcl_msgs` get a new branch for Noetic?