### PR TITLE
robot_calibration: 0.6.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6891,7 +6891,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.6.0-0
+      version: 0.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.6.1-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.0-0`

## robot_calibration

```
* Merge pull request #70 <https://github.com/mikeferguson/robot_calibration/issues/70> from Naoki-Hiraoka/enable-to-change-driver-name
  Enable to change driver name
* Merge pull request #69 <https://github.com/mikeferguson/robot_calibration/issues/69> from Naoki-Hiraoka/allow-multiple-checkerboards
  Use multiple checkerboards
* enable to change driver name
* allow multiple checkerboards
* Merge pull request #56 <https://github.com/mikeferguson/robot_calibration/issues/56> from mikeferguson/coverage
  add code coverage testing
* update code_coverage to be test_depend
* add code coverage testing
* Contributors: Michael Ferguson, Naoki-Hiraoka
```

## robot_calibration_msgs

- No changes
