### PR TITLE
launch_ros: 0.9.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -763,7 +763,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.9.3-1
+      version: 0.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.9.4-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.3-1`

## launch_ros

```
* fix new linter warnings as of flake8-comprehensions 3.1.0 (#94 <https://github.com/ros2/launch_ros/issues/94>)
* Contributors: Dirk Thomas
```

## launch_testing_ros

```
* fix new linter warnings as of flake8-comprehensions 3.1.0 (#94 <https://github.com/ros2/launch_ros/issues/94>)
* Contributors: Dirk Thomas
```

## ros2launch

- No changes
