### PR TITLE
demos: 0.8.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -307,7 +307,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.8.4-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.3-1`

## action_tutorials_cpp

```
* Return without sending goal if exiting (#415 <https://github.com/ros2/demos/issues/415>)
* Contributors: Shane Loretz
```

## action_tutorials_interfaces

- No changes

## action_tutorials_py

```
* Make demos handle SIGINT gracefully. (#377 <https://github.com/ros2/demos/issues/377>)
* Contributors: Michel Hidalgo
```

## composition

- No changes

## demo_nodes_cpp

```
* Add in a more helpful usage message to allocator_tutorial. (#409 <https://github.com/ros2/demos/issues/409>)
* Contributors: Chris Lalancette
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Make demos handle SIGINT gracefully. (#377 <https://github.com/ros2/demos/issues/377>)
* Contributors: Michel Hidalgo
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes
