### PR TITLE
variants: 0.8.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2287,7 +2287,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.8.3-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.2-1`

## desktop

- No changes

## ros_base

- No changes

## ros_core

```
* Add ros2doctor to ros_core variant (#21 <https://github.com/ros2/variants/issues/21>)
* Contributors: Shane Loretz
```
