### PR TITLE
rqt_tf_tree: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2646,6 +2646,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_srv.git
       version: crystal-devel
     status: maintained
+  rqt_tf_tree:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: dashing-devel
+    status: maintained
   rqt_top:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros2-gbp/rqt_tf_tree-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## rqt_tf_tree

```
* port package to ROS 2 (#13 <https://github.com/ros-visualization/rqt_tf_tree/issues/13>)
* minor cleanup (#12 <https://github.com/ros-visualization/rqt_tf_tree/issues/12>)
```
