### PR TITLE
Added doc indexing for ur_robot_driver

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9749,6 +9749,11 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  ur_robot_driver:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
+      version: master
   urdf:
     doc:
       type: git


### PR DESCRIPTION
This adds a doc entry for the ur_robot_driver. A binary release will follow once all upstream requirements are merged.