### PR TITLE
py_trees_ros: 1.3.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -973,7 +973,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 1.2.1-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -968,7 +968,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros.git
-      version: release/1.2.x
+      version: release/1.3.x
     release:
       tags:
         release: release/eloquent/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `1.3.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.1-1`

## py_trees_ros

```
* [transforms] add missing mocks and update to latest blackboard api, #125 <https://github.com/splintered-reality/py_trees_ros/pull/125>
```
