### PR TITLE
py_trees_ros: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -968,7 +968,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros.git
-      version: release/1.2.x
+      version: release/2.0.x
     release:
       tags:
         release: release/eloquent/{package}/{version}

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -973,7 +973,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 1.2.1-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.0.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.2.1-1`

## py_trees_ros

```
* [blackboards] updated pretty printing to differentiate namespace vs attribute access, #123 <https://github.com/splintered-reality/py_trees_ros/pull/123>
* [blackboards] api updates for namespaced clients, #122 <https://github.com/splintered-reality/py_trees_ros/pull/122>,
* [tests] migrated tests from unittest to pytest
* [transforms] From and To behaviours added, #121 <https://github.com/splintered-reality/py_trees_ros/pull/121>
* [transforms] add missing mocks and update to latest blackboard api, #125 <https://github.com/splintered-reality/py_trees_ros/pull/125>
```
