### PR TITLE
cyclonedds: 0.1.0-7 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -273,6 +273,7 @@ repositories:
       version: 0.1.0-7
     source:
       test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: 08d9c296f1b569c18188528fd5e8f086e94dd67d

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -276,7 +276,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: b6b0c2535585dafd794478e0778ed15c71a7afbb
+      version: 08d9c296f1b569c18188528fd5e8f086e94dd67d
     status: developed
   demos:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -270,7 +270,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.1.0-6
+      version: 0.1.0-7
     source:
       test_commits: false
       test_pull_requests: false

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -273,7 +273,6 @@ repositories:
       version: 0.1.0-7
     source:
       test_commits: false
-      test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
       version: 08d9c296f1b569c18188528fd5e8f086e94dd67d


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.1.0-7`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-6`
