### PR TITLE
swarmros: 0.3.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14803,6 +14803,19 @@ repositories:
       url: https://github.com/cpswarm/swarm_functions.git
       version: kinetic-devel
     status: developed
+  swarmros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/amilankovich-slab/swarmros-release.git
+      version: 0.3.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/amilankovich-slab/swarmros.git
+      version: master
+    status: developed
+    status_description: developed
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swarmros` to `0.3.1-2`:

- upstream repository: https://github.com/amilankovich-slab/swarmros.git
- release repository: https://github.com/amilankovich-slab/swarmros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
