### PR TITLE
Added python-configparser rosdep rule.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1025,6 +1025,12 @@ python-concurrent.futures:
   fedora: [python-futures]
   gentoo: [virtual/python-futures]
   ubuntu: [python-concurrent.futures]
+python-configparser:
+  arch: [python2-configparser]
+  debian: [python-configparser]
+  fedora: [python-configparser]
+  gentoo: [dev-python/configparser]
+  ubuntu: [python-configparser]
 python-construct:
   debian: [python-construct]
   ubuntu: [python-construct]


### PR DESCRIPTION
https://packages.ubuntu.com/disco/python-configparser
https://packages.debian.org/buster/python-configparser
https://apps.fedoraproject.org/packages/python-configparser
https://packages.gentoo.org/packages/dev-python/configparser
https://www.archlinux.org/packages/extra/any/python2-configparser/