### PR TITLE
panda_moveit_config: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5717,7 +5717,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/panda_moveit_config-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.3-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.7.2-1`

## panda_moveit_config

```
* cleanup warehouse settings (#43 <https://github.com/ros-planning/panda_moveit_config/issues/43>)
* demo_chomp.launch: Rename arg planner to pipeline (#42 <https://github.com/ros-planning/panda_moveit_config/issues/42>)
  Fixup of 0b7ac4e6ea147003fd01d0b51723452ff320a5ea (#29 <https://github.com/ros-planning/panda_moveit_config/issues/29>)
* Remove deprecated inorder tag to fix warning (#36 <https://github.com/ros-planning/panda_moveit_config/issues/36>)
* Necessary files to run LERP (#40 <https://github.com/ros-planning/panda_moveit_config/issues/40>)
  * added new files for emptyplan
  * edited demo.launch to accept planner arg
  * Added emptyplan_planning.yaml so it can be used for new planners. It is an empty file.
  Added rosparam in emptyplan_planning_pipeline.launch.xml to load its yaml file
  * added necessary files for LERP
  * chaged the virtual joint to fixed
  * added yaml file
  * addressed the comments
  * revet back to floating for virtual joint and revert moveit.rviz
* Add fully extended pose: 'extended' (#39 <https://github.com/ros-planning/panda_moveit_config/issues/39>)
* Add TrajOpt launch files to panda_moveit_config (#29 <https://github.com/ros-planning/panda_moveit_config/issues/29>)
  * added new files for emptyplan
  * edited demo.launch to accept planner arg
  * Added emptyplan_planning.yaml so it can be used for new planners. It is an empty file.
  Added rosparam in emptyplan_planning_pipeline.launch.xml to load its yaml file
  * from empty to trajopt
  * modified some comment
  * renamed and edited the context of files from empty to trajopt
  * removed  move_group_trajop.launch, we do not need this file
  * applied Dave's comments
  * restored setup_assistant
  * added trajopt params in yaml file
  removed extra planner arg in demo.launch
  * addressed the comments
  * corrected pipeline in move_group
* Added open and closed poses (#34 <https://github.com/ros-planning/panda_moveit_config/issues/34>)
* Adapt pipelines (#31 <https://github.com/ros-planning/panda_moveit_config/issues/31>)
  * add default_planner_request_adapters/ResolveConstraintFrames
  * chomp pipeline: define default planning adapters
* demo.launch: expose planner arg (#30 <https://github.com/ros-planning/panda_moveit_config/issues/30>)
* Contributors: Dave Coleman, Henning Kayser, Jafar Abdi, Omid Heidari, Robert Haschke, simonGoldstein
```
