### PR TITLE
blender_gazebo: 0.0.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1061,6 +1061,21 @@ repositories:
       url: https://github.com/durovsky/binpicking_utils.git
       version: master
     status: maintained
+  blender_gazebo:
+    doc:
+      type: git
+      url: https://github.com/david0429/blender_gazebo.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/david0429-gbp/blender_gazebo_gbp.git
+      version: 0.0.3-2
+    source:
+      type: git
+      url: https://github.com/david0429/blender_gazebo.git
+      version: master
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `blender_gazebo` to `0.0.3-2`:

- upstream repository: https://github.com/david0429/blender_gazebo.git
- release repository: https://github.com/david0429-gbp/blender_gazebo_gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## blender_gazebo

```
* Fixed deps
* Contributors: Dave Niewinski
```
