### PR TITLE
Added Qt5 Multimedia, Quick and Qml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3065,6 +3065,9 @@ libqt5-gui:
   rhel: [qt5-qtbase-gui]
   slackware: [qt5]
   ubuntu: [libqt5gui5]
+libqt5-multimedia:
+  debian: [libqt5multimedia5]
+  ubuntu: [libqt5multimedia5]
 libqt5-network:
   arch: [qt5-base]
   debian: [libqt5network5]
@@ -3098,6 +3101,12 @@ libqt5-printsupport:
   freebsd: [qt5-printsupport]
   gentoo: ['dev-qt/qtprintsupport:5']
   ubuntu: [libqt5printsupport5]
+libqt5-qml:
+  debian: [libqt5qml5]
+  ubuntu: [libqt5qml5]
+libqt5-quick:
+  debian: [libqt5quick5]
+  ubuntu: [libqt5quick5]
 libqt5-serialport:
   arch: [qt5-serialport]
   debian: [libqt5serialport5]


### PR DESCRIPTION
# libqt5-multimedia
https://packages.debian.org/sid/libqt5multimedia5
https://packages.ubuntu.com/bionic/libqt5multimedia5

# libqt5-qml
https://packages.debian.org/sid/libqt5qml5
https://packages.ubuntu.com/bionic/libqt5qml5

# libqt5-quick
https://packages.debian.org/sid/libqt5quick5
https://packages.ubuntu.com/bionic/libqt5quick5

Naming differs from Ubuntu packages to keep them consistent with the other libqt5-* packages.