### PR TITLE
kinetic: mark ur_modern_driver as EOL

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16036,7 +16036,7 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/ur_modern_driver.git
       version: kinetic-devel
-    status: maintained
+    status: end-of-life
   urdf:
     doc:
       type: git


### PR DESCRIPTION
As per subject.

Context: [Deprecation of ur_modern_driver](https://discourse.ros.org/t/deprecation-of-ur-modern-driver/11629).
