### PR TITLE
universal_robot: 1.2.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16015,7 +16015,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.2.6-1
+      version: 1.2.7-1
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `universal_robot` to `1.2.7-1`:

- upstream repository: https://github.com/ros-industrial/universal_robot.git
- release repository: https://github.com/ros-industrial-release/universal_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.6-1`

## universal_robot

- No changes

## universal_robots

- No changes

## ur10_e_moveit_config

```
* Fix loading e-series robot_description param (#467 <https://github.com/ros-industrial/universal_robot/issues/467>)
* Contributors: Gonzalo Casas
```

## ur10_moveit_config

- No changes

## ur3_e_moveit_config

```
* Fix loading e-series robot_description param (#467 <https://github.com/ros-industrial/universal_robot/issues/467>)
* Contributors: Gonzalo Casas
```

## ur3_moveit_config

- No changes

## ur5_e_moveit_config

```
* Fix loading e-series robot_description param (#467 <https://github.com/ros-industrial/universal_robot/issues/467>)
* Contributors: Gonzalo Casas
```

## ur5_moveit_config

- No changes

## ur_bringup

- No changes

## ur_description

- No changes

## ur_driver

```
* Modernize python 2 codes (#457 <https://github.com/ros-industrial/universal_robot/issues/457>)
* Contributors: cclauss, gavanderhoorn
```

## ur_e_description

- No changes

## ur_e_gazebo

- No changes

## ur_gazebo

- No changes

## ur_kinematics

```
* Modernize python 2 codes (#457 <https://github.com/ros-industrial/universal_robot/issues/457>)
* Contributors: cclauss, gavanderhoorn
```

## ur_msgs

- No changes
