### PR TITLE
octomap: 1.9.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1449,7 +1449,7 @@ repositories:
     source:
       type: git
       url: https://github.com/octomap/octomap.git
-      version: v1.9.1
+      version: devel
     status: maintained
   ompl:
     release:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1432,6 +1432,25 @@ repositories:
       url: https://github.com/intel/ros2_object_msgs.git
       version: master
     status: maintained
+  octomap:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: v1.9.1
+    release:
+      packages:
+      - dynamic_edt_3d
+      - octomap
+      - octovis
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros-gbp/octomap-release.git
+      version: 1.9.1-1
+    source:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: v1.9.1
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.1-1`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
