### PR TITLE
[dep] Add rsyslog.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4820,6 +4820,10 @@ rsync:
   gentoo: [net-misc/rsync]
   opensuse: [rsync]
   ubuntu: [rsync]
+rsyslog:
+  debian: [rsyslog]
+  fedora: [rsyslog]
+  ubuntu: [rsyslog]
 rti-connext-dds-5.3.1:
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]


### PR DESCRIPTION
`rsyslog` is an [alternative to `syslog` etc.](https://serverfault.com/questions/692309/what-is-the-difference-between-syslog-rsyslog-and-syslog-ng) and system monitoring tool can utilize its api.   

debian https://packages.debian.org/buster/rsyslog
fedora https://rpmfind.net/linux/rpm2html/search.php?query=rsyslog&submit=Search+...&system=&arch=
macports [none](https://www.macports.org/ports.php?by=name&substr=rsyslog)
ubuntu https://packages.ubuntu.com/xenial/rsyslog