### PR TITLE
Adding get_parameters to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2632,6 +2632,21 @@ repositories:
       url: https://github.com/ros/geometry_tutorials.git
       version: indigo-devel
     status: maintained
+  get_parameters:
+    doc:
+      type: git
+      url: https://github.com/ubtvisbot/get_parameters.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ubtvisbot/get_parameters-release.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/ubtvisbot/get_parameters.git
+      version: master
+    status: developed
   gl_dependency:
     doc:
       type: git


### PR DESCRIPTION
Adding get_parameters to documentation index for distro