### PR TITLE
py_trees: 2.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -943,7 +943,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 2.0.1-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.0.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-1`

## py_trees

```
* [trees] revert to using user signals if available to avoid shenanigans with SIGINT, #264 <https://github.com/splintered-reality/py_trees/pull/264>
* [trees] play nicely, reset signal handlers after setup, #262 <https://github.com/splintered-reality/py_trees/pull/262>
* [visitors] bugfix the snapshot visitor to look for exclusive write keys as well
```
