### PR TITLE
rviz: 1.13.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8606,7 +8606,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.5-1
+      version: 1.13.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.6-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.13.5-1`

## rviz

```
* [fix] Memory leak in rviz::Robot
* [fix] assimp importer: repair invalid normals (#1452 <https://github.com/ros-visualization/rviz/issues/1452>)
* [fix] Fixup cmake file issues
  * Remove redundant include_directories()
  * Generate export headers in devel space
  * Use cmake find_package(yaml-cpp) (#1445 <https://github.com/ros-visualization/rviz/issues/1445>)
* [fix] Gracefully ignore invalid floats (nans) in:
  * LineStripMarker (#1440 <https://github.com/ros-visualization/rviz/issues/1440>)
  * EffortDisplay (#1437 <https://github.com/ros-visualization/rviz/issues/1437>)
* [fix] MovableText: correctly rotate AABB
* [fix] Correctly delete old marker if its type changed
* [maintanence] MovableText:
  * Simplify scaling (there was a scaling by factor 0.5 in getWorldTransforms(), requiring a scaling of 2.0 in _setupGeometry())
  * Simplify _setupGeometry()
* [maintanence] ignore catkin_lint errors/warnings
* [maintanence] Properties: inform model about changed data
* Contributors: Antoine Hoarau, Michael Görner, Robert Haschke
```
