### PR TITLE
ubt_msgs: 0.0.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9686,6 +9686,21 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: master
     status: maintained
+  ubt_msgs:
+    doc:
+      type: git
+      url: https://github.com/ubtvisbot/ubt_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ubtvisbot/ubt_msgs-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/ubtvisbot/ubt_msgs.git
+      version: master
+    status: developed
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubt_msgs` to `0.0.1-3`:

- upstream repository: https://github.com/ubtvisbot/ubt_msgs.git
- release repository: https://github.com/ubtvisbot/ubt_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
