### PR TITLE
Turning off PR testing for image_pipeline in Crystal

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -668,7 +668,6 @@ repositories:
       url: https://github.com/ros2-gbp/image_pipeline-release.git
       version: 2.0.0-0
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
       version: ros2


### PR DESCRIPTION
We are now targeting Dashing and this probably shouldn't have been turned on anyway.