### PR TITLE
get_parameters: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2632,6 +2632,21 @@ repositories:
       url: https://github.com/ros/geometry_tutorials.git
       version: indigo-devel
     status: maintained
+  get_parameters:
+    doc:
+      type: git
+      url: https://github.com/ubtvisbot/get_parameters.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ubtvisbot/get_parameters-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/ubtvisbot/get_parameters.git
+      version: master
+    status: developed
   gl_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `get_parameters` to `0.0.3-1`:

- upstream repository: https://github.com/ubtvisbot/get_parameters.git
- release repository: https://github.com/ubtvisbot/get_parameters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## get_parameters

```
* docs: modify email
* 0.0.2
* docs: modify CHANGLOG
* Contributors: lifu.qin
```
