### PR TITLE
py_script-release: 0.0.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10259,6 +10259,16 @@ repositories:
       url: https://github.com/PX4/px4_msgs-release.git
       version: 1.0.0-3
     status: developed
+  py_script-release:
+    release:
+      packages:
+      - humanoid_shp
+      - humanoid_shp_moveit
+      - py_script
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/dippingconda/py_script-release.git
+      version: 0.0.1-2
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_script-release` to `0.0.1-2`:

- upstream repository: https://github.com/dippingconda/sim_fall_det.git
- release repository: https://github.com/dippingconda/py_script-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## humanoid_shp

```
* first commit
* Contributors: pshyeok
```

## humanoid_shp_moveit

```
* first commit
* Contributors: pshyeok
```

## py_script

```
* first commit
* Contributors: pshyeok
```
