### PR TITLE
humanoid_shp_moveit-release: 0.0.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4898,6 +4898,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/humanoid_navigation.git
       version: kinetic-devel
     status: maintained
+  humanoid_shp_moveit-release:
+    release:
+      packages:
+      - humanoid_shp
+      - humanoid_shp_moveit
+      - py_script
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/dippingconda/humanoid_shp_moveit-release.git
+      version: 0.0.1-2
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `humanoid_shp_moveit-release` to `0.0.1-2`:

- upstream repository: https://github.com/dippingconda/sim_fall_det.git
- release repository: https://github.com/dippingconda/humanoid_shp_moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## humanoid_shp

```
* first commit
* Contributors: pshyeok
```

## humanoid_shp_moveit

```
* first commit
* Contributors: pshyeok
```

## py_script

```
* first commit
* Contributors: pshyeok
```
