### PR TITLE
Add benchmark to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -226,6 +226,14 @@ beep:
   fedora: [beep]
   gentoo: [app-misc/beep]
   ubuntu: [beep]
+benchmark:
+  debian:
+    '*': [libbenchmark-dev]
+    stretch: null
+  fedora: [google-benchmark]
+  ubuntu:
+    '*': [libbenchmark-dev]
+    xenial: null
 binutils:
   arch: [binutils]
   debian: [binutils-dev]


### PR DESCRIPTION
Add benchmark to rosdep
    
Add Google's benchmark library to rosdep/base.yaml, for:
    
* Debian: https://packages.debian.org/buster/libbenchmark-dev
* Fedora: https://src.fedoraproject.org/rpms/google-benchmark
* Ubuntu: https://packages.ubuntu.com/bionic/libbenchmark-dev
    
This library became available in the following stable versions:
    
* Debian: Buster
* Fedora: EPEL 8
* Ubuntu: Bionic