### PR TITLE
geographic_info: 1.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -580,6 +580,17 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: eloquent
     status: developed
+  geographic_info:
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros-geographic-info/geographic_info-release.git
+      version: 1.0.1-1
+    status: maintained
   geometry2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `1.0.1-1`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
