### PR TITLE
blender_gazebo: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -478,6 +478,21 @@ repositories:
       url: https://github.com/ros-gbp/bfl-release.git
       version: 0.8.0-1
     status: unmaintained
+  blender_gazebo:
+    doc:
+      type: git
+      url: https://github.com/david0429/blender_gazebo.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/david0429-gbp/blender_gazebo_gbp.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/david0429/blender_gazebo.git
+      version: master
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `blender_gazebo` to `0.0.3-1`:

- upstream repository: https://github.com/david0429/blender_gazebo.git
- release repository: https://github.com/david0429-gbp/blender_gazebo_gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## blender_gazebo

```
* Fixed deps
* Contributors: Dave Niewinski
```
