### PR TITLE
control_msgs: 1.5.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2024,7 +2024,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/control_msgs-release.git
-      version: 1.5.0-0
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `1.5.1-1`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.5.0-0`

## control_msgs

```
* add description of JointControllerState.msg (#30 <https://github.com/ros-controls/control_msgs/issues/30>)
* Contributors: Shuang Li
```
