### PR TITLE
Updating carla_ros_bridge to documentation index for kinetic distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1250,7 +1250,7 @@ repositories:
       url: https://github.com/ipa320/care-o-bot-release.git
       version: 0.6.7-0
     status: maintained
-  carla_ros_bridge_0.9.6:
+  carla_ros_bridge:
     doc:
       type: git
       url: https://github.com/carla-simulator/ros-bridge.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1250,11 +1250,15 @@ repositories:
       url: https://github.com/ipa320/care-o-bot-release.git
       version: 0.6.7-0
     status: maintained
-  carla_ros_bridge:
+  carla_ros_bridge_0.9.6:
     doc:
       type: git
       url: https://github.com/carla-simulator/ros-bridge.git
-      version: master
+      version: 0.9.6
+    source:
+      type: git
+      url: https://github.com/carla-simulator/ros-bridge.git
+      version: 0.9.6
     status: maintained
   cartesian_msgs:
     doc:


### PR DESCRIPTION
I'd like package carla_ros_bridge to be indexed and documented on ros.org.
Earlier it was linked with the master which we want to change and link with branch 0.9.6, so we can maintain it properly.