### PR TITLE
ament_package: 0.8.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6,5 +6,21 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  ament_package:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_package-release.git
+      version: 0.8.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.8.5-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ament_package

```
* Fix sh command to remove trailing separator (#105 <https://github.com/ament/ament_package/issues/105>)
* Always prepend with a trailing separator (#104 <https://github.com/ament/ament_package/issues/104>)
* Contributors: Jacob Perron
```
