### PR TITLE
octomap: 1.9.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5246,7 +5246,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.2-1`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.9.1-1`
