### PR TITLE
baldor: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -423,6 +423,21 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
       version: 0.1.3-0
+  baldor:
+    doc:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/crigroup/baldor-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+      version: master
+    status: maintained
   basler_tof:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baldor` to `0.1.2-1`:

- upstream repository: https://github.com/crigroup/baldor.git
- release repository: https://github.com/crigroup/baldor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## baldor

```
* Add function to estimate the transformation between two axes (#3)
* Contributors: Francisco
```
