### PR TITLE
criutils: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1353,6 +1353,21 @@ repositories:
       type: git
       url: https://github.com/whoenig/crazyflie_ros.git
       version: master
+  criutils:
+    doc:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/crigroup/criutils-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    status: maintained
   cv_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.3-1`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## criutils

```
* Add automatic TF broadcaster node
* Add missing dependency to OpenCV
* Add and improve test coverage
* Use baldor package instead of tf.transformations
* Fix documentation generation for ROS indigo (#2)
* Contributors: Francisco, fsuarez6
```
