### PR TITLE
handeye: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2796,6 +2796,21 @@ repositories:
       url: https://github.com/aws-robotics/kinesisvideo-encoder-ros1.git
       version: master
     status: maintained
+  handeye:
+    doc:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/crigroup/handeye-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    status: maintained
   haros_catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.1-1`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## handeye

```
* Fix np.linalg.lstsq bug
* Add installation rules for python node
* Contributors: fsuarez6
```
