### PR TITLE
multi_object_tracking_lidar: 1.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7743,7 +7743,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multi_object_tracking_lidar` to `1.0.2-1`:

- upstream repository: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
- release repository: https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.1-1`

## multi_object_tracking_lidar

```
* Added link to wiki pages
* Updated readme with suuported pointcloud sources
* Updated README to clarify real, sim, dataset LiDAR data
* Contributors: Praveen Palanisamy
```
