### PR TITLE
Add python3-parameterized key for rclpy test

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,6 +5268,11 @@ python3-pandas:
   fedora: [python3-pandas]
   gentoo: [dev-python/pandas]
   ubuntu: [python3-pandas]
+python3-parameterized:
+  debian: [python3-parameterized]
+  fedora: [python3-parameterized]
+  gentoo: [dev-python/parameterized]
+  ubuntu: [python3-parameterized]
 python3-paramiko:
   debian: [python3-paramiko]
   fedora: [python3-paramiko]


### PR DESCRIPTION
Debian https://packages.debian.org/buster/python3-parameterized
Fedora https://apps.fedoraproject.org/packages/python3-parameterized
Gentoo https://packages.gentoo.org/packages/dev-python/parameterized
Ubuntu https://packages.ubuntu.com/bionic/python3-parameterized

Test code for rclpy  depend on python3-parameterized (refer to https://github.com/ros2/rclpy/pull/469).   
So apply to add this dependency package.