### PR TITLE
Push trac ik 1.5.1

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15424,7 +15424,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.5.0-0
+      version: 1.5.1-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9366,7 +9366,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
I noticed that despite the (as far as I can tell) successful [buildfarm](http://build.ros.org/job/Msrc_uB__trac_ik__ubuntu_bionic__source/) that was triggered a few months ago, the package version of `trac_ik` was never updated. The [release repo](https://github.com/traclabs/trac_ik-release/blob/master/README.md) seems to have been updated fine, and I think the only step left is to update this repo. 

Tagging @pbeeson, in case he wants to take over this PR. 