### PR TITLE
autoware_msgs: 1.13.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -352,6 +352,7 @@ repositories:
       - autoware_can_msgs
       - autoware_config_msgs
       - autoware_external_msgs
+      - autoware_lanelet2_msgs
       - autoware_map_msgs
       - autoware_msgs
       - autoware_system_msgs
@@ -360,7 +361,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/messages-release.git
-      version: 1.12.0-1
+      version: 1.13.0-1
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.13.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
- release repository: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/messages-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.12.0-1`

## autoware_can_msgs

```
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley
```

## autoware_config_msgs

```
* Lateral limitation filter by twist_filter
* add param of decision_maker: disable insert stopline
* Add Message Properties for use_sim and use_decision_maker
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley, Yuma Nihei, s-azumi
```

## autoware_external_msgs

```
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley
```

## autoware_lanelet2_msgs

```
* Update package.xml of autoware_lanelet2_msgs for release.
* Rename lanelet2_msgs to autoware_lanelet2_msgs
* Contributors: Joshua Whitley, Kenji Miyake
```

## autoware_map_msgs

```
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley
```

## autoware_msgs

```
* Adding service message for TF-based TLR
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley
```

## autoware_system_msgs

```
* Update emergency category in DiagnosticStatus message
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley, Yuma Nihei
```

## tablet_socket_msgs

```
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley
```

## vector_map_msgs

```
* Update package.xml files to Format 2.
* Contributors: Joshua Whitley
```
