### PR TITLE
py_trees_ros: 2.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1003,7 +1003,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.0.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.0-1`

## py_trees_ros

```
* [trees] periodically publish snapshots, #131 <https://github.com/splintered-reality/py_trees_ros/pull/131>,
* [trees] permit setup visitors, provide a default with timings, #129 <https://github.com/splintered-reality/py_trees_ros/pull/129>,
* [trees] bugfix non-infinite timeout arg getting ignored, #129 <https://github.com/splintered-reality/py_trees_ros/pull/129>,
* [trees] snapshot now publishing tree changed flag and key access info, #128 <https://github.com/splintered-reality/py_trees_ros/pull/128>,
* [utilities] deprecate myargv for rclpy.utilities.remove_ros_args, #130 <https://github.com/splintered-reality/py_trees_ros/pull/130>,
```
