### PR TITLE
py_trees_ros_tutorials: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1034,7 +1034,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_tutorials-release.git
-      version: 1.0.6-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1029,7 +1029,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
-      version: release/1.0.x
+      version: release/2.0.x
     release:
       tags:
         release: release/eloquent/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `2.0.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/stonier/py_trees_ros_tutorials-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.6-1`
