### PR TITLE
pilz_robots: 0.5.13-1 & pilz_industrial_motion: 0.4.10-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5894,7 +5894,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.9-1
+      version: 0.4.10-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git
@@ -5919,7 +5919,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.12-1
+      version: 0.5.13-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.13-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.12-1`

## pilz_control

- No changes

## pilz_robots

- No changes

## pilz_testutils

- No changes

## pilz_utils

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Use brake-test definitions from pilz_msgs
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

- No changes

## prbt_support

- No changes


Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.10-1`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.9-1`

## pilz_extensions

- No changes

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

- No changes

## pilz_msgs

- No changes

## pilz_robot_programming

```
* Adapt to new brake test srv definitions in pilz_msgs
* Contributors: Pilz GmbH and Co. KG
```

## pilz_trajectory_generation

- No changes
