### PR TITLE
ament_virtualenv: 0.0.3-0 in 'dashing/distribution.yaml' & 'cr…

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -139,7 +139,7 @@ repositories:
       - ament_cmake_virtualenv
       - ament_virtualenv
       tags:
-        release: release/dashing/{package}/{version}
+        release: release/crystal/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
       version: 0.0.3-2
     source:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -141,7 +141,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.2-1
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -141,7 +141,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.3-0
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -213,7 +213,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -213,7 +213,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.2-1
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_virtualenv` to 0.0.3-0:

- upstream repository: https://github.com/esol-community/ament_virtualenv.git
- release repository: https://github.com/esol-community/ament_virtualenv-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.2-1`

## ament_cmake_virtualenv
- Various bugfixes

## ament_virtualenv
- Various bugfixes

Increasing version of package(s) in repository `ament_virtualenv` to 0.0.3-0:

- upstream repository: https://github.com/esol-community/ament_virtualenv.git
- release repository: https://github.com/esol-community/ament_virtualenv-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.2-1`

## ament_cmake_virtualenv
- Various bugfixes

## ament_virtualenv
- Various bugfixes