### PR TITLE
teleop_tools: 1.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2128,6 +2128,27 @@ repositories:
       url: https://github.com/microROS/system_modes-release.git
       version: 0.1.5-1
     status: developed
+  teleop_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: dashing-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: dashing-devel
+    status: maintained
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.0.1-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## joy_teleop

```
* Fix install rules and dashing changes (#38 <https://github.com/ros-teleop/teleop_tools/issues/38>)
  * fix ament indexing
  * fix package resource files
  * add tk depenndency
  * add check for param index-ability
  * data files are now package agnostic
  Signed-off-by: Ted Kern <mailto:ted.kern@canonical.com>
* Contributors: Ted Kern
```

## key_teleop

```
* Fix install rules and dashing changes (#38 <https://github.com/ros-teleop/teleop_tools/issues/38>)
  * fix ament indexing
  * fix package resource files
  * add tk depenndency
  * add check for param index-ability
  * data files are now package agnostic
  Signed-off-by: Ted Kern <mailto:ted.kern@canonical.com>
* Contributors: Ted Kern
```

## mouse_teleop

```
* Fix install rules and dashing changes (#38 <https://github.com/ros-teleop/teleop_tools/issues/38>)
  * fix ament indexing
  * fix package resource files
  * add tk depenndency
  * add check for param index-ability
  * data files are now package agnostic
  Signed-off-by: Ted Kern <mailto:ted.kern@canonical.com>
* Contributors: Ted Kern
```

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
