### PR TITLE
seed_r7_ros_pkg: 0.3.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8753,6 +8753,32 @@ repositories:
       url: https://github.com/ipab-slmc/SDHLibrary-CPP.git
       version: master
     status: maintained
+  seed_r7_ros_pkg:
+    doc:
+      type: git
+      url: https://github.com/seed-solutions/seed_r7_ros_pkg.git
+      version: master
+    release:
+      packages:
+      - seed_r7_bringup
+      - seed_r7_description
+      - seed_r7_moveit_config
+      - seed_r7_navigation
+      - seed_r7_robot_interface
+      - seed_r7_ros_controller
+      - seed_r7_ros_pkg
+      - seed_r7_samples
+      - seed_r7_typef_moveit_config
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
+      version: 0.3.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/seed-solutions/seed_r7_ros_pkg.git
+      version: master
+    status: developed
   seed_smartactuator_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_r7_ros_pkg` to `0.3.3-1`:

- upstream repository: https://github.com/seed-solutions/seed_r7_ros_pkg.git
- release repository: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## seed_r7_navigation

```
* Merge branch 'master' into add_test
```

## seed_r7_ros_pkg

```
* Merge branch 'master' into add_test
* Update CMakeLists.txt
* toplevel added
* Contributors: hi-kondo
```

## seed_r7_samples

```
* Merge pull request #62 <https://github.com/hi-kondo/seed_r7_ros_pkg/issues/62> from hi-kondo/ori-master
  rostest directory of seed_r7_samples changed
* depend package added
* hand constructor added
* rostest directory of seed_r7_samples changed
* Merge pull request #61 <https://github.com/hi-kondo/seed_r7_ros_pkg/issues/61> from hi-kondo/add_rostest/roslaunch_and_demo.test
  Add rostest/roslaunch and demo.test
* rostest timeout changed
* update test
```
