### PR TITLE
cob_manipulation: 0.7.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1774,11 +1774,10 @@ repositories:
       - cob_moveit_bringup
       - cob_moveit_interface
       - cob_obstacle_distance_moveit
-      - cob_pick_place_action
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_manipulation-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.2-1`

## cob_collision_monitor

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* dual-distro compatibility
* Contributors: Felix Messmer, fmessmer
```

## cob_grasp_generation

- No changes

## cob_lookat_action

- No changes

## cob_manipulation

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* CATKIN_IGNORE cob_pick_place_action
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_bringup

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* fix moveit deprecation warning
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_interface

- No changes

## cob_obstacle_distance_moveit

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* dual-distro compatibility
* Contributors: Felix Messmer, fmessmer
```
