### PR TITLE
cob_manipulation: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1047,6 +1047,29 @@ repositories:
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
     status: maintained
+  cob_manipulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_collision_monitor
+      - cob_grasp_generation
+      - cob_lookat_action
+      - cob_manipulation
+      - cob_moveit_bringup
+      - cob_moveit_interface
+      - cob_obstacle_distance_moveit
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ipa320/cob_manipulation-release.git
+      version: 0.7.3-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: kinetic_dev
+    status: maintained
   cob_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## cob_collision_monitor

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* dual-distro compatibility
* Contributors: Felix Messmer, fmessmer
```

## cob_grasp_generation

- No changes

## cob_lookat_action

- No changes

## cob_manipulation

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* CATKIN_IGNORE cob_pick_place_action
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_bringup

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* fix moveit deprecation warning
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_interface

- No changes

## cob_obstacle_distance_moveit

```
* Merge pull request #138 <https://github.com/ipa320/cob_manipulation/issues/138> from fmessmer/melodic_checks
  [Melodic] add melodic checks
* dual-distro compatibility
* Contributors: Felix Messmer, fmessmer
```
