### PR TITLE
rosidl_typesupport_connext: 0.8.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1719,7 +1719,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `0.8.3-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.2-1`

## connext_cmake_module

- No changes

## rosidl_typesupport_connext_c

- No changes

## rosidl_typesupport_connext_cpp

```
* retry rtiddsgen(_server) invocation if it fails with a return code (#38 <https://github.com/ros2/rosidl_typesupport_connext/issues/38>)
* Contributors: Dirk Thomas
```
