### PR TITLE
qt_gui_core: 0.3.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6530,7 +6530,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.15-1
+      version: 0.3.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.16-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.15-1`

## qt_dotgraph

```
* make another test more flexible in terms of whitespaces (#194 <https://github.com/ros-visualization/qt_gui_core/issues/194>)
```

## qt_gui

```
* fix UI to enter perspective name (#198 <https://github.com/ros-visualization/qt_gui_core/issues/198>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
