### PR TITLE
hebi_cpp_api_ros: 3.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4455,7 +4455,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
-      version: 2.1.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository hebi_cpp_api_ros to 3.1.0-1:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
- distro file: kinetic/distribution.yaml
- previous version for package: 2.1.0-1

# hebi_cpp_api

```
(from 2.2.0)

* Added ability to set and clear text in the experimental mobile IO API
* Added ability to get raw feedback from experimental mobile IO API

(from 3.0.0)

* Robot Model:

  * Added "input frame" type for forward kinematics operations
  * Added end effector support (custom and parallel gripper types)
  * Added R-series support (actuator, link, bracket, and end effector)
  * Added options for link input + output type
  * Support import of HRDF format 1.2.0

* Robot Model:

  * removed "combine" functionality for addJoint and addRigidBody
  * now only allows addition of elements which match the physical interface of the previous element
  * changed the behavior of "end effector" frames; by default, none are returned any unless an "end effector" is specifically added
  * Changed usages of HebiJointType, HebiFrameType, and HebiRobotModelElementType C-style enums to C++ scoped enums

* Fixed bug when setting IO pins in commands; commands would sometimes affect other pins.

(from 3.1.0)

* Reduce conversion needs by adding (deprecated) overloads for:

  * getJ
  * getJacobians
  * getFK
  * getForwardKinematics
  * getFrameCount

* Fix multiple definition error
```