### PR TITLE
ament_package: 0.8.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -136,7 +136,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.8.5-1
+      version: 0.8.6-1
     source:
       type: git
       url: https://github.com/ament/ament_package.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.8.6-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.5-1`

## ament_package

```
* improve error message when split for dsv line raises (#108 <https://github.com/ament/ament_package/issues/108>)
* skip empty lines in dsv files (#107 <https://github.com/ament/ament_package/issues/107>)
* fix performance regression in environment setup (#106 <https://github.com/ament/ament_package/issues/106>)
* Contributors: Dirk Thomas
```
