### PR TITLE
seed_r7_ros_pkg: 0.3.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14133,12 +14133,13 @@ repositories:
       - seed_r7_navigation
       - seed_r7_robot_interface
       - seed_r7_ros_controller
+      - seed_r7_ros_pkg
       - seed_r7_samples
       - seed_r7_typef_moveit_config
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
-      version: 0.3.2-1
+      version: 0.3.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_r7_ros_pkg` to `0.3.3-2`:

- upstream repository: https://github.com/seed-solutions/noid-ros-pkg.git
- release repository: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.2-1`

## seed_r7_navigation

```
* Merge branch 'master' into add_test
```

## seed_r7_ros_pkg

```
* Merge branch 'master' into add_test
* Update CMakeLists.txt
* toplevel added
* Contributors: hi-kondo
```

## seed_r7_samples

```
* Merge pull request #62 <https://github.com/hi-kondo/seed_r7_ros_pkg/issues/62> from hi-kondo/ori-master
  rostest directory of seed_r7_samples changed
* depend package added
* hand constructor added
* rostest directory of seed_r7_samples changed
* Merge pull request #61 <https://github.com/hi-kondo/seed_r7_ros_pkg/issues/61> from hi-kondo/add_rostest/roslaunch_and_demo.test
  Add rostest/roslaunch and demo.test
* rostest timeout changed
* update test
```
