### PR TITLE
nerian_stereo: 3.6.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5020,7 +5020,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `3.6.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.5.0-1`

## nerian_stereo

```
* Updated Nerian software release to version 7.1.0
* Correct pixel format for publication of RGB camera images
* Fixed problem with LD_LIBRARY_PATH when running from catkin workspace
* Contributors: Konstantin Schauwecker, Ramin Yaghoubzadeh Torky
```
