### PR TITLE
Add rosdep entry for python opcua library

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -202,6 +202,10 @@ mercurial:
 nuitka:
   debian: [nuitka]
   ubuntu: [nuitka]
+opcua-pip:
+  ubuntu:
+    pip:
+      packages: [opcua]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]


### PR DESCRIPTION
OPCUA client/server python library.

Link: https://pypi.org/project/opcua/

We are using OPCUA to expose several telemetry data (I/O data, battery, etc.) from our robot to an external OPCUA digital twin client. Although it doesn't fully support all OPCUA functions, this is a fairly ease to use library that has allowed us to do it without mayor problems.

OPCUA is a common communications protocol in industry, so it is expected to be required in many industrial applications.