### PR TITLE
phidgets_drivers: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -929,6 +929,38 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: eloquent-devel
     status: developed
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: dashing
+    release:
+      packages:
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/phidgets_drivers-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: dashing
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## libphidget22

```
* Port libphidget22 vendor package to ament.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Patch warnings in libphidget22.
* Fix up libphidget22 package.xml dependencies.
* Add in libphidget22 package.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_accelerometer

```
* Switch from NULL to nullptr.
* Make sure to initialize class member variables.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Print out the serial number when connecting.
* Update documentation to mention device dependent fields.
* Port accelerometer to ROS 2.
* Ignore all packages for ROS 2 port.
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add support for Phidgets Accelerometer sensors.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_analog_inputs

```
* Switch from NULL to nullptr.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Add in gain and offset for the analog devices.
* Stop multiplying by ticks in the callback.
* Remove fetching of analog sensor value at startup.
* Print out the serial number when connecting.
* Update documentation to mention device dependent fields.
* Port analog inputs to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Implement data interval setting for analog inputs.
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Analog inputs.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_api

```
* Remove unnecessary base-class initialization.
* Get rid of C-style casts.
* Make sure what() method is marked as override.
* Rename method parameter name to match implementation.
* Make sure to include cstddef for libphidget22.h include.
* Make sure to initialize class member variables.
* Reformat using clang
* Make sure to set the VoltageRange to AUTO at the beginning.
* Only publish motor_back_emf if supported by DC Motor device (#53 <https://github.com/ros-drivers/phidgets_drivers/issues/53>)
* Print out the serial number when connecting.
* Port phidgets_api to ament.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Add in try/catch blocks for connecting.
* Fixes from review.
* Implement data interval setting for analog inputs.
* Add in the license files and add to the headers.
* Completely remove libphidget21.
* Rewrite Motor Phidget to use libphidget22.
* Rewrite High Speed Encoder to use libphidget22.
* Rewrite IR to use libphidget22.
* Rewrite IMU using libphidget22.
* Add support for Phidgets Magnetometer sensors.
* Add support for Phidgets Gyroscope sensors.
* Add support for Phidgets Accelerometer sensors.
* Add in support for Phidgets Temperature sensors.
* Rewrite phidgets_ik on top of libphidget22 classes.
* Add in support for Phidgets Analog inputs.
* Add in support for Phidgets Digital Inputs.
* Add in support for Phidgets Digital Outputs.
* Add in libphidget22 helper functions.
* Rename Phidget class to Phidget21 class.
* Switch to C++14.
* Merge pull request #36 <https://github.com/ros-drivers/phidgets_drivers/issues/36> from clalancette/phidget-cleanup2
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Remove unused indexHandler from Encoder class.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Small cleanups throughout the code.
* Push libphidgets API calls down to phidgets_api.
* Quiet down the to-be-overridden callbacks.
* Consistently use nullptr instead of 0.
* Make the phidget_api destructors virtual.
* Style cleanup.
* Move libusb dependency into the libphidget21 package.xml.
* Switch to package format 2.
* Cleanup spacing in all of the CMakeLists.txt
* Contributors: Chris Lalancette, Martin Günther, Peter Polidoro
```

## phidgets_digital_inputs

```
* Switch from NULL to nullptr.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Print out the serial number when connecting.
* Port digital inputs to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Digital Inputs.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_digital_outputs

```
* Switch from NULL to nullptr.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Print out the serial number when connecting.
* Port digital outputs to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Digital Outputs.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_drivers

```
* Port phidgets_drivers to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Completely remove libphidget21.
* Rewrite Motor Phidget to use libphidget22.
* Rewrite IMU using libphidget22.
* Add support for Phidgets Magnetometer sensors.
* Add support for Phidgets Gyroscope sensors.
* Add support for Phidgets Accelerometer sensors.
* Add in support for Phidgets Temperature sensors.
* Add in support for Phidgets Analog inputs.
* Add in support for Phidgets Digital Inputs.
* Add in support for Phidgets Digital Outputs.
* Add in libphidget22 package.
* Merge pull request #36 <https://github.com/ros-drivers/phidgets_drivers/issues/36> from clalancette/phidget-cleanup2
* Split custom messages into their own package.
* Add in phidgets_ik to the phidgets_drivers metapackage.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_gyroscope

```
* Switch from NULL to nullptr.
* Make sure to initialize class member variables.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Print out the serial number when connecting.
* Update documentation to mention device dependent fields.
* Update FIXME comments for sleep.
* Port gyroscope to ROS 2.
* Ignore all packages for ROS 2 port.
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
* Improve the IMU calibration service (#47 <https://github.com/ros-drivers/phidgets_drivers/issues/47>)
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add support for Phidgets Gyroscope sensors.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_high_speed_encoder

```
* Switch from NULL to nullptr.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Print out the serial number when connecting.
* Port high speed encoder to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Fix a small typo.
* Rewrite High Speed Encoder to use libphidget22.
* Rename Phidget class to Phidget21 class.
* Switch to C++14.
* Remove unused std_msgs dependency from Phidgets High Speed Encoder.
* Merge pull request #36 <https://github.com/ros-drivers/phidgets_drivers/issues/36> from clalancette/phidget-cleanup2
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Split custom messages into their own package.
* Rewrite the high speed encoder node.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Small cleanups throughout the code.
* Style cleanup.
* Switch to package format 2.
* Cleanup spacing in all of the CMakeLists.txt
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_ik

```
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Add in parameters to the IK launch file.
* Change launch output to "both" so it logs as well.
* Port IK to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Fix phidgets_ik dependencies.
* Rewrite IK as just a launch file.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Rewrite phidgets_ik on top of libphidget22 classes.
* Rename Phidget class to Phidget21 class.
* Switch to C++14.
* Merge pull request #36 <https://github.com/ros-drivers/phidgets_drivers/issues/36> from clalancette/phidget-cleanup2
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Split custom messages into their own package.
* Add in a nodelet version of the interfaceKit.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Small cleanups throughout the code.
* Push libphidgets API calls down to phidgets_api.
* Completely remove boost from the project.
* Style cleanup.
* Remove unused dependencies from phidgets_ik.
* Switch to package format 2.
* Cleanup spacing in all of the CMakeLists.txt
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_magnetometer

```
* Make sure exceptions get caught by reference.
* Switch from NULL to nullptr.
* Make sure to initialize class member variables.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Print out the serial number when connecting.
* Update documentation to mention device dependent fields.
* Port magnetometer to ROS 2.
* Ignore all packages for ROS 2 port.
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Fix small typos in README and LICENSE files.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add support for Phidgets Magnetometer sensors.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_motors

```
* Include file cleanup.
* Switch from NULL to nullptr.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Only publish motor_back_emf if supported by DC Motor device (#53 <https://github.com/ros-drivers/phidgets_drivers/issues/53>)
* Print out the serial number when connecting.
* Update documentation to mention device dependent fields.
* Port motors to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Rewrite Motor Phidget to use libphidget22.
* Contributors: Chris Lalancette, Martin Günther, Peter Polidoro
```

## phidgets_msgs

```
* Port phidgets_msgs to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Switch to C++14.
* Merge pull request #36 <https://github.com/ros-drivers/phidgets_drivers/issues/36> from clalancette/phidget-cleanup2
* Switch to C++14 everywhere.
* Split custom messages into their own package.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_spatial

```
* Include file cleanup.
* Make sure exceptions get caught by reference.
* Switch from NULL to nullptr.
* Make sure to initialize class member variables.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Print out the serial number when connecting.
* Update documentation to mention device dependent fields.
* Update FIXME comments for sleep.
* Port spatial to ROS 2.
* Ignore all packages for ROS 2 port.
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
* Improve the IMU calibration service (#47 <https://github.com/ros-drivers/phidgets_drivers/issues/47>)
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Finish removing launch file from phidgets_spatial.
* Rewrite IMU using libphidget22.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_temperature

```
* Switch from NULL to nullptr.
* Make sure to initialize class member variables.
* Update READMEs to use "Published Topics" and "Subscribed Topics". (#59 <https://github.com/ros-drivers/phidgets_drivers/issues/59>)
* Change launch output to "both" so it logs as well.
* Make publish_rate a double.
* Print out the serial number when connecting.
* Update documentation to mention device dependent fields.
* Fix silly allocation bug in analog inputs.
* Port temperature to ROS 2.
* Ignore all packages for ROS 2 port.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Temperature sensors.
* Contributors: Chris Lalancette, Martin Günther
```
