### PR TITLE
phidgets_drivers: 2.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -954,7 +954,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.0.1-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.0-1`

## libphidget22

- No changes

## phidgets_accelerometer

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_analog_inputs

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_api

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_digital_inputs

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_digital_outputs

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_high_speed_encoder

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_motors

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```

## phidgets_temperature

```
* Switch the buildtoo_depend to ament_cmake_ros. (#65 <https://github.com/ros-drivers/phidgets_drivers/issues/65>)
* Contributors: Chris Lalancette
```
