### PR TITLE
resource_retriever: 2.1.2-1 in 'dashing/distribution.yaml' [bl…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1965,7 +1965,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 2.1.0-2
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.1.2-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.1.0-2`

## libcurl_vendor

- No changes

## resource_retriever

```
* Catch ament_index_cpp::PackageNotFoundError (#34 <https://github.com/ros/resource_retriever/issues/34>)
* Contributors: Shane Loretz
```
