### PR TITLE
add uwb_hardware_driver for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16288,6 +16288,11 @@ repositories:
       url: https://github.com/uuvsimulator/uuv_simulator.git
       version: master
     status: developed
+  uwb_hardware_driver:
+    doc:
+      type: git
+      url: https://github.com/inomuh/uwb_hardware_driver.git
+      version: master
   uwsim_bullet:
     release:
       tags:


### PR DESCRIPTION
I created a package which is uwb_hardware_driver in my machine - which is in the same directory with indoor_localization package. And also, I've already add this package in ROS index (http://wiki.ros.org/indoor_localization). (Both packages work together.)

When I check the last build in the Travis, I am getting this error:
the following packages/stacks could not have their rosdep keys resolved to system dependencies:
indoor_localization: Cannot locate rosdep definition for [uwb_hardware_driver]

I thought that this error could be fixed if I add the package uwb_hardware_driver under ROS index. So, I'm openning this pull request for this reason.