### PR TITLE
rclpy: 0.6.5-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1238,7 +1238,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.6.4-0
+      version: 0.6.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.6.5-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.4-0`

## rclpy

```
* Send feedback callbacks properly in send_goal() of action client (#451 <https://github.com/ros2/rclpy/issues/451>) (#467 <https://github.com/ros2/rclpy/issues/467>)
* Action server: catch exception from user execute callback (#437 <https://github.com/ros2/rclpy/issues/437>)
* Contributors: Jacob Perron, Werner Neubauer
```
