### PR TITLE
rviz: 5.1.1-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -1947,7 +1947,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 5.1.0-0
+      version: 5.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `5.1.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `5.1.0-0`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

```
* Constraint Freetype dependencies for more predictable build result on Windows. (#393 <https://github.com/ros2/rviz/issues/393>)
* Contributors: Sean Yen
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
