### PR TITLE
Add asr_msgs as doc dependency to several packages

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -378,6 +378,8 @@ repositories:
       version: master
   asr_direct_search_manager:
     doc:
+      depends:
+      - asr_msgs
       type: git
       url: https://github.com/asr-ros/asr_direct_search_manager.git
       version: master
@@ -518,6 +520,8 @@ repositories:
       version: master
   asr_next_best_view:
     doc:
+      depends:
+      - asr_msgs
       type: git
       url: https://github.com/asr-ros/asr_next_best_view.git
       version: master
@@ -543,11 +547,15 @@ repositories:
       version: master
   asr_recognizer_prediction_ism:
     doc:
+      depends:
+      - asr_msgs
       type: git
       url: https://github.com/asr-ros/asr_recognizer_prediction_ism.git
       version: master
   asr_recognizer_prediction_psm:
     doc:
+      depends:
+      - asr_msgs
       type: git
       url: https://github.com/asr-ros/asr_recognizer_prediction_psm.git
       version: master
@@ -608,6 +616,8 @@ repositories:
       version: master
   asr_world_model:
     doc:
+      depends:
+      - asr_msgs
       type: git
       url: https://github.com/asr-ros/asr_world_model.git
       version: master


### PR DESCRIPTION
Adding depends tag to packages which provide interface files depending on asr_msgs to fix build errors on jenkins doc server (as suggested in [this](https://answers.ros.org/question/339311/jenkins-doc-build-fails-because-of-nested-custom-messages-which-are-hosted-in-external-unreleased-package/) ROS-answers post)