### PR TITLE
xacro: 1.13.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10645,7 +10645,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.4-1
+      version: 1.13.5-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.5-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.13.4-1`

## xacro

```
* [feature] Expose abs_filename() (#220 <https://github.com/ros/xacro/issues/220>)
* [feature] Catch missing closing brace in $() and ${} expressions
* [maintanence]
  - Replace deprecated yaml.load() -> yaml.safe_load()
  - Save macro names internally w/o 'xacro:' prefix
  - Correctly issue deprecation warning for non-prefixed xacro tags
* Contributors: Robert Haschke
```
