### PR TITLE
blender_gazebo: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -503,7 +503,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/david0429-gbp/blender_gazebo_gbp.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/david0429/blender_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `blender_gazebo` to `0.0.4-1`:

- upstream repository: https://github.com/david0429/blender_gazebo.git
- release repository: https://github.com/david0429-gbp/blender_gazebo_gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.3-1`

## blender_gazebo

```
* Fixed install
* Contributors: Dave Niewinski
```
