### PR TITLE
blender_gazebo: 0.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1070,7 +1070,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/david0429-gbp/blender_gazebo_gbp.git
-      version: 0.0.3-2
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/david0429/blender_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `blender_gazebo` to `0.0.4-1`:

- upstream repository: https://github.com/david0429/blender_gazebo.git
- release repository: https://github.com/david0429-gbp/blender_gazebo_gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.3-2`

## blender_gazebo

```
* Fixed install
* Contributors: Dave Niewinski
```
