### PR TITLE
ament_virtualenv: 0.0.4-1 in 'dashing/distribution.yaml' [bloo…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -213,7 +213,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_virtualenv` to `0.0.4-1`:

- upstream repository: https://github.com/esol-community/ament_virtualenv.git
- release repository: https://github.com/esol-community/ament_virtualenv-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.3-1`

## ament_cmake_virtualenv

```
* added fallbacks for different environments
```

## ament_virtualenv

```
* added fallbacks for different environments
```
