### PR TITLE
Add roslint source entry for noetic.

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -323,6 +323,12 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: kinetic-devel
     status: maintained
+  roslint:
+    source:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    status: maintained
   roslisp:
     source:
       type: git


### PR DESCRIPTION
Quick smoke test shows that the C++ and Python linting works fine with Py3 shebangs.

Closes https://github.com/ros/roslint/issues/70.