### PR TITLE
ros2_tracing: 0.2.11-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1473,7 +1473,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 0.2.10-1
+      version: 0.2.11-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.2.11-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.10-1`

## ros2trace

```
* Remove duplicated code for trace command
* Contributors: Christophe Bedard
```

## tracetools_launch

```
* Register Python packages in the ament index
* Contributors: Christophe Bedard
```

## tracetools_read

```
* Register Python packages in the ament index
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Fix working directory for tracetools_test Python tests
* Fix version regex to support multi-digit numbers
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Register Python packages in the ament index
* Contributors: Christophe Bedard
```
