### PR TITLE
Add pip install dual quaternions ros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -130,10 +130,10 @@ ds4drv-pip:
       packages: [ds4drv]
 dual-quaternions-ros-pip:
   debian:
-    pip: 
+    pip:
       packages: [dual-quaternions-ros]
   fedora:
-    pip: 
+    pip:
       packages: [dual-quaternions-ros]
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -129,6 +129,12 @@ ds4drv-pip:
     pip:
       packages: [ds4drv]
 dual-quaternions-ros-pip:
+  debian:
+    pip: 
+      packages: [dual-quaternions-ros]
+  fedora:
+    pip: 
+      packages: [dual-quaternions-ros]
   ubuntu:
     pip:
       packages: [dual-quaternions-ros]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -128,6 +128,10 @@ ds4drv-pip:
   ubuntu:
     pip:
       packages: [ds4drv]
+dual-quaternions-ros-pip:
+  ubuntu:
+    pip:
+      packages: [dual-quaternions-ros]
 epydoc:
   arch: [epydoc]
   debian: [python-epydoc]


### PR DESCRIPTION
## Description

Python 2 package for dual quaternion operations. This installs the ROS wrapper which has a dependency for the pure Pythonic [dual-quaternions](https://pypi.org/project/dual-quaternions/) package

* Package on PyPi: [dual-quaternions-ros](https://pypi.org/project/dual-quaternions-ros/)
* what are dual quaternions?: https://github.com/Achllle/dual_quaternions_ros/tree/iss42