### PR TITLE
geometry2: 0.11.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -918,7 +918,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.11.5-1
+      version: 0.11.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.11.6-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.11.5-1`

## tf2

```
* Fix up -Wcast-qual warning (#193 <https://github.com/ros2/geometry2/issues/193>)
* Contributors: Yu, Yan
```

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes
