### PR TITLE
variants: 0.7.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3225,7 +3225,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.7.3-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.2-1`

## desktop

```
* add rqt_common_plugins to desktop (#18 <https://github.com/ros2/variants/issues/18>) (#22 <https://github.com/ros2/variants/issues/22>)
  Signed-off-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
* Contributors: Mikael Arguedas
```

## ros_base

- No changes

## ros_core

- No changes
