### PR TITLE
variants: 0.8.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2442,7 +2442,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.8.4-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.3-1`

## desktop

```
* add rqt_common_plugins to desktop (#18 <https://github.com/ros2/variants/issues/18>)
* Contributors: Mikael Arguedas
```

## ros_base

- No changes

## ros_core

- No changes
