### PR TITLE
catkin: 0.7.20-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -699,7 +699,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.19-1
+      version: 0.7.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.20-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.19-1`

## catkin

```
* fix checking dependency conditions (#1041 <https://github.com/ros/catkin/issues/1041>)
* fix gtest-not-found bug, regression from 0.7.19 (#1040 <https://github.com/ros/catkin/issues/1040>)
* support build_type tag with condition attribute (#1038 <https://github.com/ros/catkin/issues/1038>)
* use ${prefix} variable in generated pkg-config (#1037 <https://github.com/ros/catkin/issues/1037>)
* check for INTERFACE library type in add_library function (#1034 <https://github.com/ros/catkin/issues/1034>)
```
