### PR TITLE
rviz: 6.1.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2807,7 +2807,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 6.1.4-1
+      version: 6.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.1.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `6.1.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

```
* Skip freetype2 dependencies (#405 <https://github.com/ros2/rviz/issues/405>) (#489 <https://github.com/ros2/rviz/issues/489>)
* Contributors: Jacob Perron, Sean Yen
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
