### PR TITLE
rcl: 0.7.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1800,7 +1800,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.7.7-1
+      version: 0.7.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.7.8-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.7-1`

## rcl

```
* Set allocator before goto fail. (#540 <https://github.com/ros2/rcl/issues/540>)
* Contributors: Borja Outerelo
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Avoid C4703 error on UWP. (#282 <https://github.com/ros2/rcl/issues/282>) (#536 <https://github.com/ros2/rcl/issues/536>)
* Contributors: Sean Kelly
```
