### PR TITLE
duckbot-ros: 0.0.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2678,6 +2678,14 @@ repositories:
       url: https://github.com/naoki-mizuno/ds4_driver.git
       version: master
     status: maintained
+  duckbot-ros:
+    release:
+      packages:
+      - duckbot
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/sachinkum0009/duckbot-ros.git
+      version: 0.0.1-2
   dwm1001_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `duckbot-ros` to `0.0.1-2`:

- upstream repository: https://github.com/sachinkum0009/duckbot-ros.git
- release repository: https://github.com/sachinkum0009/duckbot-ros.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## duckbot

```
* bug 0 algo
* changed the dockerfile
* no check
* ubuntu 16
* few changes
* again
* let's try with 18.04
* remove q
* added y
* added git
* removed git
* few changes
* added the git install
* added ubuntu
* added ubuntu 16:0
* added docker file
* some minor changes
* obstacle avoidance
* Added the left front and right front wheels.
* Working fine
* some major changes
* Merge branch 'master' of https://github.com/SACHINKUMARHACKER/duckbot-ros
* added travis
* Added the image for demonstration
* added image of duckbot
* first commit
* initial commit
* Contributors: SACHINKUMARHACKER, Sachin Kumar
```
