### PR TITLE
cis_camera: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -745,7 +745,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/cis_camera-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cis_camera` to `0.0.4-1`:

- upstream repository: https://github.com/tork-a/cis_camera.git
- release repository: https://github.com/tork-a/cis_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.3-1`

## cis_camera

```
* Merge pull request #25 <https://github.com/tork-a/cis_camera/issues/25> from tork-a/add-comments
  Add document and comments for document
* add 'Trouble Shooting' in index.rst
* fix style 2 by yy
* fix style
* Merge branch 'add-comments' of https://github.com/tork-a/cis_camera into add-comments
* remove doc/manifest.yaml
* Update index.rst
* mod index.rst format
* mod spec. list
* remove 'Fig.' for captions
* update documant index.rst, add build process for making document pdf file.
* update documents
* mod maintainer as mailto:dev@TORK and add author informaiton, add files for documents.
* remove doc/html/ folder
* doc/html generated by rosdoc_lite
* Merge branch 'master' into add-comments
* Merge pull request #24 <https://github.com/tork-a/cis_camera/issues/24> from tork-a/fix-zero-depth-cnv-gain
  Fix zero depth cnv gain and add RGB camera info dynamic_reconfigure
* add rgb camera info dynamic_reconfigure
* fix depth_cnv_gain_ getting zero sometimes after the launch.
* Merge pull request #23 <https://github.com/tork-a/cis_camera/issues/23> from tork-a/add-frame-data-check
  mod num_worker_threads from 32 to 4, mod unexpected frame data size w…
* mod num_worker_threads from 32 to 4, mod unexpected frame data size warning message.
* Merge pull request #22 <https://github.com/tork-a/cis_camera/issues/22> from tork-a/add-frame-data-check
  Add frame data check, mod RGB pointcloud with tf
* add processing.launch.xml for RGB pointcloud with tf
* remove old code lines those are commented out
* add frame data size check to avoid memory segmentation error, add debug mode.
* add comments for documents
* Merge branch 'master' of https://github.com/tork-a/cis_camera into mod-cmakelists
* add tf_conversions in CMakeLists.txt
* Contributors: Tokyo Opensource Robotics Developer 534, Yosuke Yamamoto
```
