### PR TITLE
Enable test_abi in: rclcpp, rcl, rclpy, turtlesim, ament_cmake

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1804,8 +1804,8 @@ repositories:
       url: https://github.com/ros2-gbp/rcl-release.git
       version: 0.7.8-1
     source:
-      test_pull_requests: true
       test_abi: true
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
       version: dashing
@@ -1869,8 +1869,8 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.7.12-1
     source:
-      test_pull_requests: true
       test_abi: true
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
       version: dashing
@@ -1886,8 +1886,8 @@ repositories:
       url: https://github.com/ros2-gbp/rclpy-release.git
       version: 0.7.9-1
     source:
-      test_pull_requests: true
       test_abi: true
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
       version: dashing
@@ -3119,8 +3119,8 @@ repositories:
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
       version: 1.0.1-1
     source:
-      test_pull_requests: true
       test_abi: true
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_tutorials.git
       version: dashing-devel

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -94,6 +94,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_cmake-release.git
       version: 0.7.4-1
     source:
+      test_abi: true
       type: git
       url: https://github.com/ament/ament_cmake.git
       version: dashing
@@ -1261,6 +1262,7 @@ repositories:
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
       version: 1.0.0-1
     source:
+      test_abi: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
       version: dashing
@@ -1803,6 +1805,7 @@ repositories:
       version: 0.7.8-1
     source:
       test_pull_requests: true
+      test_abi: true
       type: git
       url: https://github.com/ros2/rcl.git
       version: dashing
@@ -1867,6 +1870,7 @@ repositories:
       version: 0.7.12-1
     source:
       test_pull_requests: true
+      test_abi: true
       type: git
       url: https://github.com/ros2/rclcpp.git
       version: dashing
@@ -1883,6 +1887,7 @@ repositories:
       version: 0.7.9-1
     source:
       test_pull_requests: true
+      test_abi: true
       type: git
       url: https://github.com/ros2/rclpy.git
       version: dashing
@@ -3115,6 +3120,7 @@ repositories:
       version: 1.0.1-1
     source:
       test_pull_requests: true
+      test_abi: true
       type: git
       url: https://github.com/ros/ros_tutorials.git
       version: dashing-devel

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -823,6 +823,7 @@ repositories:
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
       version: 1.0.0-1
     source:
+      test_abi: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
@@ -1196,6 +1197,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcl-release.git
       version: 0.8.3-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
@@ -1261,6 +1263,7 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.8.3-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
@@ -1277,6 +1280,7 @@ repositories:
       url: https://github.com/ros2-gbp/rclpy-release.git
       version: 0.8.3-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
@@ -2348,6 +2352,7 @@ repositories:
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
       version: 1.1.0-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_tutorials.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1263,9 +1263,7 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.8.3-1
     source:
-      # false positives in abi checker
-      # https://github.com/osrf/auto-abi-checker/issues/15
-      test_abi: false
+      test_abi: false # see https://github.com/osrf/auto-abi-checker/issues/15
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1263,7 +1263,7 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.8.3-1
     source:
-      test_abi: false # see https://github.com/osrf/auto-abi-checker/issues/15
+      test_abi: false
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1263,7 +1263,6 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.8.3-1
     source:
-      test_abi: false
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1263,7 +1263,9 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 0.8.3-1
     source:
-      test_abi: true
+      # false positives in abi checker
+      # https://github.com/osrf/auto-abi-checker/issues/15
+      test_abi: false
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git


### PR DESCRIPTION
Please note that we probably need to wait until merging:
 * ros_buildfarm support: https://github.com/ros-infrastructure/ros_buildfarm/pull/681

This PR will enable the abi-checking for a reduced set of jobs in order to get a production testing before we enable it widely. All the builds were tested in the testing jenkins instance (attached links on each one). The candidates I want to test are:

 * ament_cmake -- no binary interface, no failure
[![Build Status](http://18.206.154.49/buildStatus/icon?job=Ddev__ament_cmake__ubuntu_bionic_amd64)](http://18.206.154.49/job/Ddev__ament_cmake__ubuntu_bionic_amd64/)
 * libyaml_vendor -- 1 header / library
[![Build Status](http://18.206.154.49/buildStatus/icon?job=Ddev__libyaml_vendor__ubuntu_bionic_amd64)](http://18.206.154.49/job/Ddev__libyaml_vendor__ubuntu_bionic_amd64/)
 * rclcpp -- 107 header files / 3 libraries
[![Build Status](http://18.206.154.49/buildStatus/icon?job=Ddev__rclpy__ubuntu_bionic_amd64)](http://18.206.154.49/job/Ddev__rclpy__ubuntu_bionic_amd64/)
 * rcl -- 43 header files / 4 libraries
[![Build Status](http://18.206.154.49/buildStatus/icon?job=Ddev__rcl__ubuntu_bionic_amd64)](http://18.206.154.49/job/Ddev__rcl__ubuntu_bionic_amd64/)
 * rclpy -- no binary interface, no failure
[![Build Status](http://18.206.154.49/buildStatus/icon?job=Ddev__rclpy__ubuntu_bionic_amd64)](http://18.206.154.49/job/Ddev__rclpy__ubuntu_bionic_amd64/)
 * turtlesim -- 92 headers files / 4 libraries (include idl code, tricky)
[![Build Status](http://18.206.154.49/buildStatus/icon?job=Ddev__turtlesim__ubuntu_bionic_amd64)](http://18.206.154.49/job/Ddev__turtlesim__ubuntu_bionic_amd64/)

Also needs rosdistro 0.8 release [for the implementation of test_abi parsing](https://github.com/ros-infrastructure/rosdistro/pull/147).

//cc @chapulina