### PR TITLE
Add python-construct-pip dependency to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1034,6 +1034,13 @@ python-configparser:
 python-construct:
   debian: [python-construct]
   ubuntu: [python-construct]
+python-construct-pip:
+  debian:
+    pip:
+      packages: [construct]
+  ubuntu:
+    pip:
+      packages: [construct]
 python-control-pip:
   debian:
     pip:


### PR DESCRIPTION
Adds the `python-construct-pip` dependency to python.py. The *construct* package can be found on PyPI under https://pypi.org/project/construct and is used for declarativly creating parsers and builders for binary data.

**Note:** `python-construct` is already a dependency in python.yaml, but on e.g. Ubuntu 18.04 LTS the 2.8 version lacks hard-to-replace features like `FixedSized` subcons in contrast to the newer 2.9 on PyPI. This makes the inclusion of the PyPI version of *construct* a useful addition to the ROS ecosystem.