### PR TITLE
moose: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7381,6 +7381,25 @@ repositories:
       url: https://github.com/strands-project/mongodb_store.git
       version: kinetic-devel
     status: developed
+  moose:
+    doc:
+      type: git
+      url: https://github.com/moose-cpr/moose.git
+      version: master
+    release:
+      packages:
+      - moose_control
+      - moose_description
+      - moose_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/moose-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/moose-cpr/moose.git
+      version: master
+    status: maintained
   motoman:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose` to `0.1.0-1`:

- upstream repository: https://github.com/moose-cpr/moose.git
- release repository: https://github.com/clearpath-gbp/moose-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## moose_control

```
* Updated collisions,
* Made the generator optional
* Moved interactive markers to manned control and removed joy
* Added wheels to URDF.
* Initial commit for Moose.
* Contributors: Dave Niewinski, Tony Baltovski
```

## moose_description

```
* Updated collisions,
* Made the generator optional
* Moved interactive markers to manned control and removed joy
* Added wheels to URDF.
* Initial commit for Moose.
* Contributors: Dave Niewinski, Tony Baltovski
```

## moose_msgs

```
* Initial commit for Moose.
* Contributors: Tony Baltovski
```
