### PR TITLE
ompl: 1.4.2-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5455,7 +5455,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.4.2-3
+      version: 1.4.2-5
   omron_os32c_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.4.2-5`:

- upstream repository: https://bitbucket.org/ompl/ompl
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.4.2-3`
