### PR TITLE
jsk_3rdparty: 2.1.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5685,6 +5685,7 @@ repositories:
       - downward
       - ff
       - ffha
+      - gdrive_ros
       - jsk_3rdparty
       - julius
       - julius_ros
@@ -5707,7 +5708,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.14-1
+      version: 2.1.15-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.15-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.1.14-1`

## assimp_devel

- No changes

## bayesian_belief_networks

- No changes

## collada_urdf_jsk_patch

- No changes

## dialogflow_task_executive

```
* add url in dialogflow_task_executive (#181 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/181>)
* Contributors: Shingo Kitagawa
```

## downward

- No changes

## ff

- No changes

## ffha

- No changes

## gdrive_ros

```
* add gdrive_ros package (#182 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/182>)
* Contributors: Shingo Kitagawa
```

## jsk_3rdparty

```
* add gdrive_ros package (#182 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/182>)
* [dialogflow_task_executive] add dialogflow_task_executive run_depend in jsk_3rdparty (#183 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/183>)
* Contributors: Shingo Kitagawa
```

## julius

- No changes

## julius_ros

- No changes

## laser_filters_jsk_patch

- No changes

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nlopt

- No changes

## opt_camera

- No changes

## pgm_learner

- No changes

## respeaker_ros

```
* [respeaker_ros] add pixel-ring in run_depend of respeaker_ros (#184 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/184>)
* [respeaker_ros] install config dir in respeaker_ros (#185 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/185>)
* Contributors: Shingo Kitagawa
```

## ros_speech_recognition

- No changes

## rospatlite

- No changes

## rosping

- No changes

## rostwitter

- No changes

## sesame_ros

```
* [sesame_ros] Add dependency for building cryptograpy (#180 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/180>)
  
    * Add url of ROS wiki for sesame_ros
    * Add k-okada to maintainer of sesame_ros
    * Add libffi-dev and libssl-dev as dependencies of cryptography
  
* Contributors: Yuto Uchimi
```

## slic

- No changes

## voice_text

- No changes
