### PR TITLE
mavros: 0.33.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4325,7 +4325,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.33.3-1
+      version: 0.33.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `0.33.4-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.33.3-1`

## libmavconn

```
* add macro for get_io_service() to work with boost>1.70
* Contributors: acxz
```

## mavros

```
* Replaced estimator status hardcoded definition with cog.
* Refactor.
* Replaced bool with git add -u as already done.
* Added a publisher for estimator status message received from mavlink in sys_status.
* Contributors: saifullah3396
```

## mavros_extras

```
* obstacle_distance: Fill both increment and increment_f fields
* obstacle_distance: Fix wrong angle increment
  The computation req->angle_increment * RAD_TO_DEG correctly computes
  angle increment in degrees as a float, but the increment field of the
  OBSTACLE_DISTANCE MAVLink message is a uint8, so the float value gets
  truncated. So if your real increment is 10 degrees, you may a floating
  point value of something like 9.999999, which results in the integer value
  9 getting written to the increment field.
  An improvement would be to round properly, with something like
  static_cast<uint8_t>(increment_deg_float),
  but a better solution is to allow non-integer degree values for the
  increment, which is supported by the increment_f field. According
  to the MAVLink reference, increment_f is used instead of increment
  whenever increment_f is nonzero.
* Contributors: Morten Fyhn Amundsen
```

## mavros_msgs

```
* Splitted the message fields.
* Updated esimator status msg according to the new cog based definition of estimator status.
* Added comments to msg.
* Added new line char at end of message.
* Added a publisher for estimator status message received from mavlink in sys_status.
* Contributors: saifullah3396
```

## test_mavros

- No changes
