### PR TITLE
Removing serial_driver from Autoware.Auto

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -33,7 +33,6 @@ repositories:
       - point_cloud_fusion
       - ray_ground_classifier
       - ray_ground_classifier_nodes
-      - serial_driver
       - velodyne_driver
       - velodyne_node
       - voxel_grid


### PR DESCRIPTION
For release under transport_drivers. See https://github.com/ros-drivers/transport_drivers