### PR TITLE
automotive_autonomy_msgs: 3.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -761,7 +761,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 2.0.3-0
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
Release generated by bloom but PR generated manually. See ros-infrastructure/bloom#557 for details.

Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.1-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.3-0`

## automotive_autonomy_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Fixing XML linting errors.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

## automotive_navigation_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Adding migration rules.
* Fixing XML linting errors.
* Making all messages ROS2-compliant.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Fixing XML linting errors.
* Making all messages ROS2-compliant.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

