### PR TITLE
automotive_autonomy_msgs: 3.0.1-2 in 'dashing/distribution.yam…

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -305,19 +305,20 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git
-      version: dashing-devel
+      version: master
     release:
       packages:
+      - automotive_autonomy_msgs
       - automotive_navigation_msgs
       - automotive_platform_msgs
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 3.0.0-1
+      version: 3.0.1-2
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git
-      version: dashing-devel
+      version: master
     status: developed
   aws_common:
     doc:


### PR DESCRIPTION
Release generated by bloom but PR generated manually. See ros-infrastructure/bloom#557 for details.

Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.1-2`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.0-1`

## automotive_autonomy_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Fixing XML linting errors.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

## automotive_navigation_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Adding migration rules.
* Fixing XML linting errors.
* Making all messages ROS2-compliant.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Fixing XML linting errors.
* Making all messages ROS2-compliant.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

