### PR TITLE
automotive_autonomy_msgs: 3.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -158,6 +158,25 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  automotive_autonomy_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    release:
+      packages:
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/astuff/automotive_autonomy_msgs-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    status: developed
   behaviortree_cpp_v3:
     doc:
       type: git


### PR DESCRIPTION
Release generated by bloom but PR generated manually. See ros-infrastructure/bloom#557 for details.

Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.1-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## automotive_autonomy_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Fixing XML linting errors.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

## automotive_navigation_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Adding migration rules.
* Fixing XML linting errors.
* Making all messages ROS2-compliant.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Merge pull request #15 <https://github.com/astuff/automotive_autonomy_msgs/issues/15> from astuff/maint/ros1_ros2_hybrid
  ROS1/ROS2 Hybrid Packages
* Fixing XML linting errors.
* Making all messages ROS2-compliant.
* Hybridizing all packages.
* Contributors: Joshua Whitley
```

