### PR TITLE
uwb_hardware_driver: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16300,6 +16300,17 @@ repositories:
       type: git
       url: https://github.com/inomuh/uwb_hardware_driver.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/inomuh/uwb_hardware_driver-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/inomuh/uwb_hardware_driver.git
+      version: master
+    status: developed
   uwsim_bullet:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `uwb_hardware_driver` to `0.1.0-1`:

- upstream repository: https://github.com/inomuh/uwb_hardware_driver.git
- release repository: https://github.com/inomuh/uwb_hardware_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## uwb_hardware_driver

```
* first public release
```
