### PR TITLE
keras-retinanet: 0.5.1 in 'rosdep/python.yaml'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2132,6 +2132,10 @@ python-keras-pip:
   ubuntu:
     pip:
       packages: [keras]
+python-keras-retinanet:
+  ubuntu:
+    pip:
+      packages: [keras-retinanet]
 python-keras-rl-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2133,6 +2133,15 @@ python-keras-pip:
     pip:
       packages: [keras]
 python-keras-retinanet:
+  debian:
+    pip:
+      packages: [keras-retinanet]
+  fedora:
+    pip:
+      packages: [keras-retinanet]
+  osx:
+    pip:
+      packages: [keras-retinanet]
   ubuntu:
     pip:
       packages: [keras-retinanet]


### PR DESCRIPTION
Rosdep rule for keras-retinanet 0.5.1. Deep learning architecture used for object detection.

https://pypi.org/project/keras-retinanet/