### PR TITLE
popf-release: 0.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1027,6 +1027,23 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: eloquent
     status: maintained
+  popf-release:
+    doc:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: eloquent-devel
+    release:
+      packages:
+      - popf
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/fmrico/popf-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: eloquent-devel
+    status: maintained
   px4_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `popf-release` to `0.0.3-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/fmrico/popf-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## popf

- No changes
