### PR TITLE
Add python-can on Python 3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5060,7 +5060,9 @@ python3-cairo:
 python3-can:
   debian: [python3-can]
   fedora: [python3-can]
-  ubuntu: [python3-can]
+  ubuntu:
+    '*': [python3-can]
+    xenial: null
 python3-catkin-pkg:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5057,6 +5057,11 @@ python3-cairo:
     slackpkg:
       packages: [py3cairo]
   ubuntu: [python3-cairo]
+python3-can:
+  debian:
+    '*': [python3-can]
+  ubuntu:
+    '*': [python3-can]
 python3-catkin-pkg:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5058,10 +5058,9 @@ python3-cairo:
       packages: [py3cairo]
   ubuntu: [python3-cairo]
 python3-can:
-  debian:
-    '*': [python3-can]
-  ubuntu:
-    '*': [python3-can]
+  debian: [python3-can]
+  ubuntu: [python3-can]
+  fedora: [python3-can]
 python3-catkin-pkg:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5059,8 +5059,8 @@ python3-cairo:
   ubuntu: [python3-cairo]
 python3-can:
   debian: [python3-can]
-  ubuntu: [python3-can]
   fedora: [python3-can]
+  ubuntu: [python3-can]
 python3-catkin-pkg:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]


### PR DESCRIPTION
This is the same package as `python-can`, just for Python 3 instead of Python 2. To quote the docs:
> The python-can library provides Controller Area Network support for Python, providing common abstractions to different hardware devices, and a suite of utilities for sending and receiving messages on a CAN bus.

It is also used in some robotics environments and thus qualifies for this list.

For [Debian](https://packages.debian.org/search?keywords=python3-can) & [Ubuntu](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-can&searchon=names).