### PR TITLE
seed_r7_ros_pkg: 0.3.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14194,7 +14194,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
-      version: 0.3.3-2
+      version: 0.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_r7_ros_pkg` to `0.3.4-1`:

- upstream repository: https://github.com/seed-solutions/noid-ros-pkg.git
- release repository: https://github.com/seed-solutions/seed_r7_ros_pkg-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.3-2`
