### PR TITLE
ypspur_ros: 0.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17285,7 +17285,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/ypspur_ros-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/openspur/ypspur_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.3.1-1`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.0-1`

## ypspur_ros

```
* Fix communication error handling (#64 <https://github.com/openspur/ypspur_ros/issues/64>)
* Drop support for yp-spur<1.17.0 to simplify the code (#63 <https://github.com/openspur/ypspur_ros/issues/63>)
* Add sleep to ensure publishing rosout before exit (#61 <https://github.com/openspur/ypspur_ros/issues/61>)
* Fix coding style (#62 <https://github.com/openspur/ypspur_ros/issues/62>)
* Add post-release test script (#58 <https://github.com/openspur/ypspur_ros/issues/58>)
* Disable CI build on indigo (#59 <https://github.com/openspur/ypspur_ros/issues/59>)
* Contributors: Atsushi Watanabe
```
