### PR TITLE
criutils: 0.1.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1416,7 +1416,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/crigroup/criutils-release.git
-      version: 0.1.3-1
+      version: 0.1.3-2
     source:
       type: git
       url: https://github.com/crigroup/criutils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.3-2`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.3-1`

## criutils

```
* Add automatic TF broadcaster node
* Add missing dependency to OpenCV
* Add and improve test coverage
* Use baldor package instead of tf.transformations
* Fix documentation generation for ROS indigo (#2)
* Contributors: Francisco, fsuarez6
```
