### PR TITLE
handeye: 0.1.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2899,7 +2899,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/crigroup/handeye-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/crigroup/handeye.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.1-2`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.1-1`

## handeye

```
* Fix np.linalg.lstsq bug
* Add installation rules for python node
* Contributors: fsuarez6
```
