### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9402,6 +9402,11 @@ repositories:
       type: git
       url: https://github.com/teknologisk-institut/pattern_manager.git
       version: master
+    source:
+      type: git
+      url: https://github.com/teknologisk-institut/pattern_manager.git
+      version: master
+    status: developed
   pcdfilter_pa:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9397,6 +9397,11 @@ repositories:
       url: https://github.com/AutonomyLab/parrot_arsdk.git
       version: indigo-devel
     status: developed
+  pattern_manager:
+    doc:
+      type: git
+      url: https://github.com/teknologisk-institut/pattern_manager.git
+      version: master
   pcdfilter_pa:
     doc:
       type: git


### PR DESCRIPTION
I'd like pattern_manager to be indexed and documentet on ros.org