### PR TITLE
sick_safetyscanners: 1.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8935,7 +8935,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners` to `1.0.4-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners.git
- release repository: https://github.com/SICKAG/sick_safetyscanners-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.3-1`

## sick_safetyscanners

```
* Fixed Bug with enum for interface type
* Eoved enums in class
  Enums are not in the class scope where they are used.
  Prevents redefinitions and pollution of namespace.
* Correctet variable index for username command
* Typecode read and parsed from variable
* Used static casts instead of implicit conversion
* Contributors: Lennart Puck
```
