### PR TITLE
hebi_cpp_api_ros: 3.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4484,7 +4484,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository hebi_cpp_api_ros to 3.1.1-1:

upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
distro file: kinetic/distribution.yaml
bloom version: 0.8.0
previous version for package: 3.1.0-1

## hebi_cpp_api
```
* Fixes incorrect behavior when getting and setting IO pin values
```