### PR TITLE
shared_autonomy_manipulation: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8928,6 +8928,25 @@ repositories:
       url: https://github.com/wjwwood/serial.git
       version: master
     status: maintained
+  shared_autonomy_manipulation:
+    doc:
+      type: git
+      url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
+      version: hydro-devel
+    release:
+      packages:
+      - safe_teleop_base
+      - safe_teleop_pr2
+      - safe_teleop_stage
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
+      version: hydro-devel
+    status: unmaintained
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `shared_autonomy_manipulation` to `0.0.3-1`:

- upstream repository: https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation.git
- release repository: https://github.com/ros-gbp/shared_autonomy_manipulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## safe_teleop_base

```
* add clear_costmap service (#4 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/4>)
* add param to plan safe trajectory on backwards (#13 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/13>)
* update travis.yml and fix for latest costmap_2d using tf2 (#11 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/11>)
  * fix for latest costmap_2d using tf2
  * remove pcl depends
* Contributors: Kei Okada, Yuki Furuta, Chi Wun Au
```

## safe_teleop_pr2

- No changes

## safe_teleop_stage

```
* add param to plan safe trajectory on backwards (#13 <https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation/issues/13>)
* add safe_teleop + move_base example
  
  see https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_fetch_robot/jsk_fetch_startup for detail
  select joystick with safe mode : 'rosservice call /cmd_vel_mux/select /safe_teleop_base/safe_vel'
  select move_base navigation    : 'rosservice call /cmd_vel_mux/select /cmd_vel'
  
    * fix safe_teleop_stage.launch
  
* Contributors: Yuki Furuta, Kei Okada
```
