### PR TITLE
psen_scan: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6416,7 +6416,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan` to `1.0.2-1`:

- upstream repository: https://github.com/PilzDE/psen_scan.git
- release repository: https://github.com/PilzDE/psen_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.1-1`

## psen_scan

```
* Change spinner to AsyncSpinner. (#6)
* Add missing install of launch files (#5)
```
