### PR TITLE
fake_joint: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2100,6 +2100,25 @@ repositories:
       url: https://github.com/eyeware/eyeware-ros.git
       version: master
     status: maintained
+  fake_joint:
+    doc:
+      type: git
+      url: https://github.com/tork-a/fake_joint.git
+      version: master
+    release:
+      packages:
+      - fake_joint
+      - fake_joint_driver
+      - fake_joint_launch
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/fake_joint-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/tork-a/fake_joint.git
+      version: master
+    status: developed
   fanuc:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fake_joint` to `0.0.4-1`:

- upstream repository: https://github.com/tork-a/fake_joint.git
- release repository: https://github.com/tork-a/fake_joint-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## fake_joint

- No changes

## fake_joint_driver

- No changes

## fake_joint_launch

```
* Changes for melodic release (#4 <https://github.com/tork-a/fake_joint/issues/4>)
  - Add melodic entries for travis.yml
  - Remove and rename files which is not supported by current Melodic release
  - Rename UR related launch files for Melodic release
* Remove dependencies that are not in melodic (#6 <https://github.com/tork-a/fake_joint/issues/6>)
* Remove vs060 example
* Contributors: Ryosuke Tajima, Tyler Weaver
```
