### PR TITLE
rviz: 1.13.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8742,7 +8742,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.6-1
+      version: 1.13.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.7-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.13.6-1`

## rviz

```
* [fix] Fix segfault when removing displays on presence of DisplayGroupVisibilityProperty
* [fix] CameraDisplay: don't call getCameraInfoTopic() for empty topic
* [fix] MarkerDisplay: clear old markers on topic change (#1455 <https://github.com/ros-visualization/rviz/issues/1455>)
* [maintanence] Fix various warnings
* [maintanence] Support python3 for python bindings (#1454 <https://github.com/ros-visualization/rviz/issues/1454>)
* Contributors: Mike Purvis, Robert Haschke
```
