### PR TITLE
Add python3-hypothesis

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5172,8 +5172,8 @@ python3-gnupg:
   ubuntu: [python3-gnupg]
 python3-hypothesis:
   debian: [python3-hypothesis]
-  ubuntu: [python3-hypothesis]
   fedora: [python3-hypothesis]
+  ubuntu: [python3-hypothesis]
 python3-ifcfg:
   debian:
     buster: [python3-ifcfg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5170,6 +5170,10 @@ python3-gnupg:
   fedora: [python3-gnupg]
   gentoo: [dev-python/python-gnupg]
   ubuntu: [python3-gnupg]
+python3-hypothesis:
+  debian: [python3-hypothesis]
+  ubuntu: [python3-hypothesis]
+  fedora: [python3-hypothesis]
 python3-ifcfg:
   debian:
     buster: [python3-ifcfg]


### PR DESCRIPTION
[Hypothesis](https://hypothesis.readthedocs.io/en/latest/) is a great stable property-based testing framework for Python 3.

Its available on [Ubuntu](https://packages.ubuntu.com/bionic/python3-hypothesis), [Debian](https://packages.debian.org/search?keywords=python3-hypothesis) and [Fedora](https://fedora.pkgs.org/30/fedora-x86_64/python3-hypothesis-3.66.11-2.fc30.noarch.rpm.html).