### PR TITLE
nonpersistent_voxel_layer: 2.1.0-2 in 'eloquent/distribution.yaml' [b…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -928,6 +928,22 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: eloquent
     status: maintained
+  nonpersistent_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
+      version: 2.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: eloquent-devel
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
…loom]

Increasing version of package(s) in repository `nonpersistent_voxel_layer` to `2.1.0-2`:

- upstream repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
- release repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
