### PR TITLE
spatio_temporal_voxel_layer: 2.1.2-2 in 'eloquent/distribution.yaml' …

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2242,6 +2242,22 @@ repositories:
       url: https://github.com/stonier/sophus.git
       version: release/1.1-eloquent
     status: maintained
+  spatio_temporal_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
+      version: 2.1.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: eloquent-devel
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
…[bloom]

Increasing version of package(s) in repository `spatio_temporal_voxel_layer` to `2.1.2-2`:

- upstream repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
- release repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
