### PR TITLE
plotjuggler: 2.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6099,7 +6099,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.4.3-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.5.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.4.3-1`

## plotjuggler

```
* Fix issues #196 <https://github.com/facontidavide/PlotJuggler/issues/196> and #236 <https://github.com/facontidavide/PlotJuggler/issues/236>: allow user to use deterministic color sequence
* fix the edit button
* fix issue #235 <https://github.com/facontidavide/PlotJuggler/issues/235>
* Update appimage_howto.md
* fix timestamp problem in streaming
* Contributors: Davide Faconti
```
