### PR TITLE
automotive_autonomy_msgs: 3.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -771,7 +771,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
Still seeing ros-infrastructure/bloom#557 so PR created manually.

Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.2-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.0.1-1`

## automotive_autonomy_msgs

```
* Adding missing dependency on ros_environment.
* Contributors: Joshua Whitley
```

## automotive_navigation_msgs

```
* Adding missing dependency on ros_environment.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Adding missing dependency on ros_environment.
* Contributors: Joshua Whitley
```