### PR TITLE
Add fmt to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -806,6 +806,12 @@ fluid:
   macports: [fltk]
   opensuse: [fltk-devel]
   ubuntu: [fluid]
+fmt:
+  arch: [fmt]
+  debian: [libfmt-dev]
+  fedora: [fmt-devel]
+  gentoo: [dev-libs/libfmt]
+  ubuntu: [libfmt-dev]
 fping:
   arch: [fping]
   debian: [fping]


### PR DESCRIPTION
## Description
I would like to add [fmtlib/fmt](https://github.com/fmtlib/fmt) package to base.yaml.
It is an efficient formatting library for C++, and will be C++20 std::format.

arch: https://www.archlinux.org/packages/extra/x86_64/fmt/
debian: https://packages.debian.org/buster/libfmt-dev
fedora: https://fedora.pkgs.org/31/fedora-x86_64/fmt-devel-5.3.0-2.fc31.x86_64.rpm.html
gentoo: https://packages.gentoo.org/packages/dev-libs/libfmt
ubuntu: https://packages.ubuntu.com/bionic/libfmt-dev

We can implicitly use fmt if we depend on [rosfmt](https://github.com/xqms/rosfmt) which is a rosconsole extension using fmt.
However, I would like to directly depend on fmt when we don't use rosfmt features.
