### PR TITLE
[popf] Change the name of the package

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1093,7 +1093,7 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: eloquent
     status: maintained
-  popf-release:
+  popf:
     doc:
       type: git
       url: https://github.com/fmrico/popf.git


### PR DESCRIPTION
Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>

I have just noticed that I uploaded my package as `popf-release` instead of `popf`. This PR fixes it.

I have just released a new version of this package to fix dependencies that made fail the built. Now it's version 0.011. Bloom failed in the last step to make the PR. It said that there was already a popf package. Could you help me with this? 🥺

I apologize for these errors. It's the first time that I release a package.

Best