### PR TITLE
naoqi_libqi: 2.9.0-8 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4940,7 +4940,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
-      version: 2.9.0-7
+      version: 2.9.0-8
     status: maintained
   navigation:
     doc:


### PR DESCRIPTION
Update release version from 2.9.0-7 to 2.9.0-8 