### PR TITLE
Add watson_ins

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16822,6 +16822,21 @@ repositories:
       url: https://github.com/warthog-cpr/warthog_simulator.git
       version: kinetic-devel
     status: maintained
+  watson_ins:
+    doc:
+      type: git
+      url: https://github.com/AutonomousVehicleLaboratory/watson_ins.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/AutonomousVehicleLaboratory/watson_ins-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/AutonomousVehicleLaboratory/watson_ins.git
+      version: master
+    status: maintained
   waypoint:
     doc:
       type: git


### PR DESCRIPTION
This PR adds support for the Watson Inertial Measurement System DMS-SGP02. It is a small wrapper on top of the serial interface on the driver.

For documentation, see [README](https://github.com/AutonomousVehicleLaboratory/watson_ins/blob/master/README.md)