### PR TITLE
New Version of popf 0.0.11-1

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1093,7 +1093,7 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: eloquent
     status: maintained
-  popf-release:
+  popf:
     doc:
       type: git
       url: https://github.com/fmrico/popf.git
@@ -1104,7 +1104,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/fmrico/popf-release.git
-      version: 0.0.3-1
+      version: 0.0.11-1
     source:
       type: git
       url: https://github.com/fmrico/popf.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1115,8 +1115,6 @@ repositories:
       url: https://github.com/fmrico/popf.git
       version: eloquent-devel
     release:
-      packages:
-      - popf
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/fmrico/popf-release.git


### PR DESCRIPTION
Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>

Hi

This new release tries to fix the building of popf. The last version did not include the dependencies to build the source.

This version is 0.0.11-1 and the last one is 0.0.3-1. I am still not an expert with bloom, and the automated script increased the minor every time I tried to fix it. I hope that 0.0.11-1 will be ok. 

There is also a PR #23347 to fix the name of the package.

Best
