### PR TITLE
moose_simulator: 0.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7433,6 +7433,24 @@ repositories:
       url: https://github.com/moose-cpr/moose_desktop.git
       version: kinetic-devel
     status: maintained
+  moose_simulator:
+    doc:
+      type: git
+      url: https://github.com/moose-cpr/moose_simulator.git
+      version: master
+    release:
+      packages:
+      - moose_gazebo
+      - moose_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/moose_simulator-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/moose-cpr/moose_simulator.git
+      version: master
+    status: maintained
   motoman:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_simulator` to `0.1.0-2`:

- upstream repository: https://github.com/moose-cpr/moose_simulator.git
- release repository: https://github.com/clearpath-gbp/moose_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## moose_gazebo

```
* Merge pull request #1 <https://github.com/moose-cpr/moose_simulator/issues/1> from dniewinski/gazebo_cleanup
  Gazebo cleanup
* Added script install
* Made a dummy keyswitch node to still use the same mux setup as the robot
* Using moose_description instead of duplicating description
* Merge branch 'master' into 'master'
  Initial Moose simulator
  See merge request research/moose_simulator!1
* Initial Moose simulator
* Contributors: Dave Niewinski, Loic Azzalini, Tony Baltovski
```

## moose_simulator

```
* Merge branch 'master' into 'master'
  Initial Moose simulator
  See merge request research/moose_simulator!1
* Initial Moose simulator
* Contributors: Loic Azzalini, Tony Baltovski
```
