### PR TITLE
lvr2: 19.12.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4189,6 +4189,21 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/lusb.git
       version: master
     status: developed
+  lvr2:
+    doc:
+      type: git
+      url: https://github.com/uos/lvr2.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/lvr2-release.git
+      version: 19.12.0-1
+    source:
+      type: git
+      url: https://github.com/uos/lvr2.git
+      version: master
+    status: developed
   map_merge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `19.12.0-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/uos-gbp/lvr2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
