### PR TITLE
pybind11_catkin: 2.4.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10411,7 +10411,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wxmerkt/pybind11_catkin-release.git
-      version: 2.2.4-4
+      version: 2.4.3-1
     source:
       type: git
       url: https://github.com/ipab-slmc/pybind11_catkin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.4.3-1`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.2.4-4`

## pybind11_catkin

```
* Clean-up of CMake files and logic (by @rhaschke) - #11 <https://github.com/ipab-slmc/pybind11_catkin/issues/11>
* Ensure pybind11 uses same python version as catkin
* Update pybind11 version to 2.4.3
* Clarify bleeding edge vs releases in README - cf #9 <https://github.com/ipab-slmc/pybind11_catkin/issues/9>
* Contributors: Robert Haschke, Wolfgang Merkt
```
