### PR TITLE
v4l2_camera: 0.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2515,6 +2515,21 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: eloquent
     status: maintained
+  v4l2_camera:
+    doc:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    status: developed
   variants:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.1.1-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## v4l2_camera

```
* Add missing rclcpp_components build dependency
* Contributors: Sander G. van Dijk
```
