### PR TITLE
qpmad: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6638,6 +6638,17 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbmove-ros.git
       version: production-melodic
     status: developed
+  qpmad:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/asherikov/qpmad-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/asherikov/qpmad.git
+      version: master
+    status: maintained
   qpoases_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpmad` to `1.0.1-1`:

- upstream repository: https://github.com/asherikov/qpmad.git
- release repository: https://github.com/asherikov/qpmad-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## qpmad

```
* Doxygen documentation.
* Initial ROS release.
```
