### PR TITLE
ariles_ros: 1.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -240,7 +240,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/asherikov/ariles-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     status: developed
   astuff_sensor_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ariles_ros` to `1.3.2-1`:

- upstream repository: https://github.com/asherikov/ariles.git
- release repository: https://github.com/asherikov/ariles-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.1-1`

## ariles_ros

```
* Sync to 1.3.2 (bugfixes).
```
