### PR TITLE
Add python3-packaging rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2720,7 +2720,15 @@ python-oyaml-pip:
 python-packaging:
   debian: [python-packaging]
   fedora: [python-packaging]
-  ubuntu: [python-packaging]
+  ubuntu:
+    '*': [python-packaging]
+    artful_python3: [python3-packaging]
+    bionic_python3: [python3-packaging]
+    trusty_python3: [python3-packaging]
+    wily_python3: [python3-packaging]
+    xenial_python3: [python3-packaging]
+    yakkety_python3: [python3-packaging]
+    zesty_python3: [python3-packaging]
 python-paho-mqtt-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2720,15 +2720,7 @@ python-oyaml-pip:
 python-packaging:
   debian: [python-packaging]
   fedora: [python-packaging]
-  ubuntu:
-    '*': [python-packaging]
-    artful_python3: [python3-packaging]
-    bionic_python3: [python3-packaging]
-    trusty_python3: [python3-packaging]
-    wily_python3: [python3-packaging]
-    xenial_python3: [python3-packaging]
-    yakkety_python3: [python3-packaging]
-    zesty_python3: [python3-packaging]
+  ubuntu: [python-packaging]
 python-paho-mqtt-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5305,6 +5305,11 @@ python3-opengl:
   fedora: [python3-pyopengl]
   gentoo: [dev-python/pyopengl]
   ubuntu: [python3-opengl]
+python3-packaging:
+  debian: [python3-packaging]
+  fedora: [python3-packaging]
+  gentoo: [dev-python/packaging]
+  ubuntu: [python3-packaging]
 python3-pandas:
   debian: [python3-pandas]
   fedora: [python3-pandas]


### PR DESCRIPTION
Packaging is part of the core utilities for Python packages and includes version handling, specifiers, markers, requirements, tags, utilities.

Homepage: https://github.com/pypa/packaging

Package references:

* Debian: https://packages.debian.org/sid/python3-packaging
* Fedora: https://src.fedoraproject.org/rpms/python-packaging
* Ubuntu: https://packages.ubuntu.com/bionic/python3-packaging