### PR TITLE
octomap: 1.9.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -941,7 +941,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.2-1
+      version: 1.9.3-1
     source:
       type: git
       url: https://github.com/octomap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.3-1`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.9.2-1`
