### PR TITLE
octomap: 1.9.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1491,7 +1491,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.2-1
+      version: 1.9.3-1
     source:
       type: git
       url: https://github.com/octomap/octomap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.3-1`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.9.2-1`
