### PR TITLE
asr_msgs: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -513,6 +513,15 @@ repositories:
       type: git
       url: https://github.com/asr-ros/asr_msgs.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/asr-ros/asr_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/asr-ros/asr_msgs.git
+      version: master
   asr_navfn:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `asr_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/asr-ros/asr_msgs.git
- release repository: https://github.com/asr-ros/asr_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## asr_msgs

```
* Create initial version of this package
```
