### PR TITLE
vrx: 1.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16751,7 +16751,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/vrx-release.git
-      version: 1.2.6-1
+      version: 1.3.0-1
     source:
       type: hg
       url: https://bitbucket.org/osrf/vrx/


### PR DESCRIPTION
Increasing version of package(s) in repository `vrx` to `1.3.0-1`:

- upstream repository: https://bitbucket.org/osrf/vrx
- release repository: https://github.com/ros-gbp/vrx-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.6-1`

## usv_gazebo_plugins

```
* Make code_check happy.
* Mod to make use of maxCmd and update to .hgignore
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero
```

## vrx_gazebo

```
* Fix pose frame in scan_and_dock1.world
* make marker id more intelligible
* documenting new yaw parameter
* adding direction indicator to visual markers for stationkeeping and wayfinding
* Fix perception plugin object types.
* Fix offset in 2016 dynamic dock.
* Center all placards in the dock bays.
* Update expected type in perception plugin for surmark objects.
* Set initial and ready states to 10 seconds in dock tasks.
* Merged in worlds_refactor (pull request #213)
  Refactor VRX worlds location
  Approved-by: Coline Ramee <mailto:coline.ramee@gatech.edu>
  Approved-by: Brian Bingham <mailto:briansbingham@gmail.com>
* Make the exit gate a blue-red gate.
* Refactor VRX worlds location.
* Updated perception score according to the 1.4 version of the tasks document.
* dealing with fail and style tweaks
* adding a modified nav course world to speed up testing
* changing scoring method to be consistent with documentation
* tracking down more bad dock worlds
* disables color checker in example models and by default in dock.xacro
* prohibiting p3d sensor in compliance check
* update old worlds
* changing task names in standalone
* initializing error total
* adding worlds and models used in Phase2 for Phase 3 practice
* adding xacro parameter to specify task name in plugin
* adding commad line arg to keydrive launch
* remapping for new namespace
* Add sail and rudder link to wamv base, as well as turn post to wind direction arrow
* Extra path to be added to GAZEBO_MODEL_PATH.
* Set GAZEBO_MODEL_PATH while playing back.
* adding practice worlds for stationkeeping and wayfinding
* Contributors: Brian Bingham <mailto:briansbingham@gmail.com>, Carlos Aguero, Carlos Agüero <mailto:cen.aguero@gmail.com>, Tyler Lum <mailto:tylergwlum@gmail.com>, m1chaelm
```

## wamv_description

```
* Move rudder farther back
* Add sail and rudder link to wamv base, as well as turn post to wind direction arrow
* Add sail link and joint
* Contributors: Tyler Lum <mailto:tylergwlum@gmail.com>
```

## wamv_gazebo

```
* Switch to 0 0 1 in axis.
* Create links where the GPS and IMU sensors are attached.
* Contributors: Carlos Aguero
```

## wave_gazebo

- No changes

## wave_gazebo_plugins

- No changes
