### PR TITLE
add librealsense2 to melodic/distribution.yaml

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4069,6 +4069,22 @@ repositories:
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
     status: maintained
+  librealsense2:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/IntelRealSense/librealsense2-release.git
+      version: 2.31.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    status: maintained
   libsick_ldmrs:
     doc:
       type: git


### PR DESCRIPTION
This adds librealsense2 to melodic.  If this fails to build due to cmake errors for missing packages I have a PR to fix that (https://github.com/IntelRealSense/librealsense/pull/5523).  Hopefully that can get merged soon.