### PR TITLE
gazebo_ros_pkgs: 2.8.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2527,7 +2527,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.8.4-0
+      version: 2.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.8.6-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.8.4-0`

## gazebo_dev

- No changes

## gazebo_msgs

```
* ROS API: remove unhelpful error in GetWorldProperties call (#747 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/747>)
* Contributors: Kevin Allen
```

## gazebo_plugins

```
* gazebo_plugins: export plugin path in package.xml (#923 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/923>)
* Fix destructor of gazebo_ros_diff_drive.cpp (#1021 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1021>)
  Fix issue referenced in #123 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/123> where the destructor of ROS DiffDrive plugin causes gzserver to crash on model deletion.
* [Windows][melodic-devel] more Windows build break fix (#975 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/975>)
  * Fix CMake install error for Windows build.
  * conditionally include <sys/time.h>
* Use ignition::math::Rand utility for portability. (#878 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/878>)
* Contributors: Ben Wolsieffer, RemiRigal, Sean Yen
```

## gazebo_ros

```
* ROS API: remove unhelpful error in GetWorldProperties call (#747 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/747>)
* Create reconfigure thread only if network enabled (#919 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/919>)
  This thread was blocked in client.waitForExistance because the services
  it depends on are only created if enable_ros_network is true. This in
  turn blocked gazebo from being shut down.
  Signed-off-by: Shane Loretz <mailto:sloretz@osrfoundation.org>
* spawn_model: Fix urlparse imports for Python 3
* spawn_model: Ensure that "model_xml" is a string, required for Python 3
* catkin_find gazebo plugin from bin folder. (#993 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/993>)
* [Windows][melodic-devel] more Windows build break fix (#975 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/975>)
  * Fix CMake install error for Windows build.
  * conditionally include <sys/time.h>
* provide Windows implemenation for setenv. (#879 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/879>)
* implement basic gazebo scripts to support launch file on Windows build. (#880 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/880>)
* Contributors: Kartik Mohta, Kevin Allen, Sean Yen, Shane Loretz
```

## gazebo_ros_control

```
* restrict Windows header namespace. (#1023 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1023>)
* [Windows][melodic-devel] more Windows build break fix (#975 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/975>)
  * Fix CMake install error for Windows build.
  * conditionally include <sys/time.h>
* Contributors: Sean Yen
```

## gazebo_ros_pkgs

- No changes
