### PR TITLE
py_trees_js: 0.6.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1136,7 +1136,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git
-      version: release/0.5.x
+      version: release/0.6.x
     release:
       tags:
         release: release/eloquent/{package}/{version}
@@ -1145,7 +1145,7 @@ repositories:
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git
-      version: release/0.5.x
+      version: release/0.6.x
     status: developed
   py_trees_ros:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1141,7 +1141,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_js-release.git
-      version: 0.5.1-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/stonier/py_trees_js-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.1-1`
