### PR TITLE
py_trees_ros: 2.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1172,7 +1172,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.0.1-1
+      version: 2.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.0.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.1-1`

## py_trees_ros

```
* [infra] add a marker file to assist with ros2cli discovery #138 <https://github.com/splintered-reality/py_trees_ros/pull/138>,
```
