### PR TITLE
rosdep: add python3-future

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5166,6 +5166,10 @@ python3-flake8:
     '*': ['python%{python3_pkgversion}-flake8']
     '7': null
   ubuntu: [python3-flake8]
+python3-future:
+  debian: [python3-future]
+  fedora: [python3-future]
+  ubuntu: [python3-future]
 python3-gitlab:
   debian:
     '*': [python3-gitlab]


### PR DESCRIPTION
On the next release of mavlink i'm going to do release for ROS2.
But in that case we need to use python 3, so I'll update package.xml to third format and add conditional depends on py3 version of `future`.

That PR introduces that new dependency.