### PR TITLE
mavlink: 2019.12.30-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -847,6 +847,21 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
     status: maintained
+  mavlink:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/eloquent/mavlink
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: 2019.12.30-1
+    source:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/eloquent/mavlink
+    status: maintained
   message_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2019.12.30-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
