### PR TITLE
py_trees_ros_tutorials: 2.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1203,7 +1203,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_tutorials-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `2.0.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/stonier/py_trees_ros_tutorials-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.0-1`

## py_trees_ros_tutorials

```
* [launch] switch to ros2 launch (not ros2 run)
* [launch] dashing/eloquent handling of emulate_tty
* [tests] moved from unittest to pytest
* [tutorials] catch and log appropriately when ctrl-c engaged in setup
* [tutorials] catch the setup specific TimedOutError so other errors are easy to diagnose
```
