### PR TITLE
py_trees_ros: 2.0.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1172,7 +1172,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.0.1-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.0.4-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.1-1`

## py_trees_ros

```
* [blackboard] bugfix protection against activity stream not activitated for views, #140 <https://github.com/splintered-reality/py_trees_ros/pull/140>,
* [trees] bugfix toggle for activity client on reconfigure, #139 <https://github.com/splintered-reality/py_trees_ros/pull/139>,
```
