### PR TITLE
Revert "automotive_autonomy_msgs: 3.0.1-1 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -771,7 +771,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 3.0.1-1
+      version: 2.0.3-0
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
Reverts ros/rosdistro#23299

This release is causing the build to fail for all binary packages. 

Ticketed upstream: https://github.com/astuff/automotive_autonomy_msgs/issues/16