### PR TITLE
qpmad: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6688,7 +6688,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/asherikov/qpmad-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/asherikov/qpmad.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpmad` to `1.0.2-1`:

- upstream repository: https://github.com/asherikov/qpmad.git
- release repository: https://github.com/asherikov/qpmad-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.1-1`

## qpmad

```
* Added missing dependency in package.xml.
```
