### PR TITLE
mavros: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7067,7 +7067,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 0.33.4-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.0.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.33.4-1`

## libmavconn

- No changes

## mavros

- No changes

## mavros_extras

```
* Change odometry subscription queue to 1 to avoid buffering.
* Contributors: James Goppert
```

## mavros_msgs

- No changes

## test_mavros

- No changes
