### PR TITLE
cross_compile: 0.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -299,6 +299,18 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: crystal-devel
     status: maintained
+  cross_compile:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros-tooling/cross_compile-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-tooling/cross_compile.git
+      version: eloquent
+    status: developed
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `cross_compile` to `0.2.0-1`:

- upstream repository: https://github.com/ros-tooling/cross_compile.git
- release repository: https://github.com/ros-tooling/cross_compile-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
