### PR TITLE
asr_msgs: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -242,6 +242,20 @@ repositories:
       url: https://github.com/asherikov/ariles-release.git
       version: 1.3.2-1
     status: developed
+  asr_msgs:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/asr-ros/asr_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/asr-ros/asr_msgs.git
+      version: master
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `asr_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/asr-ros/asr_msgs.git
- release repository: https://github.com/asr-ros/asr_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## asr_msgs

```
* Create initial version of this package
```
