### PR TITLE
swarm_behaviors: 1.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14938,6 +14938,31 @@ repositories:
       url: https://github.com/SvenzvaRobotics/svenzva_ros.git
       version: master
     status: developed
+  swarm_behaviors:
+    doc:
+      type: git
+      url: https://github.com/cpswarm/swarm_behaviors.git
+      version: kinetic-devel
+    release:
+      packages:
+      - swarm_behaviors
+      - swarm_behaviors_position
+      - swarm_behaviors_velocity
+      - uav_local_coverage
+      - uav_optimal_coverage
+      - uav_random_direction
+      - uav_simple_tracking
+      - ugv_random_walk
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/cpswarm/swarm_behaviors-release.git
+      version: 1.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cpswarm/swarm_behaviors.git
+      version: kinetic-devel
+    status: developed
   swarm_functions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swarm_behaviors` to `1.3.0-1`:

- upstream repository: https://github.com/cpswarm/swarm_behaviors.git
- release repository: https://github.com/cpswarm/swarm_behaviors-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## swarm_behaviors

```
* Changed: Rename position library to swarm_behaviors_position
* Changed: Rename velocity library to swarm_behaviors_velocity
```

## swarm_behaviors_position

```
* Changed: Rename position library to swarm_behaviors_position
```

## swarm_behaviors_velocity

```
* Changed: Rename velocity library to swarm_behaviors_velocity
```

## uav_local_coverage

- No changes

## uav_optimal_coverage

- No changes

## uav_random_direction

- No changes

## uav_simple_tracking

- No changes

## ugv_random_walk

- No changes
