### PR TITLE
lvr2: 19.12.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4212,7 +4212,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/lvr2-release.git
-      version: 19.12.0-1
+      version: 19.12.0-2
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `19.12.0-2`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/uos-gbp/lvr2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `19.12.0-1`
