### PR TITLE
lvr2: 19.12.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4212,7 +4212,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/lvr2-release.git
-      version: 19.12.0-1
+      version: 19.12.1-1
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `19.12.1-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/uos-gbp/lvr2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `19.12.0-1`

## lvr2

```
* Initial release of lvr2
* Contributors: = Adrien Devresse, Aleksandr Ovcharenko, Alexander Altemöller, Alexander Löhr, Alexander Mock, Ali Can Demiralp, Ann-Katrin Haeuser, Bao Tran, Benedikt Schumacher, Christian Swan, Daniel Nachbaur, David J. Luitz, Denis Meyer, Devresse Adrien, Dmitri Bichko, Dominik Feldschnieders, Felix Igelbrink, Fernando Pereira, Florian Otte, Henning Deeken, Henning Strüber, Isaak Mitschke, Jan Philipp Vogtherr, Jan Toennemann, Jochen Sprickerhof, Johan M. von Behren, Juan Hernando Vieites, Kim Oliver Rinnewitz, Kristin Schmidt, Lars Kiesow, Lennart Niecksch, Lukas Kalbertodt, Malte kl. Piening, Marcel Mrozinski, Marcel Wiegand, Martin Günther, Matthias Greshake, Michael Görner, Michael V. DePalatis, Mike Gevaert, Nils Niemann, Pablo Toharia, Raphael Marx, Rasmus Diederichsen, Sabine Rast, Sebastian Pütz, Sergei Sobol, Simon Herkenhoff, Stefan Eilemann, Steffen Hinderink, Sven Albrecht, Thomas Wiemann, Tristan Igelbrink, Wilko Müller, Wolf Vollprecht
```
