### PR TITLE
add opencl-headers package to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4388,6 +4388,11 @@ omniorb:
   gentoo: [net-misc/omniORB]
   macports: [omniORB]
   ubuntu: [omniorb, omniidl, omniorb-idl, omniorb-nameserver, libomniorb4-dev]
+opencl-headers:
+  arch: [opencl-headers]
+  debian: [opencl-headers]
+  fedora: [opencl-headers]
+  ubuntu: [opencl-headers]
 opende:
   arch: [ode]
   debian: [libode-dev]


### PR DESCRIPTION
opencl headers are needed for OpenCl with CL2 used within c++

- https://packages.debian.org/de/sid/opencl-headers
- https://packages.ubuntu.com/search?keywords=opencl-headers
- https://src.fedoraproject.org/rpms/opencl-headers
- https://www.archlinux.org/packages/extra/any/opencl-headers/