### PR TITLE
ros2_ouster_driver: 0.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1636,6 +1636,25 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: eloquent
     status: maintained
+  ros2_ouster_driver:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: eloquent-devel
+    release:
+      packages:
+      - ouster_msgs
+      - ros2_ouster
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: eloquent-devel
+    status: developed
   ros2_tracing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_ouster_driver` to `0.0.1-1`:

- upstream repository: https://github.com/SteveMacenski/ros2_ouster_drivers.git
- release repository: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
