### PR TITLE
ros2_ouster_driver: 0.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2169,6 +2169,25 @@ repositories:
       url: https://github.com/intel/ros2_object_analytics.git
       version: master
     status: maintained
+  ros2_ouster_driver:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: dashing-devel
+    release:
+      packages:
+      - ouster_msgs
+      - ros2_ouster
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
+      version: 0.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: dashing-devel
+    status: developed
   ros2_tracing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_ouster_driver` to `0.0.0-1`:

- upstream repository: https://github.com/SteveMacenski/ros2_ouster_drivers.git
- release repository: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
