### PR TITLE
Add python-can-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -802,6 +802,25 @@ python-can:
     yakkety:
       pip:
         packages: [python-can]
+python-can-pip:
+  alpine:
+    pip:
+      packages: [python-can]
+  arch:
+    pip:
+      packages: [python-can]
+  debian:
+    pip:
+      packages: [python-can]
+  fedora:
+    pip:
+      packages: [python-can]
+  osx:
+    pip:
+      packages: [python-can]
+  ubuntu:
+    pip:
+      packages: [python-can]
 python-cantools-pip:
   debian:
     pip:


### PR DESCRIPTION
This adds the `python-can` packages as an explicit pip dependency. It already exists as an dependency for Python 2 (called `python-can`) and Python 3 (called `python3-can`). But we still need it from pip in our project, as we the version available in Ubuntu Bionic (18.04) is to old for our use case. We only require Python 3 btw. Is it valid to add such a pip-only *additional* dependency? What would be another way if it is not allowed?

link to the package: https://pypi.org/project/python-can/

The rationale for `python-can` is the same as in #23307.