### PR TITLE
mcl_3dl: 0.1.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7082,7 +7082,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.1.6-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.1.7-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.6-1`

## mcl_3dl

```
* Update assets to v0.0.6 (#273 <https://github.com/at-wat/mcl_3dl/issues/273>)
* Update assets to v0.0.5 (#272 <https://github.com/at-wat/mcl_3dl/issues/272>)
* Add catkin/bloom release actions (#269 <https://github.com/at-wat/mcl_3dl/issues/269>)
* Fix codecov setting (#270 <https://github.com/at-wat/mcl_3dl/issues/270>)
* Fix codecov config (#268 <https://github.com/at-wat/mcl_3dl/issues/268>)
* Migrate C math functions to C++ (#267 <https://github.com/at-wat/mcl_3dl/issues/267>)
* Enable particle initialization using covariances (#259 <https://github.com/at-wat/mcl_3dl/issues/259>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```
