### PR TITLE
naoqi_libqicore: 2.9.0-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4978,6 +4978,13 @@ repositories:
       url: https://github.com/ros-naoqi/libqi-release.git
       version: 2.9.0-8
     status: maintained
+  naoqi_libqicore:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-naoqi/libqicore-release.git
+      version: 2.9.0-5
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Adding naoqi_libqicore to melodic