### PR TITLE
rqt_graph: 0.4.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13267,7 +13267,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_graph-release.git
-      version: 0.4.9-0
+      version: 0.4.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros-gbp/rqt_graph-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.9-0`

## rqt_graph

```
* skip removal of non-present tf connections (#40 <https://github.com/ros-visualization/rqt_graph/issues/40>)
* add Python 3 conditional dependencies (#37 <https://github.com/ros-visualization/rqt_graph/issues/37>)
* fix typo that caused a crash when trying to load a dot file. (#31 <https://github.com/ros-visualization/rqt_graph/issues/31>)
* autopep8 and gitignore (#19 <https://github.com/ros-visualization/rqt_graph/issues/19>)
* replace str() by unicode() (#17 <https://github.com/ros-visualization/rqt_graph/issues/17>)
* edge class is unhashable so cannot put into a set, use a list instead (#16 <https://github.com/ros-visualization/rqt_graph/issues/16>)
```
