### PR TITLE
Add python3-nose fedora entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5281,6 +5281,7 @@ python3-netifaces:
   ubuntu: [python3-netifaces]
 python3-nose:
   debian: [python3-nose]
+  fedora: [python3-nose]
   gentoo: [dev-python/nose]
   openembedded: [python3-nose@openembedded-core]
   rhel: ['python%{python3_pkgversion}-nose']


### PR DESCRIPTION
https://src.fedoraproject.org/rpms/python3-nose

This is needed to release catkin into ROS Noetic. Without it the command `git-bloom-generate -y rosrpm --prefix release/noetic noetic -i 0` fails with

```
+++ Cloning working copy for safety
Generating source RPMs for the packages: ['catkin']
RPM Incremental Version: 0
RPM Distributions: ['30']
Releasing for rosdistro: noetic

Pre-verifying RPM dependency keys...
Running 'rosdep update'...
ROS Distro index file associate with commit '7c16f7857ff84d1c7a15898145791bc84d26487e'
New ROS Distro index url: 'https://raw.githubusercontent.com/ros/rosdistro/7c16f7857ff84d1c7a15898145791bc84d26487e/index-v4.yaml'
Could not resolve rosdep key 'python3-nose' for distro '30':
No definition of [python3-nose] for OS [fedora]
	rosdep key : python3-nose
	OS name    : fedora
	OS version : 30
	Data: debian:
- python3-nose
gentoo:
- dev-python/nose
openembedded:
- python3-nose@openembedded-core
rhel:
- python%{python3_pkgversion}-nose
ubuntu:
- python3-nose

Failed to resolve python3-nose on fedora:30 with: Error running generator: Failed to resolve rosdep key 'python3-nose', aborting.
python3-nose is depended on by these packages: ['catkin']
<== Failed
Some of the dependencies for packages in this repository could not be resolved by rosdep.
You can try to address the issues which appear above and try again if you wish, or continue without releasing into RPM-based distributions (e.g. Fedora 24).
```