### PR TITLE
Release Catkin 0.7.20 to Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -31,6 +31,15 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
   catkin:
+    doc:
+      type: git
+      url: https://github.com/ros/catkin.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/catkin-release.git
+      version: 0.7.20-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Manually opened PR after doing steps here: https://github.com/ros-gbp/catkin-release/blob/master/README.md#catkin-noetic---0720-0