### PR TITLE
Add asr packages to melodic distro docu index

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -346,11 +346,6 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: kinetic-devel
     status: developed
-  asr_approx_mvbb:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_approx_mvbb.git
-      version: master
   asr_aruco_marker_recognition:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -242,6 +242,168 @@ repositories:
       url: https://github.com/asherikov/ariles-release.git
       version: 1.3.2-1
     status: developed
+  asr_approx_mvbb:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_approx_mvbb.git
+      version: master
+  asr_aruco_marker_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_aruco_marker_recognition.git
+      version: master
+  asr_calibration_tool_dome:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_calibration_tool_dome.git
+      version: master
+  asr_cyberglove_lib:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_cyberglove_lib.git
+      version: master
+  asr_cyberglove_visualization:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_cyberglove_visualization.git
+      version: master
+  asr_descriptor_surface_based_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_descriptor_surface_based_recognition.git
+      version: master
+  asr_direct_search_manager:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_direct_search_manager.git
+      version: master
+  asr_fake_object_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_fake_object_recognition.git
+      version: master
+  asr_flir_ptu_controller:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flir_ptu_controller.git
+      version: master
+  asr_flir_ptu_driver:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flir_ptu_driver.git
+      version: master
+  asr_flock_of_birds:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flock_of_birds.git
+      version: master
+  asr_flock_of_birds_tracking:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flock_of_birds_tracking.git
+      version: master
+  asr_ftc_local_planner:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ftc_local_planner.git
+      version: melodic
+  asr_gazebo_models:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_gazebo_models.git
+      version: master
+  asr_grid_creator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_grid_creator.git
+      version: master
+  asr_halcon_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_halcon_bridge.git
+      version: master
+  asr_intermediate_object_generator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_intermediate_object_generator.git
+      version: master
+  asr_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism.git
+      version: master
+  asr_ism_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism_visualizations.git
+      version: master
+  asr_ivt:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt.git
+      version: master
+  asr_ivt_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt_bridge.git
+      version: master
+  asr_kinematic_chain_dome:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_kinematic_chain_dome.git
+      version: master
+  asr_kinematic_chain_optimizer:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_kinematic_chain_optimizer.git
+      version: master
+  asr_lib_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_ism.git
+      version: master
+  asr_lib_pose_prediction_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_pose_prediction_ism.git
+      version: master
+  asr_mild_base_driving:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_driving.git
+      version: master
+  asr_mild_base_fake_driving:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_fake_driving.git
+      version: master
+  asr_mild_base_laserscanner:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_laserscanner.git
+      version: master
+  asr_mild_base_launch_files:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_launch_files.git
+      version: master
+  asr_mild_calibration_tool:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_calibration_tool.git
+      version: master
+  asr_mild_kinematic_chain:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_kinematic_chain.git
+      version: master
+  asr_mild_navigation:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_navigation.git
+      version: master
   asr_msgs:
     doc:
       type: git
@@ -255,6 +417,119 @@ repositories:
     source:
       type: git
       url: https://github.com/asr-ros/asr_msgs.git
+      version: master
+  asr_navfn:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_navfn.git
+      version: melodic
+  asr_next_best_view:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_next_best_view.git
+      version: melodic
+  asr_object_database:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_object_database.git
+      version: master
+  asr_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm.git
+      version: master
+  asr_psm_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm_visualizations.git
+      version: master
+  asr_rapidxml:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
+  asr_recognizer_prediction_ism:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_recognizer_prediction_ism.git
+      version: master
+  asr_recognizer_prediction_psm:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_recognizer_prediction_psm.git
+      version: master
+  asr_relation_graph_generator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_relation_graph_generator.git
+      version: master
+  asr_resources_for_active_scene_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_active_scene_recognition.git
+      version: master
+  asr_resources_for_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_psm.git
+      version: master
+  asr_resources_for_vision:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_vision.git
+      version: master
+  asr_robot:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_robot.git
+      version: master
+  asr_robot_model_services:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_robot_model_services.git
+      version: melodic
+  asr_ros_uri:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ros_uri.git
+      version: master
+  asr_rviz_pose_manager:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rviz_pose_manager.git
+      version: master
+  asr_sick_lms_400:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_sick_lms_400.git
+      version: master
+  asr_state_machine:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_state_machine.git
+      version: master
+  asr_visualization_server:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_visualization_server.git
+      version: master
+  asr_world_model:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_world_model.git
+      version: master
+  asr_xsd2cpp:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_xsd2cpp.git
       version: master
   astuff_sensor_msgs:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -242,11 +242,6 @@ repositories:
       url: https://github.com/asherikov/ariles-release.git
       version: 1.3.2-1
     status: developed
-  asr_approx_mvbb:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_approx_mvbb.git
-      version: master
   asr_aruco_marker_recognition:
     doc:
       type: git


### PR DESCRIPTION
* Adding all ASR packages (documented here: http://wiki.ros.org/asr) which are currently in the docu index for kinetic to melodic
* Removing asr_approx_mvbb from kinetic docu index since it is no longer in a public repo