### PR TITLE
dolly: 0.1.1-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -619,6 +619,22 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: dashing
     status: developed
+  dolly:
+    release:
+      packages:
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/chapulina/dolly-release.git
+      version: 0.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: dashing
+    status: maintained
   dynamixel_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dolly` to `0.1.1-2`:

- upstream repository: https://github.com/chapulina/dolly.git
- release repository: https://github.com/chapulina/dolly-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## dolly

```
* First Dolly release
* Contributors: chapulina
```

## dolly_follow

```
* First Dolly release
* Contributors: Karsten Knese, chapulina
```

## dolly_gazebo

```
* First Dolly release
* Contributors: chapulina
```
