### PR TITLE
doosan_robot: 1.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2642,11 +2642,11 @@ repositories:
       version: master
     release:
       packages:
+      - common
       - doosan_robot
       - doosan_robotics
       - dsr_control
       - dsr_description
-      - dsr_example_cpp
       - dsr_example_py
       - dsr_gazebo
       - dsr_launcher
@@ -2658,7 +2658,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/doosan-robotics/doosan-robot-release.git
-      version: 0.9.6-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/doosan-robotics/doosan-robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `doosan_robot` to `1.0.3-1`:

- upstream repository: https://github.com/doosan-robotics/doosan-robot.git
- release repository: https://github.com/doosan-robotics/doosan-robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.6-1`
