### PR TITLE
dolly: 0.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -395,6 +395,22 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: eloquent
     status: developed
+  dolly:
+    release:
+      packages:
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/chapulina/dolly-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: master
+    status: maintained
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dolly` to `0.2.0-1`:

- upstream repository: https://github.com/chapulina/dolly.git
- release repository: https://github.com/chapulina/dolly-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## dolly

- No changes

## dolly_follow

- No changes

## dolly_gazebo

```
* Port to Eloquent (#9 <https://github.com/chapulina/dolly/issues/9>)
  * Port to Eloquent
  * Update README
  Signed-off-by: Louise Poubel <mailto:louise@openrobotics.org>
* Contributors: chapulina
```
