### PR TITLE
tdk_robokit: 0.0.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15092,6 +15092,12 @@ repositories:
       url: https://github.com/asmodehn/tblib-rosrelease.git
       version: 1.2.0-2
     status: maintained
+  tdk_robokit:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/InvenSenseInc/tdk_robokit-release.git
+      version: 0.0.1-2
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tdk_robokit` to `0.0.1-2`:

- upstream repository: https://github.com/InvenSenseInc/tdk_robokit.git
- release repository: https://github.com/InvenSenseInc/tdk_robokit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## tdk_robokit

```
* Initial commit of robokit ROS driver
```
