### PR TITLE
debian default-jdk for stretch and newer

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1396,6 +1396,7 @@ jasper:
 java:
   arch: [jdk7-openjdk]
   debian:
+    '*': [default-jdk]
     jessie: [openjdk-7-jdk]
     wheezy: [openjdk-7-jdk]
   fedora:


### PR DESCRIPTION
This matches the ubuntu rule for recent platforms
https://packages.debian.org/stretch/default-jdk