### PR TITLE
add python-schedule and python3-schedule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3907,6 +3907,9 @@ python-scapy:
   fedora: [scapy]
   gentoo: [dev-python/scapy-python3]
   ubuntu: [python-scapy]
+python-schedule:
+  debian: [python-schedule]
+  ubuntu: [python-schedule]
 python-scipy:
   arch: [python2-scipy]
   debian: [python-scipy]
@@ -5557,6 +5560,9 @@ python3-ruamel.yaml:
     xenial: [python3-ruamel.yaml]
     yakkety: [python3-ruamel.yaml]
     zesty: [python3-ruamel.yaml]
+python3-schedule:
+  debian: [python3-schedule]
+  ubuntu: [python3-schedule]
 python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]


### PR DESCRIPTION
add `python-schedule` and `python3-schedule` package in rosdep.

pypi: https://pypi.org/project/schedule/
github: https://github.com/dbader/schedule/
ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python-schedule&searchon=names
ubuntu (python3): https://packages.ubuntu.com/search?keywords=python3-schedule&searchon=names&suite=all&section=all
debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python-schedule
debian (python3): https://packages.debian.org/search?keywords=python3-schedule&searchon=names&suite=all&section=all
