### PR TITLE
multisense_ros: 4.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4935,7 +4935,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 4.0.2-0
+      version: 4.0.3-1
     source:
       type: hg
       url: https://bitbucket.org/crl/multisense_ros


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `4.0.3-1`:

- upstream repository: https://bitbucket.org/crl/multisense_ros
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `4.0.2-0`

## multisense

```
* undo early commit
* incremented package.xml version numbers for next release
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_bringup

```
* undo early commit
* incremented package.xml version numbers for next release
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_cal_check

```
* undo early commit
* incremented package.xml version numbers for next release
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_description

```
* undo early commit
* incremented package.xml version numbers for next release
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_lib

```
* undo early commit
* incremented package.xml version numbers for next release
* libturbo in multisense_ros
* updated libpng; added libturbojpeg to package.xml
* Contributors: Kevin Nickels <mailto:knickels@trinity.edu>, Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```

## multisense_ros

```
* undo early commit
* incremented package.xml version numbers for next release
* Contributors: Quentin Torgerson <mailto:qtorgerson@carnegierobotics.com>
```
