### PR TITLE
automotive_autonomy_msgs: 3.0.3-1 in 'eloquent/distribution.yaml' [bl…

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -171,7 +171,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 3.0.1-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
…oom]
Bloom updated but created PR manually due to ros-infrastructure/bloom#557.

Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.3-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.0.1-1`

## automotive_autonomy_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```

## automotive_navigation_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```
