### PR TITLE
automotive_autonomy_msgs: 3.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -350,7 +350,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 3.0.1-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
Bloom updated but PR created manually due to ros-infrastructure/bloom#557.

Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.3-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.0.1-1`

## automotive_autonomy_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```

## automotive_navigation_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```
