### PR TITLE
automotive_autonomy_msgs: 3.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -780,7 +780,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 2.0.3-0
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
Bloom updated but PR created manually due to ros-infrastructure/bloom#557

Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.3-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.3-0`

## automotive_autonomy_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```

## automotive_navigation_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```

## automotive_platform_msgs

```
* Add find_package for ros_environment.
* Contributors: Joshua Whitley
```
