### PR TITLE
neonavigation: 0.5.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8351,7 +8351,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.5.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.0-1`

## costmap_cspace

```
* Fix header namespaces (#408 <https://github.com/at-wat/neonavigation/issues/408>)
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

```
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* Contributors: Atsushi Watanabe
```

## map_organizer

```
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

```
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

```
* planner_cspace: disable blockmem_gridmap_performance test (#413 <https://github.com/at-wat/neonavigation/issues/413>)
* Fix header namespaces (#408 <https://github.com/at-wat/neonavigation/issues/408>)
* planner_cspace: fix installing planner_2dof_serial_joints node (#409 <https://github.com/at-wat/neonavigation/issues/409>)
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* planner_cspace: split search model definition (#323 <https://github.com/at-wat/neonavigation/issues/323>)
* planner_cspace: fix debug output test (#404 <https://github.com/at-wat/neonavigation/issues/404>)
* planner_cspace: fix navigation test stability (#403 <https://github.com/at-wat/neonavigation/issues/403>)
* planner_cspace: add planner_2dof_serial_joints node test (#402 <https://github.com/at-wat/neonavigation/issues/402>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* safety_limiter: fix test stability (#411 <https://github.com/at-wat/neonavigation/issues/411>)
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* safety_limiter: fix test stability (#406 <https://github.com/at-wat/neonavigation/issues/406>)
* Contributors: Atsushi Watanabe
```

## track_odometry

```
* track_odometry: fix test stability (#412 <https://github.com/at-wat/neonavigation/issues/412>)
* Fix header namespaces (#408 <https://github.com/at-wat/neonavigation/issues/408>)
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* Contributors: Atsushi Watanabe
```

## trajectory_tracker

```
* Migrate from C math functions to C++ (#407 <https://github.com/at-wat/neonavigation/issues/407>)
* trajectory_tracker: fix test stability (#405 <https://github.com/at-wat/neonavigation/issues/405>)
* Contributors: Atsushi Watanabe
```
