### PR TITLE
[melodic] add doc/src entries for naoqi_driver

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4972,11 +4972,19 @@ repositories:
       version: 0.0.8-0
     status: maintained
   naoqi_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_driver.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver-release.git
       version: 0.5.11-0
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_driver.git
+      version: master
     status: maintained
   naoqi_libqi:
     release:


### PR DESCRIPTION
@Pandhariix FYI: this allows to generate API doc for the wiki as well as pointing to the source repository / enable CI on the master branch. This can be done directly when running bloom-release by answering yes to the prompts for source and documentation entries