### PR TITLE
[melodic] fedora 28 is EOL since 2019-05-28

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5,8 +5,6 @@
 release_platforms:
   debian:
   - stretch
-  fedora:
-  - '28'
   ubuntu:
   - bionic
 repositories:


### PR DESCRIPTION
https://fedoramagazine.org/fedora-28-end-of-life/

This allows bloom not to run for fedora, skipping error messages about missing rosdep keys along the way. 