### PR TITLE
pepper_meshes: 0.2.4-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6000,6 +6000,13 @@ repositories:
       url: https://github.com/wg-perception/people.git
       version: melodic
     status: maintained
+  pepper_meshes:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-naoqi/pepper_meshes-release.git
+      version: 0.2.4-3
+    status: maintained
   pepperl_fuchs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pepper_meshes` to `0.2.4-3`:

- upstream repository: https://github.com/ros-naoqi/pepper_meshes.git
- release repository: https://github.com/ros-naoqi/pepper_meshes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## pepper_meshes

```
* add Maxime Busy as maintainer (#6 <https://github.com/ros-naoqi/pepper_meshes/issues/6>)
* update maintainers (#4 <https://github.com/ros-naoqi/pepper_meshes/issues/4>)
* Contributors: Maxime Busy, Mikael Arguedas
```
