### PR TITLE
nao_meshes: 0.1.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8034,7 +8034,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-naoqi/nao_meshes-release.git
-      version: 0.1.11-1
+      version: 0.1.12-1
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_meshes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `0.1.12-1`:

- upstream repository: https://github.com/ros-nao/nao_meshes.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.11-1`

## nao_meshes

```
* add Maxime Busy as maintainer (#7 <https://github.com/ros-naoqi/nao_meshes/issues/7>)
* update maintainer (#5 <https://github.com/ros-naoqi/nao_meshes/issues/5>)
* Contributors: Maxime Busy, Mikael Arguedas
```
