### PR TITLE
octomap_mapping: 0.6.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5462,7 +5462,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_mapping-release.git
-      version: 0.6.3-0
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.4-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.3-0`

## octomap_mapping

- No changes

## octomap_server

```
* Add private node handle to fix nodelet support (#61 <https://github.com/OctoMap/octomap_mapping/issues/61>), fixes #39 <https://github.com/OctoMap/octomap_mapping/issues/39>
* Add octomap_server_color library by default (#60 <https://github.com/OctoMap/octomap_mapping/issues/60>) - by Matthew Powelson
* Check if part of a voxel is in occupancy range (#59 <https://github.com/OctoMap/octomap_mapping/issues/59>) - by Jasper v. B.
* Contributors: Matthew Powelson, Wolfgang Merkt, Jasper v. B.
```
