### PR TITLE
nao_meshes: 0.1.12-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4964,6 +4964,13 @@ repositories:
       url: https://github.com/yujinrobot-release/nanomsg-release.git
       version: 0.4.1-0
     status: maintained
+  nao_meshes:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_meshes-release.git
+      version: 0.1.12-2
+    status: maintained
   naoqi_bridge_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `0.1.12-2`:

- upstream repository: https://github.com/ros-nao/nao_meshes.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## nao_meshes

```
* add Maxime Busy as maintainer (#7 <https://github.com/ros-naoqi/nao_meshes/issues/7>)
* update maintainer (#5 <https://github.com/ros-naoqi/nao_meshes/issues/5>)
* Contributors: Maxime Busy, Mikael Arguedas
```
