### PR TITLE
angles: 1.12.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -228,7 +228,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.12.1-1
+      version: 1.12.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.12.2-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.12.1-1`

## angles

```
* Added support for "large limits" (#16 <https://github.com/ros/angles/issues/16>)
  * Added support for "large limits"
  * shortest_angle_with_large_limits in python
* Contributors: Franco Fusco
```
