### PR TITLE
ros2_planning_system: 0.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1692,7 +1692,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `0.0.3-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.2-1`

## plansys2_bringup

- No changes

## plansys2_domain_expert

- No changes

## plansys2_executor

```
* Add popf dependency
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_lifecycle_manager

- No changes

## plansys2_msgs

- No changes

## plansys2_patrol_navigation_example

- No changes

## plansys2_pddl_parser

- No changes

## plansys2_planner

- No changes

## plansys2_problem_expert

- No changes

## plansys2_simple_example

- No changes

## plansys2_terminal

```
* Add readline dependency
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```
