### PR TITLE
rosfmt: 6.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7992,7 +7992,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/xqms/rosfmt-release.git
-      version: 6.1.0-1
+      version: 6.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosfmt` to `6.2.0-1`:

- upstream repository: https://github.com/xqms/rosfmt.git
- release repository: https://github.com/xqms/rosfmt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `6.1.0-1`

## rosfmt

```
* ensure vformat is only instantiated once -> faster compile times
* update to fmt 6.0.0
* Contributors: Max Schwarz
```
