### PR TITLE
add librealsense2 package

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4095,8 +4095,7 @@ repositories:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
       version: master
-    status: maintained
-    status: maintained
+    status: developed
   libsick_ldmrs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4080,7 +4080,7 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
-  librealsense2: 
+  librealsense2:
     doc:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4089,7 +4089,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.31.0-2
+      version: 2.31.0-3
     source:
       test_pull_requests: true
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4080,7 +4080,7 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
-  librealsense2:
+  librealsense2: 
     doc:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4080,6 +4080,22 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/libg2o-release.git
       version: 2018.3.25-0
+  librealsense2:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/IntelRealSense/librealsense2-release.git
+      version: 2.31.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    status: maintained
     status: maintained
   libsick_ldmrs:
     doc:


### PR DESCRIPTION
This PR should replace #22938 
It incorporates flags for building without X11 dependency and maintains the naming convention of the Kinetic distribution.