### PR TITLE
kobuki_msgs: 0.8.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -805,6 +805,21 @@ repositories:
       url: https://github.com/ros2/kdl_parser.git
       version: eloquent
     status: maintained
+  kobuki_msgs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_msgs.git
+      version: release/0.8.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_msgs.git
+      version: release/0.8.x
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs` to `0.8.0-1`:

- upstream repository: https://github.com/yujinrobot/kobuki_msgs.git
- release repository: https://github.com/yujinrobot-release/kobuki_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## kobuki_msgs

```
* Ros2 eloquent upgrade, #11 <https://github.com/yujinrobot/kobuki_msgs/issues/11>
```
