### PR TITLE
rqt_topic: 0.4.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8785,7 +8785,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_topic-release.git
-      version: 0.4.10-0
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros-gbp/rqt_topic-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.10-0`

## rqt_topic

```
* fix TypeError in Python 3 (#7 <https://github.com/ros-visualization/rqt_topic/issues/7>)
* add Python 3 conditional dependencies (#13 <https://github.com/ros-visualization/rqt_topic/issues/13>)
* fix dictionary changed size during iteration (#10 <https://github.com/ros-visualization/rqt_topic/issues/10>)
* autopep8 (#6 <https://github.com/ros-visualization/rqt_topic/issues/6>)
```
