### PR TITLE
kobuki_core: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -819,7 +819,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.8.1-1`:

- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-1`

## kobuki_driver

```
* remove unused and dodgy float builder, fixed uninitialised warnings, #53 <https://github.com/yujinrobot/kobuki_core/pull/53>.
```
