### PR TITLE
geometry2: 0.6.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2725,7 +2725,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.6.5-0
+      version: 0.6.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.6.6-1`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.5-0`

## geometry2

- No changes

## tf2

```
* Fix compile error missing ros/ros.h (#400 <https://github.com/ros/geometry2/issues/400>)
  * ros/ros.h -> ros/time.h
  * tf2_eigen doesn't need ros/ros.h
* rework Eigen functions namespace hack
* separate transform function declarations into transform_functions.h
* use ROS_DEPRECATED macro for portability (#362 <https://github.com/ros/geometry2/issues/362>)
* Remove signals from find_package(Boost COMPONENTS ...).
* Remove legacy inclusion in CMakeLists of tf2.
* Contributors: James Xu, Maarten de Vries, Marco Tranzatto, Shane Loretz, Tully Foote
```

## tf2_bullet

```
* Fix compile error missing ros/ros.h (#400 <https://github.com/ros/geometry2/issues/400>)
  * ros/ros.h -> ros/time.h
  * tf2_bullet doesn't need ros.h
  * tf2_eigen doesn't need ros/ros.h
* use find_package when pkg_check_modules doesn't work (#364 <https://github.com/ros/geometry2/issues/364>)
* Contributors: James Xu, Shane Loretz
```

## tf2_eigen

```
* Fix compile error missing ros/ros.h (#400 <https://github.com/ros/geometry2/issues/400>)
  * ros/ros.h -> ros/time.h
  * tf2_bullet doesn't need ros.h
  * tf2_eigen doesn't need ros/ros.h
* rework Eigen functions namespace hack
* separate transform function declarations into transform_functions.h
* Contributors: James Xu, Shane Loretz, Tully Foote
```

## tf2_geometry_msgs

```
* Make kdl headers available (#419 <https://github.com/ros/geometry2/issues/419>)
* Fix python3 compatibility for noetic (#416 <https://github.com/ros/geometry2/issues/416>)
* add <array> from STL (#366 <https://github.com/ros/geometry2/issues/366>)
* use ROS_DEPRECATED macro for portability (#362 <https://github.com/ros/geometry2/issues/362>)
* Contributors: James Xu, Shane Loretz, Tully Foote
```

## tf2_kdl

```
* Make kdl headers available (#419 <https://github.com/ros/geometry2/issues/419>)
* Fix python3 compatibility for noetic (#416 <https://github.com/ros/geometry2/issues/416>)
* Remove roslib.load_manifest #404 <https://github.com/ros/geometry2/issues/404> from otamachan/remove-load-manifest
* Python 3 compatibility: relative imports and print statement
* Contributors: Shane Loretz, Tamaki Nishino, Timon Engelke, Tully Foote
```

## tf2_msgs

- No changes

## tf2_py

```
* use .pyd instead of .so on Windows and export symbols #363 <https://github.com/ros/geometry2/issues/363> from kejxu/fix_tf2_py_export
* limit MSVC-only change to MSVC scope (#10 <https://github.com/ros/geometry2/issues/10>)
* Fix the pyd extension and export the init function.
* use windows counterpart for .so extension
* Contributors: James Xu, Sean Yen, Tully Foote
```

## tf2_ros

```
* Remove roslib.load_manifest #404 <https://github.com/ros/geometry2/issues/404>
* Fix message filter #402 <https://github.com/ros/geometry2/issues/402>
* resolve virtual function call in destructor
* remove pending callbacks in clear()
* spelling fix: seperate -> separate #372 <https://github.com/ros/geometry2/issues/372>
* Fix dangling iterator references in buffer_server.cpp #369 <https://github.com/ros/geometry2/issues/369>
* Remove some useless code from buffer_server_main.cpp #368 <https://github.com/ros/geometry2/issues/368>
* Mark check_frequency as deprecated in docstring.
* Follow #337 <https://github.com/ros/geometry2/issues/337>: use actionlib API in BufferClient::processGoal()
* Test for equality to None with 'is' instead of '==' #355 <https://github.com/ros/geometry2/issues/355>
* added parameter to advertise tf2-frames as a service, if needed
* Contributors: Daniel Ingram, Emre Sahin, JonasTietz, Lucas Walter, Michael Grupp, Robert Haschke, Tamaki Nishino, Tully Foote
```

## tf2_sensor_msgs

```
* Affine->Isometry #378 <https://github.com/ros/geometry2/issues/378>
* Python 3 compatibility: relative imports and print statement
* Contributors: Martin Pecka, Timon Engelke, Tully Foote
```

## tf2_tools

```
* Allow to choose output precision in echo #377 <https://github.com/ros/geometry2/issues/377>
* use yaml.safe_load instead of deprecated yaml.load #373 <https://github.com/ros/geometry2/issues/373>
* Python 3 compatibility: relative imports and print statement
* Contributors: Mikael Arguedas, Timon Engelke, Tully Foote, Victor Lamoine
```
