### PR TITLE
ament_virtualenv: 0.0.5-1 in 'crystal/distribution.yaml' [bloom]

### DIFF
--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -141,7 +141,7 @@ repositories:
       tags:
         release: release/crystal/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_virtualenv` to `0.0.5-1`:

- upstream repository: https://github.com/esol-community/ament_virtualenv.git
- release repository: https://github.com/esol-community/ament_virtualenv-release.git
- distro file: `crystal/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.4-1`

## ament_cmake_virtualenv

```
* fixed various bugs identified by CI
```

## ament_virtualenv

```
* fixed various bugs identified by CI
```
