### PR TITLE
uwb_hardware_driver: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16448,7 +16448,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/inomuh/uwb_hardware_driver-release.git
-      version: 0.1.0-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uwb_hardware_driver` to `0.1.2-1`:

- upstream repository: https://github.com/inomuh/uwb_hardware_driver.git
- release repository: https://github.com/inomuh/uwb_hardware_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-1`

## uwb_hardware_driver

```
* update
* 0.1.1
* update
* Contributors: elcinerdogan
```
