### PR TITLE
Revert "octomap: 1.9.3-1 in 'melodic/distribution.yaml' [bloom] (#233…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5472,7 +5472,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.3-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git


### PR DESCRIPTION
…66)"

This reverts commit 0773b60f73f90012758a0098327028effab48226.

@wxmerkt @jlblancoc This is still causing issues between octomap and mrpt.  I'd like to do a sync, so we can resolve this in three ways:

1.  Going back again to octomap 1.9.0 (this PR).
2.  Dropping mrpt1 from Melodic.
3.  Fixing whatever the underlying problem is (though I won't have time to look into it, and I want to do a Melodic sync next week).

In the absence of any additional information, I'm going to go with option 1 (this PR), but feel free to comment here about what you want to do.