### PR TITLE
flexbe: 1.2.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3587,7 +3587,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.2.3-1`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.2-1`

## flexbe_behavior_engine

```
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* Contributors: Philipp Schillinger
```

## flexbe_core

```
* Merge pull request #97 <https://github.com/team-vigir/flexbe_behavior_engine/issues/97> from team-vigir/feature/test_behaviors
  flexbe_testing support for behaviors
* [flexbe_core] Clear previous outcome requests on state loopback (see #93 <https://github.com/team-vigir/flexbe_behavior_engine/issues/93>)
* [flexbe_core] [flexbe_onboard] Move behavior parametrization to core
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* [flexbe_core] [flexbe_widget] Add simple breakpoint feature (see #93 <https://github.com/team-vigir/flexbe_behavior_engine/issues/93>)
* Merge pull request #88 <https://github.com/team-vigir/flexbe_behavior_engine/issues/88> from team-vigir/fix/concurrency_sleep
  Fix rate sleep of concurrency container
* Fix rate sleep of concurrency container (see #87 <https://github.com/team-vigir/flexbe_behavior_engine/issues/87>)
* Contributors: Philipp Schillinger
```

## flexbe_input

```
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* Contributors: Philipp Schillinger
```

## flexbe_mirror

```
* Revise internal dependencies
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* [flexbe_mirror] Fix mirror sync lock (see FlexBE/flexbe_app#47 <https://github.com/FlexBE/flexbe_app/issues/47>)
* Contributors: Philipp Schillinger
```

## flexbe_msgs

```
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* Contributors: Philipp Schillinger
```

## flexbe_onboard

```
* Merge pull request #97 <https://github.com/team-vigir/flexbe_behavior_engine/issues/97> from team-vigir/feature/test_behaviors
  flexbe_testing support for behaviors
* [flexbe_core] [flexbe_onboard] Move behavior parametrization to core
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* [flexbe_onboard] Use proper tempdir to avoid access right issues for multi-user setups
* Merge pull request #82 <https://github.com/team-vigir/flexbe_behavior_engine/issues/82> from grejj/fix/loglevel
  Changed loglevel from logdebug to loginfo because logdebug doesn't exist in Logger
* Changed loglevel from logdebug to loginfo because logdebug doesn't exist in Logger
* Contributors: Philipp Schillinger, grejj
```

## flexbe_states

```
* Merge pull request #97 <https://github.com/team-vigir/flexbe_behavior_engine/issues/97> from team-vigir/feature/test_behaviors
  flexbe_testing support for behaviors
* Revise internal dependencies
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* [flexbe_testing] Refactor testing framework as basis for new feature
* Contributors: Philipp Schillinger
```

## flexbe_testing

```
* Merge pull request #97 <https://github.com/team-vigir/flexbe_behavior_engine/issues/97> from team-vigir/feature/test_behaviors
  flexbe_testing support for behaviors
* [flexbe_testing] Remove deprecated state tester
* [flexbe_testing] Allow specification of behavior name in test config
* [flexbe_testing] Add support for behavior tests
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* Merge pull request #94 <https://github.com/team-vigir/flexbe_behavior_engine/issues/94> from LoyVanBeek/feature/check_missing_testfile
  Fail test if provided test-yaml-file does not exist
* Generate test results also when test file is missing
* Move test configuration files to StateTester so failing to configure can also be included in the test results
* Fail test if provided test-file does not exist
  There is no way to know which arguments are intended to be filenames, so best we can do is guess?
* [flexbe_testing] Refactor testing framework as basis for new feature
* Contributors: Loy van Beek, Philipp Schillinger
```

## flexbe_widget

```
* Revise internal dependencies
* Merge remote-tracking branch 'origin/develop' into feature/test_behaviors
  # Conflicts:
  #     flexbe_testing/bin/testing_node
  #     flexbe_testing/src/flexbe_testing/state_tester.py
* [flexbe_core] [flexbe_widget] Add simple breakpoint feature (see #93 <https://github.com/team-vigir/flexbe_behavior_engine/issues/93>)
* [flexbe_widget] Support loading files as behavior args for the action server
* Merge pull request #90 <https://github.com/team-vigir/flexbe_behavior_engine/issues/90> from cjue/patch-1
  Fix evaluate_logs usage string: default log path now "~/.flexbe_logs"
* Fix evaluate_logs usage string: default log path now "~/.flexbe_logs"
  Also correct usage string whitespace, remove "," from value list
* Contributors: Christian Jülg, Philipp Schillinger
```
