### PR TITLE
rqt_image_view: 0.4.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8454,7 +8454,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_image_view-release.git
-      version: 0.4.13-0
+      version: 0.4.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `0.4.14-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros-gbp/rqt_image_view-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.13-0`

## rqt_image_view

```
* fix missing include for QSet (#31 <https://github.com/ros-visualization/rqt_image_view/issues/31>)
* add color scheme for depth images (#23 <https://github.com/ros-visualization/rqt_image_view/issues/23>)
```
