### PR TITLE
remove rqt_tf_tree from dashing

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2799,22 +2799,6 @@ repositories:
       url: https://github.com/ros-visualization/rqt_srv.git
       version: crystal-devel
     status: maintained
-  rqt_tf_tree:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/rqt_tf_tree.git
-      version: dashing-devel
-    release:
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.1-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-visualization/rqt_tf_tree.git
-      version: dashing-devel
-    status: maintained
   rqt_top:
     doc:
       type: git


### PR DESCRIPTION
In Dashing the dependency `tf2_ros` doesn't contain any Python code. That has only been ported for Eloquent.