### PR TITLE
Crystal is EOL

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -18,7 +18,7 @@ distributions:
   crystal:
     distribution: [crystal/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz
-    distribution_status: active
+    distribution_status: end-of-life
     distribution_type: ros2
     python_version: 3
   dashing:


### PR DESCRIPTION
Crystal is EOL as of last month we can't accept new PR for it: https://index.ros.org/doc/ros2/Releases/

https://discourse.ros.org/t/preparing-for-final-crystal-sync-and-patch-release-2019-12-12/11792/3