### PR TITLE
ublox: 1.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10065,7 +10065,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KumarRobotics/ublox-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/KumarRobotics/ublox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `1.3.0-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/KumarRobotics/ublox-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.0-1`

## ublox

- No changes

## ublox_gps

```
* Fix heading output to comply with REP-103
  When not reporting valid heading, overwrite covariance with big number (0 otherwise) and fix heading accuracy unit in comments
* CfgNAV5: add dynamic model bike
* Contributors: Ferry Schoenmakers, Raphael Riebl
```

## ublox_msgs

```
* Fix heading output to comply with REP-103
  When not reporting valid heading, overwrite covariance with big number (0 otherwise) and fix heading accuracy unit in comments
* CfgNAV5: add dynamic model bike
* Contributors: Ferry Schoenmakers, Raphael Riebl
```

## ublox_serialization

- No changes
