### PR TITLE
remove release of realsense2_camera due to missing release branches

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7370,7 +7370,6 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Re: https://github.com/ros/rosdistro/pull/23460#issuecomment-572838057

@doronhi FYI I'm rolling back the release @Levi-Armstrong I"m leaving the source entry.