### PR TITLE
ecl_core: 1.0.5-4 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -446,7 +446,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 1.0.4-1
+      version: 1.0.5-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `1.0.5-4`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.4-1`

## ecl_threads

```
* bugfix compilation problem on posix systems without timeout features
```
