### PR TITLE
ecl_lite: 1.0.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -471,7 +471,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 1.0.3-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `1.0.5-1`:

- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.3-1`
