### PR TITLE
ros2_planning_system: 0.0.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1734,6 +1734,7 @@ repositories:
       - plansys2_executor
       - plansys2_lifecycle_manager
       - plansys2_msgs
+      - plansys2_multidomain_example
       - plansys2_patrol_navigation_example
       - plansys2_pddl_parser
       - plansys2_planner
@@ -1743,7 +1744,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `0.0.5-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.4-1`

## plansys2_bringup

- No changes

## plansys2_domain_expert

```
* Add multi domain
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Avoid inserting duplicate types
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_executor

- No changes

## plansys2_lifecycle_manager

- No changes

## plansys2_msgs

- No changes

## plansys2_multidomain_example

```
* Add multi domain
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_patrol_navigation_example

- No changes

## plansys2_pddl_parser

```
* Avoid inserting duplicate types
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_planner

- No changes

## plansys2_problem_expert

```
* Add multi domain
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_simple_example

- No changes

## plansys2_terminal

```
* Add multi domain
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```
