### PR TITLE
ros_controllers: 0.13.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12360,7 +12360,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.13.5-0
+      version: 0.13.6-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.13.6-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.13.5-0`

## ackermann_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

- No changes

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Cherry pick nullptr fix
  * correctly parse joint trajectory options
  * Backport nullptr check
* Print error messages for all exceptions
* Contributors: Bence Magyar, Karsten Knese, Ian Frosst
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

- No changes

## velocity_controllers

- No changes
