### PR TITLE
ros_control: 0.13.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12314,7 +12314,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.13.3-0
+      version: 0.13.4-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.13.4-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.13.3-0`

## combined_robot_hw

```
* add minimum required pluginlib version
* Contributors: Mikael Arguedas
```

## combined_robot_hw_tests

- No changes

## controller_interface

```
* add minimum required pluginlib version
* remove forward declaration of InterfaceResources
* Contributors: Mathias Lüdtke, Mikael Arguedas
```

## controller_manager

```
* Touch up remaining Python2 prints and PEP8
* Initialize controller_manager node using init_node. Fixes #349 <https://github.com/ros-controls/ros_control/issues/349>
* Updated for compatibility with Python2 or Python3
* add minimum required pluginlib version
* Contributors: Bence Magyar, Daniel Ingram, Mikael Arguedas, Stefan Profanter
```

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* add minimum required pluginlib version
* Contributors: Mikael Arguedas
```
