### PR TITLE
ros2_ouster_driver: 0.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2197,7 +2197,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
-      version: 0.0.0-1
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_ouster_driver` to `0.0.2-1`:

- upstream repository: https://github.com/SteveMacenski/ros2_ouster_drivers.git
- release repository: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.0-1`
