### PR TITLE
image_pipeline: 1.14.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3493,7 +3493,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.13.0-1
+      version: 1.14.0-1
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Bloom updated version, created PR manually due to ros-infrastructure/bloom#557

Increasing version of package(s) in repository `image_pipeline` to `1.14.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.13.0-1`

## camera_calibration

```
* Add Fisheye calibration tool (#440 <https://github.com/ros-perception/image_pipeline/issues/440>)
  * Add Fisheye calibration tool
  * Restore camera_calib files permisions
  * Upgrades to calibrator tool for multi model calibration
  * Solve fisheye balance selection
  * Add fisheye calibration flags as user arguments
  * Add undistortion of points for fisheye
  * cam_calib: Style formating
* camera_calibration: Improve YAML formatting, make config dumping methods static (#438 <https://github.com/ros-perception/image_pipeline/issues/438>)
  * Add from __future__ import print_function
  * Improve YAML formatting, make some methods static
  * Improves matrix formatting in YAML.
  * Reduced decimal figures for camera and projection matrix values from 8 to 5.
  * Making the methods static allows them to be used from elsewhere as well to dump calibration info.
* camera_calibration: Fix all-zero distortion coeffs returned for a rational_polynomial model (#433 <https://github.com/ros-perception/image_pipeline/issues/433>)
  * Fix empty distortion coeffs returned for a rational_polynomial model
  * Remove the redundant distCoeffs parameter from cv2.calibrateCamera()
  * Set the shape of distortion_coefficients correctly in YAML output
* Merge pull request #437 <https://github.com/ros-perception/image_pipeline/issues/437> from valgur/enable-calibration-with-empty-queue
  camera_calibration: Make sure 'calibrate' button works even if not receiving images anymore
* Make sure 'calibrate' button works even if not receiving images anymore
* Merge pull request #432 <https://github.com/ros-perception/image_pipeline/issues/432> from valgur/melodic
  camera_calibration: Fix excessive CPU usage due to queue synchronization
* Replace deque with a modified Queue, add --queue-size param
  Base fork on upstream melodic instead of indigo
* Contributors: David Torres Ocaña, Joshua Whitley, Martin Valgur, Tim Übelhör
```

## depth_image_proc

```
* Merge pull request #478 <https://github.com/ros-perception/image_pipeline/issues/478> from ros-perception/steve_main
  added option to fill the sparse areas with neareast neighbor depth va…
* Merge pull request #336 <https://github.com/ros-perception/image_pipeline/issues/336> from madsherlock/indigo
  depth_image_proc/point_cloud_xyzi_radial Add intensity conversion (copy) for float
* depth_image_proc: fix support for mono16 intensity encoding in point_cloud_xyzi node (#352 <https://github.com/ros-perception/image_pipeline/issues/352>)
* added option to fill the sparse areas with neareast neighbor depth values on upsampling operations in depth_image_proc/register
* point_cloud_xyzi Add intensity conversion for float
* Add intensity conversion (copy) for float
  This commit enables the generation of xyzi point clouds from 32-bit floating point intensity images.
  The destination data type for intensity storage is 32-bit float, so all that is required is a data copy.
  The change in this commit is simply an extension of the if-else statement to include the TYPE_32FC1 type and apply the usual convert_intensity() method.
* Contributors: Mikael Westermann, Richard Bormann, Steven Macenski, Stewart Jamieson, Tim Übelhör
```

## image_pipeline

- No changes

## image_proc

```
* resize.cpp: fix memory leak (#489 <https://github.com/ros-perception/image_pipeline/issues/489>)
* Try catch around cvtColor to avoid demosaicing src.empty() error (#463 <https://github.com/ros-perception/image_pipeline/issues/463>)
* Merge pull request #436 <https://github.com/ros-perception/image_pipeline/issues/436> from ros-perception/throttle_warnings
* adding throttled warnings to not blast the users
* Merge pull request #423 <https://github.com/ros-perception/image_pipeline/issues/423> from lucasw/crop_decimate_resolution_change
  Avoid crashing when the x or y offset is too large
* Merge pull request #435 <https://github.com/ros-perception/image_pipeline/issues/435> from ros-perception/patch_resize_copy
* patch extra copy for nodelet users of resize
* Merge pull request #411 <https://github.com/ros-perception/image_pipeline/issues/411> from Tuebel/fix_409
  Fix 409 based on melodic branch
* Need to look at x and y offset
* Simplified copying of the camera_info message.
* Independent resize of image and camera_info
* removed unused infoCb
* Rename infoCb to cameraCb matching subscribeCamera
* replaced boost mutex & shared_ptr with std
* Removed hard coded image encoding.
  Using toCvCopy instead of toCvShared (copy is needed anyway).
* Contributors: Joshua Whitley, Lucas Walter, Tim Übelhör, Yuki Furuta, stevemacenski
```

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

```
* Merge pull request #481 <https://github.com/ros-perception/image_pipeline/issues/481> from ros-perception/fix/reliably-close-image-view
* image_view: Making window close reliably shut down node.
* Removing image_view node and replacing with image_view that loads nodelet. (#479 <https://github.com/ros-perception/image_pipeline/issues/479>)
* Fix build issue re: missing hb.h (#458 <https://github.com/ros-perception/image_pipeline/issues/458>)
* Contributors: Joshua Whitley, Steven Macenski, Tim Übelhör, acxz
```

## stereo_image_proc

```
* Expand range for min_disparity and disparity_range. (#431 <https://github.com/ros-perception/image_pipeline/issues/431>)
* Contributors: Terry Welsh, Tim Übelhör
```