### PR TITLE
transport_drivers: 0.0.4-3 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3075,11 +3075,12 @@ repositories:
       version: master
     release:
       packages:
+      - serial_driver
       - udp_driver
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-drivers-gbp/transport_drivers-release.git
-      version: 0.0.3-1
+      version: 0.0.4-3
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `0.0.4-3`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros-drivers-gbp/transport_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.3-1`

## serial_driver

```
* Making serial_driver version number consistent with repo.
* Initial commit of serial_driver.
* Contributors: Joshua Whitley
```

## udp_driver

```
* Added UdpConfig class to encapsulate configuration options
* Removed workaround for ROS 2 Dashing PR2
* Contributors: Esteve Fernandez
```
