### PR TITLE
Target Fedora 32 in Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,7 +6,8 @@ release_platforms:
   debian:
   - buster
   fedora:
-  - '30'
+  - '31'
+  - '32'
   ubuntu:
   - focal
 repositories:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,7 +6,6 @@ release_platforms:
   debian:
   - buster
   fedora:
-  - '31'
   - '32'
   ubuntu:
   - focal


### PR DESCRIPTION
Fedora 30 is scheduled to EOL around the same time that Noetic is scheduled to release. Fedora 31 is already in production, and Fedora Rawhide will branch for Fedora 32 in February.