### PR TITLE
VisualStates: 0.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,6 +8,22 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  VisualStates:
+    doc:
+      type: git
+      url: https://github.com/JdeRobot/VisualStates.git
+      version: upstream/0.2.2
+    release:
+      packages:
+      - visualstates
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/VisualStates.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/JdeRobot/VisualStates.git
+      version: upstream/0.2.2
   abb:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `VisualStates` to `0.2.2-1`:

- upstream repository: https://github.com/jderobot/VisualStates.git
- release repository: https://github.com/JdeRobot/VisualStates.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
