### PR TITLE
kobuki_ros_interfaces: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -841,6 +841,22 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_msgs.git
       version: release/0.8.x
     status: maintained
+  kobuki_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/kobuki_ros_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    status: maintained
   laser_geometry:
     doc:
       type: git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -826,21 +826,6 @@ repositories:
       url: https://github.com/yujinrobot/kobuki_core.git
       version: devel
     status: maintained
-  kobuki_msgs:
-    doc:
-      type: git
-      url: https://github.com/yujinrobot/kobuki_msgs.git
-      version: release/0.8.x
-    release:
-      tags:
-        release: release/eloquent/{package}/{version}
-      url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
-      version: 0.8.0-1
-    source:
-      type: git
-      url: https://github.com/yujinrobot/kobuki_msgs.git
-      version: release/0.8.x
-    status: maintained
   kobuki_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_ros_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_ros_interfaces.git
- release repository: https://github.com/stonier/kobuki_ros_interfaces-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## kobuki_ros_interfaces

```
* Rename from kobuki_msgs -> kobuki_ros_interfaces, #1 <https://github.com/kobuki-base/kobuki_ros_interfaces/pull/1>
* ROS2 eloquent upgrade, #11 <https://github.com/yujinrobot/kobuki_msgs/issues/11>
```
