### PR TITLE
kobuki_core: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -815,11 +815,10 @@ repositories:
       - kobuki_core
       - kobuki_dock_drive
       - kobuki_driver
-      - kobuki_ftdi
       tags:
         release: release/eloquent/{package}/{version}
-      url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.8.1-1
+      url: https://github.com/stonier/kobuki_core-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -808,8 +808,8 @@ repositories:
   kobuki_core:
     doc:
       type: git
-      url: https://github.com/yujinrobot/kobuki_core.git
-      version: release/0.8.x
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.0.x
     release:
       packages:
       - kobuki_core
@@ -822,7 +822,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/yujinrobot/kobuki_core.git
+      url: https://github.com/kobuki-base/kobuki_core.git
       version: devel
     status: maintained
   kobuki_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.0.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/stonier/kobuki_core-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## kobuki_core

```
* [infra] port and release for ROS2/Eloquent
```

## kobuki_dock_drive

```
* [infra] port and release for ROS2/Eloquent
* [dock] avoid a crash, but falls short of fixing all failing states in the docking sequence #55 <https://github.com/yujinrobot/kobuki_core/pull/55>
* [infra] some minor clang static anlayser fixes, #54 <https://github.com/yujinrobot/kobuki_core/pull/54>
```

## kobuki_driver

```
* [infra] port and release for ROS2/Eloquent
* [infra] udev rule and debian installation thereof, #13 <https://github.com/kobuki-base/kobuki_core/pull/13>.
```
