### PR TITLE
open_street_map: 0.2.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9079,7 +9079,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-geographic-info/open_street_map-release.git
-      version: 0.2.4-0
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_street_map` to `0.2.5-1`:

- upstream repository: https://github.com/ros-geographic-info/open_street_map.git
- release repository: https://github.com/ros-geographic-info/open_street_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.4-0`

## osm_cartography

```
* Remove dependency on rviz from osm_cartography (#18 <https://github.com/ros-geographic-info/open_street_map/issues/18>)
  rviz isn't a strict requirement for running the map server and people who want to use the rviz functionality probably already have rviz installed.
* Publish static marker with time 0. (#14 <https://github.com/ros-geographic-info/open_street_map/issues/14>)
* Contributors: Ronald Ensing, Will Gardner
```

## route_network

- No changes

## test_osm

- No changes
