### PR TITLE
open_street_map: 0.2.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5991,6 +5991,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations.git
       version: melodic-devel
     status: developed
+  open_street_map:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/open_street_map.git
+      version: master
+    release:
+      packages:
+      - osm_cartography
+      - route_network
+      - test_osm
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-geographic-info/open_street_map-release.git
+      version: 0.2.5-1
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/open_street_map.git
+      version: master
+    status: maintained
   opencv_apps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_street_map` to `0.2.5-1`:

- upstream repository: https://github.com/ros-geographic-info/open_street_map.git
- release repository: https://github.com/ros-geographic-info/open_street_map-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## osm_cartography

```
* Remove dependency on rviz from osm_cartography (#18 <https://github.com/ros-geographic-info/open_street_map/issues/18>)
  rviz isn't a strict requirement for running the map server and people who want to use the rviz functionality probably already have rviz installed.
* Publish static marker with time 0. (#14 <https://github.com/ros-geographic-info/open_street_map/issues/14>)
* Contributors: Ronald Ensing, Will Gardner
```

## route_network

- No changes

## test_osm

- No changes
