### PR TITLE
robot_calibration: 0.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7577,7 +7577,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.6.2-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.1-1`

## robot_calibration

```
* Merge pull request #75 <https://github.com/mikeferguson/robot_calibration/issues/75> from mikeferguson/mute_warnings
  fix warnings about build type
* fix warnings about build type
* Merge pull request #74 <https://github.com/mikeferguson/robot_calibration/issues/74> from mikeferguson/fix_tests
  fix tests broken by #71 <https://github.com/mikeferguson/robot_calibration/issues/71>
* fix tests broken by #71 <https://github.com/mikeferguson/robot_calibration/issues/71>
* Merge pull request #71 <https://github.com/mikeferguson/robot_calibration/issues/71> from Naoki-Hiraoka/fix-calculation-of-frame_offset
  Fix calculation of frame offset
* Merge pull request #73 <https://github.com/mikeferguson/robot_calibration/issues/73> from mikeferguson/multi-step
  Support multi-step optimization
* Merge pull request #68 <https://github.com/mikeferguson/robot_calibration/issues/68> from d-walsh/bugfix/isnan_error
  Fixed isnan() error on Kinetic
* refactor mutli-step support
* enable multi-step optimization
* fix frame calculation in getChainFK()
* fix calculation of frame_offset
* Fixed isnan() error on Kinetic
* Contributors: David Walsh, Michael Ferguson, Naoki-Hiraoka
```

## robot_calibration_msgs

- No changes
