### PR TITLE
rqt_console: 0.4.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8663,7 +8663,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_console-release.git
-      version: 0.4.8-0
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros-gbp/rqt_console-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.8-0`

## rqt_console

```
* fix division in Python 3 (#18 <https://github.com/ros-visualization/rqt_console/issues/18>)
* fix highlight filter by message (#17 <https://github.com/ros-visualization/rqt_console/issues/17>)
* fix exclude messages (#11 <https://github.com/ros-visualization/rqt_console/issues/11>)
* add context menu for hiding and showing columns (#13 <https://github.com/ros-visualization/rqt_console/issues/13>)
* fix handle_pause_clicked doesn't need args (#15 <https://github.com/ros-visualization/rqt_console/issues/15>)
* add Python 3 conditional dependencies (#14 <https://github.com/ros-visualization/rqt_console/issues/14>)
* flake8 (#7 <https://github.com/ros-visualization/rqt_console/issues/7>)
* autopep8 (#6 <https://github.com/ros-visualization/rqt_console/issues/6>)
```
