### PR TITLE
rqt_console: 1.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2152,7 +2152,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.1.0-1`

## rqt_console

```
* fix division in Python 3 (#18 <https://github.com/ros-visualization/rqt_console/issues/18>)
* fix highlight filter by message (#17 <https://github.com/ros-visualization/rqt_console/issues/17>)
* fix exclude messages (#11 <https://github.com/ros-visualization/rqt_console/issues/11>)
* add context menu for hiding and showing columns (#13 <https://github.com/ros-visualization/rqt_console/issues/13>)
* remove topics concept which has been removed in ROS 2 (#16 <https://github.com/ros-visualization/rqt_console/issues/16>)
* fix handle_pause_clicked doesn't need args (#15 <https://github.com/ros-visualization/rqt_console/issues/15>)
```
