### PR TITLE
kobuki_ftdi: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -825,6 +825,21 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_core.git
       version: devel
     status: maintained
+  kobuki_ftdi:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ftdi.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/kobuki_ftdi-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ftdi.git
+      version: release/1.0.x
+    status: maintained
   kobuki_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_ftdi` to `1.0.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_ftdi.git
- release repository: https://github.com/stonier/kobuki_ftdi-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## kobuki_ftdi

```
* [infra] v1 release
* [read] bugfix to process errors on return from ftdi_read_eeprom
```
