### PR TITLE
kobuki_ros: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -825,6 +825,22 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_core.git
       version: devel
     status: maintained
+  kobuki_ros:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/kobuki_ros-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: devel
+    status: maintained
   kobuki_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_ros` to `1.0.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_ros.git
- release repository: https://github.com/stonier/kobuki_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## kobuki_ros

```
* first release on eloquent
```
