### PR TITLE
toposens: 2.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9954,7 +9954,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.3.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.0.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.0-1`

## toposens

```
* Added surface normal vector of each point in PointCloud representation
* Contributors: Inshal Uddin, Sebastian Dengler
```

## toposens_description

```
* Rescaled STL and Collada files
* Contributors: Sebastian Dengler
```

## toposens_driver

- No changes

## toposens_markers

- No changes

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Generate a surface normal vector for each detected point
* Converted PointCloud of type TsPoint to PointCloud of type PointXYZINormal
* Added option to visualize normal vectors as arrows
* Contributors: Inshal Uddin, Sebastian Dengler
```

## toposens_sync

- No changes
