### PR TITLE
webots_ros: 2.0.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17015,7 +17015,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git


### PR DESCRIPTION
The packages in the `webots_ros` repository were released into the `kinetic` distro by running `/usr/bin/bloom-release --rosdistro kinetic --track kinetic webots_ros --edit` on `Wed, 15 Jan 2020 09:43:36 -0000`

The `webots_ros` package was released.

Version of package(s) in repository `webots_ros`:

- upstream repository: https://github.com/omichel/webots_ros.git
- release repository: https://github.com/cyberbotics/webots_ros-release.git
- rosdistro version: `2.0.5-1`
- old version: `2.0.5-1`
- new version: `2.0.6-1`

Versions of tools used:

- bloom version: `0.9.0`
- catkin_pkg version: `0.4.15`
- rosdep version: `0.18.0`
- rosdistro version: `0.8.0`
- vcstools version: `0.1.42`