### PR TITLE
Add python3-kitchen rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5248,7 +5248,9 @@ python3-kitchen:
   osx:
     pip:
       packages: [kitchen]
-  ubuntu: [python3-kitchen]
+  ubuntu:
+    '*': [python3-kitchen]
+    xenial: null
 python3-lark-parser:
   debian:
     buster: [python3-lark-parser]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5240,6 +5240,15 @@ python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]
   ubuntu: [python3-imageio]
+python3-kitchen:
+  arch: [python-kitchen]
+  debian: [python3-kitchen]
+  fedora: [python3-kitchen]
+  gentoo: [dev-python/kitchen]
+  osx:
+    pip:
+      packages: [kitchen]
+  ubuntu: [python3-kitchen]
 python3-lark-parser:
   debian:
     buster: [python3-lark-parser]


### PR DESCRIPTION
* https://www.archlinux.org/packages/community/any/python-kitchen/ 
* https://packages.debian.org/buster/python3-kitchen
* https://apps.fedoraproject.org/packages/python3-kitchen
* https://packages.gentoo.org/packages/dev-python/kitchen
* https://pypi.org/project/kitchen/
* https://packages.ubuntu.com/bionic/python3-kitchen


Used by [rosdoc_lite](https://github.com/ros-infrastructure/rosdoc_lite/blob/ec884e5f17f962698c653453ece65ffed03fb21d/package.xml#L25)