### PR TITLE
ament_virtualenv: 0.0.5-6 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -142,6 +142,25 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: eloquent
     status: developed
+  ament_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    release:
+      packages:
+      - ament_cmake_virtualenv
+      - ament_virtualenv
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/esol-community/ament_virtualenv-release.git
+      version: 0.0.5-6
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    status: developed
   angles:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_virtualenv` to `0.0.5-6`:

- upstream repository: https://github.com/esol-community/ament_virtualenv.git
- release repository: https://github.com/esol-community/ament_virtualenv-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ament_cmake_virtualenv

```
* fixed various bugs identified by CI
```

## ament_virtualenv

```
* fixed various bugs identified by CI
```
