### PR TITLE
Add google-glog and lua52 for Arch Linux

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -907,6 +907,7 @@ gazebo7:
   slackware: [gazebo]
   ubuntu: [gazebo7]
 gazebo9:
+  arch: [gazebo]
   debian:
     buster: [gazebo9]
     stretch: [gazebo9]
@@ -1985,6 +1986,7 @@ libgazebo7-dev:
   slackware: [gazebo]
   ubuntu: [libgazebo7-dev]
 libgazebo9-dev:
+  arch: [gazebo]
   debian:
     buster: [libgazebo9-dev]
     stretch: [libgazebo9-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -907,7 +907,6 @@ gazebo7:
   slackware: [gazebo]
   ubuntu: [gazebo7]
 gazebo9:
-  arch: [gazebo]
   debian:
     buster: [gazebo9]
     stretch: [gazebo9]
@@ -1666,7 +1665,6 @@ libcereal-dev:
   gentoo: [dev-libs/cereal]
   ubuntu: [libcereal-dev]
 libceres-dev:
-  arch: [ceres-solver]
   debian:
     buster: [libceres-dev]
     stretch: [libceres-dev]
@@ -1986,7 +1984,6 @@ libgazebo7-dev:
   slackware: [gazebo]
   ubuntu: [libgazebo7-dev]
 libgazebo9-dev:
-  arch: [gazebo]
   debian:
     buster: [libgazebo9-dev]
     stretch: [libgazebo9-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1665,6 +1665,7 @@ libcereal-dev:
   gentoo: [dev-libs/cereal]
   ubuntu: [libcereal-dev]
 libceres-dev:
+  arch: [ceres-solver]
   debian:
     buster: [libceres-dev]
     stretch: [libceres-dev]
@@ -2104,6 +2105,7 @@ libgomp1:
   gentoo: [sys-libs/gcc]
   ubuntu: [libgomp1]
 libgoogle-glog-dev:
+  arch: [google-glog]
   debian: [libgoogle-glog-dev]
   fedora: [glog-devel]
   gentoo: [dev-cpp/glog]
@@ -4035,6 +4037,7 @@ lua-dev:
   macports: [lua51]
   ubuntu: [liblua5.1-0-dev]
 lua5.2-dev:
+  arch: [lua52]
   debian: [liblua5.2-dev]
   fedora: [lua]
   gentoo: ['dev-lang/lua:5.2']


### PR DESCRIPTION
Gazebo was not specified before. It is only available in the AUR, but as other system dependencies also specify gazebo for Arch it is fine.

lua52: https://www.archlinux.org/packages/extra/x86_64/lua52/
google-glog: https://www.archlinux.org/packages/community/x86_64/google-glog/

AUR:
ceres-solver: https://aur.archlinux.org/packages/ceres-solver/
gazebo: https://aur.archlinux.org/packages/gazebo/