### PR TITLE
dataspeed_can: 1.0.14-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2295,7 +2295,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.12-0
+      version: 1.0.14-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.14-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.12-0`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

```
* Make setting the intermessage lowerbound simpler
* Document Approximate Time synchronizer using ros wiki
* Contributors: Kevin Hallenbeck, Lincoln Lorenz
```

## dataspeed_can_tools

- No changes

## dataspeed_can_usb

- No changes
