### PR TITLE
genmsg: 0.5.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -130,6 +130,7 @@ repositories:
       url: https://github.com/ros-gbp/genmsg-release.git
       version: 0.5.13-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/genmsg.git
       version: kinetic-devel

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -120,6 +120,15 @@ repositories:
       version: groovy-devel
     status: maintained
   genmsg:
+    doc:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.5.13-1
     source:
       type: git
       url: https://github.com/ros/genmsg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.13-1`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## genmsg

```
* fix escape sequences (#89 <https://github.com/ros/genmsg/issues/89>)
* Python 3 compatibility (#86 <https://github.com/ros/genmsg/issues/86>)
* improve MsgNotFound exception information
```
