### PR TITLE
Add python3-distutils key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5152,10 +5152,14 @@ python3-dev:
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-distutils:
-  debian: [python3-distutils]
+  debian:
+    '*': [python3-distutils]
+    stretch: null
   fedora: [python3]
   gentoo: [dev-lang/python]
-  ubuntu: [python3-distutils]
+  ubuntu:
+    '*': [python3-distutils]
+    xenial: null
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5151,6 +5151,11 @@ python3-dev:
   openembedded: [python3@openembedded-core]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
+python3-distutils:
+  debian: [python3-distutils]
+  fedora: [python3]
+  gentoo: [dev-lang/python]
+  ubuntu: [python3-distutils]
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]


### PR DESCRIPTION
* https://packages.debian.org/buster/python3-distutils
* https://packages.gentoo.org/packages/dev-lang/python
* https://apps.fedoraproject.org/packages/python3
* https://packages.ubuntu.com/focal/python3-distutils

Needed by [`genmsg`](https://github.com/ros/genmsg/blob/1ad8e136cd6311c6af12256fc39362334ca23988/setup.py#L1). See [this failing build](http://build.ros.org/job/Ndev__genmsg__ubuntu_focal_amd64/2/console). For fedora and gentoo the key just points to python. I couldn't find an equivalent on those platforms, so I'm assuming they don't split `distutils` into a separate package. This seems like a safe assumption since [distutils is part of cpython](https://github.com/python/cpython/tree/master/Lib/distutils).