### PR TITLE
kobuki_ros: 1.0.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -840,6 +840,22 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_ftdi.git
       version: release/1.0.x
     status: maintained
+  kobuki_ros:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/kobuki_ros-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: release/1.0.x
+    status: maintained
   kobuki_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_ros` to `1.0.0-2`:

- upstream repository: https://github.com/kobuki-base/kobuki_ros.git
- release repository: https://github.com/stonier/kobuki_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## kobuki_ros

```
* first release on eloquent
```
