### PR TITLE
vision_opencv: 2.1.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2799,7 +2799,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.1.4-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.1.3-1`

## cv_bridge

- No changes

## image_geometry

```
* Updated fromCameraInfo function to match ROS2 CameraInfo message (#295 <https://github.com/ros-perception/vision_opencv/issues/295>)
* Contributors: Luca Della Vedova
```

## vision_opencv

- No changes
