### PR TITLE
class_loader: 1.4.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -255,7 +255,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `1.4.1-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.4.0-1`

## class_loader

```
* Use .empty() to check for an empty string. (#132 <https://github.com/ros/class_loader/issues/132>)
* Fix travis on macOS. (#135 <https://github.com/ros/class_loader/issues/135>)
* Contributors: Chris Lalancette
```
