### PR TITLE
rosidl: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1984,7 +1984,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-1`

## rosidl_adapter

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Fix double free issue when initialization is failed (#423 <https://github.com/ros2/rosidl/issues/423>)
* Contributors: DongheeYe
```

## rosidl_generator_cpp

- No changes

## rosidl_parser

```
* Allow 'get_const_expr_value' to parse either literals or scoped_names… (#430 <https://github.com/ros2/rosidl/issues/430>)
* Use imperative mood in constructor docstring. (#425 <https://github.com/ros2/rosidl/issues/425>)
* Contributors: Steven! Ragnarök, kylemarcey
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
