### PR TITLE
ros1_bridge: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1746,7 +1746,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.8.1-4
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.1-4`

## ros1_bridge

```
* fix building test when ROS 1 diagnostic_msgs is isolated from roscpp (#236 <https://github.com/ros2/ros1_bridge/issues/236>)
* fix service with custom mapped message field (#234 <https://github.com/ros2/ros1_bridge/issues/234>)
* Contributors: Dirk Thomas
```
