### PR TITLE
rclpy: 0.8.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1517,7 +1517,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.8.4-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.3-1`

## rclpy

```
* Guard against unexpected action responses (#474 <https://github.com/ros2/rclpy/issues/474>) (#476 <https://github.com/ros2/rclpy/issues/476>)
* Send feedback callbacks properly in send_goal() of action client (#451 <https://github.com/ros2/rclpy/issues/451>) (#465 <https://github.com/ros2/rclpy/issues/465>)
* Contributors: Jacob Perron, Werner Neubauer
```
