### PR TITLE
Adding release information for the kvh_geo_fog_3d set of packages.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6221,6 +6221,16 @@ repositories:
       type: git
       url: https://github.com/MITRE/kvh_geo_fog_3d.git
       version: master
+    release:
+      packages:
+      - kvh_geo_fog_3d
+      - kvh_geo_fog_3d_driver
+      - kvh_geo_fog_3d_msgs
+      - kvh_geo_fog_3d_rviz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/MITRE/kvh_geo_fog_3d-release.git
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/MITRE/kvh_geo_fog_3d.git


### PR DESCRIPTION
The -release repository is now up, populated, and ready for the Kinetic release. Melodic to follow.