### PR TITLE
rclcpp: 0.8.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1501,7 +1501,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `0.8.4-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.3-1`

## rclcpp

```
* Intra-process subscriber should use RMW actual qos (ros2`#913 <https://github.com/ros2/rclcpp/issues/913>`_) (#914 <https://github.com/ros2/rclcpp/issues/914>) (#965 <https://github.com/ros2/rclcpp/issues/965>)
* Contributors: Todd Malsbary
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Remove absolute path from installed CMake code (#948 <https://github.com/ros2/rclcpp/issues/948>) (#950 <https://github.com/ros2/rclcpp/issues/950>)
* Contributors: Jacob Perron
```

## rclcpp_lifecycle

- No changes
