### PR TITLE
velocity_smoother: 0.13.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2786,6 +2786,22 @@ repositories:
       url: https://github.com/ros2/variants.git
       version: master
     status: maintained
+  velocity_smoother:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/velocity_smoother.git
+      version: release/0.13.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/velocity_smoother-release.git
+      version: 0.13.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/velocity_smoother.git
+      version: devel
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velocity_smoother` to `0.13.0-1`:

- upstream repository: https://github.com/kobuki-base/velocity_smoother.git
- release repository: https://github.com/stonier/velocity_smoother-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## velocity_smoother

```
* Refactored for ROS 2 and renamed to velocity_smoother, #1 <https://github.com/kobuki-base/velocity_smoother/pull/1>
```
