### PR TITLE
Fix mapviz branches

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6900,7 +6900,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     release:
       packages:
       - mapviz
@@ -6915,7 +6915,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     status: developed
   marker_msgs:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4523,7 +4523,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     release:
       packages:
       - mapviz
@@ -4538,7 +4538,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     status: developed
   marker_msgs:
     doc:


### PR DESCRIPTION
Development and documentation for mapviz are on the `master` branch for
both Kinetic and Melodic, not `kinetic-devel`, so these need to be
updated appropriately.