### PR TITLE
axis_camera: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -694,6 +694,21 @@ repositories:
       url: https://github.com/aws-robotics/utils-ros1.git
       version: master
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/axis_camera-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    status: unmaintained
   backward_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `0.3.0-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/ros-drivers-gbp/axis_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## axis_camera

```
* Merge pull request #49 <https://github.com/ros-drivers/axis_camera/issues/49> from rossctaylor/feature/support_for_f34
  Add: support for Axis F34 multicamera switch
* Merge pull request #48 <https://github.com/ros-drivers/axis_camera/issues/48> from tonybaltovski/pan-tilt-parms
  Added ROS params for the pan and tilt axis.
* Contributors: Ross Taylor, Tony Baltovski
```
