### PR TITLE
mcl_3dl_msgs: 0.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7102,7 +7102,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl_msgs-release.git
-      version: 0.1.2-0
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl_msgs.git
- release repository: https://github.com/at-wat/mcl_3dl_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.2-0`

## mcl_3dl_msgs

```
* Update assets to v0.0.6 (#11 <https://github.com/at-wat/mcl_3dl_msgs/issues/11>)
* Update assets to v0.0.5 (#10 <https://github.com/at-wat/mcl_3dl_msgs/issues/10>)
* Add catkin/bloom release action (#8 <https://github.com/at-wat/mcl_3dl_msgs/issues/8>)
* Expose internal errors (#7 <https://github.com/at-wat/mcl_3dl_msgs/issues/7>)
* Refactor CI scripts (#6 <https://github.com/at-wat/mcl_3dl_msgs/issues/6>)
* Fix package dependencies (#5 <https://github.com/at-wat/mcl_3dl_msgs/issues/5>)
* Add test on ROS Melodic (#4 <https://github.com/at-wat/mcl_3dl_msgs/issues/4>)
* Contributors: Atsushi Watanabe, Daiki Maekawa
```
