### PR TITLE
neonavigation: 0.6.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5461,7 +5461,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.5.1-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.6.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.1-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

- No changes

## safety_limiter

```
* safety_limiter: use fixed frame for accumulating input cloud (#421 <https://github.com/at-wat/neonavigation/issues/421>)
* Contributors: Yuta Koga
```

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: add a service to clear recorded path (#422 <https://github.com/at-wat/neonavigation/issues/422>)
* Contributors: Naotaka Hatao
```
