### PR TITLE
Revert "geometry2: 0.6.6-1 in 'melodic/distribution.yaml' [bloom] (#2…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2996,7 +2996,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.6.6-1
+      version: 0.6.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
…3469)"

This reverts commit 4e42f5ed7e1181376c2c0a077efdd2d3698becb7.

@tfoote @rhaschke FYI