### PR TITLE
launch: 0.9.5-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -922,7 +922,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.5-1
+      version: 0.9.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.9.5-2`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.5-1`

## launch

```
* fix PendingDeprecationWarning about asyncio.Task.current_task (#355 <https://github.com/ros2/launch/issues/355>)
* import collections.abc (#354 <https://github.com/ros2/launch/issues/354>)
* Contributors: Dirk Thomas
```

## launch_testing

```
* Make launch_testing.markers.retry_on_failure decorator more robust. (#352 <https://github.com/ros2/launch/issues/352>)
* Contributors: Michel Hidalgo
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
