### PR TITLE
Updating release version for kvh_geo_fog_3d packages.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6230,7 +6230,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/MITRE/kvh_geo_fog_3d-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://github.com/MITRE/kvh_geo_fog_3d.git


### PR DESCRIPTION
Includes a bugfix for a missing dependendy in the kvh_geo_fog_3d_rviz package.