### PR TITLE
launch: 0.9.6-1 in 'eloquent/distribution.yaml'

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -922,7 +922,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.5-1
+      version: 0.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Bloom failed to open this PR, but the rest of the process was ok (I think).

Increasing version of package(s) in repository launch to 0.9.6-1:

upstream repository: https://github.com/ros2/launch.git
release repository: https://github.com/ros2-gbp/launch-release.git
distro file: eloquent/distribution.yaml
bloom version: 0.9.0
previous version for package: 0.9.5-1