### PR TITLE
launch_ros: 0.9.5-1 in 'eloquent/distribution.yaml'

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -942,7 +942,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.9.4-1
+      version: 0.9.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Bloom failed to open this PR, but the rest of the process was ok (I think).

----

Increasing version of package(s) in repository launch_ros to 0.9.5-1:

upstream repository: https://github.com/ros2/launch_ros.git
release repository: https://github.com/ros2-gbp/launch_ros-release.git
distro file: eloquent/distribution.yaml
bloom version: 0.9.0
previous version for package: 0.9.4-1