### PR TITLE
joint_state_publisher: 1.12.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3801,10 +3801,13 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.12.13-0
+      version: 1.12.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `1.12.14-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros-gbp/joint_state_publisher-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.12.13-0`

## joint_state_publisher

```
* Split jsp and jsp gui (#31 <https://github.com/ros/joint_state_publisher/issues/31>)
* Only update one joint slider on value changed. (#11 <https://github.com/ros/joint_state_publisher/issues/11>)
* ignore 'planar' joints just as 'fixed' and 'floating' (#14 <https://github.com/ros/joint_state_publisher/issues/14>)
* Make GUI window scroll & resize for large robots (#10 <https://github.com/ros/joint_state_publisher/issues/10>)
* Contributors: Andy McEvoy, Chris Lalancette, Michael Görner
```

## joint_state_publisher_gui

```
* Split jsp and jsp gui (#31 <https://github.com/ros/joint_state_publisher/issues/31>)
* Contributors: Chris Lalancette
```
