### PR TITLE
Revert "toposens: 2.0.0-1 in 'melodic/distribution.yaml' [bloom]"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10021,7 +10021,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.0.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Reverts ros/rosdistro#23521

Due to failure to build on all platforms due to a missing dependency. Ticketed at: https://gitlab.com/toposens/public/ros-packages/issues/30

@clalancette FYI