### PR TITLE
fmilibrary_vendor: 0.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -646,7 +646,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/boschresearch/fmilibrary_vendor-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/boschresearch/fmilibrary_vendor-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.1-1`

## fmilibrary_vendor

```
* Updated to FMILibrary version 2.1 and new location on GitHub.
```
