### PR TITLE
cloudwatch_metrics_collector: 2.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1109,7 +1109,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_metrics_collector` to `2.2.0-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git
- release repository: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.1.1-1`

## cloudwatch_metrics_collector

```
* Bump package version to 2.2.0 (#42 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/42>)
* Fix default metric options
  - Fix bug where default metric storage directory, file prefix etc were
  being set to the same as logs causing issues when running both
  cloudwatch logs and metrics at the same time.
* Merge pull request #37 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/37> from aws-robotics/restore-tests
  Restored unit tests
* Restored unit tests
* 
  
    * minor README changes (#35 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/35>)
    * remove debug flag (run with level info)
  
* install missing library (#33 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/33>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* increment version for offline metrics feature (#32 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/32>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Fixing std_msgs, std_srvs dependency resolution (#30 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/30>)
  * Add std_msgs to CMakeLists.txt
  * Add build_depend on std_srvs, std_msgs
* Find std_srvs in CMakeLists.txt
* Offline Metrics (#28 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/28>)
  * ROS-1775: Adapt Interfaces to CW Metrics
  cr https://code.amazon.com/reviews/CR-10106570
  * Addressed review comments
  * Add reading of parameters from config file
  - Add reading of CloudWatch upload and file management settings from the
  config file. This is very similar to CloudWatchLogs parameter reading
  but using a different base CloudWatchOptions with some different default
  settings
  - Add sample configuration file that has all the same values as the
  default values for each option in alphabetical order.
  cr https://code.amazon.com/reviews/CR-10331605
  * Disable trigger_publish_size by default. Add comment that it cannot be larger than max_queue_size
  * Move advanced configuration to README, code style fixes
  - Move all the advanced configuration parameters for offline metrics to the
  README instead of the sample configuration.
  - Improve parameter reading to re-use functions more and not return any
  codes if they're just going to be ignored.
  cr https://code.amazon.com/reviews/CR-10537580
  * Style fixes. Change missing param WARN's to INFO's
  * [Bug] CW Metrics ROS1 Timer incorrectly created
  cr https://code.amazon.com/reviews/CR-10549890
  * Remove stream_max_queue_size as it's not used
  * Improved README. Removed performance benchmarking
  * Add stream_max_queue_size parameter
  Add reading this parameter from config file and describing it in the advanced parameters section of the README.
  cr https://code.amazon.com/reviews/CR-10583080
  *  - support service changes
  - add query for connection state
  * fix unit test failure
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Use standard CMake macros for adding gtest/gmock tests (#25 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/25>)
  * modify cloudwatch_metrics_collector to use add_rostest_gmock()
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml to be compatible with specifying multiple package names
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Add test for timestamp extraction from MetricData
* fix broken build when cmake/rostest cannot find the gmock library (#13 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/13>)
* Fix timestamp conversion bug #10 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/10>
* Update CMakeLists.txt
* Update to use non-legacy ParameterReader API (#7 <https://github.com/aws-robotics/cloudwatchmetrics-ros1/issues/7>)
  * Update to use non-legacy ParameterReader API
  * increment package version
  * address comments, remove use of Aws::CloudWatch::Metrics namespace
* Allow users to configure ROS output location
* Contributors: AAlon, Devin Bonnie, Juan Rodriguez Hortala, M. M, Ryan Newell, Tim Robinson
```
