### PR TITLE
lex_node: 2.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6418,7 +6418,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/lex_node-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lex_node` to `2.0.2-1`:

- upstream repository: https://github.com/aws-robotics/lex-ros1.git
- release repository: https://github.com/aws-gbp/lex_node-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.1-1`

## lex_common_msgs

```
* Update lex_common_msgs and lex_node versions to 2.0.2 (#30 <https://github.com/aws-robotics/lex-ros1/issues/30>)
* Refactor to make use of lex-common package (#28 <https://github.com/aws-robotics/lex-ros1/issues/28>)
  * Refactor common components of lex-ros1 into lex-common
  * fix missing header file compilation error
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* increment patch version (#25 <https://github.com/aws-robotics/lex-ros1/issues/25>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Update package.xml
* Contributors: AAlon, M. M, Ryan Newell
```

## lex_node

```
* Update lex_common_msgs and lex_node versions to 2.0.2 (#30 <https://github.com/aws-robotics/lex-ros1/issues/30>)
* Refactor to make use of lex-common package (#28 <https://github.com/aws-robotics/lex-ros1/issues/28>)
  * Refactor common components of lex-ros1 into lex-common
  * fix missing header file compilation error
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* increment patch version (#25 <https://github.com/aws-robotics/lex-ros1/issues/25>)
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Add gtest and gmock as test dependencies (#17 <https://github.com/aws-robotics/lex-ros1/issues/17>)
  * Add gtest and gmock as test dependencies
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * modify lex_node to use add_rostest_gmock()
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml to be compatible with specifying multiple package names
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Update to use non-legacy ParameterReader API (#12 <https://github.com/aws-robotics/lex-ros1/issues/12>)
* Update to use new ParameterReader API (#10 <https://github.com/aws-robotics/lex-ros1/issues/10>)
  * update lex_node_test to use the new ParameterReader API
  * increment major version number in package.xml
* Revert ParameterReader change (#8 <https://github.com/aws-robotics/lex-ros1/issues/8>)
  * Revert "Updating lex_node_test.cpp to conform to the new ParameterReader API (#6 <https://github.com/aws-robotics/lex-ros1/issues/6>)"
  This reverts commit 98b1fe112bcff0d01cf43620d17e4c956e3e9832.
  https://github.com/aws-robotics/utils-common/issues/15
* Updating lex_node_test.cpp to conform to the new ParameterReader API (#6 <https://github.com/aws-robotics/lex-ros1/issues/6>)
  * update lex_node_test.cpp to conform to the new ParameterReader API
  * update lex_node to be compatible with newer aws sdk
  * use master branch for cloud extension dependencies
* Contributors: AAlon, M. M, Ross Desmond, Ryan Newell
```
