### PR TITLE
tts: 2.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3098,7 +3098,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/tts-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/tts-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tts` to `2.0.2-1`:

- upstream repository: https://github.com/aws-robotics/tts-ros2.git
- release repository: https://github.com/aws-gbp/tts-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.1-1`

## tts

```
* bump version of tts to 2.0.2 in setup.py (#16 <https://github.com/aws-robotics/tts-ros2/issues/16>)
* bump package version for tts and tts_interfaces to 2.0.2 (#15 <https://github.com/aws-robotics/tts-ros2/issues/15>)
* missed a change with moving voicer.py to scripts directory in https://github.com/aws-robotics/tts-ros2/pull/13
* move voicer to subdirectory similar to tts-ros1
* remove unnecessary lines of code from unit tests
* Contributors: M M, Ryan Newell
```

## tts_interfaces

```
* bump package version for tts and tts_interfaces to 2.0.2 (#15 <https://github.com/aws-robotics/tts-ros2/issues/15>)
* Contributors: Ryan Newell
```
