### PR TITLE
costmap_converter: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -526,6 +526,25 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: crystal-devel
     status: maintained
+  costmap_converter:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: ros2
+    release:
+      packages:
+      - costmap_converter
+      - costmap_converter_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/costmap_converter-ros2-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: ros2
+    status: developed
   cross_compile:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.1.0-1`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-ros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## costmap_converter

```
* Port to ROS2 (thanks to Vinnam Kim and stevemacenski)
* Messages moved to a separate package
* Contributors: Christoph Rösmann, Vinnam Kim, stevemacenski
```

## costmap_converter_msgs

```
* Messages moved to a separate package
* Contributors: Vinnam Kim
```
