### PR TITLE
libg2o: 2019.11.23-3 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -949,6 +949,21 @@ repositories:
       url: https://github.com/ros2/launch_ros.git
       version: eloquent
     status: developed
+  libg2o:
+    doc:
+      type: git
+      url: https://github.com/RainerKuemmerle/g2o.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/libg2o-release.git
+      version: 2019.11.23-3
+    source:
+      type: git
+      url: https://github.com/RainerKuemmerle/g2o.git
+      version: master
+    status: maintained
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libg2o` to `2019.11.23-3`:

- upstream repository: https://github.com/RainerKuemmerle/g2o.git
- release repository: https://github.com/ros2-gbp/libg2o-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
