### PR TITLE
astuff_sensor_msgs: 3.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -545,7 +545,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 2.3.1-0
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `3.0.1-1`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.3.1-0`

## astuff_sensor_msgs

```
* Hybridizing astuff_sensor_msgs package.
* Adding ros_environment as required package to all packages.
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## delphi_esr_msgs

```
* Adding ros_environment as required package to all packages.
* ROS1/2 Hybrid: delphi_esr_msgs (#37 <https://github.com/astuff/astuff_sensor_msgs/issues/37>)
  * Adding hybrid CI.
  * Hybridizing delphi_esr_msgs.
  * Updating package.xml files for ROS2 rosdep.
  * Adding message migration rules.
* Contributors: Joshua Whitley
```

## delphi_mrr_msgs

```
* Adding ros_environment as required package to all packages.
* Hybridizing delphi_mrr_msgs. (#39 <https://github.com/astuff/astuff_sensor_msgs/issues/39>)
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## delphi_srr_msgs

```
* Adding ros_environment as required package to all packages.
* ROS1/ROS2 Hybrid: delphi_srr_msgs (#40 <https://github.com/astuff/astuff_sensor_msgs/issues/40>)
  * Hybridizing delphi_srr_msgs.
  * Adding message migration rules.
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## derived_object_msgs

```
* Adding ros_environment as required package to all packages.
* Hybridize derived_object_msgs. (#44 <https://github.com/astuff/astuff_sensor_msgs/issues/44>)
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## ibeo_msgs

```
* Adding ros_environment as required package to all packages.
* ROS1/ROS2 Hybrid: ibeo_msgs (#42 <https://github.com/astuff/astuff_sensor_msgs/issues/42>)
  * Hybridizing ibeo_msgs.
  * CI: Changing strategy for package selection.
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## kartech_linear_actuator_msgs

```
* Adding ros_environment as required package to all packages.
* Hybridizing kartech_linear_actuator_msgs. (#43 <https://github.com/astuff/astuff_sensor_msgs/issues/43>)
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## mobileye_560_660_msgs

```
* Adding ros_environment as required package to all packages.
* Hybridizing mobileye_560_660_msgs. (#45 <https://github.com/astuff/astuff_sensor_msgs/issues/45>)
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## neobotix_usboard_msgs

```
* Adding ros_environment as required package to all packages.
* Hybridizing neobotix_usboard_msgs. (#46 <https://github.com/astuff/astuff_sensor_msgs/issues/46>)
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```

## pacmod_msgs

```
* ROS1/ROS2 Hybrid: pacmod_msgs (#47 <https://github.com/astuff/astuff_sensor_msgs/issues/47>)
  * Hybridizing pacmod_msgs.
  * pacmod_msgs: Adding migration rules.
  * Hybridizing astuff_sensor_msgs package.
  * Adding ros_environment as required package to all packages.
* Merge pull request #50 <https://github.com/astuff/astuff_sensor_msgs/issues/50> from astuff/maint/add_engine_rpt
  Adding Engine Report Message
* Changing coolant temp from float to int16.
* Maint/update shiftauxrpt (#49 <https://github.com/astuff/astuff_sensor_msgs/issues/49>)
  * Adding Gear Number Avail and Gear Number.
* adding turn_hazards to PacmodCmd.msg (#48 <https://github.com/astuff/astuff_sensor_msgs/issues/48>)
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* adding rear_pass_door (#38 <https://github.com/astuff/astuff_sensor_msgs/issues/38>)
  * adding rear_pass_door
* Contributors: Joshua Whitley, Sanaz Fattahalhosseini, as-snehagn, mlemm99, snehagn
```

## radar_msgs

```
* Adding ros_environment as required package to all packages.
* Hybridizing radar_msgs. (#41 <https://github.com/astuff/astuff_sensor_msgs/issues/41>)
* Adding hybrid CI.
* Updating package.xml files for ROS2 rosdep.
* Adding message migration rules.
* Contributors: Joshua Whitley
```