### PR TITLE
ros_environment: 1.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -303,6 +303,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_environment-release.git
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros/ros_environment.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `1.3.0-1`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros-gbp/ros_environment-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
