### PR TITLE
Revert "sbg_driver: 2.0.0-1 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14155,7 +14155,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 2.0.0-1
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Reverts ros/rosdistro#23412

The last release broke the build. 

Ticketed: https://github.com/SBG-Systems/sbg_ros_driver/issues/28

![Screenshot from 2020-01-23 15-49-41](https://user-images.githubusercontent.com/447804/73033817-039c9a80-3df8-11ea-8c15-196a2e4dbe11.png)
