### PR TITLE
cmake_modules: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -54,6 +54,15 @@ repositories:
       version: melodic-devel
     status: maintained
   cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.5-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/cmake_modules-release.git
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.5.0-1`:

- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## cmake_modules

```
* Bump CMake version to avoid CMP0048 author warning (#51 <https://github.com/ros/cmake_modules/issues/51>)
* Contributors: Shane Loretz
```
