### PR TITLE
remove cnn_bridge from Melodic FTBFS

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1140,7 +1140,6 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wew84/cnn_bridge-release.git
-      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/wew84/cnn_bridge.git


### PR DESCRIPTION
Parallel: #23586 
Ticketed upstream at wew84/cnn_bridge#4

@clalancette This appears not to have ever successfully built. Leaving for you to merge.