### PR TITLE
Revert "sbg_driver: 2.0.0-1 in 'melodic/distribution.yaml' [bloom]"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9333,7 +9333,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 2.0.0-1
+      version: 1.1.7-0
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Reverts ros/rosdistro#23413

This also fails to build on melodic, kinetic revert at: #23585 it appears to have the same issue in melodic.

Upstream issue: https://github.com/SBG-Systems/sbg_ros_driver/issues/28