### PR TITLE
catkin: 0.7.21-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -39,7 +39,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.20-0
+      version: 0.7.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.21-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.20-0`

## catkin

```
* bump CMake minimum version in tests and docs (#1053 <https://github.com/ros/catkin/issues/1053>)
* bump CMake minimum version to use new behavior of CMP0048 (#1052 <https://github.com/ros/catkin/issues/1052>)
* Prefer setuptools with Python 3 (#1048 <https://github.com/ros/catkin/issues/1048>)
* Support use of gmake on FreeBSD (#1051 <https://github.com/ros/catkin/issues/1051>)
* Fix if statement in catkin_libraries (#1050 <https://github.com/ros/catkin/issues/1050>)
* Update gtest config documentation (#1046 <https://github.com/ros/catkin/issues/1046>)
* Contributors: Dirk Thomas, Matt Reynolds, Shane Loretz, dodsonmg, poggenhans
```
