### PR TITLE
moveit: 0.9.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7552,6 +7552,7 @@ repositories:
       packages:
       - chomp_motion_planner
       - moveit
+      - moveit_chomp_optimizer_adapter
       - moveit_commander
       - moveit_controller_manager_example
       - moveit_core
@@ -7579,7 +7580,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.17-1
+      version: 0.9.18-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `0.9.18-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.9.17-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* [fix] Add missing tf dependency in chomp packages
* Contributors: Robert Haschke
```

## moveit_commander

- No changes

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [maintanance] Removed dependency moveit_core -> moveit_experimental again
* Contributors: Robert Haschke
```

## moveit_experimental

- No changes

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

```
* [fix] Add missing tf dependency in chomp packages
* Contributors: Robert Haschke
```

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [maintanance] Fix plot details, correcting xlabels positions and cleaning the graph (#1658 <https://github.com/ros-planning/moveit/issues/1658>)
* Contributors: Kaike W. Reis
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [feature] Add joint state controller config by default (#1024 <https://github.com/ros-planning/moveit/issues/1024>)
* Contributors: Mohmmad Ayman
```

## moveit_simple_controller_manager

- No changes
