### PR TITLE
dataspeed_can: 1.0.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2294,7 +2294,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.14-1
+      version: 1.0.15-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.15-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.14-1`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

- No changes

## dataspeed_can_tools

```
* Use %zu for portable printf() size type
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_usb

- No changes
