### PR TITLE
change branch for catkin to noetic-devel

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -34,7 +34,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/catkin.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -44,7 +44,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/catkin.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   class_loader:
     source:


### PR DESCRIPTION
Also updated the release repo: https://github.com/ros-gbp/catkin-release/commit/17a7d2c199029c04150225d31dcd130821fe2ef5