### PR TITLE
catkin: 0.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -39,7 +39,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.21-1
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.0-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.21-1`

## catkin

```
* install devel space wrapper for Python scripts (#1044 <https://github.com/ros/catkin/issues/1044>)
* various code cleanup (#1055 <https://github.com/ros/catkin/issues/1055>)
* make catkin_install_python code a little clearer (#1054 <https://github.com/ros/catkin/issues/1054>)
```
