### PR TITLE
rosbag_migration_rule: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -334,6 +334,11 @@ repositories:
       version: melodic-devel
     status: maintained
   rosbag_migration_rule:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros/rosbag_migration_rule.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_migration_rule` to `1.0.1-1`:

- upstream repository: https://github.com/ros/rosbag_migration_rule.git
- release repository: https://github.com/ros-gbp/rosbag_migration_rule-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
