### PR TITLE
gencpp: 0.6.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -110,6 +110,15 @@ repositories:
       version: master
     status: maintained
   gencpp:
+    doc:
+      type: git
+      url: https://github.com/ros/gencpp.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/gencpp-release.git
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/ros/gencpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gencpp` to `0.6.3-1`:

- upstream repository: git@github.com:ros/gencpp.git
- release repository: https://github.com/ros-gbp/gencpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## gencpp

```
* various code cleanup (#46 <https://github.com/ros/gencpp/issues/46>)
* package.xml format 3 (#45 <https://github.com/ros/gencpp/issues/45>)
* use setuptools instead of distutils (#43 <https://github.com/ros/gencpp/issues/43>)
* bump CMake version to avoid CMP0048 warning (#44 <https://github.com/ros/gencpp/issues/44>)
* two patches to make the generated headers reproducible (#42 <https://github.com/ros/gencpp/issues/42>)
```
