### PR TITLE
rospack: 2.5.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -387,6 +387,15 @@ repositories:
       version: master
     status: maintained
   rospack:
+    doc:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rospack-release.git
+      version: 2.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.5.5-1`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## rospack

```
* bump to CMake 3.0.2 to avoid CMP0048 warning (#114 <https://github.com/ros/rospack/issues/114>)
* only depend on catkin_pkg/rosdep-modules (#109 <https://github.com/ros/rospack/issues/109>)
* rework validateCache for portability. (#108 <https://github.com/ros/rospack/issues/108>)
```
