### PR TITLE
roscpp_core: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -377,6 +377,21 @@ repositories:
       version: kinetic-devel
     status: maintained
   roscpp_core:
+    doc:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: noetic-devel
+    release:
+      packages:
+      - cpp_common
+      - roscpp_core
+      - roscpp_serialization
+      - roscpp_traits
+      - rostime
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/roscpp_core-release.git
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.7.0-1`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## cpp_common

```
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```

## roscpp_serialization

```
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```

## roscpp_traits

```
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```

## rostime

```
* rostime: remove empty destructor of DurationBase (#104 <https://github.com/ros/roscpp_core/issues/104>)
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```
