### PR TITLE
genpy: 0.6.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -169,6 +169,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   genpy:
+    doc:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/genpy-release.git
+      version: 0.6.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.10-1`:

- upstream repository: git@github.com:ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## genpy

```
* various code cleanup (#117 <https://github.com/ros/genpy/issues/117>)
* update logic for newer PyYAML output for dump() (#116 <https://github.com/ros/genpy/issues/116>)
* small optimization in dynamic.py (#109 <https://github.com/ros/genpy/issues/109>)
* use setuptools instead of distutils (#115 <https://github.com/ros/genpy/issues/115>)
* bump CMake version to avoid CMP0048 warning (#114 <https://github.com/ros/genpy/issues/114>)
* serialization: always set _x var for correct exception msg (#113 <https://github.com/ros/genpy/issues/113>)
* sort generated imports to make them reproducible (#111 <https://github.com/ros/genpy/issues/111>)
* make the generated "struct" constructs reproducible (#110 <https://github.com/ros/genpy/issues/110>)
```
