### PR TITLE
costmap_converter: 0.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -330,7 +330,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-ros2-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.1.1-1`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-ros2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.0-1`

## costmap_converter

```
* Fixed ament plugin export
* Revert release-mode for cmake build
* Contributors: Christoph Rösmann
```

## costmap_converter_msgs

- No changes
