### PR TITLE
roscpp_core: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -400,7 +400,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.7.1-1`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.7.0-1`

## cpp_common

```
* only depend on the boost components needed (#117 <https://github.com/ros/roscpp_core/issues/117>)
```

## roscpp_serialization

- No changes

## roscpp_traits

- No changes

## rostime

```
* only depend on the boost components needed (#117 <https://github.com/ros/roscpp_core/issues/117>)
```
