### PR TITLE
add libboost-dev key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1577,6 +1577,10 @@ libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-date-time]
   ubuntu: [libboost-date-time-dev]
+libboost-dev:
+  debian: [libboost-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-dev]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-fileystem]


### PR DESCRIPTION
I'm not sure about the fedora rule.
I didnt find a package with just the boost headers so I fell back to the `boost-devel` package that contains all the headers and all the libraries