### PR TITLE
velocity_smoother: 0.14.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2824,7 +2824,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/kobuki-base/velocity_smoother.git
-      version: release/0.13.x
+      version: release/0.14.x
     release:
       tags:
         release: release/eloquent/{package}/{version}

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2829,7 +2829,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/velocity_smoother-release.git
-      version: 0.13.0-1
+      version: 0.14.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velocity_smoother` to `0.14.0-1`:

- upstream repository: https://github.com/kobuki-base/velocity_smoother.git
- release repository: https://github.com/stonier/velocity_smoother-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.13.0-1`

## velocity_smoother

```
* [ros2] parameters/topics renamed more sensibly, #8 <https://github.com/kobuki-base/velocity_smoother/pull/8>
* [docs] moved from the ROS1 wiki and updated, #8 <https://github.com/kobuki-base/velocity_smoother/pull/8>
* [tests] translational smoothing test added, #7 <https://github.com/kobuki-base/velocity_smoother/pull/7>
```
