### PR TITLE
add and fix boost rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1569,29 +1569,84 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
+libboost-atomic:
+  debian:
+    buster: [libboost-atomic1.67.0]
+    stretch: [libboost-atomic1.62.0]
+  fedora: [boost-atomic]
+  ubuntu:
+    bionic: [libboost-atomic1.65.1]
+    eoan: [libboost-atomic1.67.0]
+    focal: [libboost-atomic1.67.0]
+    xenial: [libboost-atomic1.58.0]
+libboost-atomic-dev:
+  debian: [libboost-atomic-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-atomic-dev]
+libboost-chrono:
+  debian:
+    buster: [libboost-chrono1.67.0]
+    stretch: [libboost-chrono1.62.0]
+  fedora: [boost-chrono]
+  ubuntu:
+    bionic: [libboost-chrono1.65.1]
+    eoan: [libboost-chrono1.67.0]
+    focal: [libboost-chrono1.67.0]
+    xenial: [libboost-chrono1.58.0]
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
-  fedora: [boost-chrono]
+  fedora: [boost-devel]
   ubuntu: [libboost-chrono-dev]
+libboost-date-time:
+  debian:
+    buster: [libboost-date-time1.67.0]
+    stretch: [libboost-date-time1.62.0]
+  fedora: [boost-date-time]
+  ubuntu:
+    bionic: [libboost-date-time1.65.1]
+    eoan: [libboost-date-time1.67.0]
+    focal: [libboost-date-time1.67.0]
+    xenial: [libboost-date-time1.58.0]
 libboost-date-time-dev:
   debian: [libboost-date-time-dev]
-  fedora: [boost-date-time]
+  fedora: [boost-devel]
   ubuntu: [libboost-date-time-dev]
 libboost-dev:
   debian: [libboost-dev]
   fedora: [boost-devel]
   ubuntu: [libboost-dev]
+libboost-filesystem:
+  debian:
+    buster: [libboost-filesystem1.67.0]
+    stretch: [libboost-filesystem1.62.0]
+  fedora: [boost-filesystem]
+  ubuntu:
+    bionic: [libboost-filesystem1.65.1]
+    eoan: [libboost-filesystem1.67.0]
+    focal: [libboost-filesystem1.67.0]
+    xenial: [libboost-filesystem1.58.0]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
-  fedora: [boost-fileystem]
+  fedora: [boost-devel]
   gentoo: ['dev-libs/boost[python]']
   ubuntu: [libboost-filesystem-dev]
+libboost-iostreams:
+  debian:
+    buster: [libboost-iostreams1.67.0]
+    stretch: [libboost-iostreams1.62.0]
+  fedora: [boost-iostreams]
+  ubuntu:
+    bionic: [libboost-iostreams1.65.1]
+    eoan: [libboost-iostreams1.67.0]
+    focal: [libboost-iostreams1.67.0]
+    xenial: [libboost-iostreams1.58.0]
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
-  fedora: [boost-iostreams]
+  fedora: [boost-devel]
   ubuntu: [libboost-iostreams-dev]
 libboost-program-options:
   debian:
+    buster: [libboost-program-options1.67.0]
     jessie: [libboost-program-options1.55.0]
     stretch: [libboost-program-options1.62.0]
   fedora: [boost-program-options]
@@ -1599,6 +1654,7 @@ libboost-program-options:
     bionic: [libboost-program-options1.65.1]
     disco: [libboost-program-options1.67.0]
     eoan: [libboost-program-options1.67.0]
+    focal: [libboost-program-options1.67.0]
     trusty: [libboost-program-options1.55.0]
     xenial: [libboost-program-options1.58.0]
 libboost-program-options-dev:
@@ -1613,6 +1669,7 @@ libboost-python:
   ubuntu: [libboost-python-dev]
 libboost-random:
   debian:
+    buster: [libboost-random1.67.0]
     jessie: [libboost-random1.55.0]
     stretch: [libboost-random1.62.0]
     wheezy: [libboost-random1.49.0]
@@ -1621,23 +1678,59 @@ libboost-random:
     bionic: [libboost-random1.65.1]
     disco: [libboost-random1.67.0]
     eoan: [libboost-random1.67.0]
+    focal: [libboost-random1.67.0]
     precise: [libboost-random1.46.1]
     trusty: [libboost-random1.54.0]
+    xenial: [libboost-random1.58.0]
 libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
   ubuntu: [libboost-random-dev]
+libboost-regex:
+  debian:
+    buster: [libboost-regex1.67.0]
+    stretch: [libboost-regex1.62.0]
+  fedora: [boost-regex]
+  ubuntu:
+    bionic: [libboost-regex1.65.1]
+    eoan: [libboost-regex1.67.0]
+    focal: [libboost-regex1.67.0]
+    xenial: [libboost-regex1.58.0]
 libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
   ubuntu: [libboost-regex-dev]
+libboost-system:
+  debian:
+    buster: [libboost-system1.67.0]
+    stretch: [libboost-system1.62.0]
+  fedora: [boost-system]
+  ubuntu:
+    bionic: [libboost-system1.65.1]
+    disco: [libboost-system1.67.0]
+    eoan: [libboost-system1.67.0]
+    focal: [libboost-system1.67.0]
+    trusty: [libboost-system1.55.0]
+    xenial: [libboost-system1.58.0]
 libboost-system-dev:
   debian: [libboost-system-dev]
-  fedora: [boost-system]
+  fedora: [boost-devel]
   ubuntu: [libboost-system-dev]
+libboost-thread:
+  debian:
+    buster: [libboost-thread1.67.0]
+    stretch: [libboost-thread1.62.0]
+  fedora: [boost-thread]
+  ubuntu:
+    bionic: [libboost-thread1.65.1]
+    disco: [libboost-thread1.67.0]
+    eoan: [libboost-thread1.67.0]
+    focal: [libboost-thread1.67.0]
+    trusty: [libboost-thread1.55.0]
+    xenial: [libboost-thread1.58.0]
 libboost-thread-dev:
   debian: [libboost-thread-dev]
-  fedora: [boost-thread]
+  fedora: [boost-devel]
   ubuntu: [libboost-thread-dev]
 libcairo2-dev:
   arch: [cairo]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1577,6 +1577,10 @@ libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-date-time]
   ubuntu: [libboost-date-time-dev]
+libboost-dev:
+  debian: [libboost-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-dev]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-fileystem]


### PR DESCRIPTION
Based on https://github.com/ros/rosdistro/pull/23620#discussion_r371039051 most fedora rules for libboost-*-dev were wrong.

This PR:
- fix dev boost keys for fedora
- add non-dev boost keys for all existing dev boost keys
- add libboost-atomic and libboost-atomic-dev


## Links:

- Fedora
https://apps.fedoraproject.org/packages/boost-devel
https://apps.fedoraproject.org/packages/boost-atomic
https://apps.fedoraproject.org/packages/boost-chrono
https://apps.fedoraproject.org/packages/boost-date-time
https://apps.fedoraproject.org/packages/boost-filesystem
https://apps.fedoraproject.org/packages/boost-iostreams
https://apps.fedoraproject.org/packages/boost-program-options
https://apps.fedoraproject.org/packages/boost-random
https://apps.fedoraproject.org/packages/boost-system
https://apps.fedoraproject.org/packages/boost-thread

- libboost-atomic:
  - Ubuntu
    - xenial: https://packages.ubuntu.com/xenial/libboost-atomic1.58.0
    - bionic: https://packages.ubuntu.com/bionic/libboost-atomic1.65.1
    - eoan/focal: https://packages.ubuntu.com/eoan/libboost-atomic1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-atomic1.67.0
    - stretch: https://packages.debian.org/stretch/libboost-atomic1.62.0
- libboost-atomic-dev:
  - Ubuntu: https://packages.ubuntu.com/xenial/libboost-atomic-dev
  - Debian: https://packages.debian.org/buster/libboost-atomic-dev
- libboost-chrono:
  - Ubuntu
    - xenial: https://packages.ubuntu.com/xenial/libboost-chrono1.58.0
    - bionic: https://packages.ubuntu.com/bionic/libboost-chrono1.65.1
    - eoan/focal: https://packages.ubuntu.com/eoan/libboost-chrono1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-chrono1.67.0
    - stretch: https://packages.debian.org/stretch/libboost-chrono1.62.0
- libboost-date-time:
  - Ubuntu
    - xenial: https://packages.ubuntu.com/xenial/libboost-date-time1.58.0
    - bionic: https://packages.ubuntu.com/bionic/libboost-date-time1.65.1
    - eoan/focal: https://packages.ubuntu.com/eoan/libboost-date-time1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-date-time1.67.0
    - stretch: https://packages.debian.org/stretch/libboost-date-time1.62.0
- libboost-filesystem:
  - Ubuntu
    - xenial: https://packages.ubuntu.com/xenial/libboost-filesystem1.58.0
    - bionic: https://packages.ubuntu.com/bionic/libboost-filesystem1.65.1
    - eoan/focal: https://packages.ubuntu.com/eoan/libboost-filesystem1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-filesystem1.67.0
    - stretch: https://packages.debian.org/stretch/libboost-filesystem1.62.0
- libboost-iostreams:
  - Ubuntu
    - xenial: https://packages.ubuntu.com/xenial/libboost-iostreams1.58.0
    - bionic: https://packages.ubuntu.com/bionic/libboost-iostreams1.65.1
    - eoan/focal: https://packages.ubuntu.com/eoan/libboost-iostreams1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-iostreams1.67.0
    - stretch: https://packages.debian.org/stretch/libboost-iostreams1.62.0
- libboost-program-options:
  - Ubuntu
    - focal: https://packages.ubuntu.com/focal/libboost-program-options1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-program-options1.67.0
- libboost-random:
  - Ubuntu
    - xenial: https://packages.ubuntu.com/xenial/libboost-random1.58.0
    - focal: https://packages.ubuntu.com/focal/libboost-random1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-random1.67.0
- libboost-system:
  - Ubuntu
    - trusty: https://packages.ubuntu.com/trusty/libboost-system1.55.0
    - xenial: https://packages.ubuntu.com/xenial/libboost-system1.58.0
    - bionic: https://packages.ubuntu.com/bionic/libboost-system1.65.1
    - disco: https://packages.ubuntu.com/disco/libboost-system1.67.0
    - eoan/focal: https://packages.ubuntu.com/eoan/libboost-system1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-system1.67.0
    - stretch: https://packages.debian.org/stretch/libboost-system1.62.0
- libboost-thread:
  - Ubuntu
    - trusty: https://packages.ubuntu.com/trusty/libboost-thread1.55.0
    - xenial: https://packages.ubuntu.com/xenial/libboost-thread1.58.0
    - bionic: https://packages.ubuntu.com/bionic/libboost-thread1.65.1
    - disco: https://packages.ubuntu.com/disco/libboost-thread1.67.0
    - eoan/focal: https://packages.ubuntu.com/eoan/libboost-thread1.67.0
  - Debian
    - buster: https://packages.debian.org/buster/libboost-thread1.67.0
    - stretch: https://packages.debian.org/stretch/libboost-thread1.62.0