### PR TITLE
ros_control: 0.16.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7988,7 +7988,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.15.1-0
+      version: 0.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.15.1-0`

## combined_robot_hw

```
* Use range-based for loop
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Use #pragma once
* Replace header guard with #pragma once
* Remove unused Boost dependencies
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Fix build error in clang error: non-aggregate type 'std::vector' (aka 'vector >') cannot be initialized with an initializer list
* fix install destination
* specify RUNTIME DESTINATION for libraries needed for exporting DLLs on Windows
* Contributors: Bence Magyar, James Xu, Matt Reynolds, Victor Lopez
```

## combined_robot_hw_tests

```
* Use range-based for loop
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Merge branch 'melodic-devel' into catkin-lint
* Add ${catkin_EXPORTED_TARGETS} dependencies
* Correct test dependencies
* Use nullptr
* Replace header guard with #pragma once
* Update package.xml descriptions
* Remove unused Boost dependencies
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Fix compiler warnings
  - Comment out unused parameters
  - Make some integer literals unsigned to avoid comparison between signed and unsigned
  - Remove unnecessary semicolons
  - Make const void return type to void
* Fix build error in clang error: non-aggregate type 'std::vector' (aka 'vector >') cannot be initialized with an initializer list
* Multi-update cycle mode switch (#391 <https://github.com/ros-controls/ros_control/issues/391>)
  For more info: https://github.com/pal-robotics-forks/ros_control2/pull/5
  * Added tests for ControllerManager update
  * Mocks for controllers and controller loader in update test
  * Divided in tests with and without controllers
  * Controller state initialized in mock
  * Moved mocks to test class
  * All tests using mock class
  * Test for multiple updates in a single controller
  * Added new switchResult() function to RobotHW interface
  ControllerManager uses this function to wait for the result of the
  doSwitch() before starting the new set of controllers
  * Using ranged based loops
  * Switch is now managed in a separate function
  * Option to start controllers as soon as their joints are ready after a switch
  * Tests for controller_interface API
  * Added new STOPPED, WAITING and ABORTED states to ControllerBase
  * Split manageSwitch() into smaller functions
  * Abort pending controllers in case of switch error
  * Changed default behaviour of new switch param
  This way if it not set it will be the same behaviour as previous version
  * Added timeout parameter to switch controller
  * Removed unnecessary includes
  * Using target_include_directories for the test
  * std::all_of instead of std::count_if
  * Deleted autogenerated file
  * Adapted tests to changes in controller_manager
  * Adapted python implementation to new parameters in SwitchController
  * Added missing parameter description docstring
  * Moved all parameters used for switching to a separate object
  * Moved error messages to controller_base
  * State check functions are now const
  * Removed unnecessary comments
  * Added constants for start_asap and timeout default parameters values
* fix install destination
* Contributors: Bence Magyar, James Xu, Jordan Palacios, Markus Vieth, Matt Reynolds, Victor Lopez
```

## controller_interface

```
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Replace header guard with #pragma once
* Remove unnecessary  rosunit/rostest dependencies
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Multi-update cycle mode switch (#391 <https://github.com/ros-controls/ros_control/issues/391>)
  For more info: https://github.com/pal-robotics-forks/ros_control2/pull/5
  * Added tests for ControllerManager update
  * Mocks for controllers and controller loader in update test
  * Divided in tests with and without controllers
  * Controller state initialized in mock
  * Moved mocks to test class
  * All tests using mock class
  * Test for multiple updates in a single controller
  * Added new switchResult() function to RobotHW interface
  ControllerManager uses this function to wait for the result of the
  doSwitch() before starting the new set of controllers
  * Using ranged based loops
  * Switch is now managed in a separate function
  * Option to start controllers as soon as their joints are ready after a switch
  * Tests for controller_interface API
  * Added new STOPPED, WAITING and ABORTED states to ControllerBase
  * Split manageSwitch() into smaller functions
  * Abort pending controllers in case of switch error
  * Changed default behaviour of new switch param
  This way if it not set it will be the same behaviour as previous version
  * Added timeout parameter to switch controller
  * Removed unnecessary includes
  * Using target_include_directories for the test
  * std::all_of instead of std::count_if
  * Deleted autogenerated file
  * Adapted tests to changes in controller_manager
  * Adapted python implementation to new parameters in SwitchController
  * Added missing parameter description docstring
  * Moved all parameters used for switching to a separate object
  * Moved error messages to controller_base
  * State check functions are now const
  * Removed unnecessary comments
  * Added constants for start_asap and timeout default parameters values
* Removed unnecessary comments
* State check functions are now const
* Moved error messages to controller_base
* Using target_include_directories for the test
* Fixed lincenses
* Removed unnecessary includes
* Abort pending controllers in case of switch error
* Added new STOPPED, WAITING and ABORTED states to ControllerBase
* Tests for controller_interface API
* Contributors: Bence Magyar, Jordan Palacios, Matt Reynolds, jordan-palacios
```

## controller_manager

```
* Use range-based for loops in controller_manager
* Resolve Boost dependency issues
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Merge branch 'melodic-devel' into catkin-lint
* Add ${catkin_EXPORTED_TARGETS} dependencies
* Update package dependencies
* Add missing roscpp & rospy dependencies
* Prefer nullptr for null pointers
* Replace header guard with #pragma once
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Fix build error in clang error: non-aggregate type 'std::vector' (aka 'vector >') cannot be initialized with an initializer list
* Multi-update cycle mode switch (#391 <https://github.com/ros-controls/ros_control/issues/391>)
  For more info: https://github.com/pal-robotics-forks/ros_control2/pull/5
  * Added tests for ControllerManager update
  * Mocks for controllers and controller loader in update test
  * Divided in tests with and without controllers
  * Controller state initialized in mock
  * Moved mocks to test class
  * All tests using mock class
  * Test for multiple updates in a single controller
  * Added new switchResult() function to RobotHW interface
  ControllerManager uses this function to wait for the result of the
  doSwitch() before starting the new set of controllers
  * Using ranged based loops
  * Switch is now managed in a separate function
  * Option to start controllers as soon as their joints are ready after a switch
  * Tests for controller_interface API
  * Added new STOPPED, WAITING and ABORTED states to ControllerBase
  * Split manageSwitch() into smaller functions
  * Abort pending controllers in case of switch error
  * Changed default behaviour of new switch param
  This way if it not set it will be the same behaviour as previous version
  * Added timeout parameter to switch controller
  * Removed unnecessary includes
  * Using target_include_directories for the test
  * std::all_of instead of std::count_if
  * Deleted autogenerated file
  * Adapted tests to changes in controller_manager
  * Adapted python implementation to new parameters in SwitchController
  * Added missing parameter description docstring
  * Moved all parameters used for switching to a separate object
  * Moved error messages to controller_base
  * State check functions are now const
  * Removed unnecessary comments
  * Added constants for start_asap and timeout default parameters values
* Remove extra {
* Adding Pal Robotics to copyright notice
  Co-Authored-By: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
* Added constants for start_asap and timeout default parameters values
* Moved error messages to controller_base
* Moved all parameters used for switching to a separate object
* Added missing parameter description docstring
* Adapted python implementation to new parameters in SwitchController
* Deleted autogenerated file
* std::all_of instead of std::count_if
* Cosmetics
* Fixed lincenses
* Removed unnecessary includes
* Added timeout parameter to switch controller
* Changed default behaviour of new switch param
  This way if it not set it will be the same behaviour as previous version
* Abort pending controllers in case of switch error
* Split manageSwitch() into smaller functions
* Added new STOPPED, WAITING and ABORTED states to ControllerBase
* Option to start controllers as soon as their joints are ready after a switch
* Switch is now managed in a separate function
* Using ranged based loops
* Added new switchResult() function to RobotHW interface
  ControllerManager uses this function to wait for the result of the
  doSwitch() before starting the new set of controllers
* Test for multiple updates in a single controller
* All tests using mock class
* Moved mocks to test class
* Controller state initialized in mock
* Divided in tests with and without controllers
* Mocks for controllers and controller loader in update test
* Added tests for ControllerManager update
* fix install destination (#377 <https://github.com/ros-controls/ros_control/issues/377>)
* catch ROSInterruptException
* specify RUNTIME DESTINATION for libraries (#373 <https://github.com/ros-controls/ros_control/issues/373>)
  needed for exporting DLLs on Windows
* use this_thread::sleep_for instead of usleep (#375 <https://github.com/ros-controls/ros_control/issues/375>)
* remove unused pthread.h
* Contributors: Bence Magyar, Gérald Lelong, James Xu, Jordan Palacios, Matt Reynolds, Victor Lopez, jordan-palacios
```

## controller_manager_msgs

```
* Update package dependencies
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Fix exception module
* Contributors: Bence Magyar, Jordan Palacios, Matt Reynolds, Ryohei Ueda
```

## controller_manager_tests

```
* Merge pull request #413 <https://github.com/ros-controls/ros_control/issues/413> from matthew-reynolds/range-for
  Use range-based for loop
* Merge pull request #404 <https://github.com/ros-controls/ros_control/issues/404> from matthew-reynolds/catkin-lint
  Update CMakeLists.txt and package.xml
* Use range-based for loops in controller_manager_tests
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Merge branch 'melodic-devel' into catkin-lint
* Add ${catkin_EXPORTED_TARGETS} dependencies
* Re-install test plugin libraries
* Update package dependencies
* Re-install test plugins
* Add missing roscpp & rospy dependencies
* Correct test dependencies
* Remove installs from _tests packages
* Merge pull request #406 <https://github.com/ros-controls/ros_control/issues/406> from matthew-reynolds/pragma-once
  Use #pragma once
* Replace header guard with #pragma once
* Update package.xml descriptions
* Remove unused Boost dependencies
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Merge pull request #399 <https://github.com/ros-controls/ros_control/issues/399> from mvieth/melodic-devel
  Fix compiler warnings
* Fix compiler warnings
  - Comment out unused parameters
  - Make some integer literals unsigned to avoid comparison between signed and unsigned
  - Remove unnecessary semicolons
  - Make const void return type to void
* Merge pull request #398 <https://github.com/ros-controls/ros_control/issues/398> from matthew-reynolds/revert-cmake
  Revert CMake include_directories as SYSTEM
* Revert CMake include_directories as SYSTEM
* Merge pull request #396 <https://github.com/ros-controls/ros_control/issues/396> from pal-robotics-forks/small-fixes
  Small fixes
* Fix build error in clang
  error: non-aggregate type 'std::vector' (aka 'vector >') cannot be initialized with an initializer list
* Multi-update cycle mode switch (#391 <https://github.com/ros-controls/ros_control/issues/391>)
  For more info: https://github.com/pal-robotics-forks/ros_control2/pull/5
  * Added tests for ControllerManager update
  * Mocks for controllers and controller loader in update test
  * Divided in tests with and without controllers
  * Controller state initialized in mock
  * Moved mocks to test class
  * All tests using mock class
  * Test for multiple updates in a single controller
  * Added new switchResult() function to RobotHW interface
  ControllerManager uses this function to wait for the result of the
  doSwitch() before starting the new set of controllers
  * Using ranged based loops
  * Switch is now managed in a separate function
  * Option to start controllers as soon as their joints are ready after a switch
  * Tests for controller_interface API
  * Added new STOPPED, WAITING and ABORTED states to ControllerBase
  * Split manageSwitch() into smaller functions
  * Abort pending controllers in case of switch error
  * Changed default behaviour of new switch param
  This way if it not set it will be the same behaviour as previous version
  * Added timeout parameter to switch controller
  * Removed unnecessary includes
  * Using target_include_directories for the test
  * std::all_of instead of std::count_if
  * Deleted autogenerated file
  * Adapted tests to changes in controller_manager
  * Adapted python implementation to new parameters in SwitchController
  * Added missing parameter description docstring
  * Moved all parameters used for switching to a separate object
  * Moved error messages to controller_base
  * State check functions are now const
  * Removed unnecessary comments
  * Added constants for start_asap and timeout default parameters values
* Adapted python implementation to new parameters in SwitchController
* Adapted tests to changes in controller_manager
* fix install destination (#377 <https://github.com/ros-controls/ros_control/issues/377>)
* Contributors: Bence Magyar, James Xu, Jordan Palacios, Markus Vieth, Matt Reynolds, Victor Lopez
```

## hardware_interface

```
* Merge pull request #413 <https://github.com/ros-controls/ros_control/issues/413> from matthew-reynolds/range-for
  Use range-based for loop
* Use more meaningful pair iterator names
* Correct typo in interface_manager.h
  Co-Authored-By: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
* Merge pull request #404 <https://github.com/ros-controls/ros_control/issues/404> from matthew-reynolds/catkin-lint
  Update CMakeLists.txt and package.xml
* Use range-based for loops in hardware_interface
* Resolve Boost dependency issues
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Merge branch 'melodic-devel' into catkin-lint
* Update package dependencies
* Remove rosunit test_depend from package.xml
* Merge pull request #405 <https://github.com/ros-controls/ros_control/issues/405> from matthew-reynolds/use-nullptr
  Use nullptr
* Use nullptr in tests
* Prefer nullptr for null pointers
* Merge pull request #406 <https://github.com/ros-controls/ros_control/issues/406> from matthew-reynolds/pragma-once
  Use #pragma once
* Replace header guard with #pragma once
* Merge pull request #395 <https://github.com/ros-controls/ros_control/issues/395> from pal-robotics-forks/extend-interfaces-melodic
  Extend interfaces
* Extend joint mode interface
* Add torque sensor and absolute encoder support to transmissions and adjust tests
  Add pointer accessors for torque sensor and absoute position encoders
* Modified structures to have absolute encoder and torque sensor parameters
* Fix argument types to use enum
* hardware_interface: fix initialization order
* Created new hardware interface for switching between controller modes
* Remove unnecessary  rosunit/rostest dependencies
* Add missing Boost dependency
* Remove redundant rosconsole dependency
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Merge pull request #399 <https://github.com/ros-controls/ros_control/issues/399> from mvieth/melodic-devel
  Fix compiler warnings
* Fix compiler warnings
  - Comment out unused parameters
  - Make some integer literals unsigned to avoid comparison between signed and unsigned
  - Remove unnecessary semicolons
  - Make const void return type to void
* Merge pull request #398 <https://github.com/ros-controls/ros_control/issues/398> from matthew-reynolds/revert-cmake
  Revert CMake include_directories as SYSTEM
* Revert CMake include_directories as SYSTEM
* Merge pull request #396 <https://github.com/ros-controls/ros_control/issues/396> from pal-robotics-forks/small-fixes
  Small fixes
* Fix shadowed variables
* Multi-update cycle mode switch (#391 <https://github.com/ros-controls/ros_control/issues/391>)
  For more info: https://github.com/pal-robotics-forks/ros_control2/pull/5
  * Added tests for ControllerManager update
  * Mocks for controllers and controller loader in update test
  * Divided in tests with and without controllers
  * Controller state initialized in mock
  * Moved mocks to test class
  * All tests using mock class
  * Test for multiple updates in a single controller
  * Added new switchResult() function to RobotHW interface
  ControllerManager uses this function to wait for the result of the
  doSwitch() before starting the new set of controllers
  * Using ranged based loops
  * Switch is now managed in a separate function
  * Option to start controllers as soon as their joints are ready after a switch
  * Tests for controller_interface API
  * Added new STOPPED, WAITING and ABORTED states to ControllerBase
  * Split manageSwitch() into smaller functions
  * Abort pending controllers in case of switch error
  * Changed default behaviour of new switch param
  This way if it not set it will be the same behaviour as previous version
  * Added timeout parameter to switch controller
  * Removed unnecessary includes
  * Using target_include_directories for the test
  * std::all_of instead of std::count_if
  * Deleted autogenerated file
  * Adapted tests to changes in controller_manager
  * Adapted python implementation to new parameters in SwitchController
  * Added missing parameter description docstring
  * Moved all parameters used for switching to a separate object
  * Moved error messages to controller_base
  * State check functions are now const
  * Removed unnecessary comments
  * Added constants for start_asap and timeout default parameters values
* Option to start controllers as soon as their joints are ready after a switch
* Switch is now managed in a separate function
* Added new switchResult() function to RobotHW interface
  ControllerManager uses this function to wait for the result of the
  doSwitch() before starting the new set of controllers
* Contributors: Bence Magyar, Dave Coleman, Hilario Tome, Jordan Palacios, Markus Vieth, Matt Reynolds, Paul Mathieu, Victor Lopez
```

## joint_limits_interface

```
* Merge pull request #413 <https://github.com/ros-controls/ros_control/issues/413> from matthew-reynolds/range-for
  Use range-based for loop
* Use more meaningful pair iterator names
* Merge pull request #404 <https://github.com/ros-controls/ros_control/issues/404> from matthew-reynolds/catkin-lint
  Update CMakeLists.txt and package.xml
* Use range-based for loops in joint_limits_interface
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Merge branch 'melodic-devel' into catkin-lint
* Update package dependencies
* Remove liburdfdom-dev
* Add missing roscpp & rospy dependencies
* Remove rosunit test_depend from package.xml
* Merge pull request #405 <https://github.com/ros-controls/ros_control/issues/405> from matthew-reynolds/use-nullptr
  Use nullptr
* Prefer 0.0 for floating point literals
* Merge pull request #406 <https://github.com/ros-controls/ros_control/issues/406> from matthew-reynolds/pragma-once
  Use #pragma once
* Replace header guard with #pragma once
* Merge pull request #395 <https://github.com/ros-controls/ros_control/issues/395> from pal-robotics-forks/extend-interfaces-melodic
  Extend interfaces
* joint_limits: use an open-loop policy for velocity staturation
  The feedback from the controller is way too slow to be used on an
  actual robot. A robot that had 15 rad.s^-2 on each wheel as
  an acceleration limit could not even reach 2 rad.s^-2
  This is in line with ros_controllers`#23 <https://github.com/ros-controls/ros_control/issues/23>`_
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Merge pull request #398 <https://github.com/ros-controls/ros_control/issues/398> from matthew-reynolds/revert-cmake
  Revert CMake include_directories as SYSTEM
* Revert CMake include_directories as SYSTEM
* Merge pull request #396 <https://github.com/ros-controls/ros_control/issues/396> from pal-robotics-forks/small-fixes
  Small fixes
* Fix shadowed variables
* -Werror=overloaded-virtual and initialization of fields in constructor
* Contributors: Bence Magyar, Daniel Pinyol, Matt Reynolds, Paul Mathieu, Victor Lopez
```

## ros_control

```
* Remove _tests packages from metapackage
* Apply consistent style to package.xml files
* Contributors: Bence Magyar, Matt Reynolds
```

## rqt_controller_manager

```
* Update package dependencies
* Add missing roscpp & rospy dependencies
* Update package.xml descriptions
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Contributors: Bence Magyar, Matt Reynolds
```

## transmission_interface

```
* Use more meaningful pair iterator names
* Use range-based for loops in transmission_interface
* Resolve Boost dependency issues
* Update dependencies
  - Dependencies needed to compile are <build_depend>
  - Dependencies used in public headers are <build_export_depend>
  - Dependencies needed to link or run are <exec_depend>
* Merge branch 'melodic-devel' into catkin-lint
* Update package dependencies
* Remove rosunit test_depend from package.xml
* Prefer nullptr for null pointers
* Merge pull request #406 <https://github.com/ros-controls/ros_control/issues/406> from matthew-reynolds/pragma-once
  Use #pragma once
* Add missing header guard to loader_utils.h
* Replace header guard with #pragma once
* Merge pull request #395 <https://github.com/ros-controls/ros_control/issues/395> from pal-robotics-forks/extend-interfaces-melodic
  Extend interfaces
* Add torque sensor and absolute encoder support to transmissions and adjust tests
  Add pointer accessors for torque sensor and absoute position encoders
* Modified structures to have absolute encoder and torque sensor parameters
* Fix transmission_interface dependencies
* Apply consistent style to CMakeLists.txt files
* Apply consistent style to package.xml files
* Merge pull request #399 <https://github.com/ros-controls/ros_control/issues/399> from mvieth/melodic-devel
  Fix compiler warnings
* Fix compiler warnings
  - Comment out unused parameters
  - Make some integer literals unsigned to avoid comparison between signed and unsigned
  - Remove unnecessary semicolons
  - Make const void return type to void
* Fix build error in clang
  error: non-aggregate type 'std::vector' (aka 'vector >') cannot be initialized with an initializer list
* Merge pull request #379 <https://github.com/ros-controls/ros_control/issues/379> from bmagyar/transmission-parser-touchup
  TransmissionParser touchup
* Fix typo in docs
* TransmissionParser private -> protected
* fix install destination (#377 <https://github.com/ros-controls/ros_control/issues/377>)
* Contributors: Bence Magyar, Gennaro Raiola, Hilario Tome, James Xu, Markus Vieth, Matt Reynolds, Victor Lopez
```
