### PR TITLE
Fixing branch associated with astuff_sensor_msgs on dashing.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -272,7 +272,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
-      version: dashing-devel
+      version: master
     release:
       packages:
       - astuff_sensor_msgs
@@ -293,7 +293,7 @@ repositories:
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
-      version: dashing-devel
+      version: master
     status: developed
   async_web_server_cpp:
     release:


### PR DESCRIPTION
Somehow `bloom` knows which branch it should be on but the PR that was produced for the latest release didn't update the branch. This fixes that omission.