### PR TITLE
message_runtime: 0.4.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -244,6 +244,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   message_runtime:
+    doc:
+      type: git
+      url: https://github.com/ros/message_runtime.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/message_runtime-release.git
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/ros/message_runtime.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_runtime` to `0.4.13-1`:

- upstream repository: https://github.com/ros/message_runtime.git
- release repository: https://github.com/ros-gbp/message_runtime-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
