### PR TITLE
pacmod3: 1.3.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1591,6 +1591,21 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: dashing
     status: developed
+  pacmod3:
+    doc:
+      type: git
+      url: https://github.com/astuff/pacmod3.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/astuff/pacmod3-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod3.git
+      version: dashing-devel
+    status: developed
   pcl_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod3` to `1.3.0-1`:

- upstream repository: https://github.com/astuff/pacmod3.git
- release repository: https://github.com/astuff/pacmod3-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## pacmod3

```
* Ported to ROS2 Dashing
* Contributors: Joshua Whitley
```
