### PR TITLE
gundam_robot: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3181,6 +3181,26 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: maintained
+  gundam_robot:
+    doc:
+      type: git
+      url: https://github.com/gundam-global-challenge/gundam_robot.git
+      version: master
+    release:
+      packages:
+      - gundam_robot
+      - gundam_rx78_control
+      - gundam_rx78_description
+      - gundam_rx78_gazebo
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gundam-global-challenge/gundam_robot-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/gundam-global-challenge/gundam_robot.git
+      version: master
+    status: developed
   h264_encoder_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gundam_robot` to `0.0.3-1`:

- upstream repository: https://github.com/gundam-global-challenge/gundam_robot.git
- release repository: https://github.com/gundam-global-challenge/gundam_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## gundam_robot

- No changes

## gundam_rx78_control

```
* fix walk demo (#8 <https://github.com/gundam-global-challenge/gundam_robot/issues/8>)
* Contributors: Naoki Hiraoka
```

## gundam_rx78_description

- No changes

## gundam_rx78_gazebo

```
* add more walking tests (#8 <https://github.com/gundam-global-challenge/gundam_robot/issues/8>)
  
    * update travis.yml
    * fix check_walk_pose.py to take target pos/ros as argument and also takes walking pattern fiels
  
* Contributors: Kei Okada
```
