### PR TITLE
VisualStates: 0.2.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,6 +8,14 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  VisualStates:
+    release:
+      packages:
+      - visualstates
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/VisualStates-release.git
+      version: 0.2.3-1
   abb:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `VisualStates` to `0.2.3-1`:

- upstream repository: https://github.com/JdeRobot/VisualStates.git
- release repository: https://github.com/JdeRobot/VisualStates-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## visualstates
