### PR TITLE
Add rosdep entry for Carla

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -339,6 +339,10 @@ can-utils:
   debian: [can-utils]
   fedora: [can-utils]
   ubuntu: [can-utils]
+carla:
+  ubuntu:
+    source:
+      uri: https://raw.githubusercontent.com/carla-simulator/ros-bridge/0.9.6/carla_ros_bridge.rdmanifest
 cccc:
   debian: [cccc]
   gentoo: [dev-util/cccc]


### PR DESCRIPTION
[carla_ros_bridge](https://github.com/carla-simulator/ros-bridge) ROS package aims at providing a simple ROS bridge for the [CARLA simulator](http://carla.org/l).
https://github.com/ros/rosdistro/pull/23173
To resolve the dependency on Carla, I would like to add Carla in rosdep.