### PR TITLE
googletest: 1.8.9000-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -22,5 +22,19 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.8.9000-1
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: ros2
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.8.9000-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
