### PR TITLE
ament_cmake: 0.8.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6,6 +6,38 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  ament_cmake:
+    release:
+      packages:
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_gmock
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_nose
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_version
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake-release.git
+      version: 0.8.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: master
+    status: developed
   ament_package:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `0.8.1-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
