### PR TITLE
ros_workspace: 0.8.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -68,5 +68,16 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  ros_workspace:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 0.8.0-2
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `0.8.0-2`:

- upstream repository: https://github.com/ros2/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ros_workspace

```
* Added .dsv file generation for PYTHONPATH. (#16 <https://github.com/ros2/ros_workspace/issues/16>)
* Added support for ament_package installed with setup.py develop. (#15 <https://github.com/ros2/ros_workspace/issues/15>)
* Contributors: Dirk Thomas
```
