### PR TITLE
visualstates: 0.2.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16796,7 +16796,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/VisualStates-release.git
-      version: 0.2.2-0
+      version: 0.2.3-2
     source:
       type: git
       url: https://github.com/JdeRobot/VisualStates.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualstates` to `0.2.3-2`:

- upstream repository: https://github.com/JdeRobot/VisualStates.git
- release repository: https://github.com/JdeRobot/VisualStates-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.2-0`

## visualstates