### PR TITLE
visualstates: 0.2.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10936,6 +10936,12 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: kinetic-devel
     status: maintained
+  visualstates:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/VisualStates-release.git
+      version: 0.2.3-2
   volksbot_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualstates` to `0.2.3-2`:

- upstream repository: https://github.com/JdeRobot/VisualStates.git
- release repository: https://github.com/JdeRobot/VisualStates-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## visualstates