### PR TITLE
[melodic] fix control_toolbox upstream branch

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1637,7 +1637,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -1646,7 +1646,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   convex_decomposition:
     doc:


### PR DESCRIPTION
The `control_toolbox` upstream branch should be `melodic-devel`. https://github.com/ros-controls/control_toolbox/tree/melodic-devel