### PR TITLE
SwarmROS updated for building

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17295,8 +17295,8 @@ repositories:
     status: maintained
   swarmros:
     doc:
-      type: svn
-      url: https://github.com/cpswarm/swarmio/trunk/master/swarmros
-      version: master
+      type: git
+      url: https://github.com/amilankovich-slab/swarmros
+      version: 0.3.1
 type: distribution
 version: 2

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15025,6 +15025,10 @@ repositories:
       version: kinetic-devel
     status: developed
   swarmros:
+    doc:
+      type: git
+      url: https://github.com/amilankovich-slab/swarmros.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -15037,10 +15041,6 @@ repositories:
       version: master
     status: developed
     status_description: developed
-    doc:
-      type: git
-      url: https://github.com/amilankovich-slab/swarmros.git
-      version: master
   swri_console:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17215,6 +17215,6 @@ repositories:
     doc:
       type: svn
       url: https://github.com/cpswarm/swarmio/trunk/master/swarmros
-      version: 0.9.1
+      version: master
 type: distribution
 version: 2

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15029,6 +15029,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
+      version 0.3.1-3
     source:
       test_pull_requests: true
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15029,7 +15029,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
-      version: 0.3.1-3
+      version: 0.3.1-4
     source:
       test_pull_requests: true
       type: git
@@ -15037,6 +15037,10 @@ repositories:
       version: master
     status: developed
     status_description: developed
+    doc:
+      type: git
+      url: https://github.com/amilankovich-slab/swarmros.git
+      version: 0.3.1-4
   swri_console:
     doc:
       type: git
@@ -17573,10 +17577,5 @@ repositories:
       url: https://github.com/zivid/zivid-ros.git
       version: master
     status: maintained
-  swarmros:
-    doc:
-      type: git
-      url: https://github.com/amilankovich-slab/swarmros-release.git
-      version: 0.3.1
 type: distribution
 version: 2

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17296,7 +17296,7 @@ repositories:
   swarmros:
     doc:
       type: git
-      url: https://github.com/amilankovich-slab/swarmros
+      url: https://github.com/amilankovich-slab/swarmros-release.git
       version: 0.3.1
 type: distribution
 version: 2

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17211,5 +17211,10 @@ repositories:
       url: https://github.com/zivid/zivid-ros.git
       version: master
     status: maintained
+  swarmros:
+    doc:
+      type: svn
+      url: https://github.com/cpswarm/swarmio/trunk/master/swarmros
+      version: 0.9.1
 type: distribution
 version: 2

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15040,7 +15040,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/amilankovich-slab/swarmros.git
-      version: 0.3.1-4
+      version: master
   swri_console:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15029,7 +15029,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
-      version 0.3.1-3
+      version: 0.3.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
[Previously ](https://github.com/ros/rosdistro/pull/23586)SwarmROS did not build successfully, as some dependencies were mission. this is an attempt to fix that issue.