### PR TITLE
urg_stamped: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10618,7 +10618,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.4-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.3-1`

## urg_stamped

```
* Automate bloom release (#58 <https://github.com/seqsense/urg_stamped/issues/58>)
* Add error count check (#57 <https://github.com/seqsense/urg_stamped/issues/57>)
* Fix response status check (#56 <https://github.com/seqsense/urg_stamped/issues/56>)
* Format pointer alignment (#55 <https://github.com/seqsense/urg_stamped/issues/55>)
* Contributors: Atsushi Watanabe
```
