### PR TITLE
slide_show: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2911,6 +2911,17 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: dashing-devel
     status: developed
+  slide_show:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/slide_show-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/slide_show.git
+      version: master
+    status: developed
   sophus:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `slide_show` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/slide_show.git
- release repository: https://github.com/ros2-gbp/slide_show-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## slide_show

```
* Initial Release
* Contributors: Shane Loretz
```
