### PR TITLE
slide_show: 0.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2473,6 +2473,17 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: eloquent
     status: maintained
+  slide_show:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/slide_show-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/slide_show.git
+      version: master
+    status: developed
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slide_show` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/slide_show.git
- release repository: https://github.com/ros2-gbp/slide_show-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## slide_show

```
* Initial Release
* Contributors: Shane Loretz
```
