### PR TITLE
fmi_adapter: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2739,7 +2739,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter-release.git
-      version: 1.0.2-0
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `1.0.3-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/boschresearch/fmi_adapter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.2-0`

## fmi_adapter

```
* Fixed sporadic exception in case of small external steps.
* Updated to FMILibrary version 2.1 and to new location of FMILibrary sources.
* Fixed fmuLocation argument for fmi2_import_instantiate.
```

## fmi_adapter_examples

```
* Updated instructions for FMU export from OpenModelica.
* Created explicit output revolute1_angle.
```
