### PR TITLE
fmi_adapter_ros2: 0.1.7-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -654,7 +654,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
-      version: 0.1.6-1
+      version: 0.1.7-2
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.7-2`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/boschresearch/fmi_adapter_ros2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.1.6-1`

## fmi_adapter

```
* Fixed sporadic exception in case of small external steps.
* Fixed fmuLocation argument for fmi2_import_instantiate.
```

## fmi_adapter_examples

```
* Updated instructions for FMU export from OpenModelica.
* Created explicit output revolute1_angle.
```
