### PR TITLE
sparse_bundle_adjustment: 0.4.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9676,7 +9676,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 0.4.2-0
+      version: 0.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.4.3-1`:

- upstream repository: https://github.com/ros-perception/sparse_bundle_adjustment.git
- release repository: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.4.2-0`

## sparse_bundle_adjustment

```
* remove bouncing email from maintainers
* Merge pull request #9 <https://github.com/ros-perception/sparse_bundle_adjustment/issues/9> from seanyen/modern_cpp
  [windows] use modern cpp & more portable fixes
* modernize cpp code & CMake files.
* Changing maintainer email
* Contributors: Luc Bettaieb, Michael Ferguson, seanyen
```
