### PR TITLE
pacmod3: 1.3.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1600,7 +1600,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/astuff/pacmod3-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/astuff/pacmod3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod3` to `1.3.1-1`:

- upstream repository: https://github.com/astuff/pacmod3.git
- release repository: https://github.com/astuff/pacmod3-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.0-1`

## pacmod3

```
* Added missing dependency to package.xml.
* Contributors: Joshua Whitley
```
