### PR TITLE
add libcdd-dev key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1661,6 +1661,12 @@ libccd-dev:
   gentoo: [sci-libs/libccd]
   openembedded: [libccd@meta-ros]
   ubuntu: [libccd-dev]
+libcdd-dev:
+  arch: [cddlib]
+  debian: [libcdd-dev]
+  fedora: [cddlib]
+  gentoo: [sci-libs/cddlib]
+  ubuntu: [libcdd-dev]
 libcegui-mk2-dev:
   arch: [cegui]
   debian: [libcegui-mk2-dev]


### PR DESCRIPTION
I'd like to use `libcdd-dev` but it does not yet exist in rosdep.
I added `libcdd-dev` key.

https://www.archlinux.jp/packages/community/x86_64/cddlib/
https://packages.debian.org/buster/libcdd-dev
https://src.fedoraproject.org/rpms/cddlib
https://packages.gentoo.org/packages/sci-libs/cddlib
https://packages.ubuntu.com/xenial/libcdd-dev
https://packages.ubuntu.com/bionic/libcdd-dev
