### PR TITLE
py_trees_ros_viewer: 0.2.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1387,7 +1387,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_viewer-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_viewer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_viewer` to `0.2.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_viewer.git
- release repository: https://github.com/stonier/py_trees_ros_viewer-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.2-1`

## py_trees_ros_viewer

```
* [backend] capture paralell policy details
```
