### PR TITLE
ros_workspace: 0.8.0-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -73,7 +73,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 0.8.0-2
+      version: 0.8.0-3
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `0.8.0-3`:

- upstream repository: https://github.com/ros2/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.8.0-2`

## ros_workspace

```
* Added .dsv file generation for PYTHONPATH. (#16 <https://github.com/ros2/ros_workspace/issues/16>)
* Added support for ament_package installed with setup.py develop. (#15 <https://github.com/ros2/ros_workspace/issues/15>)
* Contributors: Dirk Thomas
```
