### PR TITLE
neonavigation: 0.7.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8382,7 +8382,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.6.0-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.7.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.6.0-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: add MoveWithToleranceAction server (#433 <https://github.com/at-wat/neonavigation/issues/433>)
* planner_cspace: fix typo (#436 <https://github.com/at-wat/neonavigation/issues/436>)
* planner_cspace: implement motion primitive algorithm for speed-up (#431 <https://github.com/at-wat/neonavigation/issues/431>)
* Contributors: Daiki Maekawa, Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

```
* trajectory_tracker: calculate correct curvature at the end of path (#435 <https://github.com/at-wat/neonavigation/issues/435>)
* trajectory_tracker: fix test initialization timeout (#432 <https://github.com/at-wat/neonavigation/issues/432>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```
