### PR TITLE
tf2_server: 1.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10013,7 +10013,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/tf2_server-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/peci1/tf2_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_server` to `1.0.4-1`:

- upstream repository: https://github.com/peci1/tf2_server.git
- release repository: https://github.com/peci1/tf2_server-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.3-1`

## tf2_server

```
* Added a parameter that can help distinguishing between the original and the upgraded TF2 server.
* Added support for running the server as nodelet.
* Added support for updating the requested subtree during runtime.
* Contributors: Martin Pecka
```
