### PR TITLE
Add libkml and python-kml rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2386,6 +2386,10 @@ libkdtree++-dev:
   debian: [libkdtree++-dev]
   fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]
+libkml-dev:
+  arch: [libkml]
+  debian: [libkml-dev]
+  ubuntu: [libkml-dev]
 liblapack-dev:
   arch: [lapack]
   debian: [liblapack-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2196,7 +2196,6 @@ python-kitchen:
       packages: [kitchen]
   ubuntu: [python-kitchen]
 python-kml:
-  arch: [libkml]
   debian: [python-kml]
   ubuntu: [python-kml]
 python-kombu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2195,6 +2195,10 @@ python-kitchen:
     pip:
       packages: [kitchen]
   ubuntu: [python-kitchen]
+python-kml:
+  arch: [libkml]
+  debian: [python-kml]
+  ubuntu: [python-kml]
 python-kombu:
   debian: [python-kombu]
   fedora: [python-kombu]


### PR DESCRIPTION
libkml is Google's reference implementation of OGC KML 2.2.

Home page: https://github.com/libkml/libkml

- Debian: https://packages.debian.org/source/buster/libkml
- Ubuntu: https://packages.ubuntu.com/source/bionic/libkml

I was unable to find Gentoo or Fedora packages, unfortunately.