### PR TITLE
rcdiscover: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7430,7 +7430,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rcdiscover-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcdiscover` to `1.0.2-1`:

- upstream repository: https://github.com/roboception/rcdiscover.git
- release repository: https://github.com/roboception-gbp/rcdiscover-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.0-1`

## rcdiscover

```
* Added filtering by model name in command line tool
* Do not append alternative interface to output of cli if --serialonly or --iponly is given
```
