### PR TITLE
laser_geometry: 2.1.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -919,7 +919,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.1.0-2`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.1.0-1`

## laser_geometry

```
* Merge pull request #46 <https://github.com/ros-perception/laser_geometry/issues/46> from sloretz/eigen3_cmake_module
* Contributors: Jonathan Binney, Shane Loretz
```
