### PR TITLE
Add Connext 5.3.1 rosdep rule for Ubuntu Focal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4974,6 +4974,7 @@ rsyslog:
 rti-connext-dds-5.3.1:
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
+    focal: [rti-connext-dds-5.3.1]
     xenial: [rti-connext-dds-5.3.1]
 rtmidi:
   debian: [librtmidi-dev]


### PR DESCRIPTION
Soon to be available via the ROS repositories

cc/ @nuclearsandwich 