### PR TITLE
cartographer_ros: 1.0.9001-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -239,7 +239,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 1.0.9000-1
+      version: 1.0.9001-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.9001-1`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.9000-1`

## cartographer_ros

```
* Init rclcpp first (#41 <https://github.com/ros2/cartographer_ros/issues/41>)
* Strip ROS args before passing to GFlags (#40 <https://github.com/ros2/cartographer_ros/issues/40>)
* Fix argument intiialization to allow node to take in params (#39 <https://github.com/ros2/cartographer_ros/issues/39>)
* Contributors: Emerson Knapp, Shane Loretz
```

## cartographer_ros_msgs

- No changes
