### PR TITLE
vision_msgs: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2839,6 +2839,21 @@ repositories:
       url: https://github.com/kobuki-base/velocity_smoother.git
       version: devel
     status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: ros2
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/Kukanani/vision_msgs.git
- release repository: https://github.com/Kukanani/vision_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
