### PR TITLE
random_numbers: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -310,6 +310,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release.git
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `0.3.2-1`:

- upstream repository: https://github.com/ros-planning/random_numbers.git
- release repository: https://github.com/ros-gbp/random_numbers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## random_numbers

```
* Update maintainership. (#11 <https://github.com/ros-planning/random_numbers/issues/11>)
* Contributors: Steven! Ragnarök
```
