### PR TITLE
navigation2: 0.3.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1057,7 +1057,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.3.3-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.2-1`

I'm attempting to fix the debian generation for nav2_system_tests (http://build.ros2.org/job/Ebin_uB64__nav2_system_tests__ubuntu_bionic_amd64__binary/)  with the issues described here (https://github.com/ros-planning/navigation2/issues/1506). 
