### PR TITLE
Add pcg-gazebo to rosdep list

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3408,6 +3408,9 @@ libsoqt4-dev:
   fedora: [SoQt-devel]
   gentoo: [media-libs/SoQt]
   ubuntu: [libsoqt4-dev]
+libspatialindex-dev:
+  debian: [libspatialindex-dev]
+  ubuntu: [libspatialindex-dev]
 libspatialite:
   arch: [libspatialite]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -233,15 +233,6 @@ paramiko:
       packages: [paramiko]
   rhel: [python-paramiko]
   ubuntu: [python-paramiko]
-pcg-gazebo-pip:
-  debian:
-    pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
-      packages: [pcg-gazebo]
-  ubuntu:
-    pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
-      packages: [pcg-gazebo]
 pi-ina219-pip:
   debian:
     pip:
@@ -2889,6 +2880,15 @@ python-pcapy:
   fedora: [pcapy]
   gentoo: [dev-python/pcapy]
   ubuntu: [python-pcapy]
+python-pcg-gazebo-pip:
+  debian:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
+  ubuntu:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
 python-pep8:
   arch: [python2-pep8]
   debian: [pep8]
@@ -5410,6 +5410,15 @@ python3-paramiko:
   fedora: [python3-paramiko]
   gentoo: [dev-python/paramiko]
   ubuntu: [python3-paramiko]
+python3-pcg-gazebo-pip:
+  debian:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
+  ubuntu:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
 python3-pep8:
   alpine: [py3-pycodestyle]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -233,6 +233,15 @@ paramiko:
       packages: [paramiko]
   rhel: [python-paramiko]
   ubuntu: [python-paramiko]
+pcg-gazebo-pip:
+  debian:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
+  ubuntu:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
 pi-ina219-pip:
   debian:
     pip:


### PR DESCRIPTION
`pcg-gazebo` is a Python package for procedural generation for Gazebo that has been published as a `pip` package recently. 

PyPi: https://pypi.org/project/pcg-gazebo/

It includes three dependencies, two of which can already be found in `base.yaml` (`geos` and `pybind11-dev`). It was necessary to add the third one (`libspatialindex-dev`) to `base.yaml`.

- Debian: https://packages.debian.org/buster/libspatialindex-dev
- Ubuntu: https://packages.ubuntu.com/bionic/libspatialindex-dev