### PR TITLE
plotjuggler: 2.5.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6615,7 +6615,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.5.0-1
+      version: 2.5.1-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.5.1-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.5.0-1`

## plotjuggler

```
* Fixed slow Menu Bar
* Use ordered map, appendData needs to insert data in order (#245 <https://github.com/facontidavide/PlotJuggler/issues/245>)
  Otherwise the time order may not be respected and the data is loaded
  incorrectly
* prevent call of dropEvent() when not needed
* fix issue #239 <https://github.com/facontidavide/PlotJuggler/issues/239>
* add include array header file to fix build error (#234 <https://github.com/facontidavide/PlotJuggler/issues/234>)
* Contributors: Davide Faconti, Victor Lopez, xiaowei zhao
```
