### PR TITLE
gennodejs: 2.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -181,6 +181,11 @@ repositories:
       version: kinetic-devel
     status: maintained
   gennodejs:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/sloretz/gennodejs-release.git
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/RethinkRobotics-opensource/gennodejs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gennodejs` to `2.0.2-1`:

- upstream repository: https://github.com/sloretz/gennodejs.git
- release repository: https://github.com/sloretz/gennodejs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
