### PR TITLE
rosdoc_lite: 0.2.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -443,6 +443,21 @@ repositories:
       url: https://github.com/ros/roscpp_core.git
       version: noetic-devel
     status: maintained
+  rosdoc_lite:
+    doc:
+      type: git
+      url: https://github.com/ros-infrastructure/rosdoc_lite.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosdoc_lite-release.git
+      version: 0.2.10-1
+    source:
+      type: git
+      url: https://github.com/ros-infrastructure/rosdoc_lite.git
+      version: master
+    status: maintained
   roslint:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosdoc_lite` to `0.2.10-1`:

- upstream repository: https://github.com/ros-infrastructure/rosdoc_lite.git
- release repository: https://github.com/ros-gbp/rosdoc_lite-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## rosdoc_lite

```
* Add mdfile to INPUT
* Use conditional dependencies (#93 <https://github.com/ros-infrastructure/rosdoc_lite/issues/93>)
  * Use conditional dependencies for all Python rosdep keys
  * Only depend on epydoc if using Python 2
  * Switch to python?-catkin-pkg-modules since the CLI tools aren't used
  * Python 2 and 3 versions are side-by-side installable
  * Switch to python?-rospkg-modules since the CLI tools aren't used
  * Python 2 and 3 versions are side-by-side installable
* Add mdfile to INPUT
* backwards-compatible fix for python3 API changes
* fix cmake failure when building without tests
* Removes obsolete doxygen options
  fix cmake failure when building without tests
* enable linking to documentation hosted on third party server
* Update exception handling to Python2.6+ / Python3 syntax
* Fix getting doxygen path when output_folder is defined
* Add unit tests for getting doxygen path
* Better name of function getting the documentation path
* Update exception handling to Python2.6+ / Python3 syntax
* Merge branch 'master' of github.com:jobleier/rosdoc_lite
* enable 'docs_url' pointing to documentation hosted on third party server with external Doxygen documentation using tag files
* Contributors: Alexander Gutenkunst, Finn-Thorben Sell, Johannes Bleier, Matthijs van der Burgh, Paul Dinh, Riku Shigematsu, Shane Loretz, Tully Foote, v4hn
```
