### PR TITLE
class_loader: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -47,6 +47,15 @@ repositories:
       version: noetic-devel
     status: maintained
   class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/class_loader-release.git
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.5.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## class_loader

```
* Declare specific boost dependencies. (#136 <https://github.com/ros/class_loader/issues/136>)
* Contributors: Mikael Arguedas
```
