### PR TITLE
mikrotik_swos_tools: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4916,6 +4916,21 @@ repositories:
       url: https://github.com/ros-drivers/microstrain_mips.git
       version: master
     status: developed
+  mikrotik_swos_tools:
+    doc:
+      type: git
+      url: https://github.com/peci1/mikrotik_swos_tools.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/mikrotik_swos_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/peci1/mikrotik_swos_tools.git
+      version: master
+    status: developed
   mir_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mikrotik_swos_tools` to `1.0.1-1`:

- upstream repository: https://github.com/peci1/mikrotik_swos_tools.git
- release repository: https://github.com/peci1/mikrotik_swos_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## mikrotik_swos_tools

```
* Initial commit.
* Contributors: Martin Pecka
```
