### PR TITLE
tf2_server: 1.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10024,7 +10024,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/tf2_server-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/peci1/tf2_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_server` to `1.0.5-1`:

- upstream repository: https://github.com/peci1/tf2_server.git
- release repository: https://github.com/peci1/tf2_server-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.4-1`

## tf2_server

```
* Added support for streams whose TF tree can be updated during runtime.
* Added support for initial streams.
* Added possibility to specify desired names of the published transform streams.
* Contributors: Martin Pecka
```
