### PR TITLE
ros_cvb_camera_driver: 0.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12406,6 +12406,16 @@ repositories:
       type: git
       url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
+      version: master
+    status: maintained
   ros_emacs_utils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_cvb_camera_driver` to `0.0.1-1`:

- upstream repository: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
- release repository: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ros_cvb_camera_driver

```
* Added license in package.xml
* Changed package xml
* Finished ros_cvb_camera_driver. Rectified image can now be published.
* Added camera_info
* Cropped fish eye image
* Initial commit
* Contributors: Johanna Gleichauf
```
