### PR TITLE
catkin_virtualenv: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1027,7 +1027,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.5.2-1`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.1-1`

## catkin_virtualenv

```
* First python2 issue of 2020 (#49)
  * Clean up options, virtualenv installs setuptools by default
  * Make sure we install a compatible setuptools version for py2 venv
* Contributors: Paul Bovbel
```
