### PR TITLE
pointcloud_to_laserscan: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1279,6 +1279,22 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: eloquent
     status: maintained
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: eloquent-devel
+    status: maintained
   popf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `2.0.0-1`:

- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## pointcloud_to_laserscan

```
* ROS 2 Migration (#33 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/33>)
  * ROS 2 Migration
  Signed-off-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
* Contributors: Michel Hidalgo
```
