### PR TITLE
exotica: 5.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2375,7 +2375,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/exotica-release.git
-      version: 5.1.0-1
+      version: 5.1.1-1
     source:
       type: git
       url: https://github.com/ipab-slmc/exotica.git


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica` to `5.1.1-1`:

- upstream repository: https://github.com/ipab-slmc/exotica.git
- release repository: https://github.com/ipab-slmc/exotica-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `5.1.0-1`

## exotica

- No changes

## exotica_aico_solver

- No changes

## exotica_cartpole_dynamics_solver

- No changes

## exotica_collision_scene_fcl

- No changes

## exotica_collision_scene_fcl_latest

- No changes

## exotica_core

```
* Fix to avoid duplicate ID=0 in KinematicTree (#683 <https://github.com/ipab-slmc/exotica/issues/683>)
* Added explicit general dependency on libzmq3-dev to fix buildfarm build issues
* Contributors: Vladimir Ivan, Wolfgang Merkt
```

## exotica_core_task_maps

- No changes

## exotica_ddp_solver

- No changes

## exotica_double_integrator_dynamics_solver

- No changes

## exotica_dynamics_solvers

- No changes

## exotica_examples

- No changes

## exotica_ik_solver

- No changes

## exotica_ilqg_solver

- No changes

## exotica_ilqr_solver

- No changes

## exotica_levenberg_marquardt_solver

- No changes

## exotica_ompl_control_solver

- No changes

## exotica_ompl_solver

- No changes

## exotica_pendulum_dynamics_solver

- No changes

## exotica_pinocchio_dynamics_solver

- No changes

## exotica_python

- No changes

## exotica_quadrotor_dynamics_solver

- No changes

## exotica_scipy_solver

- No changes

## exotica_time_indexed_rrt_connect_solver

- No changes
