### PR TITLE
pacmod: 2.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9405,7 +9405,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/pacmod-release.git
-      version: 2.0.2-0
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/astuff/pacmod.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod` to `2.1.0-1`:

- upstream repository: https://github.com/astuff/pacmod.git
- release repository: https://github.com/astuff/pacmod-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.0.2-0`

## pacmod

```
* Merge pull request #14 <https://github.com/astuff/pacmod/issues/14> from astuff/fix/updated_msgs
  URGENT: Fix message changes from pacmod_msgs.
* Merge pull request #13 <https://github.com/astuff/pacmod/issues/13> from astuff/maint/code_cleanup
  Formatting clean-up of code and updating of license headers.
* Merge pull request #11 <https://github.com/astuff/pacmod/issues/11> from astuff/maint/roslint_cleanup
  Removing roslint exception. Cleaning up include paths.
* Merge pull request #10 <https://github.com/astuff/pacmod/issues/10> from astuff/maint/remove_redundant_folders
  Moving all files up a directory, consistent with other packages.
* Moving DBC to new repo. CI: Removing Indigo.
* Merge pull request #6 <https://github.com/astuff/pacmod/issues/6> from astuff/maint/add_melodic_build
  Maint/add melodic build
* Allowed_failures wasn't working before.
* Forgot to remove ROSINSTALL_FILENAME from allowed failures.
* Removing ROSINSTALL_FILE as it isn't necessary with a version postfix.
* Fixing ROSINSTALL_FILENAME in Travis.
* Adding separate rosinstall files for lunar and melodic.
* Adding melodic build to Travis.
* Contributors: Daniel-Stanek, Joe Kale, Joshua Whitley, Nishanth Samala, Sam Rustan, Zach Oakes
```
