### PR TITLE
teleop_tools: 0.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15201,7 +15201,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.3.0-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.3.1-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.0-0`

## joy_teleop

```
* fix python3 compatibility (#42 <https://github.com/ros-teleop/teleop_tools/issues/42>)
* Contributors: Yutaka Kondo
```

## key_teleop

- No changes

## mouse_teleop

- No changes

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
