### PR TITLE
teleop_tools: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9940,7 +9940,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: melodic-devel
+      version: kinetic-devel
     release:
       packages:
       - joy_teleop
@@ -9951,11 +9951,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.3.0-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: melodic-devel
+      version: kinetic-devel
     status: maintained
   teleop_twist_joy:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.3.1-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.0-0`

## joy_teleop

```
* fix python3 compatibility (#42 <https://github.com/ros-teleop/teleop_tools/issues/42>)
* Contributors: Yutaka Kondo
```

## key_teleop

- No changes

## mouse_teleop

- No changes

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
