### PR TITLE
message_generation: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -261,6 +261,15 @@ repositories:
       version: indigo-devel
     status: maintained
   message_generation:
+    doc:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/message_generation-release.git
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros/message_generation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.4.1-1`:

- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/ros-gbp/message_generation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
