### PR TITLE
message_generation: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4840,7 +4840,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/message_generation-release.git
-      version: 0.4.0-0
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros/message_generation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_generation` to `0.4.1-1`:

- upstream repository: https://github.com/ros/message_generation.git
- release repository: https://github.com/ros-gbp/message_generation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.4.0-0`
