### PR TITLE
std_msgs: 0.5.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -601,6 +601,15 @@ repositories:
       version: master
     status: maintained
   std_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/std_msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/std_msgs-release.git
+      version: 0.5.13-1
     source:
       type: git
       url: https://github.com/ros/std_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs` to `0.5.13-1`:

- upstream repository: git@github.com:ros/std_msgs.git
- release repository: https://github.com/ros-gbp/std_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
