### PR TITLE
qwt_dependency: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -336,6 +336,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   qwt_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qwt_dependency.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/qwt_dependency-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/qwt_dependency.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qwt_dependency` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/qwt_dependency.git
- release repository: https://github.com/ros-gbp/qwt_dependency-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
