### PR TITLE
webkit_dependency: 1.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -672,7 +672,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/webkit_dependency-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/webkit_dependency.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webkit_dependency` to `1.1.2-1`:

- upstream repository: https://github.com/ros-visualization/webkit_dependency.git
- release repository: https://github.com/ros-gbp/webkit_dependency-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.1.1-1`
