### PR TITLE
add python3-lxml osx entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5317,6 +5317,9 @@ python3-lxml:
   freebsd: [py36-lxml]
   gentoo: [dev-python/lxml]
   openembedded: [python3-lxml@meta-python]
+  osx:
+    pip:
+      packages: [lxml]
   rhel: ['python%{python3_pkgversion}-lxml']
   ubuntu: [python3-lxml]
 python3-matplotlib:


### PR DESCRIPTION
Add osx entry for lxml.

Packages:
- pip: https://pypi.org/project/lxml/

Needed in [nodl](https://github.com/ubuntu-robotics/nodl) and [SROS2](https://github.com/ros2/sros2).

Signed-off-by: Ted Kern <ted.kern@canonical.com>