### PR TITLE
Add python3-serial

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5638,6 +5638,10 @@ python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
   ubuntu: [python3-scp]
+python3-serial:
+  debian: [python3-serial]
+  fedora: [python3-pyserial]
+  ubuntu: [python3-serial]
 python3-setuptools:
   debian: [python3-setuptools]
   fedora: [python3-setuptools]


### PR DESCRIPTION
This currently only exists as _python3 distribution codenames. This PR adds it as a new entry as well.