### PR TITLE
ainstein_radar: 3.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -204,7 +204,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 2.0.2-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ainstein_radar` to `3.0.1-1`:

- upstream repository: https://github.com/AinsteinAI/ainstein_radar.git
- release repository: https://github.com/AinsteinAI/ainstein_radar-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.0.2-1`

## ainstein_radar

- No changes

## ainstein_radar_drivers

- No changes

## ainstein_radar_filters

```
* Minor, add missing dependency
* Contributors: Nick Rotella
```

## ainstein_radar_gazebo_plugins

- No changes

## ainstein_radar_msgs

- No changes

## ainstein_radar_rviz_plugins

- No changes

## ainstein_radar_tools

- No changes
