### PR TITLE
ros: 1.14.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7963,7 +7963,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.14.7-1
+      version: 1.14.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.14.8-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.14.7-1`

## mk

```
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## rosbash

```
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Replace $1 and $2 with $pkg_name and $file_name (#239 <https://github.com/ros/ros/issues/239>)
* add roscp. (#237 <https://github.com/ros/ros/issues/237>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
* fix find -perm /mode usage for FreeBSD (#232 <https://github.com/ros/ros/issues/232>)
```

## rosboost_cfg

```
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Use setuptools instead of distutils (#235 <https://github.com/ros/ros/issues/235>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## rosbuild

```
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## rosclean

```
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Use setuptools instead of distutils (#235 <https://github.com/ros/ros/issues/235>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## roscreate

```
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Use setuptools instead of distutils (#235 <https://github.com/ros/ros/issues/235>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## roslang

```
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## roslib

```
* fix various issues discovered by flake8 (#241 <https://github.com/ros/ros/issues/241>)
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* restrict boost dependencies to components used (#236 <https://github.com/ros/ros/issues/236>)
* Use setuptools instead of distutils (#235 <https://github.com/ros/ros/issues/235>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## rosmake

```
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Use setuptools instead of distutils (#235 <https://github.com/ros/ros/issues/235>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```

## rosunit

```
* fix various issues discovered by flake8 (#241 <https://github.com/ros/ros/issues/241>)
* update style to pass flake8 (#240 <https://github.com/ros/ros/issues/240>)
* Use setuptools instead of distutils (#235 <https://github.com/ros/ros/issues/235>)
* Bump CMake version to avoid CMP0048 warning (#234 <https://github.com/ros/ros/issues/234>)
```
