### PR TITLE
ros: 1.15.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -421,7 +421,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   ros_comm:
     source:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -396,6 +396,27 @@ repositories:
       version: noetic-devel
     status: maintained
   ros:
+    doc:
+      type: git
+      url: https://github.com/ros/ros.git
+      version: noetic-devel
+    release:
+      packages:
+      - mk
+      - ros
+      - rosbash
+      - rosboost_cfg
+      - rosbuild
+      - rosclean
+      - roscreate
+      - roslang
+      - roslib
+      - rosmake
+      - rosunit
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros-release.git
+      version: 1.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.0-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## mk

- No changes

## rosbash

```
* add heuristic to run python devel space relays (#233 <https://github.com/ros/ros/issues/233>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

- No changes
