### PR TITLE
rosconsole: 1.13.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -482,6 +482,15 @@ repositories:
       version: master
     status: maintained
   rosconsole:
+    doc:
+      type: git
+      url: https://github.com/ros/rosconsole.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosconsole-release.git
+      version: 1.13.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole` to `1.13.12-1`:

- upstream repository: https://github.com/ros/rosconsole.git
- release repository: https://github.com/ros-gbp/rosconsole-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## rosconsole

```
* declare specific boost dependencies (#35 <https://github.com/ros/rosconsole/issues/35>)
* fix console printer to also print unknown levels (#34 <https://github.com/ros/rosconsole/issues/34>)
* fix level comparison for compatibility with upstream log4cxx (#33 <https://github.com/ros/rosconsole/issues/33>)
```
