### PR TITLE
rosconsole: 1.13.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -490,7 +490,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole-release.git
-      version: 1.13.12-1
+      version: 1.13.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole` to `1.13.13-1`:

- upstream repository: https://github.com/ros/rosconsole.git
- release repository: https://github.com/ros-gbp/rosconsole-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.13.12-1`

## rosconsole

```
* bump minimum CMake version to avoid CMP0048 warning (#36 <https://github.com/ros/rosconsole/issues/36>)
```
