### PR TITLE
system_modes: 0.2.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2570,7 +2570,11 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.1.5-1
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/microROS/system_modes.git
+      version: master
     status: developed
   teleop_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.2.0-2`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.1.5-1`
