### PR TITLE
ira_laser_tools: 1.0.3-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3743,6 +3743,21 @@ repositories:
       url: https://github.com/KITrobotics/ipr_extern.git
       version: kinetic-devel
     status: developed
+  ira_laser_tools:
+    doc:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/iralabdisco/ira_laser_tools-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    status: developed
   ivcon:
     doc:
       type: git


### PR DESCRIPTION
ira_laser_tools: 1.0.3-1 in 'melodic/distribution.yaml'

upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
distro file: melodic/distribution.yaml
previous version for package: null