### PR TITLE
ira_laser_tools: 1.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5491,7 +5491,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ira_laser_tools` to `1.0.4-1`:

- upstream repository: https://github.com/iralabdisco/ira_laser_tools.git
- release repository: https://github.com/iralabdisco/ira_laser_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.3-1`

## ira_laser_tools

```
* fix worning
  "<command-line>:0:0: warning: missing whitespace after the macro name"
* change email maintainer
* Contributors: Pietro Colombo
```
