### PR TITLE
ColorTuner: 0.0.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,6 +8,19 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  ColorTuner:
+    release:
+      packages:
+      - jderobot_color_tuner
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/ColorTuner.git
+      version: master
   abb:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ColorTuner` to `0.0.3-2`:

- upstream repository: https://github.com/JdeRobot/ColorTuner.git
- release repository: https://github.com/JdeRobot/ColorTuner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## jderobot_color_tuner

- No changes
