### PR TITLE
jderobot_drones: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3841,12 +3841,13 @@ repositories:
     release:
       packages:
       - drone_wrapper
+      - jderobot_drones
       - rqt_drone_teleop
       - rqt_ground_robot_teleop
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.2.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.1-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.0-1`

## drone_wrapper

```
* Fixing dependency on metapackage
* Contributors: Pedro Arias
```

## jderobot_drones

```
* Fixing dependency on metapackage
* Contributors: Pedro Arias
```

## rqt_drone_teleop

```
* Fixing dependency on metapackage
* Contributors: Pedro Arias
```

## rqt_ground_robot_teleop

```
* Fixing dependency on metapackage
* Contributors: Pedro Arias
```
