### PR TITLE
python: Add python3-autobahn package definition

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5088,6 +5088,10 @@ python3-asyncssh:
   debian: [python3-asyncssh]
   fedora: [python3-asyncssh]
   ubuntu: [python3-asyncssh]
+python3-autobahn:
+  debian: [python3-autobahn]
+  fedora: [python3-autobahn]
+  ubuntu: [python3-autobahn]
 python3-babeltrace:
   debian: [python3-babeltrace]
   ubuntu: [python3-babeltrace]


### PR DESCRIPTION
Add `python3-autobahn` package definition for Debian, Ubuntu, Fedora.

`python3-autobahn` package definition is required for `rosbridge_suite`, specifically for https://github.com/RobotWebTools/rosbridge_suite/pull/460 to work.