### PR TITLE
ifm3d-release: 0.17.0-9 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5039,6 +5039,7 @@ repositories:
       url: https://github.com/ifm/ifm3d-release.git
       version: 0.17.0-9
     source:
+      test_commits: false
       type: git
       url: https://github.com/ifm/ifm3d.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5034,8 +5034,6 @@ repositories:
       url: https://github.com/ifm/ifm3d.git
       version: master
     release:
-      packages:
-      - ifm3d_core
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5029,6 +5029,10 @@ repositories:
       version: release
     status: developed
   ifm3d-release:
+    doc:
+      type: git
+      url: https://github.com/ifm/ifm3d.git
+      version: master
     release:
       packages:
       - ifm3d-core
@@ -5036,6 +5040,11 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
       version: 0.17.0-6
+    source:
+      type: git
+      url: https://github.com/ifm/ifm3d.git
+      version: master
+    status: maintained
   ifm_o3mxxx:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5029,20 +5029,11 @@ repositories:
       version: release
     status: developed
   ifm3d_core:
-    doc:
-      type: git
-      url: https://github.com/ifm/ifm3d.git
-      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
       version: 0.17.0-9
-    source:
-      test_commits: false
-      type: git
-      url: https://github.com/ifm/ifm3d.git
-      version: master
     status: maintained
   ifm_o3mxxx:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5039,7 +5039,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-6
+      version: 0.17.0-8
     source:
       type: git
       url: https://github.com/ifm/ifm3d.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5028,6 +5028,14 @@ repositories:
       url: https://github.com/astuff/ibeo_lux.git
       version: release
     status: developed
+  ifm3d-release:
+    release:
+      packages:
+      - ifm3d-core
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.17.0-6
   ifm_o3mxxx:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5028,18 +5028,18 @@ repositories:
       url: https://github.com/astuff/ibeo_lux.git
       version: release
     status: developed
-  ifm3d-release:
+  ifm3d_core:
     doc:
       type: git
       url: https://github.com/ifm/ifm3d.git
       version: master
     release:
       packages:
-      - ifm3d-core
+      - ifm3d_core
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-8
+      version: 0.17.0-9
     source:
       type: git
       url: https://github.com/ifm/ifm3d.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d-release` to `0.17.0-9`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
