### PR TITLE
ifm3d-release: 0.17.0-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3458,18 +3458,18 @@ repositories:
       url: https://github.com/astuff/ibeo_lux.git
       version: release
     status: developed
-  ifm3d-release:
+  ifm3d_core:
     doc:
       type: git
       url: https://github.com/ifm/ifm3d.git
       version: master
     release:
       packages:
-      - ifm3d-core
+      - ifm3d_core
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-4
+      version: 0.17.0-5
     source:
       type: git
       url: https://github.com/ifm/ifm3d.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3464,8 +3464,6 @@ repositories:
       url: https://github.com/ifm/ifm3d.git
       version: master
     release:
-      packages:
-      - ifm3d_core
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3459,19 +3459,11 @@ repositories:
       version: release
     status: developed
   ifm3d_core:
-    doc:
-      type: git
-      url: https://github.com/ifm/ifm3d.git
-      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
       version: 0.17.0-5
-    source:
-      type: git
-      url: https://github.com/ifm/ifm3d.git
-      version: master
     status: maintained
   ifopt:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3469,7 +3469,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-3
+      version: 0.17.0-4
     source:
       type: git
       url: https://github.com/ifm/ifm3d.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3458,6 +3458,14 @@ repositories:
       url: https://github.com/astuff/ibeo_lux.git
       version: release
     status: developed
+  ifm3d-release:
+    release:
+      packages:
+      - ifm3d-core
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.17.0-3
   ifopt:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3459,6 +3459,10 @@ repositories:
       version: release
     status: developed
   ifm3d-release:
+    doc:
+      type: git
+      url: https://github.com/ifm/ifm3d.git
+      version: master
     release:
       packages:
       - ifm3d-core
@@ -3466,6 +3470,11 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
       version: 0.17.0-3
+    source:
+      type: git
+      url: https://github.com/ifm/ifm3d.git
+      version: master
+    status: maintained
   ifopt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d-release` to `0.17.0-5`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
