### PR TITLE
dbw_fca_ros: 1.0.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2354,7 +2354,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.0.6-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `1.0.9-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.6-1`

## dbw_fca

- No changes

## dbw_fca_can

```
* Update firmware versions
* Report NAN for signals that are unavailable/faulted
* Add door commands
* Contributors: Kevin Hallenbeck
```

## dbw_fca_description

- No changes

## dbw_fca_joystick_demo

```
* Add door commands
* Contributors: Kevin Hallenbeck
```

## dbw_fca_msgs

```
* Add door commands
* Contributors: Kevin Hallenbeck
```
