### PR TITLE
dbw_mkz_ros: 1.2.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2372,11 +2372,10 @@ repositories:
       - dbw_mkz_description
       - dbw_mkz_joystick_demo
       - dbw_mkz_msgs
-      - dbw_mkz_twist_controller
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.2.3-1
+      version: 1.2.7-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_mkz_ros` to `1.2.7-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.2.3-1`

## dbw_mkz

- No changes

## dbw_mkz_can

```
* Update firmware versions
* Report NAN for signals that are unavailable/faulted
* Use fewer function calls to setup message sync
* Add Lincoln Aviator to list of platforms
* Contributors: Kevin Hallenbeck
```

## dbw_mkz_description

- No changes

## dbw_mkz_joystick_demo

- No changes

## dbw_mkz_msgs

- No changes
