### PR TITLE
pluginlib: 1.12.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -325,6 +325,15 @@ repositories:
       version: indigo-devel
     status: maintained
   pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/pluginlib-release.git
+      version: 1.12.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.12.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## pluginlib

```
* Add bin to library search path on Windows. (#145 <https://github.com/ros/pluginlib/issues/145>)
* Bump minimum CMake version to avoid CMP0048 warning. (#173 <https://github.com/ros/pluginlib/issues/173>)
* Check for NULL in XMLElement::Attribute. (#163 <https://github.com/ros/pluginlib/issues/163>)
* Check for NULL in XMLElement::GetText. (#159 <https://github.com/ros/pluginlib/issues/159>)
* Check for NULL in XMLNode::Value. (#158 <https://github.com/ros/pluginlib/issues/158>)
* Update header migration script for Python 3. (#148 <https://github.com/ros/pluginlib/issues/148>)
* Make Steven! Ragnarok the maintainer. (#129 <https://github.com/ros/pluginlib/issues/129>)
* Fix spelling Attirbute=>Attribute. (#128 <https://github.com/ros/pluginlib/issues/128>)
* Link test_plugins against class_loader for Windows compilation. (#125 <https://github.com/ros/pluginlib/issues/125>)
* Fix build issue when build on Windows (#123 <https://github.com/ros/pluginlib/issues/123>)
* Contributors: James Xu, Jeremie Deray, Johnson Shih, Markus Grimm, Mikael Arguedas, Shane Loretz, josch
```
