### PR TITLE
ubnt_airos_tools: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10523,6 +10523,21 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: master
     status: maintained
+  ubnt_airos_tools:
+    doc:
+      type: git
+      url: https://github.com/peci1/ubnt_airos_tools.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/ubnt_airos_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/peci1/ubnt_airos_tools.git
+      version: master
+    status: developed
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ubnt_airos_tools` to `1.0.1-1`:

- upstream repository: https://github.com/peci1/ubnt_airos_tools.git
- release repository: https://github.com/peci1/ubnt_airos_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ubnt_airos_tools

```
* Initial commit.
* Contributors: Martin Pecka
```
