### PR TITLE
ardu_offb: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -233,6 +233,16 @@ repositories:
       url: https://github.com/vanadiumlabs/arbotix_ros.git
       version: indigo-devel
     status: maintained
+  ardu_offb:
+    doc:
+      type: git
+      url: https://github.com/AhmedHumais/ardu_offb
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/AhmedHumais/ardu_offb.git
+      version: 0.0.2-1
   ariles_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ardu_offb` to `0.0.2-1`:

- upstream repository: https://github.com/AhmedHumais/ardu_offb.git
- release repository: https://github.com/AhmedHumais/ardu_offb.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
