### PR TITLE
iirob_filters: 0.8.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3494,7 +3494,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KITrobotics/iirob_filters-release.git
-      version: 0.8.1-2
+      version: 0.8.3-2
     source:
       type: git
       url: https://github.com/KITrobotics/iirob_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iirob_filters` to `0.8.3-2`:

- upstream repository: https://github.com/KITrobotics/iirob_filters.git
- release repository: https://github.com/KITrobotics/iirob_filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.8.1-2`
