### PR TITLE
Add rafcon-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5567,6 +5567,16 @@ python3-qt5-bindings-webkit:
   fedora: [python3-qt5-webkit]
   gentoo: ['dev-python/PyQt5[webkit]']
   ubuntu: [python3-pyqt5.qtwebkit]
+python3-rafcon-pip:
+  debian:
+    pip:
+      packages: [rafcon]
+  fedora:
+    pip:
+      packages: [rafcon]
+  ubuntu:
+    pip:
+      packages: [rafcon]
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5749,6 +5749,16 @@ quadprog-pip:
     pip: [quadprog]
   ubuntu:
     pip: [quadprog]
+rafcon-pip:
+  debian:
+    pip:
+      packages: [rafcon]
+  fedora:
+    pip:
+      packages: [rafcon]
+  ubuntu:
+    pip:
+      packages: [rafcon]
 rosbag-metadata-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5759,16 +5759,6 @@ quadprog-pip:
     pip: [quadprog]
   ubuntu:
     pip: [quadprog]
-rafcon-pip:
-  debian:
-    pip:
-      packages: [rafcon]
-  fedora:
-    pip:
-      packages: [rafcon]
-  ubuntu:
-    pip:
-      packages: [rafcon]
 rosbag-metadata-pip:
   debian:
     pip:


### PR DESCRIPTION
[RAFCON](https://dlr-rm.github.io/RAFCON/) is a state machine library with a graphical authoring interface.