### PR TITLE
pyquaternion: 0.9.6-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10498,7 +10498,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Achllle/pyquaternion-release.git
-      version: 0.9.6-2
+      version: 0.9.6-3
     source:
       type: git
       url: https://github.com/Achllle/pyquaternion.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10489,6 +10489,21 @@ repositories:
       url: https://github.com/ipab-slmc/pybind11_catkin.git
       version: master
     status: developed
+  pyquaternion:
+    doc:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Achllle/pyquaternion-release.git
+      version: 0.9.6-2
+    source:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: master
+    status: developed
   pyros:
     doc:
       type: git

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3368,16 +3368,6 @@ python-pyqrcode:
     xenial:
       pip:
         packages: [PyQRCode]
-python-pyquaternion-pip:
-  debian:
-    pip:
-      packages: [pyquaternion]
-  fedora:
-    pip:
-      packages: [pyquaternion]
-  ubuntu:
-    pip:
-      packages: [pyquaternion]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]


### PR DESCRIPTION
Increasing version of package(s) in repository `pyquaternion` to `0.9.6-3`:

- upstream repository: https://github.com/Achllle/pyquaternion
- release repository: https://github.com/Achllle/pyquaternion-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## pyquaternion

```
Post ROS package conversion
* Change exec depend naming from numpy to python-numpy
* Add numpy dependency to package.xml
* Create catkin package, rename and move some files
* Fix casting error in trace_method
* Add setter for vector
```
