### PR TITLE
roslisp: 1.9.24-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -557,6 +557,15 @@ repositories:
       version: master
     status: maintained
   roslisp:
+    doc:
+      type: git
+      url: https://github.com/ros/roslisp.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/roslisp-release.git
+      version: 1.9.24-1
     source:
       type: git
       url: https://github.com/ros/roslisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roslisp` to `1.9.24-1`:

- upstream repository: git://github.com/ros/roslisp.git
- release repository: https://github.com/ros-gbp/roslisp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
