### PR TITLE
system_modes: 0.2.0-4 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3029,7 +3029,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.2.0-2
+      version: 0.2.0-4
     source:
       type: git
       url: https://github.com/microROS/system_modes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.2.0-4`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.2.0-2`
