### PR TITLE
iirob_filters: 0.8.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5079,7 +5079,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/iirob_filters-release.git
-      version: 0.8.1-3
+      version: 0.8.4-1
     source:
       type: git
       url: https://github.com/KITrobotics/iirob_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iirob_filters` to `0.8.4-1`:

- upstream repository: https://github.com/KITrobotics/iirob_filters.git
- release repository: https://github.com/KITrobotics/iirob_filters-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.8.1-3`
