### PR TITLE
moveit_resources: 0.6.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5132,7 +5132,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.4-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.5-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.6.4-0`

## moveit_resources

```
* [maintenance] unify with official panda_moveit_config: define ready and extended poses
* [maintenance] fanuc_moveit_config: cleanup definition of move_group capabilities (#23 <https://github.com/ros-planning/moveit_resources/issues/23>)
* [fix]         fixed normals of link4 STLs
* Contributors: Robert Haschke
```
