### PR TITLE
moveit_resources: 0.6.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7675,7 +7675,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.4-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.6.5-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.6.4-0`

## moveit_resources

```
* [maintenance] unify with official panda_moveit_config: define ready and extended poses
* [maintenance] fanuc_moveit_config: cleanup definition of move_group capabilities (#23 <https://github.com/ros-planning/moveit_resources/issues/23>)
* [fix]         fixed normals of link4 STLs
* Contributors: Robert Haschke
```
