### PR TITLE
disable PR tests for rosbag2_bag_v2_plugins

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2003,7 +2003,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.7-4
     source:
-      test_pull_requests: true
+      test_pull_requests: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master


### PR DESCRIPTION
Due to not sourcing `melodic`, the bridge is not available which makes the source PR jobs fail.
@zmichaels11 fyi