### PR TITLE
eband_local_planner: 0.3.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2877,7 +2877,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
-      version: 0.3.1-0
+      version: 0.3.1-2
     source:
       type: git
       url: https://github.com/utexas-bwi/eband_local_planner.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner` to `0.3.1-2`:

- upstream repository: https://github.com/utexas-bwi/eband_local_planner.git
- release repository: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.3.1-0`

## eband_local_planner

```
* Find Eigen3 and not Eigen to compile cleanly on Kinetic (#21 <https://github.com/utexas-bwi/eband_local_planner/issues/21>)
* For Indigo, find Eigen if Eigen3 not found (#21 <https://github.com/utexas-bwi/eband_local_planner/issues/21>)
* Contributors: Jack O'Quin
```
