### PR TITLE
eband_local_planner: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2076,6 +2076,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: melodic-devel
     status: developed
+  eband_local_planner:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
+    status: maintained
   eca_a9:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eband_local_planner` to `0.4.0-1`:

- upstream repository: https://github.com/utexas-bwi/eband_local_planner.git
- release repository: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## eband_local_planner

```
* Adds Dynamic Reconfigure for planner parameters
* Updates library usage from tf to tf2 as necessary for Melodic
* Release for ROS Melodic (closes #28 <https://github.com/utexas-bwi/eband_local_planner/issues/28> )
* Contributors: Maxwell Svetlik, Yifeng Zhu
```
