### PR TITLE
media_export: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -269,6 +269,22 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  media_export:
+    doc:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/media_export-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    status: maintained
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export` to `0.2.0-1`:

- upstream repository: https://github.com/ros/media_export.git
- release repository: https://github.com/ros-gbp/media_export-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## media_export

```
* set myself (william) as maintainer
* Contributors: William Woodall
```
