### PR TITLE
euslisp: 9.27.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3201,7 +3201,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.26.0-1
+      version: 9.27.0-1
     source:
       type: git
       url: https://github.com/euslisp/EusLisp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslisp` to `9.27.0-1`:

- upstream repository: https://github.com/euslisp/EusLisp
- release repository: https://github.com/tork-a/euslisp-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `9.26.0-1`
