### PR TITLE
Update distribution.yaml

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13807,11 +13807,14 @@ repositories:
     release:
       packages:
       - rr_control_input_manager
+      - rr_openrover_description
+      - rr_openrover_driver
       - rr_openrover_driver_msgs
+      - rr_openrover_stack
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
-      version: 0.7.3-2
+      version: 0.7.4-1
     status: maintained
   rr_swiftnav_piksi:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository rr_openrover_stack to 0.7.4-1:

upstream repository: https://github.com/RoverRobotics/rr_openrover_stack.git
release repository: https://github.com/RoverRobotics/rr_openrover_stack-release.git
distro file: kinetic/distribution.yaml
bloom version: 0.9.1
previous version for package: 0.7.3