### PR TITLE
[melodic] Add the upstream source for cartographer_ros and cartographer

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -945,6 +945,10 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 1.0.0-0
+    source:
+      type: git
+      url: https://github.com/googlecartographer/cartographer.git
+      version: master
     status: developed
   cartographer_ros:
     doc:
@@ -960,6 +964,10 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
       version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/googlecartographer/cartographer_ros.git
+      version: master
     status: developed
   caster:
     doc:


### PR DESCRIPTION
Add the upstream repository for completeness.

This is motivated by that https://aka.ms/ros project currently is not able to use `rosinstall_generator` to pull down the upstream repository information because of the missing information and has to maintain a separate `.rosinstall` file for `cartographer` related builds.