### PR TITLE
rosbridge_suite: 0.11.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12727,7 +12727,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.3-1
+      version: 0.11.4-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.4-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.3-1`

## rosapi

```
* Add cbor-raw compression (#452 <https://github.com/RobotWebTools/rosbridge_suite/issues/452>)
  The CBOR compression is already a huge win over JSON or PNG encoding,
  but it’s still suboptimal in some situations. This PR adds support for
  getting messages in their raw binary (ROS-serialized) format. This has
  benefits in the following cases:
  - Your application already knows how to parse messages in bag files
  (e.g. using [rosbag.js](https://github.com/cruise-automation/rosbag.js),
  which means that now you can use consistent code paths for both bags
  and live messages.
  - You want to parse messages as late as possible, or in parallel, e.g.
  only in the thread or WebWorker that cares about the message. Delaying
  the parsing of the message means that moving or copying the message to
  the thread is cheaper when its in binary form, since no serialization
  between threads is necessary.
  - You only care about part of the message, and don't need to parse the
  rest of it.
  - You really care about performance; no conversion between the ROS
  binary format and CBOR is done in the rosbridge_sever.
* Fix rosapi get_action_servers (#429 <https://github.com/RobotWebTools/rosbridge_suite/issues/429>)
  The currently used proxy.get_topics function does not exists and results in the following error: "AttributeError: 'module' object has no attribute 'get_topics'n"
  This change uses the existing get_topics_and_types method to get a list of topics.
* Contributors: Jan Paul Posma, Jørgen Borgesen
```

## rosbridge_library

```
* Concurrency review (#458 <https://github.com/RobotWebTools/rosbridge_suite/issues/458>)
  * Safer locking in PublisherConsistencyListener
  * Safer locking in ros_loader
  * Print QueueMessageHandler exceptions to stderr
  * Register before resuming outgoing valve
  * Don't pause a finished socket valve
* Add cbor-raw compression (#452 <https://github.com/RobotWebTools/rosbridge_suite/issues/452>)
  The CBOR compression is already a huge win over JSON or PNG encoding,
  but it’s still suboptimal in some situations. This PR adds support for
  getting messages in their raw binary (ROS-serialized) format. This has
  benefits in the following cases:
  - Your application already knows how to parse messages in bag files
  (e.g. using [rosbag.js](https://github.com/cruise-automation/rosbag.js),
  which means that now you can use consistent code paths for both bags
  and live messages.
  - You want to parse messages as late as possible, or in parallel, e.g.
  only in the thread or WebWorker that cares about the message. Delaying
  the parsing of the message means that moving or copying the message to
  the thread is cheaper when its in binary form, since no serialization
  between threads is necessary.
  - You only care about part of the message, and don't need to parse the
  rest of it.
  - You really care about performance; no conversion between the ROS
  binary format and CBOR is done in the rosbridge_sever.
* Fix typos in rosbridge_library's description (#450 <https://github.com/RobotWebTools/rosbridge_suite/issues/450>)
* Python 3 fix for dict::values (#446 <https://github.com/RobotWebTools/rosbridge_suite/issues/446>)
  Under Python 3, values() returns a view-like object, and because that object is used outside the mutex, we were getting RuntimeError: dictionary changed size during iteration under some circumstances. This creates a copy of the values, restoring the Python 2 behaviour and fixing the problem.
* Contributors: Jan Paul Posma, Matt Vollrath, Mike Purvis, miller-alex
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Concurrency review (#458 <https://github.com/RobotWebTools/rosbridge_suite/issues/458>)
  * Safer locking in PublisherConsistencyListener
  * Safer locking in ros_loader
  * Print QueueMessageHandler exceptions to stderr
  * Register before resuming outgoing valve
  * Don't pause a finished socket valve
* Add cbor-raw compression (#452 <https://github.com/RobotWebTools/rosbridge_suite/issues/452>)
  The CBOR compression is already a huge win over JSON or PNG encoding,
  but it’s still suboptimal in some situations. This PR adds support for
  getting messages in their raw binary (ROS-serialized) format. This has
  benefits in the following cases:
  - Your application already knows how to parse messages in bag files
  (e.g. using [rosbag.js](https://github.com/cruise-automation/rosbag.js),
  which means that now you can use consistent code paths for both bags
  and live messages.
  - You want to parse messages as late as possible, or in parallel, e.g.
  only in the thread or WebWorker that cares about the message. Delaying
  the parsing of the message means that moving or copying the message to
  the thread is cheaper when its in binary form, since no serialization
  between threads is necessary.
  - You only care about part of the message, and don't need to parse the
  rest of it.
  - You really care about performance; no conversion between the ROS
  binary format and CBOR is done in the rosbridge_sever.
* Fix Autobahn WebSocket vs. Python 3 (#451 <https://github.com/RobotWebTools/rosbridge_suite/issues/451>)
  Fixes #448 <https://github.com/RobotWebTools/rosbridge_suite/issues/448>
* Install scripts with catkin_install_python. (#449 <https://github.com/RobotWebTools/rosbridge_suite/issues/449>)
* autobahn_websocket.py: Convert BSON to bytes before call to sendMessage (#443 <https://github.com/RobotWebTools/rosbridge_suite/issues/443>)
  autobahn.websocket.WebSocketServerProtocol.sendMessage asserts whether message is of type bytes, which fails for message of type bson.BSON
* Autobahn WebSocket server (#426 <https://github.com/RobotWebTools/rosbridge_suite/issues/426>)
  * Autobahn WebSocket server
  * Bring back explicit Twisted dependency
  Still used directly by the UDP handler.
  * Warn when reactor wasn't running at shutdown hook
  * More descriptive websocket startup log msg
  * Remove extreneous OutgoingValve stop log
  * More comment for OutgoingValve
  * Fix --address parsing as int
  * Use Autobahn's ws url creation util method
  * Backwards compatibility for empty websocket addr
  This was the default in previous versions, but invalid input to
  Autobahn.
  * Factor out websocket onConnect
  We have access to this information in onOpen.
  * Add smoke test for rosbridge websocket server
  * Revert "Use Autobahn's ws url creation util method"
  This reverts commit 4224671528a03875847918ae7164e672c4ba5fce.
  This create_url method doesn't exist yet in Ubuntu kinetic.
  * Preserve RosbridgeWebSocket Tornado ABI
  * Run rosbridge_websocket tests with ephemeral port
  Avoid network collisions and unnecessary configuration while testing.
  * Fix broken test create_url on kinetic
  * Smokier smoke test
  Send 100 large messages in each direction to saturate buffers.
* Contributors: Jan Paul Posma, Matt Vollrath, Mike Purvis, dma307
```

## rosbridge_suite

- No changes
