### PR TITLE
sick_scan2: 0.1.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2498,7 +2498,7 @@ repositories:
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan2.git
-      version: https://github.com/SICKAG/sick_scan2/tree/master
+      version: master
     status: developed
     status_description: developed
   slide_show:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2489,6 +2489,18 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: eloquent
     status: maintained
+  sick_scan2:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/SICKAG/sick_scan2-release.git
+      version: 0.1.5-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan2.git
+      version: https://github.com/SICKAG/sick_scan2/tree/master
+    status: developed
+    status_description: developed
   slide_show:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan2` to `0.1.5-1`:

- upstream repository: https://github.com/SICKAG/sick_scan2.git
- release repository: https://github.com/SICKAG/sick_scan2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
