### PR TITLE
Revert "[melodic] Add the upstream source for cartographer_ros and cartographer"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -945,10 +945,6 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer-release.git
       version: 1.0.0-0
-    source:
-      type: git
-      url: https://github.com/googlecartographer/cartographer.git
-      version: master
     status: developed
   cartographer_ros:
     doc:
@@ -964,10 +960,6 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/cartographer_ros-release.git
       version: 1.0.0-1
-    source:
-      type: git
-      url: https://github.com/googlecartographer/cartographer_ros.git
-      version: master
     status: developed
   caster:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#23819

@mikaelarguedas @seanyen @clalancette FYI

Confirmed that it doesn't build. Though it does appear to generate doxygen correctly. 

http://build.ros.org/job/Mdev__cartographer_ros__ubuntu_bionic_amd64/1/console
http://build.ros.org/job/Mdev__cartographer__ubuntu_bionic_amd64/
