### PR TITLE
mpc_local_planner: 0.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5237,6 +5237,26 @@ repositories:
       url: https://github.com/peci1/movie_publisher.git
       version: melodic-devel
     status: developed
+  mpc_local_planner:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
+      version: melodic-devel
+    release:
+      packages:
+      - mpc_local_planner
+      - mpc_local_planner_examples
+      - mpc_local_planner_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner-release.git
+      version: 0.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
+      version: melodic-devel
+    status: developed
   mrpt1:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mpc_local_planner` to `0.0.1-2`:

- upstream repository: https://github.com/rst-tu-dortmund/mpc_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/mpc_local_planner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## mpc_local_planner

```
* First release
* Contributors: Christoph Rösmann
```

## mpc_local_planner_examples

```
* First release
* Contributors: Christoph Rösmann
```

## mpc_local_planner_msgs

```
* First release
* Contributors: Christoph Rösmann
```
