### PR TITLE
ros_comm: 1.14.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8089,7 +8089,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.14.3-0
+      version: 1.14.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.14.4-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.14.3-0`

## message_filters

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* add overload of ApproximateTime::setInterMessageLowerBound() to set all topics to the same value (#1860 <https://github.com/ros/ros_comm/issues/1860>)
* update approximate time filter to work with Python 2 and 3 (#1660 <https://github.com/ros/ros_comm/issues/1660>)
* message_filters/__init__.py - Added reduce import for Python 3 compatability (#1633 <https://github.com/ros/ros_comm/issues/1633>)
* remove messages that are newer than the newly added message (#1438 <https://github.com/ros/ros_comm/issues/1438>)
* remove signals from find_package(Boost COMPONENTS ...) (#1580 <https://github.com/ros/ros_comm/issues/1580>)
* fix message_filters build issue on the template syntax (#1483 <https://github.com/ros/ros_comm/issues/1483>)
```

## ros_comm

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
```

## rosbag

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* add quotes around file name so they can be click selected in terminal (#1813 <https://github.com/ros/ros_comm/issues/1813>)
* catch exceptions by const ref (#1874 <https://github.com/ros/ros_comm/issues/1874>)
* read GPG passphrase from an environment variable (#1856 <https://github.com/ros/ros_comm/issues/1856>)
* fix missing import of roslib (#1818 <https://github.com/ros/ros_comm/issues/1818>)
* fix regression from pycrypodome switchover (#1814 <https://github.com/ros/ros_comm/issues/1814>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* add pycryptodome as default (#1609 <https://github.com/ros/ros_comm/issues/1609>)
* encrypted rosbag fixes for Python 3 (#1777 <https://github.com/ros/ros_comm/issues/1777>)
* fix bug in bag migration (#1786 <https://github.com/ros/ros_comm/issues/1786>)
* keep latched topics latched (#1708 <https://github.com/ros/ros_comm/issues/1708>)
* wrap the rosbag filter eval in a lambda (#1712 <https://github.com/ros/ros_comm/issues/1712>)
* record: fix signed int overflow (#1741 <https://github.com/ros/ros_comm/issues/1741>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* pickleable rosbag exceptions (#1210 <https://github.com/ros/ros_comm/issues/1210> revisited). (#1652 <https://github.com/ros/ros_comm/issues/1652>)
* fix topic message count for rosbag indexed v1.2 (#1648 <https://github.com/ros/ros_comm/issues/1648>)
* fix wrong error handling in migration (#1639 <https://github.com/ros/ros_comm/issues/1639>)
* modernization: replaced BOOST_FOREACH with range-based for-loops, used algorithm where appropriated (#1641 <https://github.com/ros/ros_comm/issues/1641>)
* fix IOError during Python file operation (#1617 <https://github.com/ros/ros_comm/issues/1617>)
* add Windows.h usage explicitly (#44 <https://github.com/ros/ros_comm/issues/44>) (#1616 <https://github.com/ros/ros_comm/issues/1616>)
* fix waitForSubscribers hanging with simtime (#1543 <https://github.com/ros/ros_comm/issues/1543>)
* publish last message from latch topics when start time > 0 (#1537 <https://github.com/ros/ros_comm/issues/1537>)
* add a new option to publish when a bag write begin (#1527 <https://github.com/ros/ros_comm/issues/1527>)
```

## rosbag_storage

```
* catch polymorphic exceptions by reference (#1887 <https://github.com/ros/ros_comm/issues/1887>)
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* use find_library for abs path of crypto and gpgme libraries (#1867 <https://github.com/ros/ros_comm/issues/1867>)
* remove unnecessary writing to map in write only mode (#1798 <https://github.com/ros/ros_comm/issues/1798>)
* check for fclose returning 0 (#1750 <https://github.com/ros/ros_comm/issues/1750>)
* fix windows build (#1687 <https://github.com/ros/ros_comm/issues/1687>)
* move bag encryption plugins into separate library (#1499 <https://github.com/ros/ros_comm/issues/1499>)
* modernization: replaced BOOST_FOREACH with range-based for loops, used algorithm, where appropriated (#1640 <https://github.com/ros/ros_comm/issues/1640>)
* fix dangeling if-else (#1637 <https://github.com/ros/ros_comm/issues/1637>)
* fix infinite loop in rosbag buffer resize (#1623 <https://github.com/ros/ros_comm/issues/1623>)
* update CMakeLists.txt in rosbag_storage (#1618 <https://github.com/ros/ros_comm/issues/1618>)
* fix various test problems (#1601 <https://github.com/ros/ros_comm/issues/1601>)
* visibility macros update (#1591 <https://github.com/ros/ros_comm/issues/1591>)
* fix issues when built or run on Windows (#1466 <https://github.com/ros/ros_comm/issues/1466>)
```

## roscpp

```
* add default ROS_MASTER_URI (#1666 <https://github.com/ros/ros_comm/issues/1666>)
* add default assignment operator for various classes (#1888 <https://github.com/ros/ros_comm/issues/1888>)
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* do not display error message if poll yields EINTR (#1868 <https://github.com/ros/ros_comm/issues/1868>)
* [windows] portable duration cast (#1882 <https://github.com/ros/ros_comm/issues/1882>)
* drop custom implementation of boost::condition_variable to fix busy-wait spinning (#1878 <https://github.com/ros/ros_comm/issues/1878>)
* disable rosout via ROSCPP_NO_ROSOUT environment variable (#1858 <https://github.com/ros/ros_comm/issues/1858>)
* [windows] conditionally guard sys/socket.h (#1876 <https://github.com/ros/ros_comm/issues/1876>)
* explicit include of socket.h to support FreeBSD (#1864 <https://github.com/ros/ros_comm/issues/1864>)
* remove DEBUG statements from getImpl (#1823 <https://github.com/ros/ros_comm/issues/1823>)
* use c++11 std::snprintf (#1820 <https://github.com/ros/ros_comm/issues/1820>)
* TransportTCP: Allow socket() to return 0 (#1707 <https://github.com/ros/ros_comm/issues/1707>)
* fix dynamic windowing for Topic Statistics (#1695 <https://github.com/ros/ros_comm/issues/1695>)
* service_publication: removed int-bool-comparison (#1710 <https://github.com/ros/ros_comm/issues/1710>)
* add Timer::isValid() const (#1779 <https://github.com/ros/ros_comm/issues/1779>)
* add possibility to pass rospy.Duration as timeout to wait_for_service and wait_for_message (#1703 <https://github.com/ros/ros_comm/issues/1703>)
* fix segfault in TransportPublisherLink (#1714 <https://github.com/ros/ros_comm/issues/1714>)
* TransportTCP: enable poll event POLLRDHUP to detect dead connections properly (#1704 <https://github.com/ros/ros_comm/issues/1704>)
* transportUDP: zero-initialize sockaddr_in object (#1740 <https://github.com/ros/ros_comm/issues/1740>)
* unregisterService returns result of execute("unregisterService") (#1751 <https://github.com/ros/ros_comm/issues/1751>)
* use safe string check (#1771 <https://github.com/ros/ros_comm/issues/1771>)
* fix memory leak of global variable (#1503 <https://github.com/ros/ros_comm/issues/1503>)
* fix exception boost::lock_error during shutdown (#1656 <https://github.com/ros/ros_comm/issues/1656>)
* avoid deadlock in TopicManager (#1645 <https://github.com/ros/ros_comm/issues/1645>)
* use WallTime/WallDuration for waiting for service (#1638 <https://github.com/ros/ros_comm/issues/1638>)
* add missing include path (for bazel workspaces) (#1636 <https://github.com/ros/ros_comm/issues/1636>)
* fix bug in statistics decision making if one should publish (#1625 <https://github.com/ros/ros_comm/issues/1625>)
* add hasStarted() const to WallTimer and SteadyTimer API (#1565 <https://github.com/ros/ros_comm/issues/1565>)
* remove signals from find_package(Boost COMPONENTS ...) (#1580 <https://github.com/ros/ros_comm/issues/1580>)
* fix string error on windows (#1582 <https://github.com/ros/ros_comm/issues/1582>)
* visibility macros update (#1591 <https://github.com/ros/ros_comm/issues/1591>)
* fix race due tounprotected access to callbacks_ (#1595 <https://github.com/ros/ros_comm/issues/1595>)
* fix nullptr access from Timer().hasStarted() (#1541 <https://github.com/ros/ros_comm/issues/1541>)
* add const specifier to NodeHandle::param(param_name, default_val). (#1539 <https://github.com/ros/ros_comm/issues/1539>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
* fix stamp_age_mean overflow when stamp age very big (#1526 <https://github.com/ros/ros_comm/issues/1526>)
* remove explicit -std=c++11, default to 14
* fix memory error due to missing rosout_disable_topics_generation parameter (#1507 <https://github.com/ros/ros_comm/issues/1507>)
* fix issues when built or run on Windows (#1466 <https://github.com/ros/ros_comm/issues/1466>)
```

## rosgraph

```
* add default ROS_MASTER_URI (#1666 <https://github.com/ros/ros_comm/issues/1666>)
* fix test which fails on Noetic (#1891 <https://github.com/ros/ros_comm/issues/1891>)
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* [Windows] Python 3 compatibility (#1819 <https://github.com/ros/ros_comm/issues/1819>)
* fix escape sequences in regular expressions (#1837 <https://github.com/ros/ros_comm/issues/1837>)
* fix RospyLogger findCaller arguments in Python 3.8 (#1838 <https://github.com/ros/ros_comm/issues/1838>)
* [Windows] make test code to be more portable (#1726 <https://github.com/ros/ros_comm/issues/1726>)
* fix Coverity forward null (#1787 <https://github.com/ros/ros_comm/issues/1787>)
* make log config from rosgraph optional (#1797 <https://github.com/ros/ros_comm/issues/1797>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* add is_legal_remap() to rosgraph to make remap-detection more precise (#1683 <https://github.com/ros/ros_comm/issues/1683>)
* more Python 3 compatibility (#1783 <https://github.com/ros/ros_comm/issues/1783>)
* more Python 3 compatibility (#1782 <https://github.com/ros/ros_comm/issues/1782>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* use urlparse for parsing the port, whick makes ipv6 possible (#1698 <https://github.com/ros/ros_comm/issues/1698>)
* fix paths (and regex for paths) comparison issues (#1592 <https://github.com/ros/ros_comm/issues/1592>)
* fix various test problems (#1601 <https://github.com/ros/ros_comm/issues/1601>)
* fix typos: awhile -> a while (#1534 <https://github.com/ros/ros_comm/issues/1534>)
```

## roslaunch

```
* allow empty machine arg in node tag (#1885 <https://github.com/ros/ros_comm/issues/1885>)
* use double quotes for portable roslaunch-check command (#1883 <https://github.com/ros/ros_comm/issues/1883>)
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* wrap env prefix with double quotes (#1810 <https://github.com/ros/ros_comm/issues/1810>)
* add ignore default args option to roslaunch-check (#1788 <https://github.com/ros/ros_comm/issues/1788>)
* add platform check for --args code path (#1809 <https://github.com/ros/ros_comm/issues/1809>)
* [Windows] workaround for Python 2 xmlrpc performance issues (#1872 <https://github.com/ros/ros_comm/issues/1872>)
* allow empty ssh password for remote launching (#1826 <https://github.com/ros/ros_comm/issues/1826>)
* [Windows] escape drive as well as path separator (#1815 <https://github.com/ros/ros_comm/issues/1815>)
* more Python 3 compatibility (#1795 <https://github.com/ros/ros_comm/issues/1795>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* [Windows] skip cat related test cases on Windows build (#1724 <https://github.com/ros/ros_comm/issues/1724>)
* [Windows] use taskkill to kill process tree (#1725 <https://github.com/ros/ros_comm/issues/1725>)
* pass missing args (#1733 <https://github.com/ros/ros_comm/issues/1733>)
* fix for roslaunch-check on Python 3
* roslaunch added --required option (#1681 <https://github.com/ros/ros_comm/issues/1681>)
* more Python 3 compatibility (#1783 <https://github.com/ros/ros_comm/issues/1783>)
* more Python 3 compatibility (#1782 <https://github.com/ros/ros_comm/issues/1782>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* fix $(dirname) for roslaunch-check (#1624 <https://github.com/ros/ros_comm/issues/1624>)
* change how commands are executed (#1628 <https://github.com/ros/ros_comm/issues/1628>)
* add option to hide summary from roslaunch output (#1655 <https://github.com/ros/ros_comm/issues/1655>)
* make roslaunch-check respect arg remappings with command line argument (#1653 <https://github.com/ros/ros_comm/issues/1653>)
* add POSIX flag for shlex.split() (#1619 <https://github.com/ros/ros_comm/issues/1619>)
* respawn if process died while checking should_respawn() (#1590 <https://github.com/ros/ros_comm/issues/1590>)
* add python prefix for python scripts when there is no .py extension (#1589 <https://github.com/ros/ros_comm/issues/1589>)
* xmlloader: use continue instead of pass for args_only (#1540 <https://github.com/ros/ros_comm/issues/1540>)
* fix various test problems (#1601 <https://github.com/ros/ros_comm/issues/1601>)
* normalize strings to utf-8 before setting as environment variable (#1593 <https://github.com/ros/ros_comm/issues/1593>)
* fix typos: awhile -> a while (#1534 <https://github.com/ros/ros_comm/issues/1534>)
* add more useful helper text here to indicate that this might be a permission error (#1568 <https://github.com/ros/ros_comm/issues/1568>)
* exclude unused args check if pass_all_args is set (#1520 <https://github.com/ros/ros_comm/issues/1520>)
* add an option in XmlLoader to only load arg tags (#1521 <https://github.com/ros/ros_comm/issues/1521>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
* improve exception handling when resource is not found (#1476 <https://github.com/ros/ros_comm/issues/1476>)
* fix issues when built or run on Windows (#1466 <https://github.com/ros/ros_comm/issues/1466>)
```

## roslz4

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* add alternative lz4 name for Windows (#1821 <https://github.com/ros/ros_comm/issues/1821>)
* check for XXH_malloc NULL return (#1778 <https://github.com/ros/ros_comm/issues/1778>)
* update install destination for roslz4 (#1620 <https://github.com/ros/ros_comm/issues/1620>)
* fix issues when built or run on Windows (#1466 <https://github.com/ros/ros_comm/issues/1466>)
```

## rosmaster

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* use thread local storage for caching instances of ServerProxy (#1732 <https://github.com/ros/ros_comm/issues/1732>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* fix issue occuring during alternating calls of getParamCached and setParam (#1439 <https://github.com/ros/ros_comm/issues/1439>)
* fix docstring in unregisterSubscriber (#1553 <https://github.com/ros/ros_comm/issues/1553>)
* set correctly typed @apivalidate default return values (#1472 <https://github.com/ros/ros_comm/issues/1472>)
```

## rosmsg

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* more Windows test code fixes (#1727 <https://github.com/ros/ros_comm/issues/1727>)
* [Windows] make test code to be more portable (#1726 <https://github.com/ros/ros_comm/issues/1726>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* more Python 3 compatibility (#1783 <https://github.com/ros/ros_comm/issues/1783>)
* normalize paths before comparison in rosmsg (#1586 <https://github.com/ros/ros_comm/issues/1586>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
```

## rosnode

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* prevent indefinitely trapping in unknown error state (#1854 <https://github.com/ros/ros_comm/issues/1854>)
* duplicate test nodes which aren't available to other packages, add missing dependencies (#1611 <https://github.com/ros/ros_comm/issues/1611>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
* explicitly handle socket.timeout in rosnode ping (#1517 <https://github.com/ros/ros_comm/issues/1517>)
* show connection info on rosnode info (#1497 <https://github.com/ros/ros_comm/issues/1497>)
```

## rosout

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* fix use-after-free issue in rosout (#1764 <https://github.com/ros/ros_comm/issues/1764>)
* include cctype for std::tolower (#1587 <https://github.com/ros/ros_comm/issues/1587>)
* disable rosout.log by using environment variable (#1425 <https://github.com/ros/ros_comm/issues/1425>)
```

## rosparam

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* change unsafe yaml.load to yaml.safe_load (#1835 <https://github.com/ros/ros_comm/issues/1835>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
```

## rospy

```
* add default ROS_MASTER_URI (#1666 <https://github.com/ros/ros_comm/issues/1666>)
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* reuse xmlrpc connections everywhere (#1471 <https://github.com/ros/ros_comm/issues/1471>)
* use cached parameter for rosout_disable_topics_generation (#1881 <https://github.com/ros/ros_comm/issues/1881>)
* add args and kwargs to rospy.log* (#1289 <https://github.com/ros/ros_comm/issues/1289>)
* add kwargs to internal logging functions (#1290 <https://github.com/ros/ros_comm/issues/1290>)
* add get_param_cached (#1515 <https://github.com/ros/ros_comm/issues/1515>)
* more Python 3 compatibility (#1795 <https://github.com/ros/ros_comm/issues/1795>)
* fix line endings to be LF (#1794 <https://github.com/ros/ros_comm/issues/1794>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* fix dynamic windowing for Topic Statistics (#1695 <https://github.com/ros/ros_comm/issues/1695>)
* do not raise socket exception during shutdown (#1720 <https://github.com/ros/ros_comm/issues/1720>)
* add possibility to pass rospy.Duration as timeout to wait_for_service and wait_for_message (#1703 <https://github.com/ros/ros_comm/issues/1703>)
* add is_legal_remap() to rosgraph to make remap-detection more precise (#1683 <https://github.com/ros/ros_comm/issues/1683>)
* add missing comma in the list of strings (#1760 <https://github.com/ros/ros_comm/issues/1760>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* fix error handling for Topic constructor (#1701 <https://github.com/ros/ros_comm/issues/1701>)
* make sigterm handling Python 3 compatible (#1559 <https://github.com/ros/ros_comm/issues/1559>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
* show connection info on rosnode info (#1497 <https://github.com/ros/ros_comm/issues/1497>)
* import socket, threading in udpros.py (#1494 <https://github.com/ros/ros_comm/issues/1494>)
```

## rosservice

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* rosservice: use myargv() (#1667 <https://github.com/ros/ros_comm/issues/1667>)
* catch exeption when searching for services and a single service fails (#1519 <https://github.com/ros/ros_comm/issues/1519>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
```

## rostest

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* more Python 3 compatibility (#1795 <https://github.com/ros/ros_comm/issues/1795>)
* rostest: add advertisetest (#1761 <https://github.com/ros/ros_comm/issues/1761>)
* fix flaky hztests (#1661 <https://github.com/ros/ros_comm/issues/1661>)
* use AnyMsg in publishtest (#1659 <https://github.com/ros/ros_comm/issues/1659>)
* fix various test problems (#1601 <https://github.com/ros/ros_comm/issues/1601>)
* invoke rostest from CMake with the PYTHON_EXECUTABLE (#1583 <https://github.com/ros/ros_comm/issues/1583>)
```

## rostopic

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* [Windows] make test code to be more portable (#1726 <https://github.com/ros/ros_comm/issues/1726>)
* add --use-rostime for pub (#1717 <https://github.com/ros/ros_comm/issues/1717>)
* _rostopic_list_group_by_host: publisher/subscriber lists have correct type now (#1780 <https://github.com/ros/ros_comm/issues/1780>)
* more Python 3 compatibility (#1783 <https://github.com/ros/ros_comm/issues/1783>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* fix typo, confict -> conflict (#1690 <https://github.com/ros/ros_comm/issues/1690>)
* repeatedly republish message from file (#1635 <https://github.com/ros/ros_comm/issues/1635>)
* duplicate test nodes which aren't available to other packages, add missing dependencies (#1611 <https://github.com/ros/ros_comm/issues/1611>)
* update wiki.ros.org URLs (#1536 <https://github.com/ros/ros_comm/issues/1536>)
```

## roswtf

```
* add default ROS_MASTER_URI (#1666 <https://github.com/ros/ros_comm/issues/1666>)
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* do not try to run online checks if there are no roslaunch uris (#1848 <https://github.com/ros/ros_comm/issues/1848>)
* more Python 3 compatibility (#1796 <https://github.com/ros/ros_comm/issues/1796>)
* use condition attributes to specify Python 2 and 3 dependencies (#1792 <https://github.com/ros/ros_comm/issues/1792>)
* print exception content to show better idea why loading plugin failed (#1721 <https://github.com/ros/ros_comm/issues/1721>)
* duplicate test nodes which aren't available to other packages, add missing dependencies (#1611 <https://github.com/ros/ros_comm/issues/1611>)
* query ipv6 only if specified (#1596 <https://github.com/ros/ros_comm/issues/1596>)
* fix typos: awhile -> a while (#1534 <https://github.com/ros/ros_comm/issues/1534>)
* improve msg replacement for 'No package or stack in context'. (#1505 <https://github.com/ros/ros_comm/issues/1505>)
```

## topic_tools

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* use node namespace when looking up topic  (#1663 <https://github.com/ros/ros_comm/issues/1663>)
* more Windows test code fixes (#1727 <https://github.com/ros/ros_comm/issues/1727>)
* more Python 3 compatibility (#1795 <https://github.com/ros/ros_comm/issues/1795>)
* relay: fix boost::lock exception (#1696 <https://github.com/ros/ros_comm/issues/1696>)
* relay_field: add --tcpnodely (#1682 <https://github.com/ros/ros_comm/issues/1682>)
* switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688 <https://github.com/ros/ros_comm/issues/1688>)
* fix flaky hztests (#1661 <https://github.com/ros/ros_comm/issues/1661>)
* transform: create publisher before subscriber, because callback may use the publisher (#1669 <https://github.com/ros/ros_comm/issues/1669>)
* duplicate test nodes which aren't available to other packages, add missing dependencies (#1611 <https://github.com/ros/ros_comm/issues/1611>)
* mux: do not dereference the end-iterator (#1579 <https://github.com/ros/ros_comm/issues/1579>)
* fix topic_tools environment hook (#1486 <https://github.com/ros/ros_comm/issues/1486>)
* mux: add ~latch option (#1489 <https://github.com/ros/ros_comm/issues/1489>)
```

## xmlrpcpp

```
* bump CMake minimum version to avoid CMP0048 warning (#1869 <https://github.com/ros/ros_comm/issues/1869>)
* [Windows] workaround WSAPoll doesn't report failed connections (#1816 <https://github.com/ros/ros_comm/issues/1816>)
* fix base64 decode error on ARM platforms (#1853 <https://github.com/ros/ros_comm/issues/1853>)
* use c++11 std::snprintf (#1820 <https://github.com/ros/ros_comm/issues/1820>)
* fix dead loop if accept connection error in XmlRpcServer (#1791 <https://github.com/ros/ros_comm/issues/1791>)
* fix test build errors (#1723 <https://github.com/ros/ros_comm/issues/1723>)
* fix base64 encode error (#1769 <https://github.com/ros/ros_comm/issues/1769>)
* XmlRpcValue added bool assignment operator (#1709 <https://github.com/ros/ros_comm/issues/1709>)
* add const indexer for xmlrpc (#1759 <https://github.com/ros/ros_comm/issues/1759>)
* xmlrpcpp: fixed invalid zero index (#1631 <https://github.com/ros/ros_comm/issues/1631>)
* avoid calling memcpy on NULL pointer with size 0 (#1546 <https://github.com/ros/ros_comm/issues/1546>)
* revert "Revert "move the winsock2.h into cpp."" (#1588 <https://github.com/ros/ros_comm/issues/1588>)
* visibility macros update (#1591 <https://github.com/ros/ros_comm/issues/1591>)
* remove explicit -std=c++11, default to 14
* fix test code build issues on Windows (#1479 <https://github.com/ros/ros_comm/issues/1479>)
* fix issues when built or run on Windows (#1466 <https://github.com/ros/ros_comm/issues/1466>)
```
