### PR TITLE
Adding raspimouse_description to documentatioin index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7423,6 +7423,16 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    status: developed
   raspimouse_sim:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspimouse_description for ROS Melodic to be doc'd and indexed.