### PR TITLE
Adding raspimouse_description to documentatioin index for kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10951,6 +10951,16 @@ repositories:
       url: https://github.com/raspberrypigibbon/raspigibbon_sim.git
       version: kinetic-devel
     status: developed
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    status: developed
   raspimouse_ros:
     doc:
       type: git


### PR DESCRIPTION
I'd like to add raspimouse_description for ROS Kinetic to be doc'd and indexed.