### PR TITLE
plotjuggler: 2.6.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9921,7 +9921,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.5.1-2
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.6.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.5.1-2`

## plotjuggler

```
* bug fix
* fix splashscreen delay
* GUI refinement
* regex filter removed. bug fix in column resize
* new icons in CurveList panel
* add text placeholder
* smaller buttons
* moved buttons to top right corner to gain more space
* changed style (sharper corners)
* bug fix: potential crash trying to save data into rosbag
* more ememes #248 <https://github.com/facontidavide/PlotJuggler/issues/248>
* bug fix in Lua functions
* cleanups
* Merge branch 'lua_scripting'
* Adding custom parser for Imu message (issue #238 <https://github.com/facontidavide/PlotJuggler/issues/238>)
* remember the last value in the function editor
* minor update
* Both javascript and Lua langiages can be selected in preferences
* WIP to support both QML and Lua
* fix menu bar size of PlotJuggler
* scripting moved to Lua
* adding lua stuff to 3rd party libraries
* preliminary change to support #244 <https://github.com/facontidavide/PlotJuggler/issues/244> (#247 <https://github.com/facontidavide/PlotJuggler/issues/247>)
* preliminary change to support #244 <https://github.com/facontidavide/PlotJuggler/issues/244>
* Update .appveyor.yml
* Update README.md
* Update .appveyor.yml
* Update .appveyor.yml
* further cleanup
* moved files and cleanup
* Contributors: Davide Faconti
```
