### PR TITLE
Add rosdep rules for orocos kdl and orocos bfl

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2854,20 +2854,20 @@ liborocos-bfl:
   debian:
     '*': [liborocos-bfl0.8]
     'stretch': null
-  fedora: [liborocos-bfl]
+  fedora: [orocos-bfl]
   ubuntu:
     '*': [liborocos-bfl0.8]
     'bionic': null
     'xenial': null
 liborocos-bfl-dev:
   debian: [liborocos-bfl-dev]
-  fedora: [liborocos-bfl-devel]
+  fedora: [orocos-bfl-devel]
   ubuntu: [liborocos-bfl-dev]
 liborocos-kdl:
   debian:
     '*': [liborocos-kdl1.4]
     'stretch': [liborocos-kdl1.3]
-  fedora: [liborocos-kdl]
+  fedora: [orocos-kdl]
   gentoo: [sci-libs/orocos_kdl]
   ubuntu:
     '*': [liborocos-kdl1.4]
@@ -2875,7 +2875,7 @@ liborocos-kdl:
     'xenial': [liborocos-kdl1.3]
 liborocos-kdl-dev:
   debian: [liborocos-kdl-dev]
-  fedora: [liborocos-kdl-devel]
+  fedora: [orocos-kdl-devel]
   gentoo: [sci-libs/orocos_kdl]
   ubuntu: [liborocos-kdl-dev]
 libosmesa6-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2854,7 +2854,7 @@ liborocos-bfl:
   debian:
     '*': [liborocos-bfl0.8]
     'stretch': null
-  fedora: [liborocos-kdl]
+  fedora: [liborocos-bfl]
   ubuntu:
     '*': [liborocos-bfl0.8]
     'bionic': null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2850,6 +2850,19 @@ libopenvdb-dev:
   fedora: [openvdb-devel]
   gentoo: [media-gfx/openvdb]
   ubuntu: [libopenvdb-dev, libilmbase-dev]
+liborocos-bfl:
+  debian:
+    '*': [liborocos-bfl0.8]
+    'stretch': null
+  fedora: [liborocos-kdl]
+  ubuntu:
+    '*': [liborocos-bfl0.8]
+    'bionic': null
+    'xenial': null
+liborocos-bfl-dev:
+  debian: [liborocos-bfl-dev]
+  fedora: [liborocos-bfl-devel]
+  ubuntu: [liborocos-bfl-dev]
 liborocos-kdl:
   debian:
     '*': [liborocos-kdl1.4]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2850,6 +2850,21 @@ libopenvdb-dev:
   fedora: [openvdb-devel]
   gentoo: [media-gfx/openvdb]
   ubuntu: [libopenvdb-dev, libilmbase-dev]
+liborocos-kdl:
+  debian:
+    '*': [liborocos-kdl1.4]
+    'stretch': [liborocos-kdl1.3]
+  fedora: [liborocos-kdl]
+  gentoo: [sci-libs/orocos_kdl]
+  ubuntu:
+    '*': [liborocos-kdl1.4]
+    'bionic': [liborocos-kdl1.3]
+    'xenial': [liborocos-kdl1.3]
+liborocos-kdl-dev:
+  debian: [liborocos-kdl-dev]
+  fedora: [liborocos-kdl-devel]
+  gentoo: [sci-libs/orocos_kdl]
+  ubuntu: [liborocos-kdl-dev]
 libosmesa6-dev:
   arch: [mesa]
   debian: [libosmesa6-dev]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -263,6 +263,14 @@ libopenni2-dev:
   osx:
     homebrew:
       packages: [openni2]
+liborocos-kdl:
+  osx:
+    homebrew:
+      packages: [orocos-kdl]
+liborocos-kdl-dev:
+  osx:
+    homebrew:
+      packages: [orocos-kdl]
 libpcap:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5516,6 +5516,15 @@ python3-pygraphviz:
   rhel: ['python%{python3_pkgversion}-pygraphviz']
   slackware: [pygraphviz]
   ubuntu: [python3-pygraphviz]
+python3-pykdl:
+  debian:
+    '*': [python3-pykdl]
+    'bionic': null
+    'xenial': null
+  ubuntu:
+    '*': [python3-pykdl]
+    'bionic': null
+    'xenial': null
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]


### PR DESCRIPTION
Re: https://github.com/ros-gbp/bfl-release/issues/12

bfl rosdep keys:
ubuntu: https://packages.ubuntu.com/source/focal/orocos-bfl
debian: https://packages.debian.org/source/buster/orocos-bfl
fedora: https://debian.pkgs.org/10/debian-main-amd64/liborocos-bfl-dev_0.8.0-5_amd64.deb.html

python3-pykdl:
ubuntu: https://packages.ubuntu.com/focal/python3-pykdl
debian: https://packages.debian.org/buster/python3-pykdl

kdl keys: 
Fedora: https://fedora.pkgs.org/30/fedora-x86_64/orocos-kdl-devel-1.4.0-3.fc30.x86_64.rpm.html
Ubuntu: https://packages.ubuntu.com/xenial/liborocos-kdl-dev
Debian: https://packages.debian.org/source/buster/misc/orocos-kdl
Homebrew: https://formulae.brew.sh/formula/orocos-kdl
Gentoo: https://packages.gentoo.org/packages/sci-libs/orocos_kdl


@sloretz @jacobperron We should look at not releasing bfl and kdl into ROS packages for Noetic and Foxy with these being available upstream now. @meyerj @smits Does that make sense?

