### PR TITLE
ifm3d: 0.6.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5027,6 +5027,21 @@ repositories:
       url: https://github.com/astuff/ibeo_lux.git
       version: release
     status: developed
+  ifm3d:
+    doc:
+      type: git
+      url: https://github.com/ifm/ifm3d-ros.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-ros-release.git
+      version: 0.6.2-1
+    source:
+      type: git
+      url: https://github.com/ifm/ifm3d-ros.git
+      version: master
+    status: developed
   ifm3d_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d` to `0.6.2-1`:

- upstream repository: https://github.com/ifm/ifm3d-ros
- release repository: https://github.com/ifm/ifm3d-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
