### PR TITLE
Update Boost python rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1683,7 +1683,7 @@ libboost-python:
     bionic: [libboost-python1.65.1]
     disco: [libboost-python1.67.0]
     eoan: [libboost-python1.67.0]
-    focal: [libboost-python1.67.0]
+    focal: [libboost-python1.71.0]
     trusty: [libboost-python-1.54.0]
     xenial: [libboost-python-1.58.0]
 libboost-python-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1674,9 +1674,18 @@ libboost-program-options-dev:
   ubuntu: [libboost-program-options-dev]
 libboost-python:
   alpine: [boost-python2]
-  debian: [libboost-python-dev]
+  debian:
+    buster: [libboost-python1.67.0]
+    jessie: [libboost-python1.55.0]
+    stretch: [libboost-python1.62.0]
   fedora: [boost-python2-devel]
-  ubuntu: [libboost-python-dev]
+  ubuntu:
+    bionic: [libboost-python1.65.1]
+    disco: [libboost-python1.67.0]
+    eoan: [libboost-python1.67.0]
+    focal: [libboost-python1.67.0]
+    trusty: [libboost-python-1.54.0]
+    xenial: [libboost-python-1.58.0]
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1677,6 +1677,11 @@ libboost-python:
   debian: [libboost-python-dev]
   fedora: [boost-python2-devel]
   ubuntu: [libboost-python-dev]
+libboost-python-dev:
+  alpine: [boost-python2]
+  debian: [libboost-python-dev]
+  fedora: [boost-python2-devel]
+  ubuntu: [libboost-python-dev]
 libboost-random:
   debian:
     buster: [libboost-random1.67.0]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1678,7 +1678,7 @@ libboost-python:
     buster: [libboost-python1.67.0]
     jessie: [libboost-python1.55.0]
     stretch: [libboost-python1.62.0]
-  fedora: [boost-python2-devel]
+  fedora: [boost-python2-devel, boost-python3-devel]
   ubuntu:
     bionic: [libboost-python1.65.1]
     disco: [libboost-python1.67.0]


### PR DESCRIPTION
Firs commit creates a `libboost-python-dev` key and copies the content of `libboost-python` into it

The second updates `libboost-python` to not include all the development headers. Note that this is changing the rules of the key existing before this PR

Note: on debian/ubuntu: libboost-python is a hybrid package providing libraries for both python2 and python3. It's unclear to me what rule to use for system that have different packages for python2 and python3 e.g. fedora. So I opted to both to be the closest to ubuntu/debian behavior