### PR TITLE
plotjuggler: 2.6.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9936,7 +9936,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.5.1-2
+      version: 2.6.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.6.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.5.1-2`

## plotjuggler

```
* fix issue #253 <https://github.com/facontidavide/PlotJuggler/issues/253> and some cleanup
* fix issue #254 <https://github.com/facontidavide/PlotJuggler/issues/254>
* Fix #251 <https://github.com/facontidavide/PlotJuggler/issues/251>
* Contributors: Davide Faconti
```
