### PR TITLE
force_torque_sensor: 0.9.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3682,7 +3682,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.8.1-1
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3677,7 +3677,7 @@ repositories:
       - iirob_filters
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: kinetic-devel
+      version: melodic
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -3686,7 +3686,7 @@ repositories:
     source:
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: kinetic-devel
+      version: melodic
     status: developed
   force_torque_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `force_torque_sensor` to `0.9.3-1`:

- upstream repository: https://github.com/KITrobotics/force_torque_sensor.git
- release repository: https://github.com/KITrobotics/force_torque_sensor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.8.1-1`

## force_torque_sensor

```
* Changelog
* Contributors: Denis Štogl
```
