### PR TITLE
force_torque_sensor: 0.9.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2790,6 +2790,22 @@ repositories:
       url: https://github.com/boschresearch/fmi_adapter.git
       version: master
     status: maintained
+  force_torque_sensor:
+    doc:
+      type: git
+      url: https://github.com/KITrobotics/force_torque_sensor.git
+      version: melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/KITrobotics/force_torque_sensor-release.git
+      version: 0.9.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/KITrobotics/force_torque_sensor.git
+      version: melodic
+    status: maintained
   four_wheel_steering_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `force_torque_sensor` to `0.9.3-1`:

- upstream repository: https://github.com/KITrobotics/force_torque_sensor.git
- release repository: https://github.com/KITrobotics/force_torque_sensor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## force_torque_sensor

```
* Changelog
* Contributors: Denis Štogl
```
