### PR TITLE
nmea_msgs: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1099,6 +1099,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: eloquent
     status: maintained
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    status: maintained
   nonpersistent_voxel_layer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros2-gbp/nmea_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## nmea_msgs

```
* Initial release for ROS 2
* Contributors: Andreas Klintberg, Edward Venator
```
