### PR TITLE
common_msgs: 1.12.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -88,6 +88,26 @@ repositories:
       version: 0.4-devel
     status: maintained
   common_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: jade-devel
+    release:
+      packages:
+      - actionlib_msgs
+      - common_msgs
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/common_msgs-release.git
+      version: 1.12.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.7-1`:

- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## actionlib_msgs

- No changes

## common_msgs

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Add deprecation comment about Pose2D (#130 <https://github.com/ros/common_msgs/issues/130>)
  It started as unused and still isn't recommended.
  Followup to #129 <https://github.com/ros/common_msgs/issues/129>
* Contributors: Tully Foote
```

## nav_msgs

- No changes

## sensor_msgs

```
* Include sstream on header that needs i (#131 <https://github.com/ros/common_msgs/issues/131>)
* included missing import for the read_points_list method (#128 <https://github.com/ros/common_msgs/issues/128>)
  * included missing import for the read_points_list method
* Merge pull request #127 <https://github.com/ros/common_msgs/issues/127> from ros-1/fix-typos
* Merge pull request #85 <https://github.com/ros/common_msgs/issues/85> from ros/missing_test_target_dependency
  fix missing test target dependency
* Contributors: Dirk Thomas, Jasper, Kuang Fangjun, Tully Foote, chapulina
```

## shape_msgs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
