### PR TITLE
nmea_navsat_driver: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5792,7 +5792,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
-      version: 0.5.1-0
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `0.5.2-1`:

- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.5.1-0`

## nmea_navsat_driver

```
* Use Python's SocketServer rather than low level socket APIs. (#92 <https://github.com/evenator/nmea_navsat_driver/issues/92>)
  This simplifies code and makes it easier to add TCP support in the future. The ``buffer_size`` parameter is no longer necessary because this is an internal detail of UDPServer.
* Add documentation that passes ``pydocstyle``. (#88 <https://github.com/evenator/nmea_navsat_driver/issues/88>)
* Add an Option to Use GNSS Time and Improve Time Parsing. (#79 <https://github.com/evenator/nmea_navsat_driver/issues/79>)
  
    * Add an optional parameter ``use_GNSS_time`` to use the time from the GPS sentences for ROS message time instead of using system time.
    * Improve GPS time parsing to support nanosecond precision on devices that support it.
    * Improve GPS time parsing to use RMC message for date when available.
    * Improve GPS time parsing to resolve ambiguities in date and century using system time.
  
* Refactor all nodes into entrypoint scripts. (#76 <https://github.com/evenator/nmea_navsat_driver/issues/76>).
  This will reduce the difference between ROS 1 and ROS 2 code, because ROS 2 uses Python entry points to install executables.
* Fix PEP8 Violations (#68 <https://github.com/evenator/nmea_navsat_driver/issues/68>). All Python modules and scripts now pass ``pycodestyle --max-line-length 120 src/libnmea_navsat_driver/ scripts/*``
* Add ``nmea_serial_driver`` launch file (#60 <https://github.com/evenator/nmea_navsat_driver/issues/60>)
* Removed ``roslint`` as build depend. (#59 <https://github.com/evenator/nmea_navsat_driver/issues/59>)
  ``roslint`` was accidentally re-added as a build dependency in #25 <https://github.com/evenator/nmea_navsat_driver/issues/25>.
* Contributors: Ed Venator, Ryan Govostes, Tony Baltovski, Xiangyang Zhi, diasdm
```
