### PR TITLE
Adding carla_msgs to documentation index for kinetic and melodic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1264,6 +1264,15 @@ repositories:
       url: https://github.com/ipa320/care-o-bot-release.git
       version: 0.6.7-0
     status: maintained
+  carla_msgs:
+    doc:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
   carla_ros_bridge:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -920,6 +920,15 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  carla_msgs:
+    doc:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
   cartesian_msgs:
     doc:
       type: git


### PR DESCRIPTION
I'd like package carla_ros_bridge to be indexed and documented on ros.org.