### PR TITLE
ros_control: 0.17.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8142,7 +8142,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.16.0-1
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.17.0-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.16.0-1`

## combined_robot_hw

```
* Use auto keyword
* Use default member initializers
* Improve controller and resource filtering for CombinedRobotHW
* Prefer default member initializers
* Contributors: AbhinavSingh, Bence Magyar, Matt Reynolds, Toni Oliver
```

## combined_robot_hw_tests

```
* Improve controller and resource filtering for CombinedRobotHW
* Use auto
* Contributors: AbhinavSingh, Bence Magyar, Toni Oliver
```

## controller_interface

```
* Use default member initializers
* Prefer default member initializers
* Contributors: Bence Magyar, Matt Reynolds
```

## controller_manager

```
* Use auto keyword
* Use default member initializers
* Replace boost with std
* Replace boost mutexes & locks with std
* Replace boost::bind with std::bind
* Contributors: AbhinavSingh, Bence Magyar, Matt Reynolds, suab321321
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Use auto
* Contributors: AbhinavSingh
```

## hardware_interface

```
* Use default member initializers
* Use braces for member initializers
* Replace boost with std
* Replace boost::ptr_vector<T> with std::vector<T*>
* Contributors: AbhinavSingh, Bence Magyar, Matt Reynolds
```

## joint_limits_interface

```
* Use default member initializers
* Use braces for member initializers
* Replace boost with std
* Replace boost ptrs with std ptrs in documentation
* Prefer default member initializers
* Contributors: AbhinavSingh, Bence Magyar, Matt Reynolds
```

## ros_control

- No changes

## rqt_controller_manager

```
* added missing controller state: 'initialised'
* Contributors: ThibaultRouillard
```

## transmission_interface

```
* Use default member initializers
* Use braces for member initializers
* Replace boost with std
* Replace boost ptrs with std ptrs in documentation
* Replace boost::lexical_cast<double> with std::stod
* Prefer default member initializers
* Use auto
* Contributors: AbhinavSingh, Bence Magyar, Matt Reynolds
```
