### PR TITLE
bond_core: 1.8.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -34,11 +34,27 @@ repositories:
       version: master
     status: maintained
   bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: kinetic-devel
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/bond_core-release.git
+      version: 1.8.4-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.4-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## bond

```
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Mikael Arguedas
```

## bond_core

```
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Mikael Arguedas
```

## bondcpp

```
* Solved static linking problems with bondcpp (#44 <https://github.com/ros/bond_core/issues/44>)
* Add BONDCPP_DECL for Bond class (#2 <https://github.com/ros/bond_core/issues/2>) (#45 <https://github.com/ros/bond_core/issues/45>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: James Xu, Mikael Arguedas, ivanpauno
```

## bondpy

```
* Fix import (#48 <https://github.com/ros/bond_core/issues/48>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Markus Grimm, Mikael Arguedas
```

## smclib

```
* remove windows.h to avoid namespace pollutions. (#46 <https://github.com/ros/bond_core/issues/46>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: James Xu, Mikael Arguedas
```
