### PR TITLE
ros_numpy: 0.0.2-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8277,7 +8277,7 @@ repositories:
       version: master
     release:
       tags:
-        release: release/jade/{package}/{version}
+        release: release/melodic/{package}/{version}
       url: https://github.com/eric-wieser/ros_numpy-release.git
       version: 0.0.2-0
     source:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8270,6 +8270,21 @@ repositories:
       url: https://github.com/aws-robotics/monitoringmessages-ros1.git
       version: master
     status: maintained
+  ros_numpy:
+    doc:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    release:
+      tags:
+        release: release/jade/{package}/{version}
+      url: https://github.com/eric-wieser/ros_numpy-release.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    status: developed
   ros_pytest:
     doc:
       type: git


### PR DESCRIPTION
Add ros_numpy to melodic. It is exactly the same as in jade and kinetic as there were no releases since.

Repo link [https://github.com/eric-wieser/ros_numpy](https://github.com/eric-wieser/ros_numpy)

