### PR TITLE
apex_containers: 0.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -235,6 +235,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_containers:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_containers-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    status: developed
   apriltag:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `apex_containers` to `0.0.1-1`:

- upstream repository: https://gitlab.com/ApexAI/apex_containers.git
- release repository: https://gitlab.com/ApexAI/apex_containers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
