### PR TITLE
ifm3d_core: 0.17.0-10 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5048,7 +5048,7 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
       version: 0.17.0-10
-    status: maintained
+    status: developed
   ifm_o3mxxx:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5047,7 +5047,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-9
+      version: 0.17.0-10
     status: maintained
   ifm_o3mxxx:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.17.0-10`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.17.0-9`
