### PR TITLE
ifm3d: 0.6.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3517,7 +3517,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-ros-release.git
-      version: 0.6.2-1
+      version: 0.6.2-2
     source:
       type: git
       url: https://github.com/ifm/ifm3d-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d` to `0.6.2-2`:

- upstream repository: https://github.com/ifm/ifm3d-ros
- release repository: https://github.com/ifm/ifm3d-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.6.2-1`
