### PR TITLE
ifm3d_core: 0.17.0-6 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3529,7 +3529,7 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
       version: 0.17.0-6
-    status: maintained
+    status: developed
   ifopt:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3528,7 +3528,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-5
+      version: 0.17.0-6
     status: maintained
   ifopt:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.17.0-6`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.17.0-5`
