### PR TITLE
force_torque_sensor: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3682,7 +3682,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.8.1-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `force_torque_sensor` to `1.0.0-1`:

- upstream repository: https://github.com/KITrobotics/force_torque_sensor.git
- release repository: https://github.com/KITrobotics/force_torque_sensor-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.8.1-1`

## force_torque_sensor

```
* Update README
* Added static_application parameter to example configs.
* Added functionality for static applications, i.e., the node looks only at the beginning for the transformation and u$
* Reduced INFO output (changed to DEBUG)
* Resorting of definitions in .h file
* Removing used and unnecessary variables
* Using private namespace for filters to be unified with iirob_filters implementation
* Contributors: Denis Stogl
```
