### PR TITLE
force_torque_sensor: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2799,7 +2799,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.9.3-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `force_torque_sensor` to `1.0.0-1`:

- upstream repository: https://github.com/KITrobotics/force_torque_sensor.git
- release repository: https://github.com/KITrobotics/force_torque_sensor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.9.3-1`

## force_torque_sensor

```
* Update README
* Added static_application parameter to example configs.
* Added functionality for static applications, i.e., the node looks only at the beginning for the transformation and u$
* Reduced INFO output (changed to DEBUG)
* Resorting of definitions in .h file
* Removing used and unnecessary variables
* Using private namespace for filters to be unified with iirob_filters implementation
* Contributors: Denis Stogl
```
