### PR TITLE
plotjuggler: 2.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6734,7 +6734,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.6.1-6
+      version: 2.6.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.6.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.6.1-6`

## plotjuggler

```
* bug fix in IMU parser
* added step size for the time tracker
* fis issue #256 <https://github.com/facontidavide/PlotJuggler/issues/256> (new release dialog)
* Update README.md
* Contributors: Davide Faconti
```
