### PR TITLE
casadi_vendor: 3.5.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -439,6 +439,21 @@ repositories:
       url: https://github.com/ros2/cartographer_ros.git
       version: dashing
     status: maintained
+  casadi_vendor:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor-release.git
+      version: 3.5.1-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor.git
+      version: master
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `casadi_vendor` to `3.5.1-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## casadi_vendor

```
* Updating README.
* Initial commit
* Contributors: Geoffrey Biggs, Joshua Whitley
```
