### PR TITLE
ros_sensor_msgs: 0.2.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12614,6 +12614,16 @@ repositories:
       url: https://github.com/ros/ros_realtime.git
       version: hydro-devel
     status: unmaintained
+  ros_sensor_msgs:
+    doc:
+      type: git
+      url: https://gitlab142.eng.auburn.edu/CJC0052/ros_sensor_msgs.git
+      version: 0.2.2
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/CCampos080996/tdcp_ws-release.git
+      version: 0.2.3-1
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_sensor_msgs` to `0.2.3-1`:

- upstream repository: https://gitlab142.eng.auburn.edu/CJC0052/ros_sensor_msgs
- release repository: https://github.com/CCampos080996/tdcp_ws-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ros_sensor_msgs

- No changes
