### PR TITLE
ColorTuner: 0.0.3-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,14 +8,7 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
-  ColorTuner:
-    release:
-      packages:
-      - jderobot_color_tuner
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/JdeRobot/ColorTuner-release.git
-      version: 0.0.3-4
+
   abb:
     release:
       packages:
@@ -3917,6 +3910,15 @@ repositories:
       url: https://github.com/JdeRobot/assets.git
       version: kinetic-devel
     status: developed
+  jderobot_color_tuner:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-4
+    source:
+      type: git
+      url: https://github.com/JdeRobot/ColorTuner.git
   jderobot_drones:
     release:
       packages:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,6 +8,14 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  ColorTuner:
+    release:
+      packages:
+      - jderobot_color_tuner
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-4
   abb:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ColorTuner` to `0.0.3-4`:

- upstream repository: https://github.com/JdeRobot/ColorTuner.git
- release repository: https://github.com/JdeRobot/ColorTuner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## jderobot_color_tuner

- Added License and authors file
- Added dependencies in package.xml
- Removed pre-copiled python artifacts
- removed repository name, while keeping package name only to keep jderobot packages together in the distribution file

