### PR TITLE
ati_force_torque: 1.1.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -574,6 +574,22 @@ repositories:
       url: https://github.com/gt-rail-release/async_web_server_cpp-release.git
       version: 0.0.3-0
     status: unmaintained
+  ati_force_torque:
+    doc:
+      type: git
+      url: https://github.com/KITrobotics/ati_force_torque.git
+      version: melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/KITrobotics/ati_force_torque-release.git
+      version: 1.1.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/KITrobotics/ati_force_torque.git
+      version: melodic
+    status: maintained
   audibot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ati_force_torque` to `1.1.1-3`:

- upstream repository: https://github.com/KITrobotics/ati_force_torque.git
- release repository: https://github.com/KITrobotics/ati_force_torque-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ati_force_torque

```
* Updated README with melodic description
* Added static_application parameter to example configs.
* Adapted namespace for sensor parameters
* Contributors: Denis Stogl
```
