### PR TITLE
ati_force_torque: 1.1.1-4 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -716,7 +716,7 @@ repositories:
       - iirob_filters
       type: git
       url: https://github.com/KITrobotics/ati_force_torque.git
-      version: kinetic-devel
+      version: melodic
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -725,8 +725,8 @@ repositories:
     source:
       type: git
       url: https://github.com/KITrobotics/ati_force_torque.git
-      version: kinetic-devel
-    status: developed
+      version: melodic
+    status: maintained
   auction_methods_stack:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -721,6 +721,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/ati_force_torque-release.git
+      version: 1.1.1-4
     source:
       type: git
       url: https://github.com/KITrobotics/ati_force_torque.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ati_force_torque` to `1.1.1-4`:

- upstream repository: https://github.com/KITrobotics/ati_force_torque.git
- release repository: https://github.com/KITrobotics/ati_force_torque-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ati_force_torque

```
* Updated README with melodic description
* Added static_application parameter to example configs.
* Adapted namespace for sensor parameters
* Contributors: Denis Stogl
```
