### PR TITLE
ColorTuner: 0.0.3-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,6 +8,19 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  ColorTuner:
+    release:
+      packages:
+      - jderobot_color_tuner
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/ColorTuner.git
+      version: master
   abb:
     release:
       packages:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,20 +8,7 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
-  ColorTuner:
-    release:
-      packages:
-      - jderobot_color_tuner
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/JdeRobot/ColorTuner-release.git
-      version: 0.0.3-5
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/JdeRobot/ColorTuner.git
-      version: master
-  abb:
+abb:
     release:
       packages:
       - abb
@@ -3922,6 +3909,19 @@ repositories:
       url: https://github.com/JdeRobot/assets.git
       version: kinetic-devel
     status: developed
+  jderobot_color_tuner:
+    release:
+      packages:
+      - jderobot_color_tuner
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/ColorTuner.git
+      version: master
   jderobot_drones:
     release:
       packages:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8,7 +8,7 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
-abb:
+  abb:
     release:
       packages:
       - abb


### PR DESCRIPTION
Increasing version of package(s) in repository `ColorTuner` to `0.0.3-5`:

- upstream repository: https://github.com/JdeRobot/ColorTuner.git
- release repository: https://github.com/JdeRobot/ColorTuner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## jderobot_color_tuner

- No changes
