### PR TITLE
apex_containers: 0.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -177,6 +177,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_containers:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_containers-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    status: developed
   automotive_autonomy_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apex_containers` to `0.0.1-1`:

- upstream repository: https://gitlab.com/ApexAI/apex_containers.git
- release repository: https://gitlab.com/ApexAI/apex_containers-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
