### PR TITLE
apex_test_tools: 0.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -177,6 +177,24 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_test_tools:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: master
+    release:
+      packages:
+      - apex_test_tools
+      - test_apex_test_tools
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_test_tools-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: master
+    status: developed
   automotive_autonomy_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apex_test_tools` to `0.0.1-1`:

- upstream repository: https://gitlab.com/ApexAI/apex_test_tools.git
- release repository: https://gitlab.com/ApexAI/apex_test_tools-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
