### PR TITLE
Revert ainstein radar to 2.0.2

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -130,7 +130,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 3.0.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -130,7 +130,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 3.0.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git


### PR DESCRIPTION
This reverts ainstein radar to 2.0.2, the last version known to compile on all platforms.  This PR is being put in so we can do a Melodic sync.  @nrotella-ainstein FYI.