### PR TITLE
ros_tutorials: 0.9.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8362,7 +8362,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.9.1-0
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.9.2-1`:

- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.9.1-0`

## ros_tutorials

```
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
```

## roscpp_tutorials

```
* explicitly state Boost dependencies manifests (#83 <https://github.com/ros/ros_tutorials/issues/83>)
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
* add cached parameter sample (#52 <https://github.com/ros/ros_tutorials/issues/52>)
```

## rospy_tutorials

```
* add print parenthesis for Python 3 (#82 <https://github.com/ros/ros_tutorials/issues/82>)
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
```

## turtlesim

```
* explicitly state Boost dependencies manifests (#83 <https://github.com/ros/ros_tutorials/issues/83>)
* backport Windows implemenation from eloquent. (#80 <https://github.com/ros/ros_tutorials/issues/80>)
* background colour and private nodehandle (#70 <https://github.com/ros/ros_tutorials/issues/70>)
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
* add shortcut to quit teleop (#59 <https://github.com/ros/ros_tutorials/issues/59>)
```
