### PR TITLE
ros_tutorials: 0.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -557,6 +557,20 @@ repositories:
       version: noetic
     status: maintained
   ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: melodic-devel
+    release:
+      packages:
+      - ros_tutorials
+      - roscpp_tutorials
+      - rospy_tutorials
+      - turtlesim
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_tutorials-release.git
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.9.2-1`:

- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ros_tutorials

```
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
```

## roscpp_tutorials

```
* explicitly state Boost dependencies manifests (#83 <https://github.com/ros/ros_tutorials/issues/83>)
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
* add cached parameter sample (#52 <https://github.com/ros/ros_tutorials/issues/52>)
```

## rospy_tutorials

```
* add print parenthesis for Python 3 (#82 <https://github.com/ros/ros_tutorials/issues/82>)
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
```

## turtlesim

```
* explicitly state Boost dependencies manifests (#83 <https://github.com/ros/ros_tutorials/issues/83>)
* backport Windows implemenation from eloquent. (#80 <https://github.com/ros/ros_tutorials/issues/80>)
* background colour and private nodehandle (#70 <https://github.com/ros/ros_tutorials/issues/70>)
* bump CMake minimum version to avoid CMP0048 warning (#81 <https://github.com/ros/ros_tutorials/issues/81>)
* add shortcut to quit teleop (#59 <https://github.com/ros/ros_tutorials/issues/59>)
```
