### PR TITLE
jackal_cartographer_navigation: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3878,6 +3878,21 @@ repositories:
       url: https://github.com/jackal/jackal.git
       version: kinetic-devel
     status: maintained
+  jackal_cartographer_navigation:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_cartographer_navigation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_cartographer_navigation-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_cartographer_navigation.git
+      version: melodic-devel
+    status: developed
   jackal_desktop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_cartographer_navigation` to `0.0.1-1`:

- upstream repository: https://github.com/jackal/jackal_cartographer_navigation.git
- release repository: https://github.com/clearpath-gbp/jackal_cartographer_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## jackal_cartographer_navigation

```
* Updated maintainer.
* Removed rviz to use jackal_viz.
* Merge pull request #2 <https://github.com/jackal/jackal_cartographer_navigation/issues/2> from ljazzal/master
  Update dependencies to use cartographer_ros pkg instead of building from source
* added back use_odometry config
* minor changes to install instructions
* added cartographer_ros as run_depend
* removed unused file
* Updated install instructions
* tuned cartographer parameters
* Using deb release of cartographer_ros
* minor changes to install
* Changed repo link
* Update README.md
* Updated emails
* Set version number to 0.0.0
* Revert "Remove use_landmarks and landmark_sampling_ratio"
  This reverts commit f48f031eb44f376c98351e7ae8b09779b49b9ac8
* Checkout latest working commits for Cartographer and Cartographer ROS
* Remove use_landmarks and landmark_sampling_ratio
* Update script to use version 0.3.0 of Cartographer and Cartographer ROS packages
* Update README.md
* Update README.md
* Created catkin package for repository and modified configuration file to reflect changes made in official Cartographer repository
* Created catkin package for repository and modified configuration file to reflect changes made in official Cartographer repository
* Update README.md
* Update protobuf3_local.sh to clone jackal repository
* Update README.md
* Update README.md
* Update README.md
* Created tutorial on how to use Cartographer
* Updated script to clone jackal_desktop and jackal_simulator into workspace
* Removed unnecessary files
* Changed mapping resolution
* Removed jackal_desktop and jackal_simulation
* Merge branch 'tuning-slam' of http://gitlab.clearpathrobotics.com/research/jackal_cartographer_navigation into tuning-slam
* Minor README changes
* Delete protobuf3_local.sh~
* Delete jackal.lua~
* Fixed address in install script
* Minor README changes
* Minor README changes
* Minor README changes
* Added setup steps in README
* Minor changes to Google Cartographer install script
* Initial Commit
* Contributors: Aditya Bhattacharjee, Tony Baltovski, ljazzal
```
