### PR TITLE
ridgeback_cartographer_navigation: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7737,6 +7737,21 @@ repositories:
       url: https://github.com/ridgeback/ridgeback.git
       version: kinetic-devel
     status: maintained
+  ridgeback_cartographer_navigation:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_cartographer_navigation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_cartographer_navigation-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_cartographer_navigation.git
+      version: melodic-devel
+    status: developed
   ridgeback_desktop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_cartographer_navigation` to `0.0.1-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_cartographer_navigation.git
- release repository: https://github.com/clearpath-gbp/ridgeback_cartographer_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## ridgeback_cartographer_navigation

```
* Added ridgeback_navigation as run dep.
* Updated maintainer.
* Removed rviz to use ridgeback_viz.
* Merge pull request #3 <https://github.com/ridgeback/ridgeback_cartographer_navigation/issues/3> from ljazzal/master
  Updated dependencies to use cartographer_ros pkg instead of building from source
* minor changes to carto params, install instruction
* changed tracking frame back to imu_link
* updated cartographer demo to run with cartographer_ros
* added cartographer_ros as run_depend
* removed unused file
* added rviz config to launch
* config changes
* Update to use deb release of cartographer_ros
* Added generated map and brief description of Cartographer
* Added config and launch files to use Cartographer on the Ridgeback
* Contributors: Aditya Bhattacharjee, Tony Baltovski, ljazzal
```
