### PR TITLE
visualstates: 0.2.3-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11173,7 +11173,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/VisualStates-release.git
-      version: 0.2.3-2
+      version: 0.2.3-3
   volksbot_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualstates` to `0.2.3-3`:

- upstream repository: https://github.com/JdeRobot/VisualStates.git
- release repository: https://github.com/JdeRobot/VisualStates-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.3-2`

## visualstates