### PR TITLE
py_trees: 2.0.10-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1375,7 +1375,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 2.0.9-1
+      version: 2.0.10-2
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.0.10-2`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.0.9-1`

## py_trees

```
* [trees] setup timeout error with last behaviour name included in the error message, #279 <https://github.com/splintered-reality/py_trees/pull/279>
* [blackboard] rooted variables in namespaced clients working as designed, fixed docs, #277 <https://github.com/splintered-reality/py_trees/pull/277>
```
