### PR TITLE
toposens: 2.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10254,7 +10254,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.0.2-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.0.1-1`

## toposens

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_description

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_driver

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_markers

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_msgs

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_pointcloud

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_sync

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```
