### PR TITLE
toposens: 2.0.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15650,7 +15650,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.0.2-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.0.1-1`

## toposens

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_description

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_driver

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_markers

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_msgs

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_pointcloud

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```

## toposens_sync

```
* Changed package maintainer
* Contributors: Sebastian Dengler
```
