### PR TITLE
add PySide2 / Shiboken2 to python3-qt5-bindings as of Ubuntu Focal / Debian Buster

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5572,13 +5572,25 @@ python3-pytest-timeout:
 python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
-  debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+  debian:
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
+    jessie: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+    stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, sip]
   gentoo: [dev-python/PyQt5]
   opensuse: [python3-qt5]
   rhel: ['python%{python3_pkgversion}-qt5-devel']
   slackware: [python3-PyQt5]
-  ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+  ubuntu:
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
+    artful: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    cosmic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    xenial: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    yakkety: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    zesty: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]


### PR DESCRIPTION
* Debian Buster:
  * https://packages.debian.org/buster/libdevel/libpyside2-dev
  * https://packages.debian.org/buster/libdevel/libshiboken2-dev
  * https://packages.debian.org/buster/libdevel/python3-pyside2.qtsvg
  * https://packages.debian.org/buster/libdevel/shiboken2
* Ubuntu Focal:
  * https://packages.ubuntu.com/focal/libpyside2-dev
  * https://packages.ubuntu.com/focal/libshiboken2-dev
  * https://packages.ubuntu.com/focal/python3-pyside2.qtsvg
  * https://packages.ubuntu.com/focal/shiboken2