### PR TITLE
python_qt_binding: 0.3.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10601,7 +10601,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.4-0
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.3.7-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.3.4-0`

## python_qt_binding

```
* bump CMake minimum version to avoid CMP0048 warning (#83 <https://github.com/ros-visualization/python_qt_binding/issues/83>)
* check if Shiboken2Config.cmake defines a target instead of a variable, fixes #69 <https://github.com/ros-visualization/python_qt_binding/issues/69> (#77 <https://github.com/ros-visualization/python_qt_binding/issues/77>)
```
