### PR TITLE
python_qt_binding: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7228,7 +7228,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.6-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.4.0-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.3.6-2`

## python_qt_binding

```
* use PySide2 and Shiboken2 targets for variables (#79 <https://github.com/ros-visualization/python_qt_binding/issues/79>)
* use QUIET and change warning into status msg to avoid stderr on Melodic (#85 <https://github.com/ros-visualization/python_qt_binding/issues/85>)
```
