### PR TITLE
python_qt_binding: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -386,6 +386,15 @@ repositories:
       version: melodic-devel
     status: maintained
   python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/python_qt_binding-release.git
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.4.0-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## python_qt_binding

```
* use PySide2 and Shiboken2 targets for variables (#79 <https://github.com/ros-visualization/python_qt_binding/issues/79>)
* use QUIET and change warning into status msg to avoid stderr on Melodic (#85 <https://github.com/ros-visualization/python_qt_binding/issues/85>)
```
