### PR TITLE
qt_gui_core: 0.3.17-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10749,7 +10749,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.11-0
+      version: 0.3.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.3.17-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.3.11-0`

## qt_dotgraph

```
* bump CMake minimum version to avoid CMP0048 warning (#206 <https://github.com/ros-visualization/qt_gui_core/issues/206>)
* [Windows] use the portable way to decide the line break (#200 <https://github.com/ros-visualization/qt_gui_core/issues/200>)
```

## qt_gui

```
* bump CMake minimum version to avoid CMP0048 warning (#206 <https://github.com/ros-visualization/qt_gui_core/issues/206>)
* use native default icon theme if suitable (#202 <https://github.com/ros-visualization/qt_gui_core/issues/202>)
* fix title bar buttons rendering on macOS (#205 <https://github.com/ros-visualization/qt_gui_core/issues/205>)
* fix platform check for macOS in themeSearchPaths patching (#204 <https://github.com/ros-visualization/qt_gui_core/issues/204>)
* auto adjust main window if standalone (#199 <https://github.com/ros-visualization/qt_gui_core/issues/199>)
```

## qt_gui_app

```
* bump CMake minimum version to avoid CMP0048 warning (#206 <https://github.com/ros-visualization/qt_gui_core/issues/206>)
```

## qt_gui_cpp

```
* bump CMake minimum version to avoid CMP0048 warning (#206 <https://github.com/ros-visualization/qt_gui_core/issues/206>)
```

## qt_gui_py_common

```
* bump CMake minimum version to avoid CMP0048 warning (#206 <https://github.com/ros-visualization/qt_gui_core/issues/206>)
```
