### PR TITLE
[rosdep] boost 1.71 for ubuntu focal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1587,7 +1587,7 @@ libboost-atomic:
   ubuntu:
     bionic: [libboost-atomic1.65.1]
     eoan: [libboost-atomic1.67.0]
-    focal: [libboost-atomic1.67.0]
+    focal: [libboost-atomic1.71.0]
     xenial: [libboost-atomic1.58.0]
 libboost-atomic-dev:
   debian: [libboost-atomic-dev]
@@ -1601,7 +1601,7 @@ libboost-chrono:
   ubuntu:
     bionic: [libboost-chrono1.65.1]
     eoan: [libboost-chrono1.67.0]
-    focal: [libboost-chrono1.67.0]
+    focal: [libboost-chrono1.71.0]
     xenial: [libboost-chrono1.58.0]
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
@@ -1615,7 +1615,7 @@ libboost-date-time:
   ubuntu:
     bionic: [libboost-date-time1.65.1]
     eoan: [libboost-date-time1.67.0]
-    focal: [libboost-date-time1.67.0]
+    focal: [libboost-date-time1.71.0]
     xenial: [libboost-date-time1.58.0]
 libboost-date-time-dev:
   debian: [libboost-date-time-dev]
@@ -1633,7 +1633,7 @@ libboost-filesystem:
   ubuntu:
     bionic: [libboost-filesystem1.65.1]
     eoan: [libboost-filesystem1.67.0]
-    focal: [libboost-filesystem1.67.0]
+    focal: [libboost-filesystem1.71.0]
     xenial: [libboost-filesystem1.58.0]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
@@ -1648,7 +1648,7 @@ libboost-iostreams:
   ubuntu:
     bionic: [libboost-iostreams1.65.1]
     eoan: [libboost-iostreams1.67.0]
-    focal: [libboost-iostreams1.67.0]
+    focal: [libboost-iostreams1.71.0]
     xenial: [libboost-iostreams1.58.0]
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
@@ -1664,7 +1664,7 @@ libboost-program-options:
     bionic: [libboost-program-options1.65.1]
     disco: [libboost-program-options1.67.0]
     eoan: [libboost-program-options1.67.0]
-    focal: [libboost-program-options1.67.0]
+    focal: [libboost-program-options1.71.0]
     trusty: [libboost-program-options1.55.0]
     xenial: [libboost-program-options1.58.0]
 libboost-program-options-dev:
@@ -1688,7 +1688,7 @@ libboost-random:
     bionic: [libboost-random1.65.1]
     disco: [libboost-random1.67.0]
     eoan: [libboost-random1.67.0]
-    focal: [libboost-random1.67.0]
+    focal: [libboost-random1.71.0]
     precise: [libboost-random1.46.1]
     trusty: [libboost-random1.54.0]
     xenial: [libboost-random1.58.0]
@@ -1704,7 +1704,7 @@ libboost-regex:
   ubuntu:
     bionic: [libboost-regex1.65.1]
     eoan: [libboost-regex1.67.0]
-    focal: [libboost-regex1.67.0]
+    focal: [libboost-regex1.71.0]
     xenial: [libboost-regex1.58.0]
 libboost-regex-dev:
   debian: [libboost-regex-dev]
@@ -1719,7 +1719,7 @@ libboost-system:
     bionic: [libboost-system1.65.1]
     disco: [libboost-system1.67.0]
     eoan: [libboost-system1.67.0]
-    focal: [libboost-system1.67.0]
+    focal: [libboost-system1.71.0]
     trusty: [libboost-system1.55.0]
     xenial: [libboost-system1.58.0]
 libboost-system-dev:
@@ -1735,7 +1735,7 @@ libboost-thread:
     bionic: [libboost-thread1.65.1]
     disco: [libboost-thread1.67.0]
     eoan: [libboost-thread1.67.0]
-    focal: [libboost-thread1.67.0]
+    focal: [libboost-thread1.71.0]
     trusty: [libboost-thread1.55.0]
     xenial: [libboost-thread1.58.0]
 libboost-thread-dev:


### PR DESCRIPTION
https://packages.ubuntu.com/focal/libboost-atomic1.71.0
https://packages.ubuntu.com/focal/libboost-chrono1.71.0
https://packages.ubuntu.com/focal/libboost-date-time1.71.0
https://packages.ubuntu.com/focal/libboost-filesystem1.71.0
https://packages.ubuntu.com/focal/libboost-iostreams1.71.0
https://packages.ubuntu.com/focal/libboost-program-options1.71.0
https://packages.ubuntu.com/focal/libboost-random1.71.0
https://packages.ubuntu.com/focal/libboost-regex1.71.0
https://packages.ubuntu.com/focal/libboost-system1.71.0
https://packages.ubuntu.com/focal/libboost-thread1.71.0