### PR TITLE
swarmros: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15098,7 +15098,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
-      version: 0.3.1-4
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swarmros` to `0.3.2-1`:

- upstream repository: https://github.com/amilankovich-slab/swarmros.git
- release repository: https://github.com/amilankovich-slab/swarmros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.3.1-4`
