### PR TITLE
jderobot_color_tuner: 0.0.3-6 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3934,6 +3934,17 @@ repositories:
       url: https://github.com/JdeRobot/assets.git
       version: kinetic-devel
     status: developed
+  jderobot_color_tuner:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-6
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/ColorTuner.git
+      version: master
   jderobot_drones:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_color_tuner` to `0.0.3-6`:

- upstream repository: https://github.com/JdeRobot/ColorTuner.git
- release repository: https://github.com/JdeRobot/ColorTuner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## jderobot_color_tuner

- No changes
