### PR TITLE
visp: 3.3.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11150,7 +11150,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.2.0-1
+      version: 3.3.0-3
     status: maintained
   visualization_osg:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.3.0-3`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `3.2.0-1`
