### PR TITLE
python_qt_binding: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -394,7 +394,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.4.1-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.4.0-1`

## python_qt_binding

```
* remove obsolete function used for backward compatibility (#88 <https://github.com/ros-visualization/python_qt_binding/issues/88>)
* disable Shiboken with CMake < 3.14 (#87 <https://github.com/ros-visualization/python_qt_binding/issues/87>)
* fix case of CMake function (#86 <https://github.com/ros-visualization/python_qt_binding/issues/86>)
```
