### PR TITLE
catkin: 0.8.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -48,7 +48,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.1-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.8.0-1`

## catkin

```
* always pass --root to setuptools install (#1068 <https://github.com/ros/catkin/issues/1068>)
* allow flexible CMake minimum version in metapackage CMake code (#1065 <https://github.com/ros/catkin/issues/1065>)
* [Windows] generate executables without extension name (#1061 <https://github.com/ros/catkin/issues/1061>, #1063 <https://github.com/ros/catkin/issues/1063>)
* fix CATKIN_INSTALL_INTO_PREFIX_ROOT for win32 (#1058 <https://github.com/ros/catkin/issues/1058>)
```
