### PR TITLE
catkin: 0.7.22-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1021,7 +1021,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.20-1
+      version: 0.7.22-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.22-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.7.20-1`

## catkin

```
* [Windows] rename catkin scripts for parallel package parsing support (#1066 <https://github.com/ros/catkin/issues/1066>)
* allow flexible CMake minimum version in metapackage CMake code (#1065 <https://github.com/ros/catkin/issues/1065>)
* [Windows] generate executables without extension name (#1061 <https://github.com/ros/catkin/issues/1061>, #1063 <https://github.com/ros/catkin/issues/1063>)
* fix CATKIN_INSTALL_INTO_PREFIX_ROOT for win32 (#1059 <https://github.com/ros/catkin/issues/1059>)
* various code cleanup (#1055 <https://github.com/ros/catkin/issues/1055>)
* make catkin_install_python code a little clearer (#1054 <https://github.com/ros/catkin/issues/1054>)
```
