### PR TITLE
genmsg: 0.5.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -211,7 +211,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.14-1
+      version: 0.5.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.15-1`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.5.14-1`

## genmsg

```
* bump CMake minimum version to use new behavior of CMP0048 (#91 <https://github.com/ros/genmsg/issues/91>)
```
