### PR TITLE
rospack: 2.5.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8726,7 +8726,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.5.4-1
+      version: 2.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospack` to `2.5.5-1`:

- upstream repository: https://github.com/ros/rospack.git
- release repository: https://github.com/ros-gbp/rospack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.5.4-1`

## rospack

```
* bump to CMake 3.0.2 to avoid CMP0048 warning (#114 <https://github.com/ros/rospack/issues/114>)
* only depend on catkin_pkg/rosdep-modules (#109 <https://github.com/ros/rospack/issues/109>)
* rework validateCache for portability. (#108 <https://github.com/ros/rospack/issues/108>)
```
