### PR TITLE
py_trees_js: 0.6.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1390,7 +1390,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_js-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.2-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/stonier/py_trees_js-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.6.1-1`

## py_trees_js

```
* [js] bugfix accidentally ignored tree_cache size, #123 <https://github.com/splintered-reality/py_trees_js/pull/123>
```
