### PR TITLE
neonavigation_msgs: 0.8.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8446,7 +8446,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_msgs-release.git
-      version: 0.7.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_msgs` to `0.8.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation_msgs.git
- release repository: https://github.com/at-wat/neonavigation_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.0-1`

## costmap_cspace_msgs

- No changes

## map_organizer_msgs

- No changes

## neonavigation_msgs

- No changes

## planner_cspace_msgs

- No changes

## safety_limiter_msgs

- No changes

## trajectory_tracker_msgs

```
* trajectory_tracker_msgs: add path header in TrajectoryTrackerStatus (#26 <https://github.com/at-wat/neonavigation_msgs/issues/26>)
* Contributors: Naotaka Hatao
```
