### PR TITLE
Added west key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5757,6 +5757,13 @@ python3-websocket:
   fedora: [python3-websocket-client]
   gentoo: [dev-python/websocket-client]
   ubuntu: [python3-websocket]
+python3-west-pip:
+  debian:
+    pip:
+      packages: [west]
+  ubuntu:
+    pip:
+      packages: [west]
 python3-yaml:
   alpine: [py3-yaml]
   debian: [python3-yaml]


### PR DESCRIPTION
Added west key for micro-ROS project

Zephyr RTOS build tool available via pip:
https://pypi.org/project/west/