### PR TITLE
apex_containers: 0.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -244,7 +244,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/ApexAI/apex_containers-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/apex_containers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apex_containers` to `0.0.2-1`:

- upstream repository: https://gitlab.com/ApexAI/apex_containers.git
- release repository: https://gitlab.com/ApexAI/apex_containers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.0.1-1`
