### PR TITLE
Remove Autoware.Auto

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -6,48 +6,6 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
-  Autoware.Auto:
-    doc:
-      type: git
-      url: https://gitlab.com/AutowareAuto/AutowareAuto.git
-      version: 0.0.1
-    release:
-      packages:
-      - autoware_auto_algorithm
-      - autoware_auto_cmake
-      - autoware_auto_create_pkg
-      - autoware_auto_examples
-      - autoware_auto_geometry
-      - autoware_auto_helper_functions
-      - autoware_auto_msgs
-      - euclidean_cluster
-      - euclidean_cluster_nodes
-      - hungarian_assigner
-      - kalman_filter
-      - lidar_utils
-      - localization_common
-      - localization_nodes
-      - motion_model
-      - ndt
-      - optimization
-      - point_cloud_fusion
-      - ray_ground_classifier
-      - ray_ground_classifier_nodes
-      - velodyne_driver
-      - velodyne_node
-      - voxel_grid
-      - voxel_grid_nodes
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://gitlab.com/AutowareAuto/AutowareAuto-release.git
-      version: 0.0.2-1
-    source:
-      test_commits: false
-      test_pull_requests: false
-      type: git
-      url: https://gitlab.com/AutowareAuto/AutowareAuto.git
-      version: 0.0.1
-    status: developed
   ackermann_msgs:
     doc:
       type: git


### PR DESCRIPTION
We initially submitted Autoware.Auto for release, but due to some constraints we won't have time to fix the issues, so it's just better to remove it from the index.