### PR TITLE
autoware_auto_msgs: 0.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -214,6 +214,21 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: developed
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    status: developed
   behaviortree_cpp_v3:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_auto_msgs` to `0.0.2-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
