### PR TITLE
actionlib: 1.13.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11,6 +11,18 @@ release_platforms:
   - focal
 repositories:
   actionlib:
+    doc:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: noetic-devel
+    release:
+      packages:
+      - actionlib
+      - actionlib_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/actionlib-release.git
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.13.0-1`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## actionlib

```
* Switch to timer and allow stopping actionserver/client (#142 <https://github.com/ros/actionlib/issues/142>)
* bump CMake minimum version to use new behavior of CMP0048 (#158 <https://github.com/ros/actionlib/issues/158>)
* Split actionlib and tools into separate packages (#152 <https://github.com/ros/actionlib/issues/152>)
* Contributors: Michael Carroll, Paul Bovbel, jschleicher
```

## actionlib_tools

```
* Fix syntax error; missing : (#159 <https://github.com/ros/actionlib/issues/159>)
* bump CMake minimum version to use new behavior of CMP0048 (#158 <https://github.com/ros/actionlib/issues/158>)
* Split actionlib and tools into separate packages (#152 <https://github.com/ros/actionlib/issues/152>)
* Contributors: Michael Carroll, Shane Loretz, jschleicher
```
