### PR TITLE
jackal: 0.6.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3896,7 +3896,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.6.4-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.6.3-1`

## jackal_control

```
* Update control.launch
  Somehow a ">" has gone missing. This change adds it back in.
* [jackal_control] Added control extras.
* Contributors: Jeff Schmidt, Tony Baltovski
```

## jackal_description

```
* Modify the hokuyo accessory so that it works properly in gazebo/rviz.  Add an additional environment var JACKAL_LASER_HOKUYO which overrides the default lms1xx sensor with the ust10.
* use env_run.bat on Windows (#3 <https://github.com/jackal/jackal/issues/3>)
* add setlocal
* Fix jackal_description install location & fold xacro includes (#2 <https://github.com/jackal/jackal/issues/2>)
  * Fix install location.
  * Fold xacro includes
* add env-hook batch scripts (#1 <https://github.com/jackal/jackal/issues/1>)
* Contributors: Chris I-B, James Xu, Sean Yen, Tony Baltovski
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
