### PR TITLE
Added software-properties-common to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5184,6 +5184,9 @@ socat:
   fedora: [socat]
   gentoo: [net-misc/socat]
   ubuntu: [socat]
+software-properties-common:
+  debian: [software-properties-common]
+  ubuntu: [software-properties-common]
 sound-theme-freedesktop:
   debian: [sound-theme-freedesktop]
   fedora: [sound-theme-freedesktop]


### PR DESCRIPTION
Added software-properties-common key for micro-ROS project

- Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=software-properties-common&searchon=names
- Debian: https://packages.debian.org/search?searchon=names&keywords=software-properties-common
