### PR TITLE
neonavigation: 0.8.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5759,7 +5759,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.7.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.8.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.0-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: replan immediately when path is blocked by new obstacles (#446 <https://github.com/at-wat/neonavigation/issues/446>)
* Add message package version constraints (#443 <https://github.com/at-wat/neonavigation/issues/443>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

```
* Add message package version constraints (#443 <https://github.com/at-wat/neonavigation/issues/443>)
* trajectory_tracker: check path timestamps in tests (#441 <https://github.com/at-wat/neonavigation/issues/441>)
* trajectory_tracker: add path header to TrajectoryTrackerStatus (#439 <https://github.com/at-wat/neonavigation/issues/439>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```
