### PR TITLE
py_trees_ros: 2.0.8-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1405,7 +1405,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.0.7-1
+      version: 2.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.0.8-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `2.0.7-1`

## py_trees_ros

```
* [behaviours] wait_for_server_timeout_sec in action clients, #152 <https://github.com/splintered-reality/py_trees_ros/pull/152>
* [trees] avoid irregular snapshot streams by avoiding timing jitter, #151 <https://github.com/splintered-reality/py_trees_ros/pull/151>
```
