### PR TITLE
navigation: 1.14.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8288,7 +8288,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.5-1
+      version: 1.14.6-1
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.14.6-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.14.5-1`

## amcl

```
* Implement selective resampling (#921 <https://github.com/cobalt-robotics/navigation/issues/921>)
* Add CLI option to trigger global localization before processing a bagfile (#816 <https://github.com/cobalt-robotics/navigation/issues/816>)
  Co-authored-by: alain-m <mailto:alain@savioke.com>
* Contributors: Adi Vardi, Stephan
```

## base_local_planner

- No changes

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

- No changes

## dwa_local_planner

- No changes

## fake_localization

- No changes

## global_planner

- No changes

## map_server

- No changes

## move_base

- No changes

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## robot_pose_ekf

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
