### PR TITLE
navigation: 1.16.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5623,7 +5623,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.16.3-1
+      version: 1.16.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.16.4-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.16.3-1`

## amcl

```
* Implement selective resampling (#921 <https://github.com/cobalt-robotics/navigation/issues/921>) (#971 <https://github.com/cobalt-robotics/navigation/issues/971>)
  Co-authored-by: Adi Vardi <mailto:adidasv111@gmail.com>
* Add CLI option to trigger global localization before processing a bagfile (#816 <https://github.com/cobalt-robotics/navigation/issues/816>) (#970 <https://github.com/cobalt-robotics/navigation/issues/970>)
  Co-authored-by: alain-m <mailto:alain@savioke.com>
* Fix some reconfigure parameters not being applied [amcl]. (#952 <https://github.com/cobalt-robotics/navigation/issues/952>)
* amcl: include missing CMake functions to fix build (#946 <https://github.com/cobalt-robotics/navigation/issues/946>)
* Set proper limits for the z-weights [amcl]. (#953 <https://github.com/cobalt-robotics/navigation/issues/953>)
* Merge pull request #965 <https://github.com/cobalt-robotics/navigation/issues/965> from nlimpert/nlimpert/fix_missing_cmake_include
  Add missing CMake include(CheckSymbolExists) for CMake >= 3.15
* amcl: add missing CMake include(CheckSymbolExists)
  Starting with CMake 3.15 an explicit include(CheckSymbolExists)
  is required to use the check_symbol_exists macro.
* Contributors: Ben Wolsieffer, Michael Ferguson, Nicolas Limpert, Patrick Chin
```

## base_local_planner

```
* Fixes gdist- and pdist_scale node paramter names (#936 <https://github.com/cobalt-robotics/navigation/issues/936>)
  Renames goal and path distance dynamic reconfigure parameter
  names in the cfg file in order to actually make the parameters
  used by the trajectory planner changeable.
  Fixes #935 <https://github.com/cobalt-robotics/navigation/issues/935>
* don't include a main() function in base_local_planner library (#969 <https://github.com/cobalt-robotics/navigation/issues/969>)
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Contributors: David Leins, Sean Yen, ipa-fez
```

## carrot_planner

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Contributors: Sean Yen
```

## clear_costmap_recovery

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Contributors: Sean Yen
```

## costmap_2d

```
* fix published footprint topic name (#947 <https://github.com/cobalt-robotics/navigation/issues/947>)
  The default name of the topic will be updated in noetic
* fix usage of size_locked, fixes #959 <https://github.com/cobalt-robotics/navigation/issues/959> (#966 <https://github.com/cobalt-robotics/navigation/issues/966>)
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Merge pull request #957 <https://github.com/cobalt-robotics/navigation/issues/957> from Blindnology/melodic-updateOrigin
  Optimize costmap_2d::updateOrigin
* Optimize costmap_2d::updateOrigin
* Contributors: Michael Ferguson, Pavlo Kolomiiets, Sean Yen, Yuki Furuta
```

## dwa_local_planner

```
* Fixes gdist- and pdist_scale node paramter names (#936 <https://github.com/cobalt-robotics/navigation/issues/936>)
  Renames goal and path distance dynamic reconfigure parameter
  names in the cfg file in order to actually make the parameters
  used by the trajectory planner changeable.
  Fixes #935 <https://github.com/cobalt-robotics/navigation/issues/935>
* Contributors: David Leins
```

## fake_localization

```
* remove signals dep (#945 <https://github.com/cobalt-robotics/navigation/issues/945>)
  Boost > 1.7 has signals by default
* Contributors: acxz
```

## global_planner

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* parameter for enabling outlineMap added (#926 <https://github.com/cobalt-robotics/navigation/issues/926>)
* Contributors: Pavel Shumejko, Sean Yen
```

## map_server

- No changes

## move_base

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Contributors: Sean Yen
```

## move_slow_and_clear

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Merge pull request #955 <https://github.com/cobalt-robotics/navigation/issues/955> from isjfk/melodic-devel
  Fix move_slow_and_clear sending obsolete params to dwa_local_planner
* Fix move_slow_and_clear sending obsolete params to dwa_local_planner
  issue.
* Contributors: Jimmy F. Klarke, Michael Ferguson, Sean Yen
```

## nav_core

- No changes

## navfn

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Add frame ID to empty NavFn paths (#964 <https://github.com/cobalt-robotics/navigation/issues/964>)
  * Don't publish empty paths
  RViz will complain about not being able to transform the path if it doesn't have a frame ID, so we'll just drop these
  Closes #963 <https://github.com/cobalt-robotics/navigation/issues/963>
  * Publish empty paths with a valid frame
  * Fix indexing into empty plan for timestamp
* Contributors: Nick Walker, Sean Yen
```

## navigation

- No changes

## rotate_recovery

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Contributors: Sean Yen
```

## voxel_grid

```
* [Windows][melodic] Navigation (except for map_server and amcl) Windows build bring up (#851 <https://github.com/cobalt-robotics/navigation/issues/851>)
* Contributors: Sean Yen
```
