### PR TITLE
Adding pouco2000 to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6888,6 +6888,16 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  pouco2000:
+    doc:
+      type: git
+      url: https://github.com/PoussPouss/pouco2000.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/PoussPouss/pouco2000.git
+      version: master
+    status: maintained
   power_msgs:
     release:
       tags:


### PR DESCRIPTION
i'd like pouco2000 to be indexed and documented on ros.org. 