### PR TITLE
Add RHEL rules from the EPEL repositories

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -444,6 +444,8 @@ coinor-libipopt-dev:
   debian: [coinor-libipopt-dev]
   fedora: [coin-or-CoinUtils-devel]
   gentoo: [sci-libs/ipopt]
+  rhel:
+    '7': [coin-or-CoinUtils-devel]
   ubuntu: [coinor-libipopt-dev]
 coinor-libosi-dev:
   debian: [coinor-libosi-dev]
@@ -848,6 +850,7 @@ ftdi-eeprom:
   debian: [ftdi-eeprom]
   fedora: [libftdi-devel, libftdi-c++-devel]
   gentoo: [dev-embedded/ftdi_eeprom]
+  rhel: [libftdi-devel, libftdi-c++-devel]
   ubuntu: [ftdi-eeprom]
 fxload:
   debian: [fxload]
@@ -1111,6 +1114,7 @@ graphicsmagick:
   fedora: [GraphicsMagick-c++-devel]
   gentoo: [virtual/imagemagick-tools]
   macports: [GraphicsMagick]
+  rhel: [GraphicsMagick-c++-devel]
   ubuntu: [libgraphicsmagick++1-dev]
 graphviz:
   arch: [graphviz]
@@ -1477,6 +1481,8 @@ lcov:
   debian: [lcov]
   fedora: [lcov]
   gentoo: [dev-util/lcov]
+  rhel:
+    '7': [lcov]
   ubuntu: [lcov]
 leveldb:
   debian: [libleveldb-dev]
@@ -1806,6 +1812,8 @@ libceres-dev:
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   openembedded: [ceres-solver@meta-oe]
+  rhel:
+    '7': [ceres-solver-devel]
   ubuntu: [libceres-dev]
 libclang-dev:
   arch: [clang]
@@ -2082,6 +2090,7 @@ libftdi-dev:
   debian: [libftdi-dev]
   fedora: [libftdi-devel]
   gentoo: [dev-embedded/libftdi]
+  rhel: [libftdi-devel]
   ubuntu: [libftdi-dev]
 libftdi1-dev:
   arch: [libftdi]
@@ -2159,6 +2168,7 @@ libgeos++-dev:
   debian: [libgeos++-dev]
   fedora: [geos-devel]
   gentoo: [sci-libs/geos]
+  rhel: [geos-devel]
   ubuntu: [libgeos++-dev]
 libgeotiff-dev:
   arch: [libgeotiff]
@@ -2172,6 +2182,8 @@ libgflags-dev:
   fedora: [gflags-devel]
   gentoo: [dev-cpp/gflags]
   openembedded: [gflags@meta-oe]
+  rhel:
+    '7': [gflags-devel]
   ubuntu: [libgflags-dev]
 libgfortran3:
   arch: [gcc-libs]
@@ -2251,6 +2263,8 @@ libgoogle-glog-dev:
   fedora: [glog-devel]
   gentoo: [dev-cpp/glog]
   openembedded: [glog@meta-oe]
+  rhel:
+    '7': [glog-devel]
   ubuntu: [libgoogle-glog-dev]
 libgpgme-dev:
   alpine: [gpgme-dev]
@@ -2296,6 +2310,7 @@ libgps:
   fedora: [gpsd-devel]
   gentoo: [sci-geosciences/gpsd]
   opensuse: [gpsd-devel]
+  rhel: [gpsd-devel]
   ubuntu: [libgps-dev]
 libgsl:
   arch: [gsl]
@@ -4102,6 +4117,7 @@ libzmq3-dev:
   fedora: [zeromq-devel]
   gentoo: [net-libs/cppzmq]
   openembedded: [zeromq@meta-oe]
+  rhel: [zeromq-devel]
   ubuntu: [libzmq3-dev]
 libzmqpp-dev:
   ubuntu: [libzmqpp-dev]
@@ -4156,6 +4172,8 @@ log4cplus:
   arch: [log4cplus]
   debian: [liblog4cplus-dev]
   fedora: [log4cplus-devel]
+  rhel:
+    '7': [log4cplus-devel]
   ubuntu: [liblog4cplus-dev]
 log4cxx:
   alpine: [log4cxx-dev]
@@ -4831,6 +4849,7 @@ proj:
   freebsd: [proj]
   gentoo: [sci-libs/proj]
   opensuse: [proj]
+  rhel: [proj-devel]
   slackware: [proj]
   ubuntu: [libproj-dev]
 protobuf:
@@ -5114,6 +5133,8 @@ sdl-image:
   macports: [libsdl_image]
   openembedded: [libsdl-image@meta-oe]
   opensuse: [SDL_image]
+  rhel:
+    '7': [SDL_image-devel]
   ubuntu: [libsdl-image1.2-dev]
 sdl-mixer:
   arch: [sdl_mixer]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -309,6 +309,8 @@ bullet:
   macports: [bullet]
   openembedded: [bullet@meta-ros]
   opensuse: [libbullet]
+  rhel:
+    '7': [bullet-devel]
   ubuntu:
     '*': [libbullet-dev]
     trusty_python3: [libbullet-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -842,6 +842,8 @@ python-catkin-pkg:
   osx:
     pip:
       packages: [catkin-pkg]
+  rhel:
+    '7': [python2-catkin_pkg]
   slackware:
     pip:
       packages: [catkin-pkg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3067,6 +3067,7 @@ python-psutil:
   osx:
     pip:
       packages: [psutil]
+  rhel: [python2-psutil]
   slackware: [psutil]
   ubuntu:
     artful: [python-psutil]
@@ -3356,6 +3357,8 @@ python-pyproj:
   osx:
     pip:
       packages: [pyproj]
+  rhel:
+    '7': [pyproj]
   ubuntu: [python-pyproj]
 python-pyqrcode:
   arch: [python2-qrcode]
@@ -5135,6 +5138,7 @@ python3-bson:
   osx:
     pip:
       packages: [bson]
+  rhel: ['python%{python3_pkgversion}-bson']
   ubuntu: [python3-bson]
 python3-cairo:
   arch: [python-cairo]
@@ -5227,6 +5231,8 @@ python3-docker:
   arch: [python-docker]
   debian: [python3-docker]
   fedora: [python3-docker]
+  rhel:
+    '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
 python3-empy:
   debian:
@@ -5253,6 +5259,7 @@ python3-flake8:
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]
+  rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
 python3-gitlab:
   debian:
@@ -5729,6 +5736,7 @@ python3-tornado:
   osx:
     pip:
       packages: [tornado]
+  rhel: ['python%{python3_pkgversion}-tornado']
   ubuntu: [python3-tornado]
 python3-twisted:
   arch: [python-twisted]
@@ -5756,6 +5764,7 @@ python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]
   gentoo: [dev-python/websocket-client]
+  rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
 python3-west-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5415,6 +5415,8 @@ python3-packaging:
   debian: [python3-packaging]
   fedora: [python3-packaging]
   gentoo: [dev-python/packaging]
+  rhel:
+    '7': ['python%{python3_pkgversion}-packaging']
   ubuntu: [python3-packaging]
 python3-pandas:
   debian: [python3-pandas]


### PR DESCRIPTION
These keys are used across ROS 2 Eloquent.

| rosdep key | system package name | src link | pkgs link |
|------------|---------------------|----------|-----------|
| bullet | bullet-devel | [src](https://src.fedoraproject.org/rpms/bullet#bodhi_updates) | |
| coinor-libipopt-dev | coin-or-CoinUtils-devel | [src](https://src.fedoraproject.org/rpms/coin-or-CoinUtils#bodhi_updates) | |
| ftdi-eeprom | libftdi-devel | [src](https://src.fedoraproject.org/rpms/libftdi#bodhi_updates) | |
| ftdi-eeprom | libftdi-c++-devel | [src](https://src.fedoraproject.org/rpms/libftdi#bodhi_updates) | |
| graphicsmagick | GraphicsMagick-c++-devel | [src](https://src.fedoraproject.org/rpms/GraphicsMagick#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/GraphicsMagick-c++-devel) |
| lcov | lcov | [src](https://src.fedoraproject.org/rpms/lcov#bodhi_updates) | |
| libceres-dev | ceres-solver-devel | [src](https://src.fedoraproject.org/rpms/ceres-solver#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/ceres-solver-devel) |
| libftdi-dev | libftdi-devel | [src](https://src.fedoraproject.org/rpms/libftdi#bodhi_updates) | |
| libgeos++-dev | geos-devel | [src](https://src.fedoraproject.org/rpms/geos#bodhi_updates) | |
| libgflags-dev | gflags-devel | [src](https://src.fedoraproject.org/rpms/gflags#bodhi_updates) | |
| libgoogle-glog-dev | glog-devel | [src](https://src.fedoraproject.org/rpms/glog#bodhi_updates) | |
| libgps | gpsd-devel | [src](https://src.fedoraproject.org/rpms/gpsd#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/gpsd-devel) |
| libzmq3-dev | zeromq-devel | [src](https://src.fedoraproject.org/rpms/zeromq#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/zeromq-devel) |
| log4cplus | log4cplus-devel | [src](https://src.fedoraproject.org/rpms/log4cplus#bodhi_updates) | |
| proj | proj-devel | [src](https://src.fedoraproject.org/rpms/proj#bodhi_updates) | |
| sdl-image | SDL_image-devel | [src](https://src.fedoraproject.org/rpms/SDL_image#bodhi_updates) | |
| python-catkin-pkg | python2-catkin_pkg | [src](https://src.fedoraproject.org/rpms/python-catkin_pkg#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python2-catkin_pkg) |
| python-psutil | python2-psutil | [src](https://src.fedoraproject.org/rpms/python-psutil#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python2-psutil) |
| python-pyproj | pyproj | [src](https://src.fedoraproject.org/rpms/pyproj#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/pyproj) |
| python3-bson | python%{python3_pkgversion}-bson | [src](https://src.fedoraproject.org/rpms/python-pymongo#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python3-bson) |
| python3-docker | python%{python3_pkgversion}-docker | [src](https://src.fedoraproject.org/rpms/python-docker#bodhi_updates) | |
| python3-future | python%{python3_pkgversion}-future | [src](https://src.fedoraproject.org/rpms/future#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python3-future) |
| python3-packaging | python%{python3_pkgversion}-packaging | [src](https://src.fedoraproject.org/rpms/python-packaging#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python3-packaging) |
| python3-tornado | python%{python3_pkgversion}-tornado | [src](https://src.fedoraproject.org/rpms/python-tornado#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python3-tornado) |
| python3-websocket | python%{python3_pkgversion}-websocket-client | [src](https://src.fedoraproject.org/rpms/python-websocket-client#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python3-websocket-client) |

```
$ yum list -q --showduplicates available GraphicsMagick-c++-devel \
> SDL_image-devel bullet-devel ceres-solver-devel coin-or-CoinUtils-devel \
> geos-devel gflags-devel glog-devel gpsd-devel lcov libftdi-c++-devel \
> libftdi-devel log4cplus-devel proj-devel pyproj python2-catkin_pkg \
> python2-psutil python36-bson python36-docker python36-future \
> python36-packaging python36-tornado python36-websocket-client zeromq-devel
Available Packages
GraphicsMagick-c++-devel.x86_64        1.3.34-1.el7                        epel
SDL_image-devel.x86_64                 1.2.12-11.el7                       epel
bullet-devel.x86_64                    2.82-2.el7                          epel
ceres-solver-devel.x86_64              1.12.0-2.el7                        epel
coin-or-CoinUtils-devel.x86_64         2.10.13-1.el7                       epel
geos-devel.x86_64                      3.4.2-2.el7                         epel
gflags-devel.x86_64                    2.1.1-6.el7                         epel
glog-devel.x86_64                      0.3.3-8.el7                         epel
gpsd-devel.x86_64                      3.10-5.20140524gitd6b65b.el7        epel
lcov.noarch                            1.13-1.el7                          epel
libftdi-c++-devel.x86_64               1.1-4.el7                           epel
libftdi-devel.x86_64                   1.1-4.el7                           epel
log4cplus-devel.x86_64                 1.1.3-0.4.rc3.el7                   epel
proj-devel.x86_64                      4.8.0-4.el7                         epel
pyproj.x86_64                          1.9.2-6.20120712svn300.el7          epel
python2-catkin_pkg.noarch              0.4.14-1.el7                        epel
python2-psutil.x86_64                  5.6.7-1.el7                         epel
python36-bson.x86_64                   2.5.2-5.el7                         epel
python36-docker.noarch                 2.6.1-3.el7                         epel
python36-future.noarch                 0.18.2-2.el7                        epel
python36-packaging.noarch              16.8-6.el7                          epel
python36-tornado.x86_64                4.4.2-2.el7                         epel
python36-websocket-client.noarch       0.47.0-2.el7                        epel
zeromq-devel.x86_64                    4.1.4-6.el7                         epel
```