### PR TITLE
lgsvl_msgs: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4556,7 +4556,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lgsvl/lgsvl_msgs-release.git
-      version: 0.0.1-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.1-0`

## lgsvl_msgs

```
* Include signal messages in README
* add messages for ground truth signals
* updated license
* Contributors: David Uhm
```
