### PR TITLE
Add RHEL rules from the RHEL base repository

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5009,6 +5009,7 @@ qttools5-dev:
 qttools5-dev-tools:
   debian: [qttools5-dev-tools]
   fedora: [qt5-qttools-devel]
+  rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
 r-base:
   debian: [r-base]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -868,6 +868,7 @@ g++-static:
   fedora: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   gentoo: [sys-devel/gcc]
   openembedded: []
+  rhel: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   ubuntu: [g++]
 gamin:
   debian: [gamin]
@@ -1181,9 +1182,11 @@ gstreamer1.0:
   debian: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
   fedora: [gstreamer1]
   gentoo: ['media-libs/gstreamer:1.0']
+  rhel: [gstreamer1]
   ubuntu: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
 gstreamer1.0-alsa:
   debian: [gstreamer1.0-alsa]
+  rhel: [gstreamer1-plugins-base]
   ubuntu: [gstreamer1.0-alsa]
 gstreamer1.0-libav:
   arch: [gst-libav]
@@ -1208,6 +1211,7 @@ gstreamer1.0-plugins-good:
   debian: [gstreamer1.0-plugins-good]
   fedora: [gstreamer1-plugins-good]
   gentoo: ['media-libs/gst-plugins-good:1.0']
+  rhel: [gstreamer1-plugins-good]
   ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:
   arch: [gst-plugins-ugly]
@@ -1660,6 +1664,7 @@ libboost-program-options:
     jessie: [libboost-program-options1.55.0]
     stretch: [libboost-program-options1.62.0]
   fedora: [boost-program-options]
+  rhel: [boost-program-options]
   ubuntu:
     bionic: [libboost-program-options1.65.1]
     disco: [libboost-program-options1.67.0]
@@ -1671,6 +1676,7 @@ libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
   openembedded: [boost@openembedded-core]
+  rhel: [boost-devel]
   ubuntu: [libboost-program-options-dev]
 libboost-python:
   alpine: [boost-python2]
@@ -1729,6 +1735,7 @@ libboost-system:
     buster: [libboost-system1.67.0]
     stretch: [libboost-system1.62.0]
   fedora: [boost-system]
+  rhel: [boost-system]
   ubuntu:
     bionic: [libboost-system1.65.1]
     disco: [libboost-system1.67.0]
@@ -1739,6 +1746,7 @@ libboost-system:
 libboost-system-dev:
   debian: [libboost-system-dev]
   fedora: [boost-devel]
+  rhel: [boost-devel]
   ubuntu: [libboost-system-dev]
 libboost-thread:
   debian:
@@ -1762,6 +1770,7 @@ libcairo2-dev:
   fedora: [cairo-devel]
   gentoo: [x11-libs/cairo]
   openembedded: [cairo@openembedded-core]
+  rhel: [cairo-devel]
   ubuntu: [libcairo2-dev]
 libcap-dev:
   arch: [libcap]
@@ -2525,6 +2534,8 @@ liblapack-dev:
   fedora: [lapack-devel]
   gentoo: [virtual/lapack]
   openembedded: [lapack@meta-ros]
+  rhel:
+    '7': [lapack-devel]
   ubuntu: [liblapack-dev]
 liblapacke-dev:
   debian: [liblapacke-dev]
@@ -2803,6 +2814,8 @@ libopenexr-dev:
   debian: [libopenexr-dev]
   fedora: [OpenEXR-devel]
   gentoo: [media-libs/openexr]
+  rhel:
+    '7': [OpenEXR-devel]
   ubuntu: [libopenexr-dev]
 libopenni-dev:
   arch: [openni]
@@ -2888,6 +2901,8 @@ libpcap:
   gentoo: [net-libs/libpcap]
   macports: [libpcap]
   openembedded: [libpcap@openembedded-core]
+  rhel:
+    '7': [libpcap-devel]
   ubuntu: [libpcap0.8-dev]
 libpcl-all:
   arch: [pcl]
@@ -3359,6 +3374,8 @@ libqtgui4:
   debian: [libqtgui4]
   fedora: [qt-x11]
   gentoo: ['dev-qt/qtgui:4']
+  rhel:
+    '7': [qt-x11]
   ubuntu: [libqtgui4]
 libqtwebkit-dev:
   arch: [qt5-webkit]
@@ -3423,6 +3440,7 @@ libreadline:
   fedora: [readline]
   gentoo: [sys-libs/readline]
   macports: [readline]
+  rhel: [readline]
   ubuntu: [libreadline-dev]
 libreadline-dev:
   arch: [readline]
@@ -3781,6 +3799,7 @@ libusb-1.0:
     beefy: [libusb1]
   gentoo: ['virtual/libusb:1']
   opensuse: [libusb-1_0-0]
+  rhel: [libusbx]
   ubuntu: [libusb-1.0-0]
 libusb-1.0-dev:
   arch: [libusbx]
@@ -3800,6 +3819,8 @@ libusb-dev:
   fedora: [libusb-devel]
   gentoo: [virtual/libusb]
   macports: [libusb]
+  rhel:
+    '7': [libusb-devel]
   ubuntu: [libusb-dev]
 libuv-dev:
   debian:
@@ -4224,6 +4245,7 @@ lua5.2-dev:
   fedora: [lua]
   gentoo: ['dev-lang/lua:5.2']
   openembedded: [lua@meta-oe]
+  rhel: [lua-devel]
   ubuntu: [liblua5.2-dev]
 lz4:
   alpine: [lz4-dev]
@@ -4234,6 +4256,7 @@ lz4:
   gentoo: [app-arch/lz4]
   openembedded: [lz4@openembedded-core]
   opensuse: [lz4]
+  rhel: [lz4-devel]
   slackware: [lz4]
   ubuntu: [liblz4-dev]
 m4:
@@ -4870,6 +4893,8 @@ protobuf-dev:
   macports: [protobuf-cpp]
   openembedded: [protobuf@meta-oe]
   opensuse: [protobuf-devel]
+  rhel:
+    '7': [protobuf-devel, protobuf-compiler]
   slackware: [protobuf]
   ubuntu: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]
 ps-engine:
@@ -4979,6 +5004,7 @@ qtmultimedia5-dev:
 qttools5-dev:
   debian: [qttools5-dev]
   fedora: [qt5-qttools-devel]
+  rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev]
 qttools5-dev-tools:
   debian: [qttools5-dev-tools]
@@ -5098,6 +5124,7 @@ sdl:
   gentoo: [media-libs/libsdl]
   macports: [libsdl]
   openembedded: [libsdl@openembedded-core]
+  rhel: [SDL-devel]
   ubuntu: [libsdl1.2-dev]
 sdl-gfx:
   arch: [sdl_gfx]
@@ -5282,6 +5309,8 @@ suitesparse:
   gentoo: [sci-libs/suitesparse]
   macports: [SuiteSparse]
   openembedded: [suitesparse-cxsparse@meta-ros, suitesparse-cholmod@meta-ros]
+  rhel:
+    '7': [suitesparse-devel]
   ubuntu: [libsuitesparse-dev]
 supervisor:
   arch: [supervisor]
@@ -5422,6 +5451,7 @@ tbb:
   gentoo: [dev-cpp/tbb]
   macports: [tbb]
   opensuse: [tbb-devel]
+  rhel: [tbb-devel]
   ubuntu: [libtbb-dev]
 tcsh:
   arch: [tcsh]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4300,6 +4300,8 @@ python-sphinx:
   osx:
     pip:
       packages: [Sphinx]
+  rhel:
+    '7': [python-sphinx]
   ubuntu:
     '*': [python-sphinx]
     trusty_python3: [python3-sphinx]
@@ -4842,6 +4844,8 @@ python-virtualenv:
   debian: [python-virtualenv]
   fedora: [python-virtualenv]
   gentoo: [dev-python/virtualenv]
+  rhel:
+    '7': [python-virtualenv]
   ubuntu: [python-virtualenv]
 python-visual:
   debian: [python-visual]


### PR DESCRIPTION
These keys are used across ROS 2 Eloquent.

There aren't any official web databases for RHEL/CentOS packages, so I'll link to the packages sitting in the repository mirrors.

| rosdep key | system package |
|------------|----------------|
| g++-static | [gcc-c++](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/gcc-c++-4.8.5-39.el7.x86_64.rpm) |
| g++-static | [glibc-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/glibc-devel-2.17-292.el7.x86_64.rpm) |
| g++-static | [glibc-static](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/glibc-static-2.17-292.el7.x86_64.rpm) |
| g++-static | [libstdc++-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/libstdc++-devel-4.8.5-39.el7.x86_64.rpm) |
| g++-static | [libstdc++-static](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/libstdc++-static-4.8.5-39.el7.x86_64.rpm) |
| gstreamer1.0 | [gstreamer1](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/gstreamer1-1.10.4-2.el7.x86_64.rpm) |
| gstreamer1.0-alsa | [gstreamer1-plugins-base](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/gstreamer1-plugins-base-1.10.4-2.el7.x86_64.rpm) |
| gstreamer1.0-plugins-good | [gstreamer1-plugins-good](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/gstreamer1-plugins-good-1.10.4-2.el7.x86_64.rpm) |
| libboost-program-options | [boost-program-options](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/boost-program-options-1.53.0-27.el7.x86_64.rpm) |
| libboost-program-options-dev | [boost-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-system | [boost-system](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/boost-system-1.53.0-27.el7.x86_64.rpm) |
| libboost-system-dev | [boost-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libcairo2-dev | [cairo-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/cairo-devel-1.15.12-4.el7.x86_64.rpm) |
| liblapack-dev | [lapack-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/lapack-devel-3.4.2-8.el7.x86_64.rpm) |
| libopenexr-dev | [OpenEXR-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/OpenEXR-devel-1.7.1-7.el7.x86_64.rpm) |
| libpcap | [libpcap-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/libpcap-devel-1.5.3-11.el7.x86_64.rpm) |
| libqtgui4 | [qt-x11](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/qt-x11-4.8.7-3.el7_6.x86_64.rpm) |
| libreadline | [readline](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/readline-6.2-11.el7.x86_64.rpm) |
| libusb-1.0 | [libusbx](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/libusbx-1.0.21-1.el7.x86_64.rpm) |
| libusb-dev | [libusb-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/libusb-devel-0.1.4-3.el7.x86_64.rpm) |
| lua5.2-dev | [lua-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/lua-devel-5.1.4-15.el7.x86_64.rpm) |
| lz4 | [lz4-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/lz4-devel-1.7.5-3.el7.x86_64.rpm) |
| protobuf-dev | [protobuf-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/protobuf-devel-2.5.0-8.el7.x86_64.rpm) |
| protobuf-dev | [protobuf-compiler](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/protobuf-compiler-2.5.0-8.el7.x86_64.rpm) |
| qtmultimedia5-dev | [qt5-qttools-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/qt5-qttools-devel-5.9.7-1.el7.x86_64.rpm) |
| qttools5-dev-tools | [qt5-qttools-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/qt5-qttools-devel-5.9.7-1.el7.x86_64.rpm) |
| sdl | [SDL-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/SDL-devel-1.2.15-14.el7.x86_64.rpm) |
| suitesparse | [suitesparse-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/suitesparse-devel-4.0.2-10.el7.x86_64.rpm) |
| tbb | [tbb-devel](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/tbb-devel-4.1-9.20130314.el7.x86_64.rpm) |
| python-sphinx | [python-sphinx](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/python-sphinx-1.1.3-11.el7.noarch.rpm) |
| python-virtualenv | [python-virtualenv](http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/python-virtualenv-15.1.0-2.el7.noarch.rpm) |

```
$ yum list -q --showduplicates available boost-devel boost-program-options \
> boost-system cairo-devel gcc-c++ glibc-devel glibc-static gstreamer1 \
> gstreamer1-plugins-base gstreamer1-plugins-good lapack-devel libpcap-devel \
> libstdc++-devel libstdc++-static libusb-devel libusbx lua-devel lz4-devel \
> OpenEXR-devel protobuf-compiler protobuf-devel python-sphinx \
> python-virtualenv qt5-qttools-devel qt-x11 readline SDL-devel \
> suitesparse-devel tbb-devel
Available Packages
OpenEXR-devel.x86_64                        1.7.1-7.el7                     base
SDL-devel.x86_64                            1.2.15-14.el7                   base
boost-devel.x86_64                          1.53.0-27.el7                   base
boost-program-options.x86_64                1.53.0-27.el7                   base
boost-system.x86_64                         1.53.0-27.el7                   base
cairo-devel.x86_64                          1.15.12-4.el7                   base
gcc-c++.x86_64                              4.8.5-39.el7                    base
glibc-devel.x86_64                          2.17-292.el7                    base
glibc-static.x86_64                         2.17-292.el7                    base
gstreamer1.x86_64                           1.10.4-2.el7                    base
gstreamer1-plugins-base.x86_64              1.10.4-2.el7                    base
gstreamer1-plugins-good.x86_64              1.10.4-2.el7                    base
lapack-devel.x86_64                         3.4.2-8.el7                     base
libpcap-devel.x86_64                        14:1.5.3-11.el7                 base
libstdc++-devel.x86_64                      4.8.5-39.el7                    base
libstdc++-static.x86_64                     4.8.5-39.el7                    base
libusb-devel.x86_64                         1:0.1.4-3.el7                   base
libusbx.x86_64                              1.0.21-1.el7                    base
lua-devel.x86_64                            5.1.4-15.el7                    base
lz4-devel.x86_64                            1.7.5-3.el7                     base
protobuf-compiler.x86_64                    2.5.0-8.el7                     base
protobuf-devel.x86_64                       2.5.0-8.el7                     base
python-sphinx.noarch                        1.1.3-11.el7                    base
python-virtualenv.noarch                    15.1.0-2.el7                    base
qt-x11.x86_64                               1:4.8.7-3.el7_6                 base
qt5-qttools-devel.x86_64                    5.9.7-1.el7                     base
readline.x86_64                             6.2-11.el7                      base
suitesparse-devel.x86_64                    4.0.2-10.el7                    base
tbb-devel.x86_64                            4.1-9.20130314.el7              base
```