### PR TITLE
Add key libboost-thread-dev for Gentoo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1755,6 +1755,7 @@ libboost-thread:
 libboost-thread-dev:
   debian: [libboost-thread-dev]
   fedora: [boost-devel]
+  gentoo: ['dev-libs/boost[threads]']
   ubuntu: [libboost-thread-dev]
 libcairo2-dev:
   arch: [cairo]


### PR DESCRIPTION
This comes from roslib adding to package.xml the key `libboost-thread-dev`, this enables resolving it.

Aside note, I noticed that the key 'libboost-filesystem-dev' is resolved in Gentoo to: `'dev-libs/boost[python]'`, which technically the `[python]` USE flag is not necessary. It doesn't hurt though.