### PR TITLE
autoware_auto_msgs: 0.0.2-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -312,6 +312,21 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: developed
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    status: developed
   aws_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_auto_msgs` to `0.0.2-2`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
