### PR TITLE
Add rosdep rule for range-v3 library

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4994,6 +4994,11 @@ r-base-dev:
   fedora: [R-devel]
   gentoo: [dev-lang/R]
   ubuntu: [r-base-dev]
+range-v3:
+  debian: [librange-v3-dev]
+  fedora: [range-v3]
+  gentoo: [dev-cpp/range-v3]
+  ubuntu: [librange-v3-dev]
 rapidjson-dev:
   debian: [rapidjson-dev]
   fedora: [rapidjson]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4997,14 +4997,11 @@ r-base-dev:
 range-v3:
   debian:
     '*': [librange-v3-dev]
-    jessie: null
     stretch: null
   fedora: [range-v3]
   gentoo: [dev-cpp/range-v3]
   ubuntu:
     '*': [librange-v3-dev]
-    artful: null
-    wily: null
     xenial: null
 rapidjson-dev:
   debian: [rapidjson-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4995,10 +4995,17 @@ r-base-dev:
   gentoo: [dev-lang/R]
   ubuntu: [r-base-dev]
 range-v3:
-  debian: [librange-v3-dev]
+  debian:
+    '*': [librange-v3-dev]
+    jessie: null
+    stretch: null
   fedora: [range-v3]
   gentoo: [dev-cpp/range-v3]
-  ubuntu: [librange-v3-dev]
+  ubuntu:
+    '*': [librange-v3-dev]
+    artful: null
+    wily: null
+    xenial: null
 rapidjson-dev:
   debian: [rapidjson-dev]
   fedora: [rapidjson]


### PR DESCRIPTION
Rosdep key for [range-v3](https://ericniebler.github.io/range-v3/) library, which: _is the basis of the range support in C++20_.

I believe the ubuntu, debian and gentoo packages are correct. Package listings in the respective repositories can be found in:

- https://packages.ubuntu.com/search?keywords=range-v3&searchon=names&suite=eoan&section=all
- https://packages.debian.org/buster/librange-v3-dev
- https://packages.gentoo.org/packages/dev-cpp/range-v3

I'm not so sure about fedora. I could not find any related result in [fedora packages](https://apps.fedoraproject.org/packages/s/range-v3), but there's some result [here](https://src.fedoraproject.org/rpms/range-v3). I don't know what that means. Any help here would be appreciated.