### PR TITLE
carla_msgs: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -941,10 +941,16 @@ repositories:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git
       version: release
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/carla-simulator/ros-carla-msgs-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git
       version: release
+    status: developed
   cartesian_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carla_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/carla-simulator/ros-carla-msgs.git
- release repository: https://github.com/carla-simulator/ros-carla-msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
