### PR TITLE
psen_scan: 1.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7171,7 +7171,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan` to `1.0.4-1`:

- upstream repository: https://github.com/PilzDE/psen_scan.git
- release repository: https://github.com/PilzDE/psen_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.3-1`

## psen_scan

```
* Fix/ros parameter handling (#15)
* Add Travis and ROS Buildfarm Badges to README. (#16)
* Minor typefix (#14)
* Fix unstable udp interface test. (#13)
* Feature/code analysis tools (#12)
```
