### PR TITLE
swarmros: 0.3.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15098,7 +15098,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
-      version: 0.3.2-1
+      version: 0.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swarmros` to `0.3.4-1`:

- upstream repository: https://github.com/amilankovich-slab/swarmros.git
- release repository: https://github.com/amilankovich-slab/swarmros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.2-1`
