### PR TITLE
ifm3d_core: 0.17.0-7 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3568,7 +3568,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-6
+      version: 0.17.0-7
     status: developed
   ifopt:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.17.0-7`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.17.0-6`
