### PR TITLE
marti_messages: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1051,6 +1051,29 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
     status: maintained
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    status: developed
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.0.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## marti_can_msgs

```
* Convert to ROS2 Dashing
* Contributors: P. J. Reed
```

## marti_common_msgs

```
* Convert to ROS2 Dashing
* Contributors: P. J. Reed
```

## marti_nav_msgs

```
* Convert to ROS2 Dashing
* Contributors: P. J. Reed
```

## marti_perception_msgs

```
* Convert to ROS2 Dashing
* Contributors: P. J. Reed
```

## marti_sensor_msgs

```
* Convert to ROS2 Dashing
* Contributors: P. J. Reed
```

## marti_status_msgs

```
* Convert to ROS2 Dashing
* Contributors: P. J. Reed
```

## marti_visualization_msgs

```
* Convert to ROS2 Dashing
* Contributors: P. J. Reed
```
