### PR TITLE
gps_umd: 1.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -996,7 +996,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.2-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.0-1`

## gps_msgs

- No changes

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

```
* Fix for gpsd-3.19 compatibility (#26 <https://github.com/swri-robotics/gps_umd/issues/26>)
* Contributors: P. J. Reed
```
