### PR TITLE
marti_common: 3.0.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1331,7 +1331,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.0.4-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `3.0.3-1`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* ROS 2 Eloquent compatibility (#568 <https://github.com/swri-robotics/marti_common/issues/568>)
* Contributors: P. J. Reed
```

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* ROS 2 Eloquent compatibility (#568 <https://github.com/swri-robotics/marti_common/issues/568>)
* Replace boost::array with std::array (#567 <https://github.com/swri-robotics/marti_common/issues/567>)
* Fix a crash that happened due to an initialization error (#566 <https://github.com/swri-robotics/marti_common/issues/566>)
* Fix TransformManager so it works in ROS2 (#565 <https://github.com/swri-robotics/marti_common/issues/565>)
* Port ObstacleTransformer node to ROS2 (#559 <https://github.com/swri-robotics/marti_common/issues/559>)
* Remove "nodelets" directory (#558 <https://github.com/swri-robotics/marti_common/issues/558>)
* Contributors: P. J. Reed
```
