### PR TITLE
dynamic_reconfigure: 1.6.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2041,7 +2041,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.6.0-0
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.6.1-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.6.0-0`

## dynamic_reconfigure

```
* Use PYTHON_EXECUTABLE to generate config headers. (#146 <https://github.com/ros/dynamic_reconfigure/issues/146>)
* Python3 compatibility (#135 <https://github.com/ros/dynamic_reconfigure/issues/135>)
* Use system on gen headers (#140 <https://github.com/ros/dynamic_reconfigure/issues/140>)
* Fix GCC8 error for unnecessary parentheses (#132 <https://github.com/ros/dynamic_reconfigure/issues/132>)
* fix generate_dynamic_reconfigure_options (#10 <https://github.com/ros/dynamic_reconfigure/issues/10>) (#134 <https://github.com/ros/dynamic_reconfigure/issues/134>)
* Make Michael Carroll the maintainer (#125 <https://github.com/ros/dynamic_reconfigure/issues/125>)
* Contributors: Christopher Wecht, Markus Grimm, Michael Carroll, Mikael Arguedas, Nicolas Limpert, Sean Yen [MSFT], Victor Lopez
```
