### PR TITLE
dynamic_reconfigure: 1.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -149,6 +149,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   dynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
+      version: 1.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.7.0-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## dynamic_reconfigure

```
* Fixing compile error with cpp client when using -Werror=reorder. (#118 <https://github.com/ros/dynamic_reconfigure/issues/118>)
* ConfigType.h.template: fixed warnings (#136 <https://github.com/ros/dynamic_reconfigure/issues/136>) (#149 <https://github.com/ros/dynamic_reconfigure/issues/149>)
* Bump CMake minimum version to use CMP0048 (#148 <https://github.com/ros/dynamic_reconfigure/issues/148>)
* Use PYTHON_EXECUTABLE to generate config headers. (#146 <https://github.com/ros/dynamic_reconfigure/issues/146>)
* Python3 compatibility (#135 <https://github.com/ros/dynamic_reconfigure/issues/135>)
* Use system on gen headers (#140 <https://github.com/ros/dynamic_reconfigure/issues/140>)
* Fix GCC8 error for unnecessary parentheses (#132 <https://github.com/ros/dynamic_reconfigure/issues/132>)
* fix generate_dynamic_reconfigure_options (#10 <https://github.com/ros/dynamic_reconfigure/issues/10>) (#134 <https://github.com/ros/dynamic_reconfigure/issues/134>)
* Make Michael Carroll the maintainer (#125 <https://github.com/ros/dynamic_reconfigure/issues/125>)
* Contributors: Christopher Wecht, Markus Grimm, Michael Carroll, Mikael Arguedas, Nicolas Limpert, Sean Yen [MSFT], Victor Lopez
```
