### PR TITLE
marti_common: 3.0.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1051,6 +1051,35 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
     status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    release:
+      packages:
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 3.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    status: developed
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.0.4-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* ROS 2 Eloquent compatibility (#568 <https://github.com/swri-robotics/marti_common/issues/568>)
* Contributors: P. J. Reed
```

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* ROS 2 Eloquent compatibility (#568 <https://github.com/swri-robotics/marti_common/issues/568>)
* Replace boost::array with std::array (#567 <https://github.com/swri-robotics/marti_common/issues/567>)
* Fix a crash that happened due to an initialization error (#566 <https://github.com/swri-robotics/marti_common/issues/566>)
* Fix TransformManager so it works in ROS2 (#565 <https://github.com/swri-robotics/marti_common/issues/565>)
* Port ObstacleTransformer node to ROS2 (#559 <https://github.com/swri-robotics/marti_common/issues/559>)
* Remove "nodelets" directory (#558 <https://github.com/swri-robotics/marti_common/issues/558>)
* Contributors: P. J. Reed
```
