### PR TITLE
novatel_gps_driver: 4.0.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1513,7 +1513,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.0.3-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `4.0.2-1`

## novatel_gps_driver

```
* Handle GPGSV log with 0 satellites correctly (#77 <https://github.com/pjreed/novatel_gps_driver/issues/77>)
* Fill out error measurements in GPSFix messages (#71 <https://github.com/pjreed/novatel_gps_driver/issues/71>)
* Fix covariance in GPSFix messages (#69 <https://github.com/pjreed/novatel_gps_driver/issues/69>)
* Contributors: P. J. Reed
```

## novatel_gps_msgs

- No changes
