### PR TITLE
rc_common_msgs: 0.4.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11127,7 +11127,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_common_msgs-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/roboception/rc_common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_common_msgs` to `0.4.1-1`:

- upstream repository: https://github.com/roboception/rc_common_msgs.git
- release repository: https://github.com/roboception-gbp/rc_common_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.4.0-1`

## rc_common_msgs

```
* add CAPACITY_EXCEEDED and CAPACITY_REACHED to ReturnCodeConstants
```
