### PR TITLE
urdf: 1.13.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10841,7 +10841,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urdf-release.git
-      version: 1.13.1-0
+      version: 1.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `1.13.2-1`:

- upstream repository: https://github.com/ros/urdf.git
- release repository: https://github.com/ros-gbp/urdf-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.13.1-0`

## urdf

```
* Windows bringup. (#31 <https://github.com/ros/urdf/issues/31>)
* update library install destination (#28 <https://github.com/ros/urdf/issues/28>)
* Solved problem when static linking against urdf (#25 <https://github.com/ros/urdf/issues/25>)
* unit test: add missing link name (#26 <https://github.com/ros/urdf/issues/26>)
* update deprecated macro for MSVC (#27 <https://github.com/ros/urdf/issues/27>)
* Contributors: James Xu, Robert Haschke, Sean Yen, ivanpauno
```

## urdf_parser_plugin

```
* Bump CMake version to avoid CMP0048 warning (#32 <https://github.com/ros/urdf/issues/32>)
* Contributors: Shane Loretz
```
