### PR TITLE
urdf: 1.13.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -863,6 +863,18 @@ repositories:
       version: kinetic-devel
     status: maintained
   urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: melodic-devel
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf-release.git
+      version: 1.13.2-1
     source:
       type: git
       url: https://github.com/ros/urdf.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `1.13.2-1`:

- upstream repository: https://github.com/ros/urdf.git
- release repository: https://github.com/ros-gbp/urdf-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urdf

```
* Windows bringup. (#31 <https://github.com/ros/urdf/issues/31>)
* update library install destination (#28 <https://github.com/ros/urdf/issues/28>)
* Solved problem when static linking against urdf (#25 <https://github.com/ros/urdf/issues/25>)
* unit test: add missing link name (#26 <https://github.com/ros/urdf/issues/26>)
* update deprecated macro for MSVC (#27 <https://github.com/ros/urdf/issues/27>)
* Contributors: James Xu, Robert Haschke, Sean Yen, ivanpauno
```

## urdf_parser_plugin

```
* Bump CMake version to avoid CMP0048 warning (#32 <https://github.com/ros/urdf/issues/32>)
* Contributors: Shane Loretz
```
