### PR TITLE
pyquaternion: 0.9.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10520,6 +10520,21 @@ repositories:
       url: https://github.com/ipab-slmc/pybind11_catkin.git
       version: master
     status: developed
+  pyquaternion:
+    doc:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Achllle/pyquaternion.git
+      version: 0.9.6-1
+    source:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: master
+    status: developed
   pyros:
     doc:
       type: git

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3377,16 +3377,6 @@ python-pyqrcode:
     xenial:
       pip:
         packages: [PyQRCode]
-python-pyquaternion-pip:
-  debian:
-    pip:
-      packages: [pyquaternion]
-  fedora:
-    pip:
-      packages: [pyquaternion]
-  ubuntu:
-    pip:
-      packages: [pyquaternion]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]


### PR DESCRIPTION
Increasing version of package(s) in repository `pyquaternion` to `0.9.6-1`:

- upstream repository: https://github.com/Achllle/pyquaternion
- release repository: https://github.com/Achllle/pyquaternion.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## pyquaternion

```
Post ROS package conversion
* Change exec depend naming from numpy to python-numpy
* Add numpy dependency to package.xml
* Create catkin package, rename and move some files
* Fix casting error in trace_method
* Add setter for vector
```

This is a second attempt at #23794 which was merged and undone