### PR TITLE
rqt_joint_trajectory_plot: 0.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9110,6 +9110,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
     status: maintained
+  rqt_joint_trajectory_plot:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    status: developed
   rqt_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_joint_trajectory_plot` to `0.0.5-1`:

- upstream repository: https://github.com/tork-a/rqt_joint_trajectory_plot.git
- release repository: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_joint_trajectory_plot

```
* Add melodic release(#13 <https://github.com/tork-a/rqt_joint_trajectory_plot/issues/13>)
  - Set CI python version to 3.6
  - Merge pull request
* added ability to plot planned_path from moveit and made rqt launch file(#10 <https://github.com/tork-a/rqt_joint_trajectory_plot/issues/10>)
  - updated package.xml to include moveit_msgs for plotting display_trajectory messages
* fixed example PVA image size
* added empty display trajectory check and updated readme with instrucitons to launch PVA perspective
* added ability to plot planned_path from moveit and made rqt launch file with custom perspective
* Fix workspace name for CI (#11 <https://github.com/tork-a/rqt_joint_trajectory_plot/issues/11>)
  - Fix workspace name as https://github.com/tork-a/jog_control/pull/37/files
* added empty display trajectory check and updated readme with instrucitons to launch PVA perspective
* added ability to plot planned_path from moveit and made rqt launch file with custom perspective
* Add travis.yml
* Contributors: Ryosuke Tajima, marqrazz
```
