### PR TITLE
Add all libboost-* keys to gentoo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1588,6 +1588,7 @@ libboost-atomic:
     buster: [libboost-atomic1.67.0]
     stretch: [libboost-atomic1.62.0]
   fedora: [boost-atomic]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-atomic1.65.1]
     eoan: [libboost-atomic1.67.0]
@@ -1596,12 +1597,14 @@ libboost-atomic:
 libboost-atomic-dev:
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-atomic-dev]
 libboost-chrono:
   debian:
     buster: [libboost-chrono1.67.0]
     stretch: [libboost-chrono1.62.0]
   fedora: [boost-chrono]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-chrono1.65.1]
     eoan: [libboost-chrono1.67.0]
@@ -1610,12 +1613,14 @@ libboost-chrono:
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-chrono-dev]
 libboost-date-time:
   debian:
     buster: [libboost-date-time1.67.0]
     stretch: [libboost-date-time1.62.0]
   fedora: [boost-date-time]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-date-time1.65.1]
     eoan: [libboost-date-time1.67.0]
@@ -1624,16 +1629,19 @@ libboost-date-time:
 libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-date-time-dev]
 libboost-dev:
   debian: [libboost-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-dev]
 libboost-filesystem:
   debian:
     buster: [libboost-filesystem1.67.0]
     stretch: [libboost-filesystem1.62.0]
   fedora: [boost-filesystem]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-filesystem1.65.1]
     eoan: [libboost-filesystem1.67.0]
@@ -1649,6 +1657,7 @@ libboost-iostreams:
     buster: [libboost-iostreams1.67.0]
     stretch: [libboost-iostreams1.62.0]
   fedora: [boost-iostreams]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-iostreams1.65.1]
     eoan: [libboost-iostreams1.67.0]
@@ -1657,6 +1666,7 @@ libboost-iostreams:
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-iostreams-dev]
 libboost-program-options:
   debian:
@@ -1664,6 +1674,7 @@ libboost-program-options:
     jessie: [libboost-program-options1.55.0]
     stretch: [libboost-program-options1.62.0]
   fedora: [boost-program-options]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-program-options1.65.1]
     disco: [libboost-program-options1.67.0]
@@ -1674,6 +1685,7 @@ libboost-program-options:
 libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   openembedded: [boost@openembedded-core]
   ubuntu: [libboost-program-options-dev]
 libboost-python:
@@ -1683,6 +1695,7 @@ libboost-python:
     jessie: [libboost-python1.55.0]
     stretch: [libboost-python1.62.0]
   fedora: [boost-python2-devel, boost-python3-devel]
+  gentoo: ['dev-libs/boost[python]']
   ubuntu:
     bionic: [libboost-python1.65.1]
     disco: [libboost-python1.67.0]
@@ -1694,6 +1707,7 @@ libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]
   fedora: [boost-python2-devel]
+  gentoo: ['dev-libs/boost[python]']
   ubuntu: [libboost-python-dev]
 libboost-random:
   debian:
@@ -1702,6 +1716,7 @@ libboost-random:
     stretch: [libboost-random1.62.0]
     wheezy: [libboost-random1.49.0]
   fedora: [boost-random]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-random1.65.1]
     disco: [libboost-random1.67.0]
@@ -1713,12 +1728,14 @@ libboost-random:
 libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-random-dev]
 libboost-regex:
   debian:
     buster: [libboost-regex1.67.0]
     stretch: [libboost-regex1.62.0]
   fedora: [boost-regex]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-regex1.65.1]
     eoan: [libboost-regex1.67.0]
@@ -1727,12 +1744,14 @@ libboost-regex:
 libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-regex-dev]
 libboost-system:
   debian:
     buster: [libboost-system1.67.0]
     stretch: [libboost-system1.62.0]
   fedora: [boost-system]
+  gentoo: [dev-libs/boost]
   ubuntu:
     bionic: [libboost-system1.65.1]
     disco: [libboost-system1.67.0]
@@ -1743,12 +1762,14 @@ libboost-system:
 libboost-system-dev:
   debian: [libboost-system-dev]
   fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
   ubuntu: [libboost-system-dev]
 libboost-thread:
   debian:
     buster: [libboost-thread1.67.0]
     stretch: [libboost-thread1.62.0]
   fedora: [boost-thread]
+  gentoo: ['dev-libs/boost[threads]']
   ubuntu:
     bionic: [libboost-thread1.65.1]
     disco: [libboost-thread1.67.0]


### PR DESCRIPTION
Note that in Gentoo the libboost-* and libboost-*-dev are the same as everything is built from source.

Previously I only added a couple of keys as they were stopping builds of ROS on Gentoo. A couple more were neede now, so I figured out I could just fill them all.