### PR TITLE
jderobot_camviz: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3970,6 +3970,17 @@ repositories:
       url: https://github.com/JdeRobot/assets.git
       version: kinetic-devel
     status: developed
+  jderobot_camviz:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/CamViz-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/CamViz.git
+      version: master
   jderobot_color_tuner:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_camviz` to `0.1.0-1`:

- upstream repository: https://github.com/JdeRobot/CamViz.git
- release repository: https://github.com/JdeRobot/CamViz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## jderobot_camviz

```
* first public release of camViz for Melodic
* Contributors: Jose Maria Cañas Plaza, Pankhuri Vanjani, Francisco Perez
```
