### PR TITLE
ros_controllers: 0.15.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8335,7 +8335,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.15.0-0
+      version: 0.15.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.15.1-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.15.0-0`

## ackermann_steering_controller

```
* Fix test for ackermann_steering_controller
* Use nullptr (#447 <https://github.com/ros-controls/ros_controllers/issues/447>)
* Update null link pointer error message
* removed cyclic debug output from ackermann_steering_bot
* add include directories for tests in {ackermann/four_wheel}_steering_controller
* Contributors: Bence Magyar, Immanuel Martini, Mathias Lüdtke, Matt Reynolds
```

## diff_drive_controller

```
* Use nullptr
* add missing pluginlib deps.
* Update null link pointer error message
* Revert cmake include catkin_INCLUDE_DIRS as system
* Use C++11 std::this_thread::sleep_for.
* Contributors: Bence Magyar, Enrique Fernandez Perdomo, Matt Reynolds, Sean Yen
```

## effort_controllers

```
* add missing pluginlib deps.
* effort_controllers: fix minor typo in setGains doc
* Contributors: G.A. vd. Hoorn, Sean Yen
```

## force_torque_sensor_controller

- No changes

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* add missing pluginlib deps
* Use C++11 std::this_thread::sleep_for.
* add include directories for tests in {ackermann/four_wheel}_steering_controller
* Contributors: Davide Faconti, Mathias Lüdtke, Sean Yen
```

## gripper_action_controller

```
* Use nullptr
* add missing pluginlib deps.
* Contributors: Bence Magyar, Matt Reynolds, Sean Yen
```

## imu_sensor_controller

- No changes

## joint_state_controller

```
* Fix tipo joint_state_plugin.xml (#435 <https://github.com/ros-controls/ros_controllers/issues/435>)
  - Remove "is" from "The joint state controller is publishes"
* Contributors: Caio Amaral
```

## joint_trajectory_controller

```
* Fix instabilities in JTC unittests
* Add test_common.h
* Re-enable tolerance tests
* Make initialization of variables consistent
* Let getState() return by value
* Use nullptr (#447 <https://github.com/ros-controls/ros_controllers/issues/447>)
* Comment out tolerance check tests until #48 <https://github.com/ros-controls/ros_controllers/issues/48> is solved.
* Execution does not stop when goal gets aborted
* Fix how we assert that controller is running
* Introduce EPS for general double comparison
* Make stopramp tests more stable
* add missing pluginlib deps. (#451 <https://github.com/ros-controls/ros_controllers/issues/451>)
* Print error messages for all exceptions
* Contributors: Bence Magyar, Ian Frosst, Immanuel Martini, Matt Reynolds, Sean Yen
```

## position_controllers

```
* add missing pluginlib deps. (#451 <https://github.com/ros-controls/ros_controllers/issues/451>)
* Contributors: Sean Yen
```

## ros_controllers

```
* Remove rqt_joint_trajectory_controller from metapackage (#443 <https://github.com/ros-controls/ros_controllers/issues/443>)
* Contributors: Matt Reynolds
```

## rqt_joint_trajectory_controller

```
* Merge pull request #452 <https://github.com/ros-controls/ros_controllers/issues/452> from etsiogas/add-robot-ns-to-gui
  Added robot namespace to gui of rqt_joint_trajectory_controller
* [rqt joint trajectory controller] Python3 fixes (#458 <https://github.com/ros-controls/ros_controllers/issues/458>)
  - Use explicit relative import (with leading dot)
  - print function with parentheses
* Contributors: Bence Magyar, Bjar Ne, etsiogas
```

## velocity_controllers

```
* add missing pluginlib deps. (#451 <https://github.com/ros-controls/ros_controllers/issues/451>)
* Contributors: Sean Yen
```
