### PR TITLE
carla_msgs: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1270,10 +1270,16 @@ repositories:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git
       version: release
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/carla-simulator/ros-carla-msgs-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git
       version: release
+    status: developed
   carla_ros_bridge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carla_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/carla-simulator/ros-carla-msgs.git
- release repository: https://github.com/carla-simulator/ros-carla-msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
