### PR TITLE
Add qtbase5-private-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4962,6 +4962,9 @@ qtbase5-dev:
   slackware: [qt5]
   ubuntu: [qtbase5-dev]
 qtbase5-private-dev:
+  debian: [qtbase5-private-dev]
+  fedora: [qt5-qtbase-private-devel]
+  rhel: [qt5-qtbase-private-devel]
   ubuntu: [qtbase5-private-dev]
 qtdeclarative5-dev:
   arch: [qt5-declarative]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4961,6 +4961,8 @@ qtbase5-dev:
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qtbase5-dev]
+qtbase5-private-dev:
+  ubuntu: [qtbase5-private-dev]
 qtdeclarative5-dev:
   arch: [qt5-declarative]
   debian: [qtdeclarative5-dev]


### PR DESCRIPTION
- Alpine: [Not found](https://pkgs.alpinelinux.org/packages?page=1&branch=edge&name=qt5-qtb%2A)
- Arch: [Not found](https://www.archlinux.org/packages/?sort=&q=qt5+private&maintainer=&flagged=)
- Debian: https://packages.debian.org/buster/qtbase5-private-dev
- Fedora: https://apps.fedoraproject.org/packages/qt5-qtbase-private-devel
- FreeBSD: [Not found](https://www.freebsd.org/cgi/ports.cgi?query=qt5+&stype=all&sektion=all)
- RHEL/CentOS: Appears to be included in default base package, but has key: https://pkgs.org/download/qt5-qtbase-private-devel
- Ubuntu: https://packages.ubuntu.com/eoan/qtbase5-private-dev