### PR TITLE
WIP: add moveit_jog_arm to melodic distribution

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5190,6 +5190,7 @@ repositories:
       - moveit_core
       - moveit_experimental
       - moveit_fake_controller_manager
+      - moveit_jog_arm
       - moveit_kinematics
       - moveit_planners
       - moveit_planners_chomp


### PR DESCRIPTION
`moveit_jog_arm` is a package provided by moveit.  This would allow us to depend on it and install it as it gets released in debians.  @AndyZe is the primary developer/maintainer of it.

I marked this WIP so it is ignored until we get jog_arm in melodic-devel, which will require the latest changes in master of moveit_msgs to get merged into it's own melodic-devel.