### PR TITLE
nodelet_core: 1.10.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -388,11 +388,25 @@ repositories:
       version: ros1
     status: maintained
   nodelet_core:
+    doc:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: noetic-devel
+    release:
+      packages:
+      - nodelet
+      - nodelet_core
+      - nodelet_topic_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/nodelet_core-release.git
+      version: 1.10.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: noetic-devel
+    status: maintained
   orocos_kinematics_dynamics:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.10.0-1`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## nodelet

```
* Update maintainer to Michael Carroll (#104 <https://github.com/ros/nodelet_core/issues/104>)
* Bump CMake version to avoid CMP0048 warning (#102 <https://github.com/ros/nodelet_core/issues/102>)
* enable Windows build (#85 <https://github.com/ros/nodelet_core/issues/85>)
* Fix build issue on Windows (#82 <https://github.com/ros/nodelet_core/issues/82>)
* delay processing of queues until Nodelet::onInit() returns (#66 <https://github.com/ros/nodelet_core/issues/66>)
* Contributors: James Xu, Johnson Shih, Michael Carroll, Shane Loretz, Simon Gene Gottlieb
```

## nodelet_core

```
* Update maintainer to Michael Carroll (#104 <https://github.com/ros/nodelet_core/issues/104>)
* Bump CMake version to avoid CMP0048 warning (#102 <https://github.com/ros/nodelet_core/issues/102>)
* Contributors: Michael Carroll, Shane Loretz
```

## nodelet_topic_tools

```
* Update maintainer to Michael Carroll (#104 <https://github.com/ros/nodelet_core/issues/104>)
* Bump CMake version to avoid CMP0048 warning (#102 <https://github.com/ros/nodelet_core/issues/102>)
* Fix for #78 <https://github.com/ros/nodelet_core/issues/78> (#80 <https://github.com/ros/nodelet_core/issues/80>)
* Contributors: Lucas Walter, Michael Carroll, Shane Loretz
```
