### PR TITLE
media_export: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4986,7 +4986,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/media_export-release.git
-      version: 0.2.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros/media_export.git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export` to `0.3.0-1`:

- upstream repository: https://github.com/ros/media_export.git
- release repository: https://github.com/ros-gbp/media_export-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.2.0-0`

## media_export

```
* Bump CMake version to avoid CMP0048 warning (#2 <https://github.com/ros/media_export/issues/2>)
* Contributors: Shane Loretz
```
