### PR TITLE
media_export: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7211,7 +7211,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/media_export-release.git
-      version: 0.2.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros/media_export.git


### PR DESCRIPTION
Increasing version of package(s) in repository `media_export` to `0.3.0-1`:

- upstream repository: https://github.com/ros/media_export.git
- release repository: https://github.com/ros-gbp/media_export-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.2.0-0`

## media_export

```
* Bump CMake version to avoid CMP0048 warning (#2 <https://github.com/ros/media_export/issues/2>)
* Contributors: Shane Loretz
```
