### PR TITLE
urdf_parser_py: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2927,6 +2927,24 @@ repositories:
       url: https://github.com/ros2/urdf.git
       version: eloquent
     status: maintained
+  urdf_parser_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    release:
+      packages:
+      - urdfdom_py
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_py-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    status: maintained
   urdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_parser_py` to `1.0.0-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros2-gbp/urdfdom_py-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urdfdom_py

```
* Add in support for the version tag. (#52 <https://github.com/ros/urdf_parser_py/issues/52>) (#54 <https://github.com/ros/urdf_parser_py/issues/54>)
* ROS 2 Port (reopened) (#53 <https://github.com/ros/urdf_parser_py/issues/53>)
* Contributors: Chris Lalancette, Henning Kayser
```
