### PR TITLE
geometry2: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -290,6 +290,27 @@ repositories:
       version: melodic-devel
     status: maintained
   geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: noetic-devel
+    release:
+      packages:
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry2-release.git
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.7.0-1`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## geometry2

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Contributors: Shane Loretz
```

## tf2

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
  Signed-off-by: Shane Loretz <mailto:sloretz@osrfoundation.org>
* Fix compile error missing ros/ros.h (#400 <https://github.com/ros/geometry2/issues/400>)
  * ros/ros.h -> ros/time.h
  tf2 package depends on rostime
  * tf2_bullet doesn't need ros.h
  Signed-off-by: Shane Loretz <mailto:sloretz@osrfoundation.org>
  * tf2_eigen doesn't need ros/ros.h
  Signed-off-by: Shane Loretz <mailto:sloretz@osrfoundation.org>
* Merge pull request #367 <https://github.com/ros/geometry2/issues/367> from kejxu/add_tf2_namespace_to_avoid_name_collision
  rework Eigen functions namespace hack
* separate transform function declarations into transform_functions.h
* use ROS_DEPRECATED macro for portability (#362 <https://github.com/ros/geometry2/issues/362>)
  * use ROS_DEPRECATED for better portability
  * change ROS_DEPRECATED position (#5 <https://github.com/ros/geometry2/issues/5>)
* Remove signals from find_package(Boost COMPONENTS ...).
  tf2 is using signals2, which is not the same library.
  Additionally, signals2 has always been header only, and header only
  libraries must not be listed in find_package.
  Boost 1.69 removed the old signals library entirely, so the otherwise
  useless COMPONENTS signals actually breaks the build.
* Remove legacy inclusion in CMakeLists of tf2.
* Contributors: James Xu, Maarten de Vries, Marco Tranzatto, Shane Loretz, Tully Foote
```

## tf2_bullet

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Fix compile error missing ros/ros.h (#400 <https://github.com/ros/geometry2/issues/400>)
  * ros/ros.h -> ros/time.h
  * tf2_bullet doesn't need ros.h
  * tf2_eigen doesn't need ros/ros.h
* use find_package when pkg_check_modules doesn't work (#364 <https://github.com/ros/geometry2/issues/364>)
  * use find_package bullet for MSVC
  * use find_package when pkg_check_modules fails (#8 <https://github.com/ros/geometry2/issues/8>)
  * use find_package() when pkg_check_modules() doesn't work
* Contributors: James Xu, Shane Loretz
```

## tf2_eigen

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Fix compile error missing ros/ros.h (#400 <https://github.com/ros/geometry2/issues/400>)
  * ros/ros.h -> ros/time.h
  * tf2_bullet doesn't need ros.h
  * tf2_eigen doesn't need ros/ros.h
* Merge pull request #367 <https://github.com/ros/geometry2/issues/367> from kejxu/add_tf2_namespace_to_avoid_name_collision
* separate transform function declarations into transform_functions.h
* Contributors: James Xu, Shane Loretz, Tully Foote
```

## tf2_geometry_msgs

```
* Replace kdl packages with rosdep keys (#447 <https://github.com/ros/geometry2/issues/447>)
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Make kdl headers available (#419 <https://github.com/ros/geometry2/issues/419>)
* FIx python3 compatibility for noetic (#416 <https://github.com/ros/geometry2/issues/416>)
* add <array> from STL (#366 <https://github.com/ros/geometry2/issues/366>)
* use ROS_DEPRECATED macro for portability (#362 <https://github.com/ros/geometry2/issues/362>)
  * use ROS_DEPRECATED for better portability
  * change ROS_DEPRECATED position (#5 <https://github.com/ros/geometry2/issues/5>)
* Contributors: James Xu, Shane Loretz, Tully Foote
```

## tf2_kdl

```
* Replace kdl packages with rosdep keys (#447 <https://github.com/ros/geometry2/issues/447>)
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Make kdl headers available (#419 <https://github.com/ros/geometry2/issues/419>)
* Fix python3 compatibility for noetic (#416 <https://github.com/ros/geometry2/issues/416>)
* Merge pull request #404 <https://github.com/ros/geometry2/issues/404> from otamachan/remove-load-manifest
* Python 3 compatibility: relative imports and print statement
* Contributors: Shane Loretz, Tamaki Nishino, Timon Engelke, Tully Foote
```

## tf2_msgs

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Contributors: Shane Loretz
```

## tf2_py

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Merge pull request #363 <https://github.com/ros/geometry2/issues/363> from kejxu/fix_tf2_py_export
  use .pyd instead of .so on Windows and export symbols
* limit MSVC-only change to MSVC scope (#10 <https://github.com/ros/geometry2/issues/10>)
* Fix the pyd extension and export the init function.
* use windows counterpart for .so extension
* Contributors: James Xu, Sean Yen, Shane Loretz, Tully Foote
```

## tf2_ros

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Add arguments to TransformListener constructors that accept TransportHints for the tf topic subscriber (#438 <https://github.com/ros/geometry2/issues/438>)
* Merge pull request #404 <https://github.com/ros/geometry2/issues/404> from otamachan/remove-load-manifest
  Remove roslib.load_manifest
* Merge pull request #402 <https://github.com/ros/geometry2/issues/402> from rhaschke/fix-message-filter
  Fix message filter
* resolve virtual function call in destructor
* remove pending callbacks in clear()
* Merge pull request #372 <https://github.com/ros/geometry2/issues/372> from lucasw/patch-1
  spelling fix: seperate -> separate
* Merge pull request #369 <https://github.com/ros/geometry2/issues/369> from magazino/fix-dangling-reference
* Fix dangling iterator references in buffer_server.cpp
* Remove some useless code from buffer_server_main.cpp (#368 <https://github.com/ros/geometry2/issues/368>)
* Mark check_frequency as deprecated in docstring.
* Follow #337 <https://github.com/ros/geometry2/issues/337>: use actionlib API in BufferClient::processGoal()
* Test for equality to None with 'is' instead of '==' (#355 <https://github.com/ros/geometry2/issues/355>)
* added parameter to advertise tf2-frames as a service, if needed
* Contributors: Daniel Ingram, Emre Sahin, JonasTietz, Lucas Walter, Michael Grupp, Robert Haschke, Shane Loretz, Tamaki Nishino, Tully Foote, toliver
```

## tf2_sensor_msgs

```
* Replace kdl packages with rosdep keys (#447 <https://github.com/ros/geometry2/issues/447>)
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Merge pull request #378 <https://github.com/ros/geometry2/issues/378> from peci1/tf2_sensor_msgs_isometry
  Affine->Isometry
* Python 3 compatibility: relative imports and print statement
* Contributors: Martin Pecka, Shane Loretz, Timon Engelke, Tully Foote
```

## tf2_tools

```
* Bump CMake version to avoid CMP0048 warning (#445 <https://github.com/ros/geometry2/issues/445>)
* Merge pull request #377 <https://github.com/ros/geometry2/issues/377> from InstitutMaupertuis/melodic-devel
  Allow to choose output precision in echo
* Merge pull request #373 <https://github.com/ros/geometry2/issues/373> from mikaelarguedas/yaml_safe_load
  use yaml.safe_load instead of deprecated yaml.load
* Python 3 compatibility: relative imports and print statement
* Contributors: Mikael Arguedas, Shane Loretz, Timon Engelke, Tully Foote, Victor Lamoine
```
