### PR TITLE
ipr_extern: 0.9.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5524,7 +5524,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/ipr_extern-release.git
-      version: 0.8.8-0
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ipr_extern` to `0.9.0-1`:

- upstream repository: https://github.com/KITrobotics/ipr_extern.git
- release repository: https://github.com/KITrobotics/ipr_extern-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.8-0`

## ipr_extern

- No changes

## libmodbus

- No changes

## libreflexxestype2

- No changes

## ros_reflexxes

```
* ros_reflexxes interfaces loadable as a plugin (#4 <https://github.com/KITrobotics/ipr_extern/issues/4>)
* Contributors: Denis Štogl
```
