### PR TITLE
Add python-pathlib in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2855,6 +2855,8 @@ python-path.py:
   ubuntu:
     pip:
       packages: [path.py]
+python-pathlib:
+  ubuntu: [python-pathlib]
 python-pathos-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2857,6 +2857,10 @@ python-path.py:
       packages: [path.py]
 python-pathlib:
   ubuntu: [python-pathlib]
+  debian: [python-pathlib]
+  fedora: [python-pathlib]
+  gentoo: [dev-python/pathlib]
+  arch: [python2-pathlib]
 python-pathos-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2856,11 +2856,11 @@ python-path.py:
     pip:
       packages: [path.py]
 python-pathlib:
-  ubuntu: [python-pathlib]
+  arch: [python2-pathlib]
   debian: [python-pathlib]
   fedora: [python-pathlib]
   gentoo: [dev-python/pathlib]
-  arch: [python2-pathlib]
+  ubuntu: [python-pathlib]
 python-pathos-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2858,7 +2858,6 @@ python-path.py:
 python-pathlib:
   arch: [python2-pathlib]
   debian: [python-pathlib]
-  fedora: [python-pathlib]
   gentoo: [dev-python/pathlib]
   ubuntu: [python-pathlib]
 python-pathos-pip:


### PR DESCRIPTION
https://packages.ubuntu.com/bionic/python-pathlib
https://pypi.org/project/pathlib/

pathlib offers a set of classes to handle filesystem paths. It offers the following advantages over using string objects:

No more cumbersome use of os and os.path functions. Everything can be done easily through operators, attribute accesses, and method calls.
Embodies the semantics of different path types. For example, comparing Windows paths ignores casing.
Well-defined semantics, eliminating any warts or ambiguities (forward vs. backward slashes, etc.).