### PR TITLE
qt_ros: 0.2.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7463,6 +7463,22 @@ repositories:
       url: https://github.com/swri-robotics-gbp/qt_metapackages-release.git
       version: 1.0.1-0
     status: developed
+  qt_ros:
+    release:
+      packages:
+      - qt_build
+      - qt_create
+      - qt_ros
+      - qt_tutorials
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/qt_ros-release.git
+      version: 0.2.10-1
+    source:
+      type: git
+      url: https://github.com/stonier/qt_ros.git
+      version: indigo
+    status: maintained
   quaternion_operation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_ros` to `0.2.10-1`:

- upstream repository: https://github.com/stonier/qt_ros.git
- release repository: https://github.com/yujinrobot-release/qt_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## qt_create

```
* Workaround applied for Qt4 and BOOST_JOIN problems
```
