### PR TITLE
py_trees: 2.0.12-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1449,7 +1449,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 2.0.11-1
+      version: 2.0.12-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.0.12-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.11-1`

## py_trees

```
* [idioms] the either_or pattern, designed to replace the Chooser, #283 <https://github.com/splintered-reality/py_trees/pull/283>
* [behaviours] TickCounter, a timer based on tree ticks, #283 <https://github.com/splintered-reality/py_trees/pull/283>
* [behaviours] CheckBlackboardVariableValues, logical checks across multiple values, #283 <https://github.com/splintered-reality/py_trees/pull/283>
* [common] ComparisonExpression, a more concise way of storing checkers, #283 <https://github.com/splintered-reality/py_trees/pull/283>
* [composites] protect against adding a child to multiple parents, #281 <https://github.com/splintered-reality/py_trees/pull/281>
```
