### PR TITLE
joint_state_publisher: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1128,6 +1128,25 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: ros2
     status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: ros2
+    release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/joint_state_publisher-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: ros2
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.0.0-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## joint_state_publisher

```
* Port to ROS 2 (#30 <https://github.com/ros/joint_state_publisher/issues/30>)
* Remove the deprecated fallback option of use_gui (#34 <https://github.com/ros/joint_state_publisher/issues/34>)
* Split jsp and jsp gui (#31 <https://github.com/ros/joint_state_publisher/issues/31>)
* Only update one joint slider on value changed. (#11 <https://github.com/ros/joint_state_publisher/issues/11>)
* ignore 'planar' joints just as 'fixed' and 'floating' (#14 <https://github.com/ros/joint_state_publisher/issues/14>)
* Make GUI window scroll & resize for large robots (#10 <https://github.com/ros/joint_state_publisher/issues/10>)
* Contributors: Andy McEvoy, Chris Lalancette, Michael Görner
```

## joint_state_publisher_gui

```
* Port to ROS 2 (#30 <https://github.com/ros/joint_state_publisher/issues/30>)
* Split jsp and jsp gui (#31 <https://github.com/ros/joint_state_publisher/issues/31>)
* Contributors: Chris Lalancette
```
