### PR TITLE
marti_common: 3.0.5-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1346,7 +1346,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.0.4-1
+      version: 3.0.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.0.5-2`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `3.0.4-1`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_route_util

```
* Fix linking bugs (#569 <https://github.com/swri-robotics/marti_common/issues/569>)
* Contributors: P. J. Reed
```

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Also add NavSatFix support to swri_transform_util::LocalXyUtil (#569 <https://github.com/swri-robotics/marti_common/issues/569>)
* Contributors: P. J. Reed
```
