### PR TITLE
marti_common: 3.0.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1072,6 +1072,35 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
     status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    release:
+      packages:
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 3.0.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    status: developed
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.0.5-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_route_util

```
* Fix linking bugs (#569 <https://github.com/swri-robotics/marti_common/issues/569>)
* Contributors: P. J. Reed
```

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Also add NavSatFix support to swri_transform_util::LocalXyUtil (#569 <https://github.com/swri-robotics/marti_common/issues/569>)
* Contributors: P. J. Reed
```
