### PR TITLE
geometry: 1.12.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3074,7 +3074,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.12.0-0
+      version: 1.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.12.1-1`:

- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.12.0-0`

## eigen_conversions

```
* Bump CMake version to avoid CMP0048 warning (#204 <https://github.com/ros/geometry/issues/204>)
* Contributors: Shane Loretz
```

## geometry

```
* Bump CMake version to avoid CMP0048 warning (#204 <https://github.com/ros/geometry/issues/204>)
* Contributors: Shane Loretz
```

## kdl_conversions

```
* Bump CMake version to avoid CMP0048 warning (#204 <https://github.com/ros/geometry/issues/204>)
* windows bring up, use ROS_DEPRECATED
* Contributors: James Xu, Shane Loretz
```

## tf

```
* Use process_time() for Python 3.8 compatibility (#205 <https://github.com/ros/geometry/issues/205>)
* Bump CMake version to avoid CMP0048 warning (#204 <https://github.com/ros/geometry/issues/204>)
* Add rostest include dirs (#195 <https://github.com/ros/geometry/issues/195>)
* Remove trailing semicolons from tf sources (#187 <https://github.com/ros/geometry/issues/187>)
  * [tf] Removed trailing semicolons after functions from all sources
  Used the -Wpedantic compiler flag to find all occurrences
* Allow to choose output precision in tf_echo (#186 <https://github.com/ros/geometry/issues/186>)
  * Allow to choose output precision in tf_echo
* update how c++11 requirement is added (#184 <https://github.com/ros/geometry/issues/184>)
* update install destination in CMakeLists.txt (#183 <https://github.com/ros/geometry/issues/183>)
  * export binary to right locations
  * specify archive and runtime destinations, update whitespace (#5 <https://github.com/ros/geometry/issues/5>)
* add visibility macro
* windows bring up, use ROS_DEPRECATED
* Remove signals from find_package(Boost COMPONENTS ...)
* fixing error of casting away constness in  method void tfSwapScalarEndian(const tfScalar& sourceVal, tfScalar& destVal) in line 626 of Vector3.h (#179 <https://github.com/ros/geometry/issues/179>)
* Fix log output typo: message_notifier -> message_filter (#177 <https://github.com/ros/geometry/issues/177>)
  Almost all the log outputs use message_filter, except one. The warning
  text still referred to message_notifier. This commit fixes that.
* Contributors: C-NR, James Xu, Maarten de Vries, Martin Günther, Shane Loretz, Victor Lamoine, Yoshua Nava
```

## tf_conversions

```
* Bump CMake version to avoid CMP0048 warning (#204 <https://github.com/ros/geometry/issues/204>)
* initialize the test values (#194 <https://github.com/ros/geometry/issues/194>)
* windows bring up, use ROS_DEPRECATED
* Contributors: James Xu, Shane Loretz, Tully Foote
```
