### PR TITLE
rqt: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -786,6 +786,21 @@ repositories:
       version: noetic-devel
     status: maintained
   rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.5.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_gui

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* allow definition of settings file (#216 <https://github.com/ros-visualization/rqt/issues/216>)
* use catkin_install_python for Python script (#206 <https://github.com/ros-visualization/rqt/issues/206>)
* style changes (#143 <https://github.com/ros-visualization/rqt/issues/143>)
* autopep8 (#137 <https://github.com/ros-visualization/rqt/issues/137>)
```

## rqt_gui_cpp

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* [Windows] fix rqt_gui_cpp install path (#190 <https://github.com/ros-visualization/rqt/issues/190>)
* [Windows] fix building (#189 <https://github.com/ros-visualization/rqt/issues/189>)
* style changes (#143 <https://github.com/ros-visualization/rqt/issues/143>)
```

## rqt_gui_py

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* style changes (#143 <https://github.com/ros-visualization/rqt/issues/143>)
* autopep8 (#137 <https://github.com/ros-visualization/rqt/issues/137>)
```

## rqt_py_common

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* fix missing import bugs (#139 <https://github.com/ros-visualization/rqt/issues/139>)
* autopep8 (#137 <https://github.com/ros-visualization/rqt/issues/137>)
```
