### PR TITLE
rqt: 0.5.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8999,7 +8999,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.5.0-0
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.5.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.5.0-0`

## rqt_gui

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* allow definition of settings file (#216 <https://github.com/ros-visualization/rqt/issues/216>)
* use catkin_install_python for Python script (#206 <https://github.com/ros-visualization/rqt/issues/206>)
* style changes (#143 <https://github.com/ros-visualization/rqt/issues/143>)
* autopep8 (#137 <https://github.com/ros-visualization/rqt/issues/137>)
```

## rqt_gui_cpp

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* [Windows] fix rqt_gui_cpp install path (#190 <https://github.com/ros-visualization/rqt/issues/190>)
* [Windows] fix building (#189 <https://github.com/ros-visualization/rqt/issues/189>)
* style changes (#143 <https://github.com/ros-visualization/rqt/issues/143>)
```

## rqt_gui_py

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* style changes (#143 <https://github.com/ros-visualization/rqt/issues/143>)
* autopep8 (#137 <https://github.com/ros-visualization/rqt/issues/137>)
```

## rqt_py_common

```
* bump CMake minimum version to avoid CMP0048 warning (#219 <https://github.com/ros-visualization/rqt/issues/219>)
* fix missing import bugs (#139 <https://github.com/ros-visualization/rqt/issues/139>)
* autopep8 (#137 <https://github.com/ros-visualization/rqt/issues/137>)
```
