### PR TITLE
geometry: 1.13.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -302,7 +302,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/geometry.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   geometry2:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -283,6 +283,21 @@ repositories:
       version: kinetic-devel
     status: maintained
   geometry:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: noetic-devel
+    release:
+      packages:
+      - eigen_conversions
+      - geometry
+      - kdl_conversions
+      - tf
+      - tf_conversions
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry-release.git
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.13.0-1`:

- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## eigen_conversions

```
* Replace kdl packages with rosdep keys (#206 <https://github.com/ros/geometry/issues/206>)
* Contributors: Shane Loretz
```

## geometry

- No changes

## kdl_conversions

```
* Replace kdl packages with rosdep keys (#206 <https://github.com/ros/geometry/issues/206>)
* Contributors: Shane Loretz
```

## tf

- No changes

## tf_conversions

```
* Replace kdl packages with rosdep keys (#206 <https://github.com/ros/geometry/issues/206>)
* Contributors: Shane Loretz
```
