### PR TITLE
capabilities: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -67,6 +67,22 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
     status: maintained
+  capabilities:
+    doc:
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/capabilities-release.git
+      version: 0.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `capabilities` to `0.3.1-1`:

- upstream repository: https://github.com/osrf/capabilities.git
- release repository: https://github.com/ros-gbp/capabilities-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## capabilities

```
* Updated ``package.xml`` to format 3 and and used condition dependencies to support Python3 (#91 <https://github.com/osrf/capabilities/issues/91>)
* Contributors: William Woodall
```
