### PR TITLE
navigation_msgs: 1.14.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -443,6 +443,18 @@ repositories:
       version: kinetic-devel
     status: maintained
   navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros1
+    release:
+      packages:
+      - map_msgs
+      - move_base_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_msgs-release.git
+      version: 1.14.0-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `1.14.0-1`:

- upstream repository: https://github.com/ros-planning/navigation_msgs.git
- release repository: https://github.com/ros-gbp/navigation_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## map_msgs

```
* Bump CMake version to avoid CMP0048
  Signed-off-by: Shane Loretz <mailto:sloretz@osrfoundation.org>
* Contributors: Shane Loretz
```

## move_base_msgs

```
* Bump CMake version to avoid CMP0048
  Signed-off-by: Shane Loretz <mailto:sloretz@osrfoundation.org>
* Contributors: Shane Loretz
```
