### PR TITLE
Add noetic in list of ubuntu distros for python-numpy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2628,6 +2628,7 @@ python-numpy:
     lucid: [python-numpy]
     maverick: [python-numpy]
     natty: [python-numpy]
+    noetic: [python-numpy]
     oneiric: [python-numpy]
     precise: [python-numpy]
     quantal: [python-numpy]


### PR DESCRIPTION
Currently, depending on `python-numpy` in Noetic fails with:
```
rosdep2.lookup.ResolutionError: No definition of [python-numpy] for OS version [focal]
```

As [suggested here](https://github.com/ros/rosdistro/pull/23993#pullrequestreview-372323089), I'm adding it in here for Noetic. I left the previous version starting with 'n' (natty) in but can remove that.