### PR TITLE
realtime_tools: 1.16.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -573,6 +573,15 @@ repositories:
       version: master
     status: maintained
   realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `1.16.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## realtime_tools

```
* Use atomic types
* Bump CMake version to avoid CMP0048
* Contributors: Bence Magyar, Shane Loretz, Zheng Qu
* Bump CMake version to avoid CMP0048
* Contributors: Shane Loretz
```
