### PR TITLE
octomap_msgs: 0.3.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -480,6 +480,21 @@ repositories:
       url: https://github.com/ros/nodelet_core.git
       version: noetic-devel
     status: maintained
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 0.3.4-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: melodic-devel
+    status: maintained
   pcl_msgs:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.4-1`:

- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## octomap_msgs

```
* Bump CMake version to avoid CMP0048 (#14 <https://github.com/OctoMap/octomap_msgs/issues/14>)
* Contributors: Shane Loretz
```
