### PR TITLE
urdf_geometry_parser: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -977,6 +977,15 @@ repositories:
       version: melodic-devel
     status: maintained
   urdf_geometry_parser:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/urdf_geometry_parser.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_geometry_parser-release.git
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_geometry_parser` to `0.0.3-1`:

- upstream repository: https://github.com/ros-controls/urdf_geometry_parser.git
- release repository: https://github.com/ros-gbp/urdf_geometry_parser-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urdf_geometry_parser

```
* add travis config, based on industrial_ci
* Make sure to include urdfdom_compatibility.h.
  This ensures that urdf_geometry_parser will build on all distros
  (including older Debian Jessie).
  Signed-off-by: Chris Lalancette <mailto:clalancette@osrfoundation.org>
* Contributors: Bence Magyar, Chris Lalancette, Mathias Lüdtke
```
