### PR TITLE
rviz: 6.1.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2979,7 +2979,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 6.1.5-1
+      version: 6.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.1.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `6.1.5-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove uncessary call to render scene. (#515 <https://github.com/ros2/rviz/issues/515>)
* Contributors: Jacob Perron
```

## rviz_default_plugins

```
* Fix camera info for camera display. (#516 <https://github.com/ros2/rviz/issues/516>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
