### PR TITLE
angles: 1.9.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -38,7 +38,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.12-1
+      version: 1.9.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.9.13-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros-gbp/geometry_angles_utils-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.9.12-1`

## angles

```
* Update the angle normalization function to a simpler implementation (#19 <https://github.com/ros/angles/issues/19>)
  * Update the angle normalization function for a simpler alternative
  * Simplify 2*pi angle wrapping.
  * Simplify/fasten the C++ implementation of angle normalization (removes one fmod call)
* Bump CMake version to avoid CMP0048 warning (#20 <https://github.com/ros/angles/issues/20>)
* Contributors: Alexis Paques, Shane Loretz
```
