### PR TITLE
rqt_logger_level: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -917,6 +917,15 @@ repositories:
       version: master
     status: maintained
   rqt_logger_level:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_logger_level-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_logger_level

```
* bump CMake minimum version to avoid CMP0048 warning
* add Python 3 conditional dependencies (#6 <https://github.com/ros-visualization/rqt_logger_level/issues/6>)
* autopep8 (#4 <https://github.com/ros-visualization/rqt_logger_level/issues/4>)
```
