### PR TITLE
rqt_plot: 0.4.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -929,6 +929,15 @@ repositories:
       version: master
     status: maintained
   rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_plot-release.git
+      version: 0.4.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `0.4.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros-gbp/rqt_plot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_plot

```
* bump CMake minimum version to avoid CMP0048 warning
* add Python 3 conditional dependencies (#41 <https://github.com/ros-visualization/rqt_plot/issues/41>)
* fix KeyError when curves are removed concurrently (#37 <https://github.com/ros-visualization/rqt_plot/issues/37>)
```
