### PR TITLE
rqt_publisher: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -941,6 +941,15 @@ repositories:
       version: master
     status: maintained
   rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_publisher-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros-gbp/rqt_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_publisher

```
* bump CMake minimum version to avoid CMP0048 warning
* add Python 3 conditional dependencies (#17 <https://github.com/ros-visualization/rqt_publisher/issues/17>)
* autopep8 (#1 <https://github.com/ros-visualization/rqt_publisher/issues/1>)
```
