### PR TITLE
rqt_service_caller: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -953,6 +953,15 @@ repositories:
       version: master
     status: maintained
   rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_service_caller-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros-gbp/rqt_service_caller-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_service_caller

```
* bump CMake minimum version to avoid CMP0048 warning
* add Python 3 conditional dependencies (#12 <https://github.com/ros-visualization/rqt_service_caller/issues/12>)
* autopep8 (#5 <https://github.com/ros-visualization/rqt_service_caller/issues/5>)
* Save and restore the selected service (#3 <https://github.com/ros-visualization/rqt_service_caller/issues/3>)
  Extended the settings by adding the currently selected service
```
