### PR TITLE
rqt_web: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -971,6 +971,15 @@ repositories:
       version: master
     status: maintained
   rqt_web:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_web-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_web.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_web` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_web.git
- release repository: https://github.com/ros-gbp/rqt_web-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_web

```
* bump CMake minimum version to avoid CMP0048 warning
* add Python 3 conditional dependencies (#2 <https://github.com/ros-visualization/rqt_web/issues/2>)
* autopep8 (#1 <https://github.com/ros-visualization/rqt_web/issues/1>)
```
