### PR TITLE
rqt_pose_view: 0.5.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -970,7 +970,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pose_view-release.git
-      version: 0.5.9-1
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pose_view` to `0.5.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_pose_view.git
- release repository: https://github.com/ros-gbp/rqt_pose_view-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.5.9-1`

## rqt_pose_view

```
* auto-subscribe if topic name on param server (#5 <https://github.com/ros-visualization/rqt_pose_view/issues/5>)
```
