### PR TITLE
Add python3-pykdl for Fedora 32+

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5567,6 +5567,10 @@ python3-pykdl:
     '*': [python3-pykdl]
     'bionic': null
     'xenial': null
+  fedora:
+    '*': [python3-pykdl]
+    '31': null
+    '30': null
   ubuntu:
     '*': [python3-pykdl]
     'bionic': null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5569,8 +5569,8 @@ python3-pykdl:
     'xenial': null
   fedora:
     '*': [python3-pykdl]
-    '31': null
     '30': null
+    '31': null
   ubuntu:
     '*': [python3-pykdl]
     'bionic': null


### PR DESCRIPTION
This adds an entry for `python3-pykdl` for Fedora 32 and beyond. I put `null` entries for 31 and 30 only since [29 and below seem to be EOL](https://fedoraproject.org/wiki/End_of_life#Unsupported_Fedora_Releases).

I think this package should exist in Fedora 32 as of @cottsay's PR https://src.fedoraproject.org/rpms/orocos-kdl/pull-request/1 , but I don't actually know where to get a link proving a Fedora package exists. @cottsay is this rosdistro PR premature?