### PR TITLE
mpc_local_planner: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5351,7 +5351,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/mpc_local_planner-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mpc_local_planner` to `0.0.2-1`:

- upstream repository: https://github.com/rst-tu-dortmund/mpc_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/mpc_local_planner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.1-2`

## mpc_local_planner

```
* Added option to inherit the robot footprint model from the costmap_2d footprint by setting footprint type to costmap_2d (thanks to Alexander Xydes).
  Note that using a polygon as a robot footprint model is computationally more expensive than using two circle or line models.
* Fixed issues in fd discretization grid and graph consistency
* Fixed initialization of linear velocity output commands in simple car and unicycle models (thanks to Thomas Denewiler).
* Fixed wrong parameter namespaces for some grid parameters
* Replaced non-ASCII characters in python script
* Added find_package script for osqp in case control_box_rst is linked against it
* Contributors: Christoph Rösmann, Alexander Xydes, Thomas Denewiler
```

## mpc_local_planner_examples

```
* Added dependency on mpc_local_planner_msgs package
* Default parameter set changed
* Contributors: Christoph Rösmann
```

## mpc_local_planner_msgs

- No changes
