### PR TITLE
pilz_robots: 0.5.14-1 in melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6787,6 +6787,7 @@ repositories:
       packages:
       - pilz_control
       - pilz_robots
+      - pilz_status_indicator_rqt
       - pilz_testutils
       - pilz_utils
       - prbt_gazebo
@@ -6797,7 +6798,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.13-1
+      version: 0.5.14-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository pilz_robots to 0.5.14-1:

*    upstream repository: https://github.com/PilzDE/pilz_robots.git
*    release repository: https://github.com/PilzDE/pilz_robots-release.git