### PR TITLE
ublox: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10786,7 +10786,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KumarRobotics/ublox-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/KumarRobotics/ublox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `1.3.1-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/KumarRobotics/ublox-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.3.0-1`

## ublox

```
* Add metapackage dependencies
* Contributors: Mateusz Sadowski, Tim Clephas
```

## ublox_gps

```
* Fix unit in covariance calculation
* Contributors: Ferry Schoenmakers
```

## ublox_msgs

- No changes

## ublox_serialization

- No changes
