### PR TITLE
pyquaternion: 0.9.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -527,6 +527,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
     status: maintained
+  pyquaternion:
+    doc:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Achllle/pyquaternion-release.git
+      version: 0.9.6-1
+    source:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: noetic-devel
+    status: maintained
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyquaternion` to `0.9.6-1`:

- upstream repository: https://github.com/Achllle/pyquaternion
- release repository: https://github.com/Achllle/pyquaternion-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## pyquaternion

```
Post ROS package conversion
* Change exec depend naming from numpy to python-numpy
* Add numpy dependency to package.xml
* Create catkin package, rename and move some files
* Fix casting error in trace_method
* Add setter for vector
```

See also kinetic release: #23993 
NOTE: `bloom-release` asked the following:
```
 ! [rejected]        upstream/0.9.6 -> upstream/0.9.6 (already exists)
error: failed to push some refs to 'https://github.com/Achllle/pyquaternion-release.git'
hint: Updates were rejected because the tag already exists in the remote.
Pushing changes failed, would you like to add '--force' to 'git push --tags'?
Continue [Y/n]? Y
```
Not sure what the implications of this are. Let me know if I should modify anything