### PR TITLE
pyquaternion: 0.9.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7268,6 +7268,21 @@ repositories:
       url: https://github.com/ipab-slmc/pybind11_catkin.git
       version: master
     status: developed
+  pyquaternion:
+    doc:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Achllle/pyquaternion-release.git
+      version: 0.9.6-1
+    source:
+      type: git
+      url: https://github.com/Achllle/pyquaternion.git
+      version: master
+    status: maintained
   pyros_test:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pyquaternion` to `0.9.6-1`:

- upstream repository: https://github.com/Achllle/pyquaternion
- release repository: https://github.com/Achllle/pyquaternion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## pyquaternion

```
Post ROS package conversion
* Change exec depend naming from numpy to python-numpy
* Add numpy dependency to package.xml
* Create catkin package, rename and move some files
* Fix casting error in trace_method
* Add setter for vector
```
