### PR TITLE
joint_state_publisher: 1.12.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4015,7 +4015,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.12.14-1
+      version: 1.12.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `1.12.15-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros-gbp/joint_state_publisher-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.12.14-1`

## joint_state_publisher

```
* Make it clear robot_description is required (#42 <https://github.com/ros/joint_state_publisher/issues/42>)
* Set source_update_cb attr before creating subscribers (#41 <https://github.com/ros/joint_state_publisher/issues/41>)
* Contributors: Shane Loretz
```

## joint_state_publisher_gui

- No changes
