### PR TITLE
joint_state_publisher: 1.15.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -388,6 +388,18 @@ repositories:
       version: hydro-devel
     status: maintained
   joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: noetic-devel
+    release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/joint_state_publisher-release.git
+      version: 1.15.0-1
     source:
       type: git
       url: https://github.com/ros/joint_state_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `1.15.0-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros-gbp/joint_state_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## joint_state_publisher

```
* Bump CMake version to avoid CMP0048 (#44 <https://github.com/ros/joint_state_publisher/issues/44>)
* Set source_update_cb attr before creating subscribers (#43 <https://github.com/ros/joint_state_publisher/issues/43>)
* Make it clear robot_description is required. (#39 <https://github.com/ros/joint_state_publisher/issues/39>)
* Remove the deprecated fallback option of use_gui (#34 <https://github.com/ros/joint_state_publisher/issues/34>)
* Split jsp and jsp gui (#31 <https://github.com/ros/joint_state_publisher/issues/31>)
* Only update one joint slider on value changed. (#11 <https://github.com/ros/joint_state_publisher/issues/11>)
* ignore 'planar' joints just as 'fixed' and 'floating' (#14 <https://github.com/ros/joint_state_publisher/issues/14>)
* Make GUI window scroll & resize for large robots (#10 <https://github.com/ros/joint_state_publisher/issues/10>)
* Contributors: Andy McEvoy, Chris Lalancette, Michael Görner, Shane Loretz
```

## joint_state_publisher_gui

```
* Bump CMake version to avoid CMP0048 (#44 <https://github.com/ros/joint_state_publisher/issues/44>)
* [Noetic] GUI Title contains node name (#40 <https://github.com/ros/joint_state_publisher/issues/40>)
* Split jsp and jsp gui (#31 <https://github.com/ros/joint_state_publisher/issues/31>)
* Contributors: Chris Lalancette, Shane Loretz
```
