### PR TITLE
neonavigation: 0.8.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8430,7 +8430,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.8.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.0-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: fix flaky debug_output test (#452 <https://github.com/at-wat/neonavigation/issues/452>)
* planner_cspace: fix condition of planning finish (#451 <https://github.com/at-wat/neonavigation/issues/451>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

```
* track_odometry: increase queue sizes of message_filters::Subscriber (#450 <https://github.com/at-wat/neonavigation/issues/450>)
* Contributors: Naotaka Hatao
```

## trajectory_tracker

- No changes
