### PR TITLE
Add commonly used QML modules.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5001,6 +5001,20 @@ qhull-bin:
   fedora: [qhull]
   gentoo: [media-libs/qhull]
   ubuntu: [qhull-bin]
+qml-module-qtmultimedia:
+  ubuntu: [qml-module-qtmultimedia]
+qml-module-qtquick-controls:
+  ubuntu: [qml-module-qtquick-controls]
+qml-module-qtquick-controls2:
+  ubuntu: [qml-module-qtquick-controls2]
+qml-module-qtquick-dialogs:
+  ubuntu: [qml-module-qtquick-dialogs]
+qml-module-qtquick-layouts:
+  ubuntu: [qml-module-qtquick-layouts]
+qml-module-qtquick-templates2:
+  ubuntu: [qml-module-qtquick-templates2]
+qml-module-qtquick2:
+  ubuntu: [qml-module-qtquick2]
 qrencode:
   arch: [qrencode]
   debian: [qrencode]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5002,18 +5002,25 @@ qhull-bin:
   gentoo: [media-libs/qhull]
   ubuntu: [qhull-bin]
 qml-module-qtmultimedia:
+  debian: [qml-module-qtmultimedia]
   ubuntu: [qml-module-qtmultimedia]
 qml-module-qtquick-controls:
+  debian: [qml-module-qtquick-controls]
   ubuntu: [qml-module-qtquick-controls]
 qml-module-qtquick-controls2:
+  debian: [qml-module-qtquick-controls2]
   ubuntu: [qml-module-qtquick-controls2]
 qml-module-qtquick-dialogs:
+  debian: [qml-module-qtquick-dialogs]
   ubuntu: [qml-module-qtquick-dialogs]
 qml-module-qtquick-layouts:
+  debian: [qml-module-qtquick-layouts]
   ubuntu: [qml-module-qtquick-layouts]
 qml-module-qtquick-templates2:
+  debian: [qml-module-qtquick-templates2]
   ubuntu: [qml-module-qtquick-templates2]
 qml-module-qtquick2:
+  debian: [qml-module-qtquick2]
   ubuntu: [qml-module-qtquick2]
 qrencode:
   arch: [qrencode]


### PR DESCRIPTION
Added the QML modules used in the examples for the [qml_ros_plugin](https://github.com/StefanFabian/qml_ros_plugin) and by a currently closed-source robot user interface using QML.

qml-module-qtmultimedia: https://packages.ubuntu.com/bionic/qml-module-qtmultimedia
qml-module-qtquick-controls: https://packages.ubuntu.com/bionic/qml-module-qtquick-controls
qml-module-qtquick-controls2: https://packages.ubuntu.com/bionic/qml-module-qtquick-controls2
qml-module-qtquick-dialogs: https://packages.ubuntu.com/bionic/qml-module-qtquick-dialogs
qml-module-qtquick-layouts: https://packages.ubuntu.com/bionic/qml-module-qtquick-layouts
qml-module-qtquick-templates2: https://packages.ubuntu.com/bionic/qml-module-qtquick-templates2
qml-module-qtquick2: https://packages.ubuntu.com/bionic/qml-module-qtquick2