### PR TITLE
rclcpp_cascade_lifecycle: 0.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1721,6 +1721,24 @@ repositories:
       url: https://github.com/ros2/rclcpp.git
       version: eloquent
     status: maintained
+  rclcpp_cascade_lifecycle:
+    doc:
+      type: git
+      url: https://github.com/fmrico/rclcpp_cascade_lifecycle.git
+      version: master
+    release:
+      packages:
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/fmrico/rclcpp_cascade_lifecycle-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/fmrico/rclcpp_cascade_lifecycle.git
+      version: master
+    status: developed
   rclpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp_cascade_lifecycle` to `0.0.2-1`:

- upstream repository: https://github.com/fmrico/rclcpp_cascade_lifecycle.git
- release repository: https://github.com/fmrico/rclcpp_cascade_lifecycle-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## cascade_lifecycle_msgs

```
* Nodes chained
* Contributors: Francisco Martin Rico
```

## rclcpp_cascade_lifecycle

```
* Adding CI
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Complete functional version
* Nodes chained
* Contributors: Francisco Martin Rico
```
