### PR TITLE
launch_ros: 0.8.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1258,7 +1258,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.8.7-1
+      version: 0.8.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.8-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.7-1`

## launch_ros

```
* Fix LoadComposableNodes action so that loading happens asynchronously. (#131 <https://github.com/ros2/launch_ros/issues/131>)
* Contributors: Jacob Perron
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
