### PR TITLE
laser_geometry: 1.6.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -413,6 +413,15 @@ repositories:
       version: melodic-devel
     status: maintained
   laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/laser_geometry-release.git
+      version: 1.6.5-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.5-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros-gbp/laser_geometry-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## laser_geometry

```
* Bump CMake version to avoid CMP0048
* Update package.xml to schema version 3
* Choose python version based on what ros is using
* Make rostest headers available to projection_test
* Remove unneeded time header - it was breaking windows builds.
* add DLL import/export macro
* export dll on Windows
* rename visibility macro
* windows bringup
* extend CMake install targets
* Add dependency on tf2 for downstream packages
* Update and fix package.xml Eigen dependency
* Export Eigen dependency
* Create LICENSE
* Better use of numpy
* Contributors: Eric Wieser, James Xu, Jochen Sprickerhof, Jon Binney, Jonathan Binney, Scott K Logan, Shane Loretz, Tully Foote, Vincent Rabaud, William Woodall
```
