### PR TITLE
ros2_tracing: 0.2.12-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2352,7 +2352,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 0.2.8-1
+      version: 0.2.12-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `0.2.12-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.2.8-1`

## tracetools_launch

```
* Use imperative mood in constructor docstring.
* Contributors: Christophe Bedard, Steven! Ragnarök
```

## tracetools_test

```
* Use imperative mood in constructor docstring.
* Contributors: Christophe Bedard, Steven! Ragnarök
```
