### PR TITLE
Set dashing ros2_tracing branches to dashing explicitly

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2340,7 +2340,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-      version: master
+      version: dashing
     release:
       packages:
       - ros2trace
@@ -2356,7 +2356,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-      version: master
+      version: dashing
     status: developed
   ros2cli:
     doc:


### PR DESCRIPTION
Follow-up to #24084

I originally made it point to `master`, but now `Ddev` jobs are failing because of various changes. See https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/issues/77