### PR TITLE
Set tracetools_analysis branches to dashing & eloquent explicitly

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3201,7 +3201,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
-      version: master
+      version: dashing
     release:
       packages:
       - ros2trace_analysis
@@ -3213,7 +3213,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
-      version: master
+      version: dashing
     status: developed
   transport_drivers:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2900,7 +2900,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
-      version: master
+      version: eloquent
     release:
       packages:
       - ros2trace_analysis
@@ -2912,7 +2912,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
-      version: master
+      version: eloquent
     status: developed
   turtlesim:
     doc:


### PR DESCRIPTION
I originally made them point to `master`, but now `Ddev` and `Edev` jobs are failing because of various changes. See https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis/-/issues/29