### PR TITLE
urg_node: 0.1.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10987,7 +10987,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.11-0
+      version: 0.1.12-1
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.12-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros-gbp/urg_node-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.11-0`

## urg_node

```
* Updated roslint to only check files in this repo.
* Updated TravisCI config.
* fix(updateStatus): Update status on diagnostics update
  Otherwise the diagnostics information does not really reflect the device
  status.
* synchronize_time: reset when clock is warped
  If either the hardware clock or system clock warp, reset the EMA to
  prevent incorrect clock values from being used. Detect the warp by
  putting a limit on the absolute error between the synchronized clock
  and the system clock. When a warp is detected, reset the EMA to force
  the clocks to resynchronize. Use the system clock until the EMA has
  stabalized again.
* synchronize system clock to hardware time
  Remove jitter from the system clock by synchronizing it to the change
  in hardware time stamps. This does not synchrnoize it in an absolute
  sense (i.e., doesn't remove system latench). However, coupled with
  calibrating system latency, this results in a stable, accurate clock.
* Add Travis config.
* Fixed linter errors.
* Contributors: C. Andy Martin, Rein Appeldoorn, Tony Baltovski
```
