### PR TITLE
dccomms_ros_pkgs: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1895,7 +1895,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/dcentelles/dccomms_ros_pkgs-release.git
-      version: 0.0.2-3
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dccomms_ros_pkgs` to `0.0.3-1`:

- upstream repository: https://github.com/dcentelles/dccomms_ros_pkgs.git
- release repository: https://github.com/dcentelles/dccomms_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.2-3`

## dccomms_ros

- No changes

## dccomms_ros_msgs

- No changes
