### PR TITLE
underwater_simulation: 1.4.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10847,7 +10847,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uji-ros-pkg/underwater_simulation-release.git
-      version: 1.4.2-1
+      version: 1.4.2-2
     source:
       type: git
       url: https://github.com/uji-ros-pkg/underwater_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `underwater_simulation` to `1.4.2-2`:

- upstream repository: https://github.com/uji-ros-pkg/underwater_simulation.git
- release repository: https://github.com/uji-ros-pkg/underwater_simulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.4.2-1`
