### PR TITLE
interactive_markers: use "kinetic-devel", add to noetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5468,7 +5468,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -5477,7 +5477,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   iot_bridge:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3829,7 +3829,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -3839,7 +3839,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   ipr_extern:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -387,6 +387,21 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: hydro-devel
     status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_markers-release.git
+      version: 1.11.4-0
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: kinetic-devel
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Sets the branch for interactive_markers to kinetic-devel
for kinetic and melodic distributions.

Adds interactive_markers to noetic distribution.
