### PR TITLE
Update common_msgs source and doc branches to noetic-devel.

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -135,7 +135,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/common_msgs.git
-      version: jade-devel
+      version: noetic-devel
     release:
       packages:
       - actionlib_msgs
@@ -156,7 +156,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/common_msgs.git
-      version: jade-devel
+      version: noetic-devel
     status: maintained
   control_msgs:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

We've changed the BatteryState.msg, so we need to update the branches.  @tfoote @sloretz FYI.