### PR TITLE
slam_gmapping: 1.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9931,7 +9931,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/slam_gmapping-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.4.1-1`:

- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.4.0-1`

## gmapping

```
* Merge pull request #85 <https://github.com/ros-perception/slam_gmapping/issues/85> from k-okada/install_nodelet
  install slam_gmapping_nodelet
* Merge pull request #87 <https://github.com/ros-perception/slam_gmapping/issues/87> from acxz/patch-1
  remove signals dep
* remove signals dep
  signals is included in boost > 1.70
* install slam_gmapping_nodelet
* Contributors: Kei Okada, Michael Ferguson, acxz
```

## slam_gmapping

- No changes
