### PR TITLE
[Gentoo] Remove dev-python/rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3712,7 +3712,7 @@ python-rosdep:
   freebsd:
     pip:
       packages: [rosdep]
-  gentoo: [dev-python/rosdep]
+  gentoo: [dev-util/rosdep]
   openembedded: [python-rosdep@meta-ros]
   opensuse: [python-rosdep]
   osx:
@@ -3754,7 +3754,7 @@ python-rosdep-modules:
   freebsd:
     pip:
       packages: [rosdep]
-  gentoo: [dev-python/rosdep]
+  gentoo: [dev-util/rosdep]
   openembedded: [python-rosdep@meta-ros]
   opensuse: [python-rosdep]
   osx:


### PR DESCRIPTION
@tfoote Currently, there's a conflict that happens because there's two different rosdep ebuilds. I'm just removing the one the overlay supplies, and going with the upstream (since they tend to be much better about staying up to date than I).

In its current state, it blocks `melodic` from installing. See ros/ros-overlay#966

Signed-off-by: Hunter L. Allen <hunter.allen@ghostrobotics.io>