### PR TITLE
Release roslint 0.12.0-1 to Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -871,6 +871,15 @@ repositories:
       version: master
     status: maintained
   roslint:
+    doc:
+      type: git
+      url: https://github.com/ros/roslint.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/roslint-release.git
+      version: 0.12.0-1
     source:
       type: git
       url: https://github.com/ros/roslint.git


### PR DESCRIPTION
Doing this manually as Bloom flubbed it:

```
==> Checking on GitHub for a fork to make the pull request from...
==> Using this fork to make a pull request from: mikepurvis/rosdistro
==> Cloning mikepurvis/rosdistro...
==> mkdir -p rosdistro
==> git init
Initialized empty Git repository in /tmp/67tqs0mp/rosdistro/.git/
Pull Request Title: roslint: 0.12.0-1 in 'noetic/distribution.yaml' [bloom]
Failed to open pull request: UnicodeEncodeError - 'latin-1' codec can't encode character '\u017b' in position 1376: ordinal not in range(256)
```