### PR TITLE
unique_identifier: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1118,6 +1118,17 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: kinetic-devel
     status: maintained
+  unique_identifier:
+    release:
+      packages:
+      - unique_id
+      - unique_identifier
+      - uuid_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-geographic-info/unique_identifier-release.git
+      version: 1.0.6-1
+    status: maintained
   urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier` to `1.0.6-1`:

- upstream repository: https://github.com/ros-geographic-info/unique_identifier.git
- release repository: https://github.com/ros-geographic-info/unique_identifier-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## unique_id

- No changes

## unique_identifier

- No changes

## uuid_msgs

- No changes
