### PR TITLE
pcl_msgs: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -536,7 +536,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/pcl_msgs.git
-      version: indigo-devel
+      version: noetic-devel
     status: maintained
   pluginlib:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -527,6 +527,11 @@ repositories:
       version: melodic-devel
     status: maintained
   pcl_msgs:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/pcl_msgs-release.git
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `0.3.0-1`:

- upstream repository: https://github.com/ros-perception/pcl_msgs.git
- release repository: https://github.com/ros-gbp/pcl_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
