### PR TITLE
async_comm: 0.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/dpkoch/async_comm-release.git
-      version: 0.1.1-0
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_comm` to `0.2.0-1`:

- upstream repository: https://github.com/dpkoch/async_comm.git
- release repository: https://github.com/dpkoch/async_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.1-0`

## async_comm

```
* Fix for UDP/TCP when loopback is only device with an address
* Added listener interface
* Added custom message handler functionality
* TCPClient class implementing an async tcp client
* Contributors: Daniel Koch, James Jackson, Rein Appeldoorn
```
