### PR TITLE
Revert "ipr_extern: 0.9.0-1 in 'melodic/distribution.yaml' [bloom] (#…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3855,7 +3855,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KITrobotics/ipr_extern-release.git
-      version: 0.9.0-1
+      version: 0.8.8-1
     source:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git


### PR DESCRIPTION
…24055)"

This reverts commit 92394525829652e2e5ce867d5f755fc22f835757.

@destogl FYI, this is failing to build on amd64.  I'm going to revert for now so we can do the Melodic sync, but feel free to look into it and submit another update later.