### PR TITLE
urg_c: 1.0.4000-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3420,6 +3420,22 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: dashing
     status: developed
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_c-release.git
+      version: 1.0.4000-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    status: maintained
   v4l2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.4000-1`:

- upstream repository: https://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros2-gbp/urg_c-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urg_c

```
* migrate ros2 devel (#11 <https://github.com/ros-drivers/urg_c/issues/11>)
* Contributors: Karsten Knese, Brett, Marc-Antoine Testier, Chris Lalancette
```
