### PR TITLE
urg_c: 1.0.4000-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3041,6 +3041,22 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: eloquent
     status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_c-release.git
+      version: 1.0.4000-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    status: maintained
   urg_node_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.4000-1`:

- upstream repository: https://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros2-gbp/urg_c-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urg_c

```
* migrate ros2 devel (#11 <https://github.com/ros-drivers/urg_c/issues/11>)
* Contributors: Karsten Knese, Brett, Marc-Antoine Testier, Chris Lalancette
```
