### PR TITLE
urg_node_msgs: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3452,6 +3452,22 @@ repositories:
       url: https://github.com/ros-drivers/urg_c.git
       version: ros2-devel
     status: maintained
+  urg_node_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node_msgs-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    status: maintained
   v4l2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/ros-drivers/urg_node_msgs.git
- release repository: https://github.com/ros2-gbp/urg_node_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urg_node_msgs

```
* fix package.xml for linter tests (#3 <https://github.com/ros-drivers/urg_node_msgs/issues/3>)
* cmake cleanup (#2 <https://github.com/ros-drivers/urg_node_msgs/issues/2>)
* Moving urg_node_msgs repo to ros-drivers
* Merging repo for pull request
* Minor update to ROS 2 Bouncy
* ros2 ardent compliant
* Updated to use cmake 3.5
* Removed missing packages
* Removed old comments
* Initial commit of urg_node_msgs
  Separated messages from urg_node package to faciliate porting to ros 2.
* Initial commit
* Contributors: Brett, Brett Ponsler, Karsten Knese, Marc Testier, MarcTestier, Tony Baltovski
```
