### PR TITLE
laser_proc: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1030,6 +1030,22 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: eloquent
     status: maintained
+  laser_proc:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_proc-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    status: maintained
   launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `1.0.0-1`:

- upstream repository: https://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros2-gbp/laser_proc-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## laser_proc

```
* export symbols in laser_proc component (#8 <https://github.com/ros-perception/laser_proc/issues/8>)
* Make the laser_proc library shared. (#7 <https://github.com/ros-perception/laser_proc/issues/7>)
* Ros2 devel (#6 <https://github.com/ros-perception/laser_proc/issues/6>)
* Contributors: Chris Lalancette, Karsten Knese, Brett, Gu, Chao Jie, Marc-Antoine Testier
```
