### PR TITLE
ros: 1.15.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -697,7 +697,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.0-1
+      version: 1.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.1-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.15.0-1`

## mk

- No changes

## rosbash

- No changes

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

```
* fix missing rosunit results in Python 3 (#244 <https://github.com/ros/ros/issues/244>)
```
