### PR TITLE
adding python3-pyproj to python rosdep keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5577,6 +5577,12 @@ python3-pyparsing:
   gentoo: [dev-python/pyparsing]
   openembedded: [python3-pyparsing@meta-python]
   ubuntu: [python3-pyparsing]
+python3-pyproj:
+  arch: [python-pyproj]
+  debian: [python3-pyproj]
+  fedora: [python3-pyproj]
+  gentoo: [dev-python/pyproj]
+  ubuntu: [python3-pyproj]
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
   fedora: [python3-qt5-webengine]


### PR DESCRIPTION
Arch: https://www.archlinux.org/packages/community/x86_64/python-pyproj/
Debian: https://packages.debian.org/buster/python3-pyproj
Ubuntu: https://packages.ubuntu.com/focal/python3-pyproj
Fedora: https://koji.fedoraproject.org/koji/rpminfo?rpmID=20764115
Gentoo: https://packages.gentoo.org/packages/dev-python/pyproj