### PR TITLE
Revert "ipr_extern: 0.9.0-1 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5524,7 +5524,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/ipr_extern-release.git
-      version: 0.9.0-1
+      version: 0.8.8-0
     source:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git


### PR DESCRIPTION
Reverts ros/rosdistro#24017

Ticketed upstream: https://github.com/KITrobotics/ipr_extern/issues/6