### PR TITLE
rqt_bag: 0.4.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -943,6 +943,18 @@ repositories:
       version: kinetic-devel
     status: maintained
   rqt_bag:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: master
+    release:
+      packages:
+      - rqt_bag
+      - rqt_bag_plugins
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_bag-release.git
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `0.4.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros-gbp/rqt_bag-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_bag

```
* fix Python 3 exception, wrap filter call in list() (#46 <https://github.com/ros-visualization/rqt_bag/issues/46>)
* add Python 3 conditional dependencies (#44 <https://github.com/ros-visualization/rqt_bag/issues/44>)
* autopep8 (#30 <https://github.com/ros-visualization/rqt_bag/issues/30>)
```

## rqt_bag_plugins

```
* add Python 3 conditional dependencies (#44 <https://github.com/ros-visualization/rqt_bag/issues/44>)
* add cairocffi as the fallback module (#43 <https://github.com/ros-visualization/rqt_bag/issues/43>)
* autopep8 (#30 <https://github.com/ros-visualization/rqt_bag/issues/30>)
```
