### PR TITLE
rqt_nav_view: 0.5.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -997,6 +997,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_msg.git
       version: master
     status: maintained
+  rqt_nav_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_nav_view.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_nav_view-release.git
+      version: 0.5.7-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_nav_view.git
+      version: master
+    status: maintained
   rqt_plot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_nav_view` to `0.5.7-1`:

- upstream repository: https://github.com/ros-visualization/rqt_nav_view.git
- release repository: https://github.com/ros-gbp/rqt_nav_view-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_nav_view

- No changes
