### PR TITLE
rqt_py_console: 0.4.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1042,6 +1042,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_publisher.git
       version: master
     status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_py_console-release.git
+      version: 0.4.8-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: master
+    status: maintained
   rqt_robot_steering:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `0.4.8-1`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros-gbp/rqt_py_console-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_py_console

- No changes
