### PR TITLE
rqt_shell: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1072,6 +1072,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_service_caller.git
       version: master
     status: maintained
+  rqt_shell:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_shell-release.git
+      version: 0.4.9-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: master
+    status: maintained
   rqt_srv:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros-gbp/rqt_shell-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_shell

```
* Fixed syntax error when using a startup script with spyder shell
```
