### PR TITLE
rqt_py_console: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1126,7 +1126,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_py_console-release.git
-      version: 0.4.8-1
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros-gbp/rqt_py_console-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.4.8-1`

## rqt_py_console

```
* use conditional dependencies for Python 3 (#7 <https://github.com/ros-visualization/rqt_py_console/issues/7>)
* bump CMake minimum version to avoid CMP0048 warning
* autopep8 (#2 <https://github.com/ros-visualization/rqt_py_console/issues/2>)
```
