### PR TITLE
rqt_msg: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1061,7 +1061,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_msg-release.git
-      version: 0.4.8-1
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros-gbp/rqt_msg-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.4.8-1`

## rqt_msg

```
* bump CMake minimum version to avoid CMP0048 warning
* add Python 3 conditional dependencies (#6 <https://github.com/ros-visualization/rqt_msg/issues/6>)
* autopep8 (#1 <https://github.com/ros-visualization/rqt_msg/issues/1>)
```
