### PR TITLE
rqt_tf_tree: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1222,6 +1222,11 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_tf_tree-release.git
+      version: 0.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `0.6.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros-gbp/rqt_tf_tree-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_tf_tree

```
* bump CMake minimum version to avoid CMP0048 warning
* remove unused dependencies (#15 <https://github.com/ros-visualization/rqt_tf_tree/issues/15>)
* minor cleanup (#12 <https://github.com/ros-visualization/rqt_tf_tree/issues/12>)
```
