### PR TITLE
rqt_top: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1233,6 +1233,11 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_top.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_top-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_top.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_top` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_top.git
- release repository: https://github.com/ros-gbp/rqt_top-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_top

```
* use conditional dependencies for Python 3 (#7 <https://github.com/ros-visualization/rqt_top/issues/7>)
* bump CMake minimum version to avoid CMP0048 warning
* autopep8 (#5 <https://github.com/ros-visualization/rqt_top/issues/5>)
```
