### PR TITLE
cob_android: 0.1.7-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1569,7 +1569,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_android-release.git
-      version: 0.1.6-1
+      version: 0.1.7-2
     source:
       type: git
       url: https://github.com/ipa320/cob_android.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_android` to `0.1.7-2`:

- upstream repository: https://github.com/ipa320/cob_android.git
- release repository: https://github.com/ipa320/cob_android-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.6-1`

## cob_android

- No changes

## cob_android_msgs

```
* Merge pull request #38 <https://github.com/ipa320/cob_android/issues/38> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_android_resource_server

```
* Merge pull request #39 <https://github.com/ipa320/cob_android/issues/39> from fmessmer/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix pylint errors
* python3 compatibility via 2to3
* Contributors: Felix Messmer, fmessmer
```

## cob_android_script_server

```
* Merge pull request #39 <https://github.com/ipa320/cob_android/issues/39> from fmessmer/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix pylint errors
* python3 compatibility via 2to3
* Contributors: Felix Messmer, fmessmer
```

## cob_android_settings

- No changes
