### PR TITLE
cob_calibration_data: 0.6.14-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1584,7 +1584,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_calibration_data-release.git
-      version: 0.6.13-1
+      version: 0.6.14-1
     source:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_calibration_data` to `0.6.14-1`:

- upstream repository: https://github.com/ipa320/cob_calibration_data.git
- release repository: https://github.com/ipa320/cob_calibration_data-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.13-1`

## cob_calibration_data

```
* Merge pull request #164 <https://github.com/ipa320/cob_calibration_data/issues/164> from fmessmer/remove_cob4-22
  remove cob4-22
* remove cob4-22
* Merge pull request #163 <https://github.com/ipa320/cob_calibration_data/issues/163> from HannesBachter/add_cob4-23
  add cob4-23
* add cob4-23
* Merge pull request #162 <https://github.com/ipa320/cob_calibration_data/issues/162> from fmessmer/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* activate pylint checks from feature branch
* Merge pull request #160 <https://github.com/ipa320/cob_calibration_data/issues/160> from fmessmer/rosenv_after_script
  use rosenv for AFTER_SCRIPT
* use rosenv for AFTER_SCRIPT
* Merge pull request #159 <https://github.com/ipa320/cob_calibration_data/issues/159> from fmessmer/ci_updates
  [travis] ci updates
* sort travis.yml
* rosinstall consistency
* add CATKIN_LINT=pedantic
* update travis.yml
* catkin_lint fixes
* Merge pull request #158 <https://github.com/ipa320/cob_calibration_data/issues/158> from HannesBachter/update_cob4-16
  calibrate head cam
* calibrate head cam
* Contributors: Felix Messmer, fmessmer, hyb
```
