### PR TITLE
cob_command_tools: 0.6.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1228,11 +1228,12 @@ repositories:
       - cob_script_server
       - cob_teleop
       - generic_throttle
+      - scenario_test_tools
       - service_tools
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.15-1
+      version: 0.6.16-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.16-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.15-1`

## cob_command_gui

```
* Merge pull request #270 <https://github.com/ipa320/cob_command_tools/issues/270> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix modules
* fix more pylint errors
* use threading
* python3 compatibility via 2to3
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## cob_command_tools

- No changes

## cob_dashboard

```
* Merge pull request #270 <https://github.com/ipa320/cob_command_tools/issues/270> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix pylint errors
* python3 compatibility via 2to3
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## cob_helper_tools

```
* Merge pull request #270 <https://github.com/ipa320/cob_command_tools/issues/270> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* python3 compatibility via 2to3
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Merge pull request #265 <https://github.com/ipa320/cob_command_tools/issues/265> from HannesBachter/feature/recover_service
  add services to en- and disable auto recover
* add services to en- and disable auto recover
  add services to en- and disable auto recover
* Contributors: Felix Messmer, Loy van Beek, fmessmer, hyb
```

## cob_interactive_teleop

```
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_monitoring

```
* Merge pull request #278 <https://github.com/ipa320/cob_command_tools/issues/278> from fmessmer/fix_net_monitor
  fix int conversion for carrier_changes
* fix int conversion for carrier_changes
* Merge pull request #275 <https://github.com/ipa320/cob_command_tools/issues/275> from fmessmer/refactor_hz_monitor
  refactor hz monitor
* allow min_duration until setting no_messages_anymore
* explicit sleep
* make hz and hzerror mandatory parameters
* refactor hz_monitor
* use format for log strings
* Merge pull request #270 <https://github.com/ipa320/cob_command_tools/issues/270> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix isnumeric
* fix more pylint errors
* fix pylint errors
* python3 compatibility via 2to3
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Merge pull request #268 <https://github.com/ipa320/cob_command_tools/issues/268> from fmessmer/carrier_changes_diag_warn
  diag warn for carrier changes
* diag warn for carrier changes
* Merge pull request #267 <https://github.com/ipa320/cob_command_tools/issues/267> from HannesBachter/fix/network_error_message
  [wlan monitor] print executing user for wlan monitor error message
* print executing user for wlan monitor error message
* Contributors: Felix Messmer, Loy van Beek, fmessmer, hyb
```

## cob_script_server

```
* Merge pull request #280 <https://github.com/ipa320/cob_command_tools/issues/280> from fmessmer/fix/init_urdf_structure
  initialize urdf structure only once during init
* initialize urdf structure only once during init
* Merge pull request #270 <https://github.com/ipa320/cob_command_tools/issues/270> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* Use six to handle input vs raw_input
* cleanup cob_script_server
* fix more pylint errors
* use threading
* fix pylint errors
* python3 compatibility via 2to3
* Merge pull request #273 <https://github.com/ipa320/cob_command_tools/issues/273> from floweisshardt/fix/move_base_without_global_map
  publish move_base goal without global /map
* publish move_base goal without global /map
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Merge pull request #260 <https://github.com/ipa320/cob_command_tools/issues/260> from fmessmer/feature/calculate_traj_point_velocities
  proper traj velocity calculation
* add opt-out stop_at_waypoints
* use logdebug for debug output
* fix trajectory point velocity calculation
* drop start after time calculation
* filter duplicate or close configs in trajectory
* fix array type
* set accelerations to 0.0
* not use min_point_time 0.4
* drop first traj point if close to start_pos
* improve debug output
* remove hardcoded point velocities and accelerations
* add debug output
* epsilon check and elementwise zero-velocity
* proper traj velocity calculation
* Merge pull request #264 <https://github.com/ipa320/cob_command_tools/issues/264> from fmessmer/fix/robot_description_ns
  fix robot_description namespace handling
* fix robot_description namespace handling
* Merge pull request #259 <https://github.com/ipa320/cob_command_tools/issues/259> from LoyVanBeek/feature/faster_sss_trajectories
  Feature/faster sss trajectories
* fix log formatting
* explicit robot_description key
* Move all code to determine the desired velocity to a private method
  Code to determine this got too big to contain all the various branches and edge cases
* Fix undeclared variable
* feature/calculate traj point velocities (#1 <https://github.com/ipa320/cob_command_tools/issues/1>)
  feature/calculate traj point velocities
* fix error case velocities zero or negative
* fixup acc default value
* fixup variable name
* fixup limit_vel and add debug output
* add vel_limit check
* return failure on invalid arguments
* expose arguments to move_rel
* allow to pass default_vel via sss argument
* allow setting default_vel and default_acc per joint as list of float/int via yaml
* Rename d_max to dist
* Optionally use the URDF-derived velocities
* Extend sss.move with a speed_factor to speed up movements
* fixup! Iterate over all joints to calculate_point_time and take the  slowest time for all joints
* Get joint velocity from URDF in compose_trajectory
* Iterate over all joints to calculate_point_time and take the  slowest time for all joints
  Earlier only 1 joint velocity and acceleration was used.
  TOOD: Read velocity (and acceleration?) from URDF
* Explicitly import numpy. This was implicitly imported via at least tf.transformations and possibly others
* Contributors: Felix Messmer, Florian Weisshardt, Loy, Loy van Beek, floweisshardt, fmessmer
```

## cob_teleop

```
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## generic_throttle

```
* Merge pull request #270 <https://github.com/ipa320/cob_command_tools/issues/270> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix more pylint errors
* fix pylint errors
* Merge pull request #271 <https://github.com/ipa320/cob_command_tools/issues/271> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## scenario_test_tools

```
* Merge pull request #277 <https://github.com/ipa320/cob_command_tools/issues/277> from LoyVanBeek/feature/document_move_base
  Document move base
* Sort CMakelist
* Document other scripts
* Give 'always_succeeding_move_base' a shorter name
* Allow to both abort a goal but also send a result with that abort signal
* fixup! Add another example for move_base
* Document example_move_base further
* Add another example for move_base
* make publishing transform configurable
* get params from private ns
* get timeout param
* use node name
* Catch exceptions when replying to show a better error message
* Log how long a eply will wait for a goal
* Set default timeout to None, to match the documentation
* Put move_base a private namespace
* Use the default_reply_delay in other reply-methods as well by default
* Make names for reply_delay and 'think' more consistent
* Make result_delay an optional parameter
* Add more docs for ScriptableActionServer
* Add example move base script
* Merge pull request #274 <https://github.com/ipa320/cob_command_tools/issues/274> from LoyVanBeek/feature/scenario_test_tools
  Add new package for scenario test tools
* Fix formatting issue, passing too many args to str.format
* Make executeables installable
* Add license header to relevant files
* Add new package for scenario test tools
* Contributors: Felix Messmer, Loy van Beek, hyb
```

## service_tools

- No changes
