### PR TITLE
cob_common: 0.7.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1632,7 +1632,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.2-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.1-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

```
* Merge pull request #282 <https://github.com/ipa320/cob_common/issues/282> from fmessmer/torso_no_body
  allow torso without full body
* allow torso without full body
* Merge pull request #278 <https://github.com/ipa320/cob_common/issues/278> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* python3 compatibility via 2to3
* Merge pull request #281 <https://github.com/ipa320/cob_common/issues/281> from ipa-jba/feature/raw-mini
  Feature/raw mini
* nitpick
* add rplidar for gazebo
* Added files for raw-mini
* Merge pull request #277 <https://github.com/ipa320/cob_common/issues/277> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, Jannik Abbenseth, Loy van Beek, flg-vs, fmessmer
```

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

```
* Merge pull request #281 <https://github.com/ipa320/cob_common/issues/281> from ipa-jba/feature/raw-mini
  Feature/raw mini
* nitpick
* remove unneeded values
* add a planar move plugin for raw-mini (no mecanum)
* use updated meshes
* add a mecanum wheel (5cm wide 5cm radius)
* Updated config for raw-mini
* Added files for raw-mini
* Merge pull request #277 <https://github.com/ipa320/cob_common/issues/277> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, Jannik Abbenseth, flg-vs, fmessmer
```
