### PR TITLE
cob_control: 0.7.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1655,6 +1655,7 @@ repositories:
       - cob_footprint_observer
       - cob_frame_tracker
       - cob_hardware_emulation
+      - cob_mecanum_controller
       - cob_model_identifier
       - cob_obstacle_distance
       - cob_omni_drive_controller
@@ -1664,7 +1665,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.9-1
+      version: 0.7.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.10-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.9-1`

## cob_base_controller_utils

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_base_velocity_smoother

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_cartesian_controller

```
* Merge pull request #227 <https://github.com/ipa320/cob_control/issues/227> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility - kinetic
* disable simple_script_server import error
* fix modules
* fix pylint errors
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_collision_velocity_filter

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Merge pull request #223 <https://github.com/ipa320/cob_control/issues/223> from HannesBachter/fix/relevant_obstacle
  [kinetic] fix info of relevant_obstacles message
* publish relevant_obstacles_grid in private namespace
* fix info of relevant_obstacles message
* Contributors: Felix Messmer, fmessmer, hyb
```

## cob_control

```
* Merge pull request #229 <https://github.com/ipa320/cob_control/issues/229> from ipa-jba/feature/raw-mini
  [kinetic] add a mecanum controller
* add mecanum controller to cob_control
* Contributors: Felix Messmer, Jannik Abbenseth
```

## cob_control_mode_adapter

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_control_msgs

- No changes

## cob_footprint_observer

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_frame_tracker

```
* Merge pull request #227 <https://github.com/ipa320/cob_control/issues/227> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility - kinetic
* python3 compatibility via 2to3
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## cob_hardware_emulation

```
* Merge pull request #235 <https://github.com/ipa320/cob_control/issues/235> from fmessmer/kinetic/emulation_clock_cpp
  [kinetic] add emulation_clock publisher - cpp variant
* fix boost timer + use dt_ms
* use boost timer
* configurable emulation dt
* add emulation_clock publisher - cpp variant
* Merge pull request #232 <https://github.com/ipa320/cob_control/issues/232> from fmessmer/emulation_custom_clock
  add emulation_clock publisher
* implement emulation_clock with timer callback
* add emulation_clock publisher
* Merge pull request #227 <https://github.com/ipa320/cob_control/issues/227> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility - kinetic
* fix pylint errors
* python3 compatibility via 2to3
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, Florian Weisshardt, Loy van Beek, fmessmer
```

## cob_mecanum_controller

```
* Merge pull request #229 <https://github.com/ipa320/cob_control/issues/229> from ipa-jba/feature/raw-mini
  [kinetic] add a mecanum controller
* nitpick
* un-c++14ify
* unify version
* use <> for include
* catkin lint problems fixed
* apache license
* add a mecanum controller
* Contributors: Felix Messmer, Jannik Abbenseth, fmessmer
```

## cob_model_identifier

```
* Merge pull request #227 <https://github.com/ipa320/cob_control/issues/227> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility - kinetic
* fix pylint errors
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_obstacle_distance

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_omni_drive_controller

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_trajectory_controller

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_tricycle_controller

```
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_twist_controller

```
* Merge pull request #227 <https://github.com/ipa320/cob_control/issues/227> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility - kinetic
* disable simple_script_server import error
* Use six.moves.input for all uses of raw_input/input
* fix modules
* fix pylint errors
* python3 compatibility via 2to3
* Merge pull request #225 <https://github.com/ipa320/cob_control/issues/225> from fmessmer/ci_updates_kinetic
  [travis] ci updates - kinetic
* catkin_lint fixes
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```
