### PR TITLE
cob_control: 0.8.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1277,6 +1277,7 @@ repositories:
       - cob_footprint_observer
       - cob_frame_tracker
       - cob_hardware_emulation
+      - cob_mecanum_controller
       - cob_model_identifier
       - cob_obstacle_distance
       - cob_omni_drive_controller
@@ -1286,7 +1287,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.1-1
+      version: 0.8.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.10-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.1-1`

## cob_base_controller_utils

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_base_velocity_smoother

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_cartesian_controller

```
* Merge pull request #228 <https://github.com/ipa320/cob_control/issues/228> from fmessmer/feature/python3_compatibility_melodic
  [ci_updates] pylint + Python3 compatibility - melodic
* disable simple_script_server import error
* fix modules
* fix pylint errors
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_collision_velocity_filter

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Merge pull request #224 <https://github.com/ipa320/cob_control/issues/224> from HannesBachter/fix/relevant_obstacle
  [melodic] fix info of relevant_obstacles message
* publish relevant_obstacles_grid in private namespace
* fix info of relevant_obstacles message
* Contributors: Felix Messmer, fmessmer, hyb
```

## cob_control

```
* Merge pull request #230 <https://github.com/ipa320/cob_control/issues/230> from ipa-jba/feature/melodic/raw-mini
  [melodic] add a mecanum controller
* add mecanum controller to cob_control
* Contributors: Felix Messmer, Jannik Abbenseth
```

## cob_control_mode_adapter

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_control_msgs

- No changes

## cob_footprint_observer

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_frame_tracker

```
* Merge pull request #228 <https://github.com/ipa320/cob_control/issues/228> from fmessmer/feature/python3_compatibility_melodic
  [ci_updates] pylint + Python3 compatibility - melodic
* python3 compatibility via 2to3
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## cob_hardware_emulation

```
* Merge pull request #236 <https://github.com/ipa320/cob_control/issues/236> from fmessmer/melodic/emulation_clock_cpp
  [melodic] add emulation_clock publisher - cpp variant
* fix boost timer + use dt_ms
* use boost timer
* configurable emulation dt
* add emulation_clock publisher - cpp variant
* Merge pull request #234 <https://github.com/ipa320/cob_control/issues/234> from fmessmer/emulation_custom_clock_melodic
  [melodic] add emulation_clock publisher
* implement emulation_clock with timer callback
* add emulation_clock publisher
* Merge pull request #228 <https://github.com/ipa320/cob_control/issues/228> from fmessmer/feature/python3_compatibility_melodic
  [ci_updates] pylint + Python3 compatibility - melodic
* fix pylint errors
* python3 compatibility via 2to3
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* remove outdated script
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## cob_mecanum_controller

```
* Merge pull request #230 <https://github.com/ipa320/cob_control/issues/230> from ipa-jba/feature/melodic/raw-mini
  [melodic] add a mecanum controller
* nitpick
* un-c++14ify
* unify version
* use <> for include
* catkin lint problems fixed
* apache license
* add a mecanum controller
* Contributors: Felix Messmer, Jannik Abbenseth, fmessmer
```

## cob_model_identifier

```
* Merge pull request #228 <https://github.com/ipa320/cob_control/issues/228> from fmessmer/feature/python3_compatibility_melodic
  [ci_updates] pylint + Python3 compatibility - melodic
* fix pylint errors
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_obstacle_distance

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_omni_drive_controller

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_trajectory_controller

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_tricycle_controller

```
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_twist_controller

```
* Merge pull request #228 <https://github.com/ipa320/cob_control/issues/228> from fmessmer/feature/python3_compatibility_melodic
  [ci_updates] pylint + Python3 compatibility - melodic
* disable simple_script_server import error
* Use six.moves.input for all uses of raw_input/input
* fix modules
* fix pylint errors
* python3 compatibility via 2to3
* Merge pull request #226 <https://github.com/ipa320/cob_control/issues/226> from fmessmer/ci_updates_melodic
  [travis] ci updates - melodic
* catkin_lint fixes
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```
