### PR TITLE
cob_environments: 0.6.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1719,7 +1719,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_environments-release.git
-      version: 0.6.10-1
+      version: 0.6.11-1
     source:
       type: git
       url: https://github.com/ipa320/cob_environments.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_environments` to `0.6.11-1`:

- upstream repository: https://github.com/ipa320/cob_environments.git
- release repository: https://github.com/ipa320/cob_environments-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.10-1`

## cob_default_env_config

```
* Merge pull request #140 <https://github.com/ipa320/cob_environments/issues/140> from fmessmer/add_launch_checks
  add launch check for mandatory nav config files
* no longer support automotive-assembly-line
* add mandatory files to empty
* add launch check for mandatory nav config files
* Merge pull request #138 <https://github.com/ipa320/cob_environments/issues/138> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_environments

- No changes
