### PR TITLE
cob_extern: 0.6.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1741,7 +1741,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_extern-release.git
-      version: 0.6.14-1
+      version: 0.6.15-1
     source:
       type: git
       url: https://github.com/ipa320/cob_extern.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.15-1`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.14-1`

## cob_extern

- No changes

## libdlib

```
* Merge pull request #106 <https://github.com/ipa320/cob_extern/issues/106> from fmessmer/upgrade_dlib_19.9
  suppress warnings + upgrade dlib 19.9
* adjust -Wno-* for libdlib 19.9
* upgrade dlib version to 19.9
* add -Wno-* CXXFLAGS
* -Wno-* in CONFIGURE_COMMAND
* Merge pull request #102 <https://github.com/ipa320/cob_extern/issues/102> from fmessmer/suppress_warnings
  add -Wno-* compile option to suppress warnings
* add -Wno-* to libdlib
* Contributors: Felix Messmer, fmessmer
```

## libntcan

- No changes

## libpcan

- No changes

## libphidgets

```
* Merge pull request #106 <https://github.com/ipa320/cob_extern/issues/106> from fmessmer/upgrade_dlib_19.9
  suppress warnings + upgrade dlib 19.9
* more -Wno-* for melodic
* Merge pull request #102 <https://github.com/ipa320/cob_extern/issues/102> from fmessmer/suppress_warnings
  add -Wno-* compile option to suppress warnings
* add -Wno-* to libphidgets
* Contributors: Felix Messmer, fmessmer
```

## opengm

- No changes
