### PR TITLE
cob_supported_robots: 0.6.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1545,7 +1545,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.13-1
+      version: 0.6.14-1
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.14-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.13-1`

## cob_supported_robots

```
* Merge pull request #27 <https://github.com/ipa320/cob_supported_robots/issues/27> from fmessmer/remove_cob4-22
  remove cob4-22
* remove cob4-22
* Merge pull request #26 <https://github.com/ipa320/cob_supported_robots/issues/26> from HannesBachter/add_cob4-23
  add cob4-23
* add cob4-23
* Merge pull request #25 <https://github.com/ipa320/cob_supported_robots/issues/25> from fmessmer/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* activate pylint checks from feature branch
* Merge pull request #24 <https://github.com/ipa320/cob_supported_robots/issues/24> from fmessmer/ci_updates
  [travis] ci updates
* sort travis.yml
* add CATKIN_LINT=pedantic
* update travis.yml
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer, hyb
```
