### PR TITLE
cob_gazebo_plugins: 0.7.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1769,7 +1769,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_gazebo_plugins-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.7.4-1`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.3-1`

## cob_gazebo_plugins

- No changes

## cob_gazebo_ros_control

```
* Merge pull request #41 <https://github.com/ipa320/cob_gazebo_plugins/issues/41> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Merge pull request #40 <https://github.com/ipa320/cob_gazebo_plugins/issues/40> from fmessmer/fix_warnings
  fix catkin_package DEPENDS warning
* fix catkin_package DEPENDS warning
* Contributors: Felix Messmer, fmessmer
```
