### PR TITLE
cob_substitute: 0.6.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1530,7 +1530,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.8-1
+      version: 0.6.9-1
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.9-1`:

- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.8-1`

## cob_docker_control

```
* Merge pull request #55 <https://github.com/ipa320/cob_substitute/issues/55> from fmessmer/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* python3 compatibility via 2to3
* Contributors: Felix Messmer, fmessmer
```

## cob_reflector_referencing

- No changes

## cob_safety_controller

```
* Merge pull request #55 <https://github.com/ipa320/cob_substitute/issues/55> from fmessmer/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* python3 compatibility via 2to3
* Contributors: Felix Messmer, fmessmer
```

## cob_substitute

- No changes
