### PR TITLE
cob_hand: 0.6.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1787,7 +1787,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_hand-release.git
-      version: 0.6.6-1
+      version: 0.6.7-1
     source:
       type: git
       url: https://github.com/ipa320/cob_hand.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_hand` to `0.6.7-1`:

- upstream repository: https://github.com/ipa320/cob_hand.git
- release repository: https://github.com/ipa320/cob_hand-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.6-1`

## cob_hand

- No changes

## cob_hand_bridge

```
* Merge pull request #26 <https://github.com/ipa320/cob_hand/issues/26> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Merge pull request #25 <https://github.com/ipa320/cob_hand/issues/25> from fmessmer/suppress_warnings
  add -Wno-* compile option to suppress warnings
* add -Wno compile option to suppress warnings
* Contributors: Felix Messmer, fmessmer
```
