### PR TITLE
freenect_stack: 0.4.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3785,7 +3785,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/freenect_stack.git
-      version: master
+      version: kinetic
     status: maintained
   frontier_exploration:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2878,6 +2878,25 @@ repositories:
       url: https://github.com/frankaemika/franka_ros.git
       version: melodic-devel
     status: developed
+  freenect_stack:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/freenect_stack.git
+      version: master
+    release:
+      packages:
+      - freenect_camera
+      - freenect_launch
+      - freenect_stack
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/freenect_stack-release.git
+      version: 0.4.3-2
+    source:
+      type: git
+      url: https://github.com/ros-drivers/freenect_stack.git
+      version: master
+    status: maintained
   fsrobo_r:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `freenect_stack` to `0.4.3-2`:

- upstream repository: https://github.com/ros-drivers/freenect_stack.git
- release repository: https://github.com/ros-drivers-gbp/freenect_stack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
