### PR TITLE
fix package name for libboost-python

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1707,8 +1707,8 @@ libboost-python:
     disco: [libboost-python1.67.0]
     eoan: [libboost-python1.67.0]
     focal: [libboost-python1.71.0]
-    trusty: [libboost-python-1.54.0]
-    xenial: [libboost-python-1.58.0]
+    trusty: [libboost-python1.54.0]
+    xenial: [libboost-python1.58.0]
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]


### PR DESCRIPTION
Follow-up of https://github.com/ros/rosdistro/pull/23844

xenial: https://packages.ubuntu.com/xenial/libboost-python1.58.0
trusty: 
```
$ rmadison libboost-python1.54.0
 libboost-python1.54.0 | 1.54.0-4ubuntu3   | trusty         | amd64, arm64, armhf, i386, powerpc, ppc64el
```