### PR TITLE
cob_driver: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1325,7 +1325,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.7.1-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.1-1`

## cob_base_drive_chain

- No changes

## cob_bms_driver

- No changes

## cob_camera_sensors

- No changes

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

- No changes

## cob_mimic

```
* Merge pull request #413 <https://github.com/ipa320/cob_driver/issues/413> from fmessmer/remove_mimic_python
  remove cob_mimic python driver
* remove cob_mimic python driver
* Contributors: Felix Messmer, fmessmer
```

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

- No changes

## cob_relayboard

- No changes

## cob_scan_unifier

- No changes

## cob_sick_lms1xx

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## cob_undercarriage_ctrl

- No changes

## cob_utilities

- No changes

## cob_voltage_control

- No changes

## laser_scan_densifier

- No changes
