### PR TITLE
navigation: 1.16.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5648,7 +5648,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.16.5-1
+      version: 1.16.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.16.6-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.16.5-1`

## amcl

- No changes

## base_local_planner

```
* Fix Unknown CMake command check_include_file (navfn & base_local_planner) (#975 <https://github.com/ros-planning/navigation/issues/975>)
* Contributors: Sam Pfeiffer
```

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

- No changes

## dwa_local_planner

- No changes

## fake_localization

- No changes

## global_planner

- No changes

## map_server

- No changes

## move_base

- No changes

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

```
* Fix Unknown CMake command check_include_file (navfn & base_local_planner) (#975 <https://github.com/ros-planning/navigation/issues/975>)
* Contributors: Sam Pfeiffer
```

## navigation

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
