### PR TITLE
Set optris_drivers to maintained, add versions for Melodic and Dashing

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1579,6 +1579,12 @@ repositories:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.4.2-2
+  optris_drivers:
+    doc:
+      type: git
+      url: https://github.com/evocortex/optris_drivers2.git
+      version: master
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9319,6 +9319,7 @@ repositories:
       type: git
       url: https://github.com/evocortex/optris_drivers.git
       version: kinetic-devel
+    status: maintained
   orb_slam2_ros:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6446,6 +6446,12 @@ repositories:
       url: https://github.com/ipab-slmc/optpp_catkin.git
       version: master
     status: maintained
+  optris_drivers:
+    doc:
+      type: git
+      url: https://github.com/evocortex/optris_drivers.git
+      version: master
+    status: maintained
   orb_slam2_ros:
     doc:
       type: git


### PR DESCRIPTION
The package optris_drivers is to be maintained for both Kinetic and Melodic. Furthermore, the package optris_drivers2 is now available for Dashing.