### PR TITLE
geographic_info: 0.5.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -316,6 +316,17 @@ repositories:
       url: https://github.com/ros/genpy.git
       version: kinetic-devel
     status: maintained
+  geographic_info:
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-geographic-info/geographic_info-release.git
+      version: 0.5.5-1
+    status: maintained
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `0.5.5-1`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
