### PR TITLE
rosflight: 1.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12884,7 +12884,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosflight/rosflight-release.git
-      version: 1.0.0-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosflight` to `1.3.0-1`:

- upstream repository: https://github.com/rosflight/rosflight.git
- release repository: https://github.com/rosflight/rosflight-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-1`

## rosflight

```
* Update firmware submodule to v1.3.0
* Battery monitor support
* Changed default port to /dev/ttyACM0 to match Revo
* External attitude correction support
* Throttle "received parameters" error
* Fixes for multiple simulators running simultaneously
* Auxiliary servo/motor command support
* Fix missing dependency to eigen_stl_containers
* Hard fault handling support
* Contributors: BillThePlatypus, Cameron McQuinn, Daniel Koch, Jacob Willis, James Jackson, Parker Lusk, Trey Henrichsen
```

## rosflight_firmware

```
* Update firmware to v1.3.0
* Contributors: BillThePlatypus, Cameron McQuinn, Daniel Koch, Jacob Olson, Jacob Willis, James Jackson, Parker Lusk, Trey Henrichsen
```

## rosflight_msgs

```
* Added BatteryStatus message
* Added AuxCommand message
* Added Error message
* Changed length of values array to 14 in OutputRaw message
* Removed GPS message
* Contributors: BillThePlatypus, Cameron McQuinn, Daniel Koch, Jacob Willis, James Jackson, Trey Henrichsen
```

## rosflight_pkgs

```
* Contributors: Cameron McQuinn, Jacob Willis
```

## rosflight_sim

```
* Fixes for multiple simulators running simultaneously
* Battery monitor support
* Hard fault handling support
* Contributors: BillThePlatypus, Cameron McQuinn, Daniel Koch, Jacob Willis, James Jackson, Parker Lusk, Trey Henrichsen
```

## rosflight_utils

```
* Cleaned up rc_joy node
* Cleaned up mag visualization
* Added attitude visualization
* Contributors: BillThePlatypus, Cameron McQuinn, Daniel Koch, Jacob Willis, James Jackson, Parker Lusk
```
