### PR TITLE
Add gstreamer1.0-rtsp and libgstrtspserver-1.0 packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2414,15 +2414,9 @@ libgstreamer1.0-dev:
 libgstrtspserver-1.0-0:
   debian: [libgstrtspserver-1.0-0]
   ubuntu: [libgstrtspserver-1.0-0]
-libgstrtspserver-1.0-0-dbg:
-  debian: [libgstrtspserver-1.0-0-dbg]
-  ubuntu: [libgstrtspserver-1.0-0-dbg]
 libgstrtspserver-1.0-dev:
   debian: [libgstrtspserver-1.0-dev]
   ubuntu: [libgstrtspserver-1.0-dev]
-libgstrtspserver-1.0-doc:
-  debian: [libgstrtspserver-1.0-doc]
-  ubuntu: [libgstrtspserver-1.0-doc]
 libgtkmm:
   arch: [gtkmm]
   debian: [libgtkmm-2.4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2411,6 +2411,18 @@ libgstreamer1.0-dev:
   fedora: [gstreamer1-devel]
   gentoo: ['media-libs/gstreamer:1.0']
   ubuntu: [libgstreamer1.0-dev]
+libgstrtspserver-1.0-0:
+  debian: [libgstrtspserver-1.0-0]
+  ubuntu: [libgstrtspserver-1.0-0]
+libgstrtspserver-1.0-0-dbg:
+  debian: [libgstrtspserver-1.0-0-dbg]
+  ubuntu: [libgstrtspserver-1.0-0-dbg]
+libgstrtspserver-1.0-dev:
+  debian: [libgstrtspserver-1.0-dev]
+  ubuntu: [libgstrtspserver-1.0-dev]
+libgstrtspserver-1.0-doc:
+  debian: [libgstrtspserver-1.0-doc]
+  ubuntu: [libgstrtspserver-1.0-doc]
 libgtkmm:
   arch: [gtkmm]
   debian: [libgtkmm-2.4-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2413,6 +2413,7 @@ libgstreamer1.0-dev:
   ubuntu: [libgstreamer1.0-dev]
 libgstrtspserver-1.0-0:
   debian: [libgstrtspserver-1.0-0]
+  fedora: [gstreamer1-rtsp-server]
   ubuntu: [libgstrtspserver-1.0-0]
 libgstrtspserver-1.0-dev:
   debian: [libgstrtspserver-1.0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2416,6 +2416,7 @@ libgstrtspserver-1.0-0:
   ubuntu: [libgstrtspserver-1.0-0]
 libgstrtspserver-1.0-dev:
   debian: [libgstrtspserver-1.0-dev]
+  fedora: [gstreamer1-rtsp-server-devel]
   ubuntu: [libgstrtspserver-1.0-dev]
 libgtkmm:
   arch: [gtkmm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1229,6 +1229,9 @@ gstreamer1.0-plugins-ugly:
   fedora: [gstreamer1-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:1.0']
   ubuntu: [gstreamer1.0-plugins-ugly]
+gstreamer1.0-rtsp:
+  debian: [gstreamer1.0-rtsp]
+  ubuntu: [gstreamer1.0-rtsp]
 gstreamer1.0-tools:
   debian: [gstreamer1.0-tools]
   fedora: [gstreamer1]


### PR DESCRIPTION
gstreamer1.0-rtsp:
https://packages.ubuntu.com/bionic/gstreamer1.0-rtsp
https://packages.debian.org/buster/gstreamer1.0-rtsp
(Can't find on fedora, ditto for all below.)

libgstrtspserver-1.0-0:
https://packages.ubuntu.com/bionic/libgstrtspserver-1.0-0
https://packages.debian.org/buster/libgstrtspserver-1.0-0

libgstrtspserver-1.0-0-dbg:
https://packages.ubuntu.com/bionic/libgstrtspserver-1.0-0-dbg
https://packages.debian.org/buster/libgstrtspserver-1.0-0-dbg

libgstrtspserver-1.0-dev:
https://packages.ubuntu.com/bionic/libgstrtspserver-1.0-dev
https://packages.debian.org/buster/libgstrtspserver-1.0-dev

libgstrtspserver-1.0-doc:
https://packages.ubuntu.com/bionic/libgstrtspserver-1.0-doc
https://packages.debian.org/buster/libgstrtspserver-1.0-doc