### PR TITLE
dynamic_reconfigure: 1.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2049,7 +2049,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.6.1-1
+      version: 1.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.6.2-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.6.1-1`

## dynamic_reconfigure

```
* Set right order of SYSTEM/BEFORE options in dynamic_reconfigure-macros.cmake. Fix #150 <https://github.com/ros/dynamic_reconfigure/issues/150> (#151 <https://github.com/ros/dynamic_reconfigure/issues/151>)
* Contributors: Alexander
```
