### PR TITLE
Revert "eigenpy: 2.1.2-1 in 'melodic/distribution.yaml' [bloom] (#241…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2303,7 +2303,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 2.1.2-1
+      version: 1.6.9-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
…09)"

This reverts commit fdfcebc52174615a7e0c9cb7c6c99823ea2358ce.

@wxmerkt FYI, this is causing build failures like http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__moveit_ros_planning_interface__ubuntu_bionic_amd64__binary/33/console