### PR TITLE
dynamic_reconfigure: 1.6.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2049,7 +2049,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.6.2-1
+      version: 1.6.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.6.3-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.6.2-1`

## dynamic_reconfigure

```
* Revert #140 <https://github.com/ros/dynamic_reconfigure/issues/140> (#152 <https://github.com/ros/dynamic_reconfigure/issues/152>)
* Contributors: Michael Carroll
```
