### PR TITLE
ros_comm: 1.15.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -745,7 +745,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.3-1
+      version: 1.15.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.4-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.15.3-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* restrict boost dependencies to components used (#1871 <https://github.com/ros/ros_comm/issues/1871>)
```

## rosbag_storage

```
* restrict boost dependencies to components used (#1871 <https://github.com/ros/ros_comm/issues/1871>)
```

## roscpp

```
* restrict boost dependencies to components used (#1871 <https://github.com/ros/ros_comm/issues/1871>)
```

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* add exception for ConnectionAbortedError (#1908 <https://github.com/ros/ros_comm/issues/1908>)
* fix mac trying to use epoll instead of kqueue (#1907 <https://github.com/ros/ros_comm/issues/1907>)
* fix AttributeError: __exit__ (#1915 <https://github.com/ros/ros_comm/issues/1915>, regression from 1.14.4)
```

## rosservice

- No changes

## rostest

```
* restrict boost dependencies to components used (#1871 <https://github.com/ros/ros_comm/issues/1871>)
```

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

```
* restrict boost dependencies to components used (#1871 <https://github.com/ros/ros_comm/issues/1871>)
```
