### PR TITLE
remote_rosbag_record: 0.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7792,6 +7792,16 @@ repositories:
       type: git
       url: https://github.com/yoshito-n-students/remote_rosbag_record.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/remote_rosbag_record.git
+      version: master
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `remote_rosbag_record` to `0.0.1-1`:

- upstream repository: https://github.com/yoshito-n-students/remote_rosbag_record.git
- release repository: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## remote_rosbag_record

```
* Initial version
* Contributors: Tim Clephas, Yoshito Okada
```
