### PR TITLE
ros_comm: 1.14.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8295,7 +8295,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.14.4-1
+      version: 1.14.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.14.5-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.14.4-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

- No changes

## rosgraph

- No changes

## roslaunch

```
* update test to pass with old and new yaml (#1893 <https://github.com/ros/ros_comm/issues/1893>)
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* add exception for ConnectionAbortedError (#1908 <https://github.com/ros/ros_comm/issues/1908>)
* fix mac trying to use epoll instead of kqueue (#1907 <https://github.com/ros/ros_comm/issues/1907>)
* fix AttributeError: __exit__ (#1915 <https://github.com/ros/ros_comm/issues/1915>)
* fix dictionary changed size during iteration (#1894 <https://github.com/ros/ros_comm/issues/1894>)
```

## rosservice

- No changes

## rostest

```
* increase time limit of advertisetest/publishtest.test to reduce flakyness (#1897 <https://github.com/ros/ros_comm/issues/1897>)
```

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* fix flakyness of transform test (#1890 <https://github.com/ros/ros_comm/issues/1890>)
```

## xmlrpcpp

- No changes
