### PR TITLE
laser_geometry: 1.6.5-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4453,7 +4453,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/laser_geometry-release.git
-      version: 1.6.4-0
+      version: 1.6.5-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4448,7 +4448,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -4457,7 +4457,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   laser_pipeline:
     doc:


### PR DESCRIPTION
Note: laser_geometry is now released into melodic from the kinetic-devel in the source repo. This PR also updates the source and doc branches for laser-geometry from indigo-devel to kinetic-devel