### PR TITLE
Revert "cob_control: 0.8.10-1 in 'melodic/distribution.yaml' [bloom] …

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1278,7 +1278,6 @@ repositories:
       - cob_footprint_observer
       - cob_frame_tracker
       - cob_hardware_emulation
-      - cob_mecanum_controller
       - cob_model_identifier
       - cob_obstacle_distance
       - cob_omni_drive_controller
@@ -1288,7 +1287,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.10-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
…(#24147)"

This reverts commit 5287b527aa3831decf1b34e26f6b8ca354a1307c.

@fmessmer cob_mecanum_controller is [failing to build](http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__cob_mecanum_controller__ubuntu_bionic_amd64__binary/) on the buildfarm, so I'm going to revert this for now.