### PR TITLE
cob_control: 0.7.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1655,6 +1655,7 @@ repositories:
       - cob_footprint_observer
       - cob_frame_tracker
       - cob_hardware_emulation
+      - cob_mecanum_controller
       - cob_model_identifier
       - cob_obstacle_distance
       - cob_omni_drive_controller
@@ -1664,7 +1665,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.9-1
+      version: 0.7.11-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.11-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.9-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

- No changes

## cob_mecanum_controller

```
* Merge pull request #237 <https://github.com/ipa320/cob_control/issues/237> from fmessmer/kinetic/fix_mecanum
  [kinetic] fix eigen in mecanum controller
* fix eigen
* Contributors: Felix Messmer, fmessmer
```

## cob_model_identifier

- No changes

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
