### PR TITLE
cascade_lifecycle: 0.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -294,6 +294,24 @@ repositories:
       url: https://github.com/ros2/cartographer_ros.git
       version: dashing
     status: maintained
+  cascade_lifecycle:
+    doc:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: master
+    release:
+      packages:
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/fmrico/cascade_lifecycle-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: master
+    status: developed
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `0.0.3-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Installing headers and libs
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Add license
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```
