### PR TITLE
yp-spur: 1.18.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11726,7 +11726,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.17.1-1
+      version: 1.18.0-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.18.0-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.17.1-1`

## ypspur

```
* Accumulate packet lost count (#132 <https://github.com/openspur/yp-spur/issues/132>)
* Fix torque offset gear factor (#131 <https://github.com/openspur/yp-spur/issues/131>)
* Fix typo in error message (#130 <https://github.com/openspur/yp-spur/issues/130>)
* Add DEVICE_TIMEOUT parameter and show packet lost error (#129 <https://github.com/openspur/yp-spur/issues/129>)
* Fix --no-yp-protocol mode (#128 <https://github.com/openspur/yp-spur/issues/128>)
* Add option to ping chained devices (#127 <https://github.com/openspur/yp-spur/issues/127>)
* Update assets to v0.0.7 (#126 <https://github.com/openspur/yp-spur/issues/126>)
* Update assets to v0.0.6 (#125 <https://github.com/openspur/yp-spur/issues/125>)
* Migrate changelog format to rst (#124 <https://github.com/openspur/yp-spur/issues/124>)
* Contributors: Atsushi Watanabe
```
