### PR TITLE
rc_common_msgs: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -649,6 +649,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  rc_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_common_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_common_msgs-release.git
+      version: 0.4.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_common_msgs.git
+      version: master
+    status: developed
   rcdiscover:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_common_msgs` to `0.4.1-1`:

- upstream repository: https://github.com/roboception/rc_common_msgs.git
- release repository: https://github.com/roboception-gbp/rc_common_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rc_common_msgs

```
* add CAPACITY_EXCEEDED and CAPACITY_REACHED to ReturnCodeConstants
```
