### PR TITLE
add focal version for some base packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2011,12 +2011,9 @@ libfcl-dev:
   gentoo: [sci-libs/fcl]
   openembedded: [fcl@meta-ros]
   ubuntu:
-    artful: [libfcl-dev]
-    bionic: [libfcl-dev]
+    '*': [libfcl-dev]
     wily: [libfcl-0.5-dev]
     xenial: [libfcl-0.5-dev]
-    yakkety: [libfcl-dev]
-    zesty: [libfcl-dev]
 libffi-dev:
   debian: [libffi-dev]
   fedora: [libffi-devel]
@@ -2352,9 +2349,7 @@ libgsl:
   gentoo: [sci-libs/gsl]
   macports: [gsl]
   ubuntu:
-    artful: [libgsl-dev]
-    bionic: [libgsl-dev]
-    cosmic: [libgsl-dev]
+    '*': [libgsl-dev]
     precise: [libgsl0-dev]
     raring: [libgsl0-dev]
     saucy: [libgsl0-dev]
@@ -2362,8 +2357,6 @@ libgsl:
     utopic: [libgsl0-dev]
     vivid: [libgsl0-dev]
     wily: [libgsl0-dev]
-    xenial: [libgsl-dev]
-    yakkety: [libgsl-dev]
 libgstreamer-plugins-base0.10-0:
   arch: [gstreamer0.10-base-plugins]
   debian:
@@ -3060,8 +3053,7 @@ libpng-dev:
   opensuse: [libpng12-devel]
   slackware: [libpng]
   ubuntu:
-    artful: [libpng-dev]
-    bionic: [libpng-dev]
+    '*': [libpng-dev]
     precise: [libpng12-dev]
     quantal: [libpng12-dev]
     raring: [libpng12-dev]
@@ -3071,8 +3063,6 @@ libpng-dev:
     vivid: [libpng12-dev]
     wily: [libpng12-dev]
     xenial: [libpng12-dev]
-    yakkety: [libpng-dev]
-    zesty: [libpng-dev]
 libpng12-dev:
   arch: [libpng]
   debian: [libpng12-dev]
@@ -4950,6 +4940,7 @@ protobuf:
     artful: [libprotobuf10]
     bionic: [libprotobuf10]
     cosmic: [libprotobuf10]
+    focal: [libprotobuf17]
     precise: [libprotobuf7]
     raring: [libprotobuf7]
     saucy: [libprotobuf7]


### PR DESCRIPTION
Add ubuntu distro `focal` for some base packages:
* libfcl-dev
* libgsl
* libpng-dev
* protobuf