### PR TITLE
kobuki_firmware: 1.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -967,6 +967,17 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_core.git
       version: devel
     status: maintained
+  kobuki_firmware:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_firmware.git
+      version: release/1.2.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/kobuki_firmware-release.git
+      version: 1.2.0-1
+    status: maintained
   kobuki_ftdi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_firmware` to `1.2.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_firmware.git
- release repository: https://github.com/stonier/kobuki_firmware-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## kobuki_firmware

```
* Custom PID gain setting of wheel velocity controlled added
```
