### PR TITLE
cob_robots: 0.7.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1883,7 +1883,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.7.2-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.4-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.2-1`

## cob_bringup

```
* Merge pull request #807 <https://github.com/ipa320/cob_robots/issues/807> from fmessmer/remove_mimic_python
  remove cob_mimic python driver
* remove cob_mimic python driver
* Contributors: Felix Messmer, fmessmer
```

## cob_default_robot_behavior

- No changes

## cob_default_robot_config

- No changes

## cob_hardware_config

- No changes

## cob_moveit_config

- No changes

## cob_robots

- No changes
