### PR TITLE
cob_simulation: 0.7.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1905,7 +1905,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.4-1`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.3-1`

## cob_bringup_sim

```
* Merge pull request #174 <https://github.com/ipa320/cob_simulation/issues/174> from fmessmer/ci_updates
  [travis] ci updates
* fix test dependendies
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo

```
* Merge pull request #175 <https://github.com/ipa320/cob_simulation/issues/175> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix pylint error
* Merge pull request #174 <https://github.com/ipa320/cob_simulation/issues/174> from fmessmer/ci_updates
  [travis] ci updates
* fix test dependendies
* use catkin_install_python
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_objects

```
* Merge pull request #174 <https://github.com/ipa320/cob_simulation/issues/174> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_tools

```
* Merge pull request #175 <https://github.com/ipa320/cob_simulation/issues/175> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix pylint error
* python3 compatibility via 2to3
* Merge pull request #176 <https://github.com/ipa320/cob_simulation/issues/176> from fmessmer/conditional_inorder
  add ROS_DISTRO condition for --inorder
* add ROS_DISTRO condition for --inorder
* Merge pull request #174 <https://github.com/ipa320/cob_simulation/issues/174> from fmessmer/ci_updates
  [travis] ci updates
* use catkin_install_python
* catkin_lint fixes
* Merge pull request #173 <https://github.com/ipa320/cob_simulation/issues/173> from fmessmer/fix_move_initialpose
  improve move initialpose + fix python warnings
* better condition for move_initialpose
* fix python warnings
* fix endless loop
* add retry condition for move_initialpose
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## cob_gazebo_worlds

```
* Merge pull request #175 <https://github.com/ipa320/cob_simulation/issues/175> from LoyVanBeek/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* fix pylint error
* python3 compatibility via 2to3
* Merge pull request #174 <https://github.com/ipa320/cob_simulation/issues/174> from fmessmer/ci_updates
  [travis] ci updates
* fix roslaunch checks
* fix test dependendies
* use catkin_install_python
* catkin_lint fixes
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## cob_simulation

- No changes
