### PR TITLE
cob_navigation: 0.6.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1836,7 +1836,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_navigation-release.git
-      version: 0.6.9-1
+      version: 0.6.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.10-1`:

- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.9-1`

## cob_linear_nav

```
* Merge pull request #110 <https://github.com/ipa320/cob_navigation/issues/110> from HannesBachter/fix/more_output
  more output for linear_nav
* more output for linear_nav
* Merge pull request #111 <https://github.com/ipa320/cob_navigation/issues/111> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer, hyb
```

## cob_map_accessibility_analysis

```
* Merge pull request #113 <https://github.com/ipa320/cob_navigation/issues/113> from fmessmer/feature/python3_compatibility
  [ci_updates] pylint + Python3 compatibility
* disable pylint reporting false positives
* fix pylint errors
* Merge pull request #111 <https://github.com/ipa320/cob_navigation/issues/111> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_mapping_slam

- No changes

## cob_navigation

- No changes

## cob_navigation_config

```
* Merge pull request #114 <https://github.com/ipa320/cob_navigation/issues/114> from HannesBachter/add_cob4-23
  add cob4-23
* add cob4-23
* Contributors: Felix Messmer, hyb
```

## cob_navigation_global

```
* Merge pull request #115 <https://github.com/ipa320/cob_navigation/issues/115> from fmessmer/speedup_roslaunch_checks
  speed-up roslaunch checks
* speed-up roslaunch checks
* Merge pull request #112 <https://github.com/ipa320/cob_navigation/issues/112> from fmessmer/fix_deprecation_warning
  remove pre-hydro parameter static_map
* remove pre-hydro parameter static_map
* Merge pull request #111 <https://github.com/ipa320/cob_navigation/issues/111> from fmessmer/ci_updates
  [travis] ci updates
* catkin_lint fixes
* Contributors: Felix Messmer, fmessmer
```

## cob_navigation_local

```
* Merge pull request #112 <https://github.com/ipa320/cob_navigation/issues/112> from fmessmer/fix_deprecation_warning
  remove pre-hydro parameter static_map
* remove pre-hydro parameter static_map
* Contributors: Felix Messmer, fmessmer
```

## cob_navigation_slam

- No changes
