### PR TITLE
care_o_bot: 0.7.8-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1263,7 +1263,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/care-o-bot-release.git
-      version: 0.6.7-0
+      version: 0.7.8-2
     status: maintained
   carla_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `care_o_bot` to `0.7.8-2`:

- upstream repository: https://github.com/ipa320/care-o-bot.git
- release repository: https://github.com/ipa320/care-o-bot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.7-0`

## care_o_bot

- No changes

## care_o_bot_desktop

- No changes

## care_o_bot_robot

- No changes

## care_o_bot_simulation

- No changes
