### PR TITLE
Add libqglviewer-dev-qt5 rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3195,6 +3195,7 @@ libqd-dev:
   ubuntu: [libqd-dev]
 libqglviewer-dev-qt5:
   debian: [libqglviewer-dev-qt5]
+  fedora: [libQGLViewer-qt5-devel]
   ubuntu: [libqglviewer-dev-qt5]
 libqglviewer-qt4:
   arch: [libqglviewer-qt4]


### PR DESCRIPTION
The Fedora packages interface has really been letting me down lately. I'm not sure what to do about it.

Here are the package sources: https://src.fedoraproject.org/rpms/libQGLViewer
Here is the package as built: https://koji.fedoraproject.org/koji/rpminfo?rpmID=18315919

Follow-up to #24097 