### PR TITLE
cascade_lifecycle: 0.0.3-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -306,7 +306,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/fmrico/cascade_lifecycle-release.git
-      version: 0.0.3-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `0.0.3-2`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.3-1`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Installing headers and libs
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Add license
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```
