### PR TITLE
robot_localization: 3.0.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2216,7 +2216,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.0.3-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `3.0.2-1`
