### PR TITLE
omron_os32c_driver: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6235,7 +6235,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/omron-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ros-drivers/omron.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omron_os32c_driver` to `1.1.0-0`:

- upstream repository: https://github.com/ros-drivers/omron.git
- release repository: https://github.com/ros-drivers-gbp/omron-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.0-0`

## omron_os32c_driver

```
* Feature: invert_scan param to invert the range measurements
* Contributors: Amit Philip, Rein Appeldoorn
```
