### PR TITLE
py_trees_ros: 2.0.11-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1561,7 +1561,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.0.10-1
+      version: 2.0.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.0.11-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.10-1`

## py_trees_ros

```
* [blackboards] log a one-shot warning instead of exceptions when pickle fails, #156 <https://github.com/splintered-reality/py_trees_ros/pull/156>
```
