### PR TITLE
py_trees_ros: 0.5.19-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10507,7 +10507,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 0.5.18-0
+      version: 0.5.19-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.19-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.18-0`

## py_trees_ros

```
* [blackboards] log a one-shot warning instead of exceptions when pickle fails, #157 <https://github.com/splintered-reality/py_trees_ros/pull/157>
```
