### PR TITLE
mrt_cmake_modules: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5527,7 +5527,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.2-1`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.1-1`

## mrt_cmake_modules

```
* Fix PCL findscript, disable precompiling
* added jsoncpp
* Make sure packages search for mrt_cmake_modules in their package config
* Fix resolution of packages in underlaying workspaces
* Mention rosdoc.yaml in package.xml
* Contributors: Fabian Poggenhans, Johannes Beck, Johannes Janosovits
```
