### PR TITLE
lanelet2: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4435,7 +4435,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lanelet2` to `1.0.1-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-1`

## lanelet2

```
* Add changelogs
* Contributors: Fabian Poggenhans
```

## lanelet2_core

```
* Fix build failure if size_t is not unsigned long
* Fix build with boost 1.62
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add geometry function to compute curvature from three points
  Add tests, cleanup the validator that uses it
* Add changelogs
* Format files
* Fix clang-tidy warnings
* Contributors: Fabian Poggenhans
```

## lanelet2_examples

```
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add changelogs
* Contributors: Fabian Poggenhans
```

## lanelet2_io

```
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add changelogs
* Improve warning if wrong decimal symbol is set, also report it when loading
* Contributors: Fabian Poggenhans
```

## lanelet2_maps

```
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add changelogs
* Contributors: Fabian Poggenhans
```

## lanelet2_projection

```
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add changelogs
* Contributors: Fabian Poggenhans
```

## lanelet2_python

```
* Fix python bindings for lanelet submap
* lanelet2_python: Register constructor for SpeedLimits
* Register more geometry functions (#96, #97)
* Register Lanelet::resetCache in python
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Contributors: Fabian Poggenhans
```

## lanelet2_routing

```
* Mention laneletSubmap in README
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add changelogs
* Fix clang-tidy warnings
* Contributors: Fabian Poggenhans
```

## lanelet2_traffic_rules

```
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add changelogs
* Contributors: Fabian Poggenhans
```

## lanelet2_validation

```
* Make sure lanelet2 buildtool_export_depends on mrt_cmake_modules
* Add geometry function to compute curvature from three points
  Add tests, cleanup the validator that uses it
* Add changelogs
* Format files
* Contributors: Fabian Poggenhans
```
