### PR TITLE
urg_node: 1.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3075,6 +3075,22 @@ repositories:
       url: https://github.com/ros-drivers/urg_c.git
       version: ros2-devel
     status: maintained
+  urg_node:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    status: maintained
   urg_node_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `1.0.0-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros2-gbp/urg_node-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urg_node

```
* migrate ros2 devel (#50 <https://github.com/ros-drivers/urg_node/issues/50>)
* Merge pull request #42 <https://github.com/ros-drivers/urg_node/issues/42> from BadgerTechnologies/detect-time-warp-and-reset
* synchronize_time: reset when clock is warped
* Merge pull request #41 <https://github.com/ros-drivers/urg_node/issues/41> from BadgerTechnologies/synchronize-time
* synchronize system clock to hardware time
* Add Travis config.
* Fixed linter errors.
* Contributors: Aarush Gupta, aswinthomas, Brett, C. Andy Martin, Chris Lalancette, Gu Chao Jie, Karsten Knese, Marc-Antoine Testier, Tony Baltovski, Zoe
```
