### PR TITLE
remote_rosbag_record: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7841,7 +7841,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/remote_rosbag_record.git


### PR DESCRIPTION
Increasing version of package(s) in repository `remote_rosbag_record` to `0.0.2-1`:

- upstream repository: https://github.com/yoshito-n-students/remote_rosbag_record.git
- release repository: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.1-1`

## remote_rosbag_record

```
* call() returns number of successfull service calls
* Add joy_listener node that calls start/stop services according to joystick input
```
