### PR TITLE
flexbe: 1.2.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2770,7 +2770,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.2.3-1
+      version: 1.2.4-1
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.2.4-1`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.3-1`

## flexbe_behavior_engine

- No changes

## flexbe_core

```
* [flexbe_core] Add tests for proxies
* [flexbe_core] Several minor improvements of proxies
  (see #114 <https://github.com/team-vigir/flexbe_behavior_engine/issues/114>)
* [flexbe_msgs] [flexbe_core] Add debug level to logger
  (see #101 <https://github.com/team-vigir/flexbe_behavior_engine/issues/101>)
* Merge pull request #110 <https://github.com/team-vigir/flexbe_behavior_engine/issues/110> from team-vigir/fix/catkin_install
  Let behavior library find sourcecode in devel or install spaces
* Let behavior library find sourcecode in devel or install spaces
  (fix #104 <https://github.com/team-vigir/flexbe_behavior_engine/issues/104>)
* [flexbe_core] Fix reset of requested outcome when re-visiting the same state and immediately requesting an outcome
* [flexbe_core] Fix duplicate sleep in case of state machine inside concurrency
* [flexbe_core] Robustify priority container path handling
* Do not trigger on_resume and on_exit when stopped during pause
  (see #103 <https://github.com/team-vigir/flexbe_behavior_engine/issues/103>)
* Remove mistakenly added text
* Merge branch 'fmessmer-feature/python3_compatibility' into develop
* Remove explicit list construction where not required
* Remove redundant type check
* python3 compatibility via 2to3
* Contributors: Philipp Schillinger, fmessmer
```

## flexbe_input

```
* Merge branch 'fmessmer-feature/python3_compatibility' into develop
* use six.moves for Queue
* python3 compatibility via 2to3
* Contributors: Philipp Schillinger, fmessmer
```

## flexbe_mirror

```
* Merge branch 'fmessmer-feature/python3_compatibility' into develop
* python3 compatibility via 2to3
* Contributors: Philipp Schillinger, fmessmer
```

## flexbe_msgs

```
* [flexbe_msgs] [flexbe_core] Add debug level to logger
  (see #101 <https://github.com/team-vigir/flexbe_behavior_engine/issues/101>)
* Contributors: Philipp Schillinger
```

## flexbe_onboard

```
* Merge pull request #110 <https://github.com/team-vigir/flexbe_behavior_engine/issues/110> from team-vigir/fix/catkin_install
  Let behavior library find sourcecode in devel or install spaces
* Let behavior library find sourcecode in devel or install spaces
  (fix #104 <https://github.com/team-vigir/flexbe_behavior_engine/issues/104>)
* Merge branch 'fmessmer-feature/python3_compatibility' into develop
* python3 compatibility via 2to3
* Contributors: Philipp Schillinger, fmessmer
```

## flexbe_states

```
* Merge branch 'fmessmer-feature/python3_compatibility' into develop
* python3 compatibility via 2to3
* Contributors: Philipp Schillinger, fmessmer
```

## flexbe_testing

```
* Merge pull request #109 <https://github.com/team-vigir/flexbe_behavior_engine/issues/109> from Achllle/feature/testing/timeout_parameter
  Expose time-limit parameter from rostest
* Merge pull request #108 <https://github.com/team-vigir/flexbe_behavior_engine/issues/108> from Achllle/fix/test_bagfile_topic
  Retry reading bag file messages without backslash in unit tests
* Expose time-limit parameter from rostest
* Ignore topic backslash when no messages are found that way
* Merge branch 'fmessmer-feature/python3_compatibility' into develop
* Remove explicit list construction where not required
* python3 compatibility via 2to3
* Contributors: Achille, Philipp Schillinger, fmessmer
```

## flexbe_widget

```
* Merge pull request #110 <https://github.com/team-vigir/flexbe_behavior_engine/issues/110> from team-vigir/fix/catkin_install
  Let behavior library find sourcecode in devel or install spaces
* Let behavior library find sourcecode in devel or install spaces
  (fix #104 <https://github.com/team-vigir/flexbe_behavior_engine/issues/104>)
* Contributors: Philipp Schillinger
```
