### PR TITLE
rr_openrover_stack: 0.8.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13886,6 +13886,10 @@ repositories:
     status: developed
     status_description: pre-release-version
   rr_openrover_stack:
+    doc:
+      type: git
+      url: https://github.com/RoverRobotics/rr_openrover_stack.git
+      version: kinetic-devel
     release:
       packages:
       - rr_control_input_manager
@@ -13893,10 +13897,15 @@ repositories:
       - rr_openrover_driver
       - rr_openrover_driver_msgs
       - rr_openrover_stack
+      - rr_rover_zero_driver
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
-      version: 0.7.4-1
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/RoverRobotics/rr_openrover_stack.git
+      version: kinetic-devel
     status: maintained
   rr_swiftnav_piksi:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_stack` to `0.8.0-1`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_stack.git
- release repository: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.7.4-1`

## rr_control_input_manager

- No changes

## rr_openrover_description

- No changes

## rr_openrover_driver

- No changes

## rr_openrover_driver_msgs

- No changes

## rr_openrover_stack

- No changes

## rr_rover_zero_driver

```
* Added rr_rover_zero_driver
```
