### PR TITLE
Add trang

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5651,6 +5651,8 @@ trang:
   debian: [trang]
   fedora: [trang]
   gentoo: [trang]
+  rhel:
+    '7': [trang]
   ubuntu: [trang]
 tree:
   debian: [tree]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5647,6 +5647,11 @@ tmux:
   fedora: [tmux]
   gentoo: [app-misc/tmux]
   ubuntu: [tmux]
+trang:
+  debian: [trang]
+  fedora: [trang]
+  gentoo: [trang]
+  ubuntu: [trang]
 tree:
   debian: [tree]
   fedora: [tree]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5650,7 +5650,7 @@ tmux:
 trang:
   debian: [trang]
   fedora: [trang]
-  gentoo: [trang]
+  gentoo: [app-text/trang]
   rhel:
     '7': [trang]
   ubuntu: [trang]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -663,6 +663,10 @@ tinyxml2:
   osx:
     homebrew:
       packages: [tinyxml2]
+trang:
+  osx:
+    homebrew:
+      packages: [jing-trang]
 unzip:
   osx:
     homebrew:


### PR DESCRIPTION
CycloneDDS uses Trang to transpile its config XML schema from rnc to xsd.

https://packages.ubuntu.com/search?keywords=trang&searchon=names&suite=all&section=all
https://formulae.brew.sh/formula/jing-trang#default
https://apps.fedoraproject.org/packages/s/trang
https://packages.gentoo.org/packages/app-text/trang
https://packages.debian.org/search?keywords=trang&searchon=names&suite=buster&section=all