### PR TITLE
marti_common: 2.12.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4905,7 +4905,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.12.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.11.0-1`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Add Enum Support to DynamicParameters (#564 <https://github.com/swri-robotics/marti_common/issues/564>)
* Use safe_execute_process to generate messages instead and prevent it from running every build (#563 <https://github.com/swri-robotics/marti_common/issues/563>)
* Contributors: Matthew Bries
```

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Suppress auto_ptr warnings (#570 <https://github.com/swri-robotics/marti_common/issues/570>)
* Contributors: P. J. Reed
```

## swri_yaml_util

```
* Suppress auto_ptr warnings (#570 <https://github.com/swri-robotics/marti_common/issues/570>)
* Contributors: P. J. Reed
```
