### PR TITLE
jderobot_assets: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5632,7 +5632,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 0.1.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5636,7 +5636,7 @@ repositories:
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git
-      version: kinetic-devel
+      version: master
     status: developed
   jderobot_drones:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `1.0.1-1`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.0-1`

## jderobot_assets

```
* Fix build fail in Debian stretch for ros melodic
* fix double scene tag simple_circuit
* remove catkin deps
* fix car material and circuit lights
* Contributors: Francisco Perez, Nikhil Khedekar, Ojit
```
