### PR TITLE
jderobot_assets: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3991,7 +3991,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `1.0.1-1`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-1`

## jderobot_assets

```
* Fix build fail in Debian stretch for ros melodic
* fix double scene tag simple_circuit
* remove catkin deps
* fix car material and circuit lights
* Contributors: Francisco Perez, Nikhil Khedekar, Ojit
```
