### PR TITLE
cascade_lifecycle: 0.0.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -306,7 +306,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/fmrico/cascade_lifecycle-release.git
-      version: 0.0.3-2
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `0.0.5-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.3-2`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Fix shared_ptr ambiguous error
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```
