### PR TITLE
ros2_planning_system: 0.0.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2038,7 +2038,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `0.0.7-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.6-1`

## plansys2_bringup

```
* Fix warning in last cmake versions
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_domain_expert

```
* Fix warning in last cmake versions
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_executor

```
* ActionExecutorClient is cascade_lifecycle
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```

## plansys2_lifecycle_manager

```
* Fix warning in last cmake versions
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_msgs

- No changes

## plansys2_pddl_parser

```
* Fix warning in last cmake versions
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_planner

```
* Fix warning in last cmake versions
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_problem_expert

```
* Fix warning in last cmake versions
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```

## plansys2_terminal

```
* Fix warning in last cmake versions
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Fix spaces in command line
  Signed-off-by: Francisco Martin Rico <mailto:fmrico@gmail.com>
* Contributors: Francisco Martin Rico
```
