### PR TITLE
Add key for python filterpy library (pip)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1487,6 +1487,19 @@ python-fcn-pip:
     pip:
       depends: [liblapack-dev]
       packages: [fcn]
+python-filterpy-pip:
+  debian:
+    pip:
+      packages: [filterpy]
+  fedora:
+    pip:
+      packages: [filterpy]
+  osx:
+    pip:
+      packages: [filterpy]
+  ubuntu:
+    pip:
+      packages: [filterpy]
 python-fixtures:
   debian: [python-fixtures]
   fedora: [python-fixtures]
@@ -5271,6 +5284,19 @@ python3-empy:
   openembedded: [python3-empy@meta-ros]
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
+python3-filterpy-pip:
+  debian:
+    pip:
+      packages: [filterpy]
+  fedora:
+    pip:
+      packages: [filterpy]
+  osx:
+    pip:
+      packages: [filterpy]
+  ubuntu:
+    pip:
+      packages: [filterpy]
 python3-flake8:
   debian:
     buster: [python3-flake8]


### PR DESCRIPTION
https://pypi.org/project/filterpy/
The library implements Kalman filters and other optimal and non-optimal estimation filters in Python.
Such filters are often used to track objects in space through time and help to estimate/infer hidden (unobservable) parameters (e.g. often position of an object is observed, but its velocity is not)