### PR TITLE
control_toolbox: 1.18.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -173,6 +173,20 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: kinetic-devel
     status: maintained
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 1.18.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: melodic-devel
   diagnostics:
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.18.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## control_toolbox

```
* Bump CMake version to avoid CMP0048 warning
* add static method to generate non-deterministic seed
* migrate to STL random library
* Contributors: James Xu, Shane Loretz, ahcorde
```
