### PR TITLE
panda_moveit_config: 0.7.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6626,7 +6626,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/panda_moveit_config-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ros-planning/panda_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.4-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.3-1`

## panda_moveit_config

```
* [fix] Add time parameterization in stomp_planning_pipeline.launch (#59 <https://github.com/ros-planning/panda_moveit_config/issues/59>)
* [fix] add joint_state_publisher_gui to package.xml (#54 <https://github.com/ros-planning/panda_moveit_config/issues/54>)
* [fix] Add static transform publisher (#51 <https://github.com/ros-planning/panda_moveit_config/issues/51>)
* [maintanence] demo_chomp.launch: reuse demo.launch (#57 <https://github.com/ros-planning/panda_moveit_config/issues/57>)
* [maintanence] Define 'extended' state for 'panda_arm' group (#47 <https://github.com/ros-planning/panda_moveit_config/issues/47>)
* Contributors: Mike Lautman, Robert Haschke, Sebastian Wallkötter, jsbyysheng
```
