### PR TITLE
agni_tf_tools: 0.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -147,6 +147,7 @@ repositories:
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
       version: 0.1.3-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git
       version: master

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -145,7 +145,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/ubi-agni/agni_tf_tools.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -146,6 +146,10 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
       version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: master
     status: maintained
   agvs_common:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -146,10 +146,6 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
       version: 0.1.3-1
-    source:
-      type: git
-      url: https://github.com/ubi-agni/agni_tf_tools.git
-      version: master
     status: maintained
   agvs_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `agni_tf_tools` to `0.1.3-1`:

- upstream repository: https://github.com/ubi-agni/agni_tf_tools.git
- release repository: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.2-1`

## agni_tf_tools

```
* remove superfluous marker_node_
* avoid spurious tf messages when display was saved in disabled state
* Contributors: Robert Haschke
```
