### PR TITLE
rosflight: 1.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12904,7 +12904,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/rosflight/rosflight-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosflight` to `1.3.1-1`:

- upstream repository: https://github.com/rosflight/rosflight.git
- release repository: https://github.com/rosflight/rosflight-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.3.0-1`

## rosflight

- No changes

## rosflight_firmware

```
* Hotfix for buildfarm failure with git version commands
* Contributors: Daniel Koch
```

## rosflight_msgs

- No changes

## rosflight_pkgs

- No changes

## rosflight_sim

- No changes

## rosflight_utils

- No changes
