### PR TITLE
aws_common: 2.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -845,7 +845,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/aws_common-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/utils-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_common` to `2.2.0-1`:

- upstream repository: https://github.com/aws-robotics/utils-common.git
- release repository: https://github.com/aws-gbp/aws_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.1.0-1`

## aws_common

```
* Update package.xml
  https://github.com/aws-robotics/utils-common/pull/52 adds a new feature for expanding file paths
* Fix linting issues found by clang-tidy 6.0 (#53 <https://github.com/aws-robotics/utils-common/issues/53>)
  * fix linter errors
  * fix more linter errors
  * add linter exceptions
  * address PR comments
* Add wordexp_ros wrapper for wordexp, allowing ROS-aware path expansion
* Add buildtool dependency on ament_cmake_gtest/gmock
* Update DefineTestMacros.cmake
* Add NoRetryStrategy (#38 <https://github.com/aws-robotics/utils-common/issues/38>)
  * ROS-2222: Add Configuration For Retry Strategy
  cr https://code.amazon.com/reviews/CR-10006070
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * Don't allow max_retries to override strategy
  cr https://code.amazon.com/reviews/CR-10283519
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * cleanup NoRetryStrategy
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * increment minor version
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Fix ament macro call in DefineTestMacros.cmake (#35 <https://github.com/aws-robotics/utils-common/issues/35>)
  * Fix ament macro call in DefineTestMacros.cmake
  * Disallow Travis build failures for dashing
* Add macro for ros1/2 finding gtest and gmock (#30 <https://github.com/aws-robotics/utils-common/issues/30>)
  * Add macro for ros1/2 finding gtest and gmock
  The macro find_common_test_packages will use ament or catkin to link to gtest and gmock libraries.
  **Note:** You must add dependencies on gtest and gmock in the package.xml still
  * remove linkage against redundant library
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml to be compatible with specifying multiple package names
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * update travis.yml test matrix
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
  * make catkin a buildtool_depend
  Signed-off-by: Miaofei <mailto:miaofei@amazon.com>
* Contributors: AAlon, Avishay Alon, M. M, Miaofei Mei, Ross Desmond, Ryan Newell
```
