### PR TITLE
cloudwatch_common: 1.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1110,7 +1110,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.1.3-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.1.2-1`

## cloudwatch_logs_common

```
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Miaofei Mei, Nick Burek, Ragha Prasad
```

## cloudwatch_metrics_common

```
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Add support for Cloudwatch MetricDatum StatisticSet (#48 <https://github.com/aws-robotics/cloudwatch-common/issues/48>)
  * add support for cloudwatch metrics' StatisticSet
  * add test for metricObjectToDatum()
  * address PR comments
  * take into consideration that MetricDatum's Value and StatisticValues are mutually exclusive
  * add docstring to MetricObject constructors
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Miaofei Mei, Nick Burek, Ragha Prasad
```

## dataflow_lite

```
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Miaofei Mei, Nick Burek, Ragha Prasad
```

## file_management

```
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Fixes a bug where we did not null check the result of getting the HOM… (#43 <https://github.com/aws-robotics/cloudwatch-common/issues/43>)
  Fixes a bug where we did not null check the result of getting the HOME env variable and also switches to create_directories instead of create_directory so that it doesn't SIGABRT when asked to create multiple levels of a directory.
* Contributors: Miaofei Mei, Nick Burek, Ragha Prasad
```
