### PR TITLE
Add a rosdep rule for libopenal-soft

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2826,6 +2826,12 @@ libopal-dev:
   fedora: [opal-devel]
   gentoo: [net-libs/opal]
   ubuntu: [libopal-dev]
+libopenal-dev:
+  arch: [openal]
+  debian: [libopenal-dev]
+  fedora: [openal-soft]
+  gentoo: [media-libs/openal]
+  ubuntu: [libopenal-dev]
 libopenblas-dev:
   debian: [libopenblas-dev]
   fedora: [openblas-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2829,7 +2829,7 @@ libopal-dev:
 libopenal-dev:
   arch: [openal]
   debian: [libopenal-dev]
-  fedora: [openal-soft]
+  fedora: [openal-soft-devel]
   gentoo: [media-libs/openal]
   ubuntu: [libopenal-dev]
 libopenblas-dev:


### PR DESCRIPTION
add libopenal-soft rule for arch, debian, fedora, gentoo and ubuntu.
- arch: https://www.archlinux.org/packages/extra/x86_64/openal/
- debian: https://packages.debian.org/ja/sid/libopenal-dev
- fedora: https://apps.fedoraproject.org/packages/openal-soft
- gentoo: https://packages.gentoo.org/packages/media-libs/openal
- ubuntu: https://packages.ubuntu.com/ja/xenial/libopenal-dev

This library is for playing spatial audio, and I am developing a ROS interface to it.