### PR TITLE
sparse_bundle_adjustment: 0.3.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14807,7 +14807,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 0.3.2-0
+      version: 0.3.3-1
     status: maintained
   spatio_temporal_voxel_layer:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sparse_bundle_adjustment` to `0.3.3-1`:

- upstream repository: https://github.com/ros-perception/sparse_bundle_adjustment.git
- release repository: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.2-0`

## sparse_bundle_adjustment

```
* fix unitialized variable causing crashes (#10 <https://github.com/ros-perception/sparse_bundle_adjustment/issues/10>)
* Update email address so I see build failures
* Merge pull request #2 <https://github.com/ros-perception/sparse_bundle_adjustment/issues/2> from ros-perception/maintainer-add
* Adding myself as a maintainer for sparse_bundle_adjustment
* Contributors: Luc Bettaieb, Michael Ferguson
```
