### PR TITLE
octomap: 1.9.5-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -543,7 +543,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.5-1
+      version: 1.9.5-2
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git


### PR DESCRIPTION
**This release fixes the build failures on Debian with multi-arch support**

Increasing version of package(s) in repository `octomap` to `1.9.5-2`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.9.5-1`
