### PR TITLE
xacro: 1.14.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1436,6 +1436,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 1.14.1-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.1-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## xacro

```
* [feature]     allow optional xacro includes (#234 <https://github.com/ros/xacro/issues/234>)
* [maintanence] Use setuptools instead of distutils (#233 <https://github.com/ros/xacro/issues/233>)
* [maintanence] fix Travis: export correct ROS_PYTHON_VERSION
* Contributors: Alejandro Hernández Cordero, Robert Haschke
```
