### PR TITLE
rviz: 1.13.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9747,7 +9747,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.7-1
+      version: 1.13.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.8-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.13.7-1`

## rviz

```
* [feature]     Forward focus in PropertyTree to value field (#1480 <https://github.com/ros-visualization/rviz/issues/1480>)
* [feature]     Smooth meshes for sphere, cylinder, and cone (#1463 <https://github.com/ros-visualization/rviz/issues/1463>)
* [fix]         Handle invalid floats in points of arrow marker (#1471 <https://github.com/ros-visualization/rviz/issues/1471>)
* [fix]         Catch exceptions when creating publishers in tools (#1467 <https://github.com/ros-visualization/rviz/issues/1467>)
* [maintanence] Modernize setup.py and cmake  (#1481 <https://github.com/ros-visualization/rviz/issues/1481>)
* [maintanence] Switch libogre-dev to build_depend (#1482 <https://github.com/ros-visualization/rviz/issues/1482>)
* Contributors: Alejandro Hernández Cordero, Michael Görner, Robert Haschke, Simon Schmeisser, Wolfgang Merkt
```
