### PR TITLE
mcl_3dl: 0.2.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7165,7 +7165,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.2.2-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.2.1-1`

## mcl_3dl

```
* Make average number of accumulated clouds accurate (#293 <https://github.com/at-wat/mcl_3dl/issues/293>)
* Fix latching flag in demo bag (#294 <https://github.com/at-wat/mcl_3dl/issues/294>)
* Fix cloud accumulation logic (#290 <https://github.com/at-wat/mcl_3dl/issues/290>)
* Contributors: Atsushi Watanabe
```
