### PR TITLE
Adding omt_coscan index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11909,6 +11909,12 @@ repositories:
       url: https://github.com/stonier/zeroconf_msgs.git
       version: indigo
     status: maintained
+  omt_coscan:
+    source:
+      type: git
+      url: https://github.com/siyandong/CoScan.git
+      version: master
+    status: maintained
   zivid_camera:
     doc:
       type: git


### PR DESCRIPTION
I'd like omt_coscan indexed and documented on ros.org.