### PR TITLE
Added python3-requests to bionic

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3709,7 +3709,6 @@ python-requests:
       packages: [requests]
   ubuntu:
     '*': [python-requests]
-    bionic_python3: [python3-requests]
     trusty_python3: [python3-requests]
     utopic_python3: [python3-requests]
     vivid_python3: [python3-requests]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5706,6 +5706,9 @@ python3-rafcon-pip:
   ubuntu:
     pip:
       packages: [rafcon]
+python3-requests:
+  ubuntu:
+    bionic: [python3-requests]
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3709,14 +3709,6 @@ python-requests:
       packages: [requests]
   ubuntu:
     '*': [python-requests]
-    bionic_python3: [python3-requests]
-    trusty_python3: [python3-requests]
-    utopic_python3: [python3-requests]
-    vivid_python3: [python3-requests]
-    wily_python3: [python3-requests]
-    xenial_python3: [python3-requests]
-    yakkety_python3: [python3-requests]
-    zesty_python3: [python3-requests]
 python-requests-oauthlib:
   debian: [python-requests-oauthlib]
   fedora: [python-requests-oauthlib]
@@ -5706,6 +5698,16 @@ python3-rafcon-pip:
   ubuntu:
     pip:
       packages: [rafcon]
+python3-requests:
+  ubuntu:
+    bionic: [python3-requests]
+    trusty: [python3-requests]
+    utopic: [python3-requests]
+    vivid: [python3-requests]
+    wily: [python3-requests]
+    xenial: [python3-requests]
+    yakkety: [python3-requests]
+    zesty: [python3-requests]
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3709,6 +3709,14 @@ python-requests:
       packages: [requests]
   ubuntu:
     '*': [python-requests]
+    bionic_python3: [python3-requests]
+    trusty_python3: [python3-requests]
+    utopic_python3: [python3-requests]
+    vivid_python3: [python3-requests]
+    wily_python3: [python3-requests]
+    xenial_python3: [python3-requests]
+    yakkety_python3: [python3-requests]
+    zesty_python3: [python3-requests]
 python-requests-oauthlib:
   debian: [python-requests-oauthlib]
   fedora: [python-requests-oauthlib]
@@ -5698,16 +5706,6 @@ python3-rafcon-pip:
   ubuntu:
     pip:
       packages: [rafcon]
-python3-requests:
-  ubuntu:
-    bionic: [python3-requests]
-    trusty: [python3-requests]
-    utopic: [python3-requests]
-    vivid: [python3-requests]
-    wily: [python3-requests]
-    xenial: [python3-requests]
-    yakkety: [python3-requests]
-    zesty: [python3-requests]
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3709,6 +3709,7 @@ python-requests:
       packages: [requests]
   ubuntu:
     '*': [python-requests]
+    bionic_python3: [python3-requests]
     trusty_python3: [python3-requests]
     utopic_python3: [python3-requests]
     vivid_python3: [python3-requests]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5706,8 +5706,9 @@ python3-rafcon-pip:
     pip:
       packages: [rafcon]
 python3-requests:
-  ubuntu:
-    bionic: [python3-requests]
+  debian: [python3-requests]
+  fedora: [python3-requests]
+  ubuntu: [python3-requests]
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]


### PR DESCRIPTION
For this PR https://github.com/ros-perception/image_pipeline/pull/447 python3 `requests` library is needed to download the test data. Unfortunately it is not available for py3 in bionic (which the testing image is using). This PR adds that.

Let me know if there is anything that needs to change.