### PR TITLE
rosdep/base.yaml:  Fix `libqt4` mapping for Debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3266,7 +3266,7 @@ libqrencode-dev:
   ubuntu: [libqrencode-dev]
 libqt4:
   arch: [qt4]
-  debian: [libqt4-core]
+  debian: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
   fedora: [qt]
   freebsd: [qt4-corelib]
   gentoo: ['dev-qt/qtcore:4']


### PR DESCRIPTION
Debian `libqt4` mappings are incorrect starting from Stretch.  The
`libqt4-core` package was apparently renamed to `libqtcore4` before
Jessie, and after Jessie, the "transitional package" was removed, which
broke the `libqt4` `rosdep` mapping.  That mapping was first added in
533c8070 in 2012, when it was still valid for the latest distros.
Commit 8bafc5de from 2013 fixed the removed transitional package in
Ubuntu.  This patch does the equivalent for Debian.

This change should be valid for all non-EOL Debian releases:

    $ for DISTRO in jessie stretch buster; do
    >     echo "------ $DISTRO ------"
    >     docker run -it debian:$DISTRO bash -c '
    >         apt-get update >&/dev/null && \
    >         { apt-cache search -n "^(libqt4-core|libqtcore4)$"; }'
    > done
    ------ jessie ------
    libqt4-core - transitional package for Qt 4 core non-GUI runtime libraries
    libqtcore4 - Qt 4 core module
    ------ stretch ------
    libqtcore4 - Qt 4 core module
    ------ buster ------
    libqtcore4 - Qt 4 core module