### PR TITLE
pr2_gripper_sensor: 1.0.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7091,6 +7091,26 @@ repositories:
       url: https://github.com/pr2/pr2_ethercat_drivers.git
       version: kinetic-devel
     status: unmaintained
+  pr2_gripper_sensor:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_gripper_sensor.git
+      version: hydro-devel
+    release:
+      packages:
+      - pr2_gripper_sensor
+      - pr2_gripper_sensor_action
+      - pr2_gripper_sensor_controller
+      - pr2_gripper_sensor_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
+      version: 1.0.11-1
+    source:
+      type: git
+      url: https://github.com/PR2/pr2_gripper_sensor.git
+      version: hydro-devel
+    status: unmaintained
   pr2_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_gripper_sensor` to `1.0.11-1`:

- upstream repository: https://github.com/PR2/pr2_gripper_sensor.git
- release repository: https://github.com/pr2-gbp/pr2_gripper_sensor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## pr2_gripper_sensor

- No changes

## pr2_gripper_sensor_action

- No changes

## pr2_gripper_sensor_controller

```
* add namespaces to avoid warning (#15 <https://github.com/PR2/pr2_gripper_sensor/issues/15>)
  [ WARN] [/realtime_loop]:
  The deprecated controller type PR2GripperSensorController was not found.
  Using the namespaced version pr2_gripper_sensor_controller/PR2GripperSensorController instead.
  Please update your configuration to use the namespaced version.
* Contributors: v4hn
```

## pr2_gripper_sensor_msgs

- No changes
