### PR TITLE
Adding omt_coscan to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6251,6 +6251,16 @@ repositories:
       url: https://github.com/ose-support-ros/omronsentech_camera.git
       version: master
     status: developed
+  omt_coscan:
+    doc:
+      type: git
+      url: https://github.com/siyandong/CoScan.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/siyandong/CoScan.git
+      version: master
+    status: maintained
   open_karto:
     doc:
       type: git


### PR DESCRIPTION
I'd like omt_coscan to be indexed and documented on ros.org.