### PR TITLE
move_base_flex: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7577,7 +7577,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.3.0-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.2.5-1`

## mbf_abstract_core

```
* unify license declaration to BSD-3
```

## mbf_abstract_nav

```
* Clean up patience exceeded method
* Add last valid cmd time as class variable
* Add started state and improve output messages
* Unify license declaration to BSD-3
* Add parameter force_stop_on_cancel to send a zero-speed command on cancelation (default: true)
* remove explicit boost-exception dependency, Boost >= 1.69 provides exception by default.
* Allow the user time-consuming cancel implementations
* Rename abstract_action.h as abstract_action_base.hpp
* Remane robot_Information.cpp as robot_information.cpp
* Unify headers definitions and namespace intentation
* Add parameter to actively stop once the goal is reached
* Exit immediately from action done callbacks when action_state is CANCELED
```

## mbf_costmap_core

```
* unify license declaration to BSD-3
```

## mbf_costmap_nav

```
* add output for cancel method if nav_core plugin is wrapped
* unify license declaration to BSD-3
```

## mbf_msgs

```
* add some more error codes, e.g. out of map, or map error
* unify license declaration to BSD-3
```

## mbf_simple_nav

```
* unify license declaration to BSD-3
```

## mbf_utility

```
* Add exception classes for get_path, exe_path and recovery
* unify license declaration to BSD-3
```

## move_base_flex

```
* unify license declaration to BSD-3
```
