### PR TITLE
rviz: 1.13.9-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9782,7 +9782,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.8-1
+      version: 1.13.9-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.9-2`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.13.8-1`

## rviz

```
* Fixup  Sphere being off center (#1487 <https://github.com/ros-visualization/rviz/issues/1487>)
* Revert "Switch libogre-dev to build_depend (#1482 <https://github.com/ros-visualization/rviz/issues/1482>)"
* Configure yaml-cpp include directory (#1483 <https://github.com/ros-visualization/rviz/issues/1483>)
* Contributors: Peter Lehner, Robert Haschke, Wolfgang Merkt
```
