### PR TITLE
aws_ros2_common: 1.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/aws_ros2_common-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/utils-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws_ros2_common` to `1.0.1-1`:

- upstream repository: https://github.com/aws-robotics/utils-ros2.git
- release repository: https://github.com/aws-gbp/aws_ros2_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.0-1`

## aws_ros2_common

```
* Bump package version to 1.0.1 (#10 <https://github.com/aws-robotics/utils-ros2/issues/10>)
* Fix linting issues found by clang-tidy 6.0 (#9 <https://github.com/aws-robotics/utils-ros2/issues/9>)
  * clang-tidy fixes
  * clang-tidy linting issues fixed manually
* Guard test targets with if(BUILD_TESTING)
* Update README.md and package.xml meta tags (#3 <https://github.com/aws-robotics/utils-ros2/issues/3>)
  * Update README.md and package.xml meta tags
  * Add disclaimer about lack of apt availability
* Declare parameters in unit tests to conform to Dashing.
* Merge pull request #2 <https://github.com/aws-robotics/utils-ros2/issues/2> from aws-robotics/ci
  Add .travis.yml, .rosinstall.master, and remove aws_cpp_sdk_core obso…
* Add .travis.yml, .rosinstall.master, and remove aws_cpp_sdk_core obsolete dependency.
* Implement common interfaces of aws_common for ROS2
  * initial commit of aws_ros2_common package implementation
  * Update to use non-legacy ParameterReader API
* Contributors: AAlon, Avishay Alon, M. M, Miaofei Mei, Ryan Newell
```
