### PR TITLE
cloudwatch_logger: 3.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -472,7 +472,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_logger-release.git
-      version: 3.0.0-2
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchlogs-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_logger` to `3.0.1-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatchlogs-ros2.git
- release repository: https://github.com/aws-gbp/cloudwatch_logger-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.0.0-2`

## cloudwatch_logger

```
* Bump package version to 3.0.1 (#14 <https://github.com/aws-robotics/cloudwatchlogs-ros2/issues/14>)
* Fix linting issues found by clang-tidy 6.0 (#12 <https://github.com/aws-robotics/cloudwatchlogs-ros2/issues/12>)
  * clang-tidy fixes
  * clang-tidy linting issues fixed manually
* Contributors: Miaofei Mei, Ryan Newell
```
