### PR TITLE
cloudwatch_metrics_collector: 3.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -487,7 +487,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
-      version: 3.0.0-2
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_metrics_collector` to `3.0.1-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatchmetrics-ros2.git
- release repository: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `3.0.0-2`

## cloudwatch_metrics_collector

```
* Bump version to 3.0.1 (#18 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/18>)
* Add file management include to tests (#19 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/19>)
* Fix linting issues found by clang-tidy 6.0 (#15 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/15>)
  * clang-tidy fixes
  * clang-tidy linting issues fixed manually
  * optimize ReadTopics()
  * add more unit tests
* Revert "Add support for metrics_statistics_msgs (#14 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/14>)" (#16 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/16>)
  This reverts commit 097032087a027bfa4d218358f317b70453346688.
* Add support for metrics_statistics_msgs (#14 <https://github.com/aws-robotics/cloudwatchmetrics-ros2/issues/14>)
  * add support for metrics_statistics_msgs
  * enable subscription callback
  * move to using two distinct list of topics
  * address some PR comments
  * address more PR comments
  * address feedback regarding MetricsMessage to MetricsObject mapping
  * add unit tests for MetricsCollector
  * update MetricsMessage to MetricsObject mapping
  * address comments regarding unit tests
  * updating README.md
* Contributors: Miaofei Mei, Ryan Newell
```
