### PR TITLE
wu_ros_tools: 0.2.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17340,7 +17340,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wu-robotics/wu_ros_tools.git
-      version: 0.2.4-0
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/DLu/wu_ros_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.2.5-1`:

- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.2.4-0`
