### PR TITLE
swri_console: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3083,6 +3083,22 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: dashing
     status: developed
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_console-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: dashing-devel
+    status: developed
   system_modes:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.0-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## swri_console

```
* ROS 2 Dashing Support (#31 <https://github.com/swri-robotics/swri_console/issues/31>)
* Contributors: Jacob Hassold, P. J. Reed
```
