### PR TITLE
swri_console: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2792,6 +2792,22 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: eloquent
     status: developed
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_console-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: dashing-devel
+    status: developed
   system_modes:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.0-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## swri_console

```
* ROS 2 Dashing Support (#31 <https://github.com/swri-robotics/swri_console/issues/31>)
* Contributors: Jacob Hassold, P. J. Reed
```
