### PR TITLE
jsk_planning: 0.1.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4186,6 +4186,27 @@ repositories:
       url: https://github.com/tork-a/jsk_model_tools-release.git
       version: 0.4.3-0
     status: developed
+  jsk_planning:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    release:
+      packages:
+      - jsk_planning
+      - pddl_msgs
+      - pddl_planner
+      - pddl_planner_viewer
+      - task_compiler
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jsk_planning-release.git
+      version: 0.1.12-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_planning.git
+      version: master
+    status: developed
   jsk_pr2eus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_planning` to `0.1.12-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_planning
- release repository: https://github.com/tork-a/jsk_planning-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## jsk_planning

- No changes

## pddl_msgs

```
* Merge pull request #70 <https://github.com/jsk-ros-pkg/jsk_planning/issues/70> from furushchev/detail-error
  Add max_planning_time option
* pddl_planner: fix deadlock on planning process
* Contributors: Furushchev, Kei Okada
```

## pddl_planner

```
* Add max_planning_time option (#70 <https://github.com/jsk-ros-pkg/jsk_planning/issues/70>)
  
    * pddl_planner: revert run_depend
    * pddl.py: disable auto_start
    * add detailed infor!
    * pddl_planner: fix deadlock on planning process
    * pddl.py: print detailed info on error
  
* Set timeout for planning in task_compiler (#69 <https://github.com/jsk-ros-pkg/jsk_planning/issues/69>)
  
    * pddl_planner: add timeout for planning function
  
* Fix: add failed state if no recovery action exists (#66 <https://github.com/jsk-ros-pkg/jsk_planning/issues/66>)
  
    * pddl_planner: fix use global variables in function
  
* Fix miss configuration in test (#65 <https://github.com/jsk-ros-pkg/jsk_planning/issues/65>)
* Contributors: Yuki Furuta
```

## pddl_planner_viewer

- No changes

## task_compiler

```
* Set timeout for planning in task_compiler (#69 <https://github.com/jsk-ros-pkg/jsk_planning/issues/69>)
  
    * task_compiler: set timeout for planning
    * task_compiler: add option exit_on_finish
  
* Fix testing (#65 <https://github.com/jsk-ros-pkg/jsk_planning/issues/65>)
  
    * fix miss configuration in test
    * remove unused files
  
* Contributors: Yuki Furuta
```
