### PR TITLE
Added python-psutil for focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -373,6 +373,7 @@ python:
   ubuntu:
     artful: [python-dev]
     bionic: [python-dev]
+    focal: [python3-dev]
     lucid: [python-dev]
     maverick: [python-dev]
     natty: [python-dev]
@@ -3092,6 +3093,7 @@ python-psutil:
   ubuntu:
     artful: [python-psutil]
     bionic: [python-psutil]
+    focal: [python3-psutil]
     lucid: [python-psutil]
     maverick: [python-psutil]
     natty: [python-psutil]


### PR DESCRIPTION
According with this [failured](http://build.ros.org/job/Npr__diagnostics__ubuntu_focal_amd64/1/console). There is no entrance for focal

Signed-off-by: ahcorde <ahcorde@gmail.com>