### PR TITLE
Added python3-opencv for focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5470,6 +5470,7 @@ python3-opencv:
     cosmic: [python3-opencv]
     disco: [python3-opencv]
     eoan: [python3-opencv]
+    focal: [python3-opencv]
 python3-opengl:
   debian: [python3-opengl]
   fedora: [python3-pyopengl]


### PR DESCRIPTION
According with this [failure](http://build.ros.org/job/Npr__vision_opencv__ubuntu_focal_amd64/4/console) there is no focal key for python3-opencv

Signed-off-by: ahcorde <ahcorde@gmail.com>