### PR TITLE
diagnostics: 1.9.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -188,6 +188,24 @@ repositories:
       url: https://github.com/ros-controls/control_toolbox.git
       version: melodic-devel
   diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: noetic-devel
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_analysis
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - rosdiagnostic
+      - self_test
+      - test_diagnostic_aggregator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/diagnostics-release.git
+      version: 1.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.9.4-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## diagnostic_aggregator

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
* Merge pull request #99 <https://github.com/ros/diagnostics/issues/99> from g-gemignani/indigo-devel
  Fix discard_stale (Closes #65 <https://github.com/ros/diagnostics/issues/65>)
* Merge pull request #96 <https://github.com/ros/diagnostics/issues/96> from kejxu/use_global_gtest_library
  update CMakeLists.txt to search for local gtest first
* Fix problem with pr that skipped the timeout stale transition period
* Address pr issue about discard_stale test
* Fix copyright and remove unused imports
* Address issue 65
  Make sure that analyzers flagged with discard_stale = true are correctly
  removed after being stale for a period greater than the timeout
* update cmake include directories to use correct gtest.h
* Merge pull request #95 <https://github.com/ros/diagnostics/issues/95> from kejxu/use_operator_instead_of_alias
  use operators instead of aliases
* fix build break
* Contributors: Alejandro Hernández Cordero, Austin, Guglielmo Gemignani, James Xu, Sean Yen
```

## diagnostic_analysis

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
* Contributors: Alejandro Hernández Cordero
```

## diagnostic_common_diagnostics

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
* Contributors: Alejandro Hernández Cordero
```

## diagnostic_updater

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
* Merge pull request #105 <https://github.com/ros/diagnostics/issues/105> from mikepurvis/py3-httplib
  Fix httplib import for Python 3.
* Fix httplib import for Python 3.
* Merge pull request #97 <https://github.com/ros/diagnostics/issues/97> from kejxu/fix_windows_build_issue
  fix windows build issue
* Merge branch 'indigo-devel' into fix_windows_build_issue
* update windows bringup (#5 <https://github.com/ros/diagnostics/issues/5>)
* avoid ERROR from windows.h
* windows bringup
* Merge pull request #86 <https://github.com/ros/diagnostics/issues/86> from icolwell/diagnostic_status_custom_names
  Custom names for FrequencyStatus and TimeStampStatus
* Remove C++11 features
* Wording
* Custom names for existing diagnostics tasks
* Merge pull request #84 <https://github.com/ros/diagnostics/issues/84> from nbussas/frequency_status_name
  Make FrequencyStatus' name configurable
* Make FrequencyStatus' name configurable
* Contributors: Alejandro Hernández Cordero, Austin, Ian Colwell, James Xu, Mike Purvis, Nils Bussas, Sean Yen
```

## diagnostics

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
* Contributors: Alejandro Hernández Cordero
```

## rosdiagnostic

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
  * Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * Changes to make it work with Python3
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * Use setuptools instead of distutils
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * Changes from python2 to python3
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * update keys - diagnostic_common_diagnostics
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * Minor fixes
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero
```

## self_test

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
* Contributors: Alejandro Hernández Cordero
```

## test_diagnostic_aggregator

```
* noetic release (#136 <https://github.com/ros/diagnostics/issues/136>)
* Contributors: Alejandro Hernández Cordero
```
