### PR TITLE
added yaml-cpp to focal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6030,6 +6030,7 @@ yaml-cpp:
     cosmic: [libyaml-cpp-dev]
     disco: [libyaml-cpp-dev]
     eoan: [libyaml-cpp-dev]
+    focal: [libyaml-cpp-dev]
     lucid: [yaml-cpp0.2.6-dev]
     maverick: [yaml-cpp0.2.6-dev]
     natty: [yaml-cpp0.2.6-dev]


### PR DESCRIPTION
According with this [failure](http://build.ros.org/view/Npr/job/Npr__image_common__ubuntu_focal_amd64/1/console). yaml-cpp is need on focal

Signed-off-by: ahcorde <ahcorde@gmail.com>