### PR TITLE
urdfdom_py: 0.4.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11138,7 +11138,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.4.3-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.4.2-1`

## urdfdom_py

```
* Remove lxml dependency (#57 <https://github.com/ros/urdf_parser_py/issues/57>)
* Use setuptools instead of distutils (#56 <https://github.com/ros/urdf_parser_py/issues/56>)
* Bump CMake version to avoid CMP0048 (#55 <https://github.com/ros/urdf_parser_py/issues/55>)
* update backward compatibility on visual and collisions (#47 <https://github.com/ros/urdf_parser_py/issues/47>)
* Allow name attribute in visual tag (#31 <https://github.com/ros/urdf_parser_py/issues/31>)
* Contributors: Kei Okada, Shane Loretz, gerkey
```
