### PR TITLE
urdfdom_py: 0.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1440,6 +1440,15 @@ repositories:
       version: kinetic-devel
     status: developed
   urdfdom_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdfdom_py-release.git
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/ros/urdf_parser_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.4.3-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urdfdom_py

```
* Remove lxml dependency (#57 <https://github.com/ros/urdf_parser_py/issues/57>)
* Use setuptools instead of distutils (#56 <https://github.com/ros/urdf_parser_py/issues/56>)
* Bump CMake version to avoid CMP0048 (#55 <https://github.com/ros/urdf_parser_py/issues/55>)
* update backward compatibility on visual and collisions (#47 <https://github.com/ros/urdf_parser_py/issues/47>)
* Allow name attribute in visual tag (#31 <https://github.com/ros/urdf_parser_py/issues/31>)
* Contributors: Kei Okada, Shane Loretz, gerkey
```
