### PR TITLE
wu_ros_tools: 0.2.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11787,7 +11787,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wu-robotics/wu_ros_tools.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/DLu/wu_ros_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.2.6-1`:

- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.2.5-1`
