### PR TITLE
navigation: 1.17.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -525,6 +525,32 @@ repositories:
       version: kinetic-devel
     status: maintained
   navigation:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation.git
+      version: noetic-devel
+    release:
+      packages:
+      - amcl
+      - base_local_planner
+      - carrot_planner
+      - clear_costmap_recovery
+      - costmap_2d
+      - dwa_local_planner
+      - fake_localization
+      - global_planner
+      - map_server
+      - move_base
+      - move_slow_and_clear
+      - nav_core
+      - navfn
+      - navigation
+      - rotate_recovery
+      - voxel_grid
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation-release.git
+      version: 1.17.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.17.0-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## amcl

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* map is not subscriptable in python3
* fix python3 errors in basic_localization.py
* use upstream pykdl
* Contributors: Michael Ferguson
```

## base_local_planner

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## carrot_planner

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## clear_costmap_recovery

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## costmap_2d

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* fix invalid memory access
* attempt to get test to run
* increase required cmake version
* Contributors: Michael Ferguson
```

## dwa_local_planner

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## fake_localization

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## global_planner

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## map_server

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## move_base

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* move_base: Add options for make_plan service (#981 <https://github.com/ros-planning/navigation/issues/981>)
  Adds the following two parameters for the ~make_plan service:
  1. make_plan_clear_costmap
  Whether or not to clear the global costmap on make_plan service call.
  2. make_plan_add_unreachable_goal
  Whether or not to add the original goal to the path if it is unreachable in the make_plan service call.
* Contributors: Michael Ferguson, nxdefiant
```

## move_slow_and_clear

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## nav_core

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## navfn

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## navigation

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## rotate_recovery

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```

## voxel_grid

```
* Merge pull request #982 <https://github.com/ros-planning/navigation/issues/982> from ros-planning/noetic_prep
  Noetic Migration
* increase required cmake version
* Contributors: Michael Ferguson
```
