### PR TITLE
geometry_tutorials: 0.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -416,6 +416,21 @@ repositories:
       url: https://github.com/ros/geometry2.git
       version: melodic-devel
     status: maintained
+  geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: kinetic-devel
+    release:
+      packages:
+      - geometry_tutorials
+      - turtle_tf
+      - turtle_tf2
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_tutorials-release.git
+      version: 0.2.3-1
+    status: maintained
   gl_dependency:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -430,6 +430,10 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry_tutorials-release.git
       version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: kinetic-devel
     status: maintained
   gl_dependency:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.2.3-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## geometry_tutorials

```
* Bump CMake version to avoid CMP0048 warning (#29 <https://github.com/ros/geometry_tutorials//issues/29>)
* Contributors: Alejandro Hernández Cordero
```

## turtle_tf

```
* Bump CMake version to avoid CMP0048 warning (#29 <https://github.com/ros/geometry_tutorials//issues/29>)
* Merge pull request #26 <https://github.com/ros/geometry_tutorials//issues/26> from jwhendy/tutorial-node-name-fix
* updated node names in all tf and tf2 nodes/.py files to match filenames for simplicity
* Merge pull request #22 <https://github.com/ros/geometry_tutorials//issues/22> from 23pointsNorth/patch-1
* Clean up code
* Merge pull request #20 <https://github.com/ros/geometry_tutorials//issues/20> from romainreignier/indigo-devel
* Add install rule for turtle_tf_message_filter
* Contributors: Alejandro Hernández Cordero, Daniel Angelov, John Henderson, Romain Reignier, Tully Foote
```

## turtle_tf2

```
* Bump CMake version to avoid CMP0048 warning (#29 <https://github.com/ros/geometry_tutorials//issues/29>)
* Unify tf2 frame broadcasters (#27 <https://github.com/ros/geometry_tutorials//issues/27>)
* Merge pull request #26 <https://github.com/ros/geometry_tutorials//issues/26> from jwhendy/tutorial-node-name-fix
* updated node names in all tf and tf2 nodes/.py files to match filenames for simplicity
* Merge pull request #24 <https://github.com/ros/geometry_tutorials//issues/24> from vincentrou/message_filter_tutorial
* Merge pull request #23 <https://github.com/ros/geometry_tutorials//issues/23> from vincentrou/fix_frame_name
* [turtle_tf2] Do not use pointer for MessageFilter
* [turtle_tf2] Add message filter tutorial
* [turtle_tf2] Fix frame name
* Contributors: Alejandro Hernández Cordero, John Henderson, John Hendy, Tully Foote, Vincent Rousseau
```
