### PR TITLE
audio_common: 0.3.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -758,7 +758,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.3-0
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.4-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.3-0`

## audio_capture

```
* Merge branch 'master' of github.com:ros-drivers/audio_common
* Contributors: Gerard Canal
```

## audio_common

```
* Merge branch 'master' of github.com:ros-drivers/audio_common
* Contributors: Gerard Canal
```

## audio_common_msgs

```
* Merge branch 'master' of github.com:ros-drivers/audio_common
* Contributors: Gerard Canal
```

## audio_play

```
* audio_play fix for reproducing livestream sound (#122 <https://github.com/ros-drivers/audio_common/issues/122>)
  * Added capability to read from a udpsrc. To generalize it, possibly similarly to gscam.
  * Added parameter to control do-timestamp, as this fixes the problem with audio_play not being able to play livestream sound.
  * Aligning with the base master, removing the changes from the branch that included the udpsrc.
  Co-authored-by: Alberto Quattrini Li <mailto:albertoq@cse.sc.edu>
* Merge branch 'master' of github.com:ros-drivers/audio_common
* Contributors: Alberto Quattrini Li, Gerard Canal
```

## sound_play

```
* Merge pull request #126 <https://github.com/ros-drivers/audio_common/issues/126> from itohdak/fix-Gstreamer-memory-leak
  [sound_play/scripts/soundplay_node.py] fix Gstreamer memory leak
* Merge pull request #123 <https://github.com/ros-drivers/audio_common/issues/123> from 708yamaguchi/fix-encode
  Do not encode text when using langages which ISO-8859-15 does not support
* [sound_play/scripts/soundplay_node.py] fix Gstreamer memory leak
* do not encode text when using langages which ISO-8859-15 does not support
* Merge pull request #118 <https://github.com/ros-drivers/audio_common/issues/118> from v4hn/patch-1
  use default audio output by default
* use default audio output by default
  Not specifying a sound device defaults to *the first* sound device starting from Ubuntu 16.04., not to the one configured as default.
  The change is backward compatible and tested on ROS indigo and kinetic on a PR2 robot.
* Merge pull request #110 <https://github.com/ros-drivers/audio_common/issues/110> from gerardcanal/master
  Encoded text to be said in ISO-8859-15
* Merge branch 'master' of github.com:ros-drivers/audio_common
* Sound play: Encoded file to be said in ISO-8859-15 so that accents in languages such as Spanish, Catalan or French are correctly pronounced (based on http://festcat.talp.cat/en/usage.php which says festival expects ISO-8859-15 encoding)
* Contributors: Austin, Gerard Canal, Michael Görner, Naoya Yamaguchi, Shingo Kitagawa, itohdak
```
