### PR TITLE
robosense_simulator: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8073,6 +8073,10 @@ repositories:
       version: develop-curves-function
     status: developed
   robosense_simulator:
+    doc:
+      type: git
+      url: https://github.com/tomlogan501/robosense_simulator_release.git
+      version: master
     release:
       packages:
       - robosense_description
@@ -8085,7 +8089,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tomlogan501/robosense_simulator.git
-      version: 1.0.0
+      version: master
     status: maintained
   robot_activity:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8072,6 +8072,21 @@ repositories:
       url: https://github.com/CPFL/robosense.git
       version: develop-curves-function
     status: developed
+  robosense_simulator:
+    release:
+      packages:
+      - robosense_description
+      - robosense_gazebo_plugins
+      - robosense_simulator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tomlogan501/robosense_simulator_release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/tomlogan501/robosense_simulator.git
+      version: 1.0.0
+    status: maintained
   robot_activity:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8075,7 +8075,7 @@ repositories:
   robosense_simulator:
     doc:
       type: git
-      url: https://github.com/tomlogan501/robosense_simulator_release.git
+      url: https://github.com/tomlogan501/robosense_simulator.git
       version: master
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `robosense_simulator` to `1.0.0-1`:

- upstream repository: https://github.com/tomlogan501/robosense_simulator.git
- release repository: https://github.com/tomlogan501/robosense_simulator_release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
