### PR TITLE
common_tutorials: 0.1.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -158,6 +158,27 @@ repositories:
       url: https://github.com/ros/common_msgs.git
       version: noetic-devel
     status: maintained
+  common_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: noetic-devel
+    release:
+      packages:
+      - actionlib_tutorials
+      - common_tutorials
+      - nodelet_tutorial_math
+      - pluginlib_tutorials
+      - turtle_actionlib
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/common_tutorials-release.git
+      version: 0.1.12-1
+    source:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: noetic-devel
+    status: maintained
   control_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials` to `0.1.12-1`:

- upstream repository: https://github.com/ros/common_tutorials.git
- release repository: https://github.com/ros-gbp/common_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
