### PR TITLE
robot_state_publisher: 1.14.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8244,7 +8244,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.14.0-1
+      version: 1.14.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.14.1-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.14.0-1`

## robot_state_publisher

```
* Bump CMake version to avoid CMP0048 warning (#132 <https://github.com/ros/robot_state_publisher/issues/132>)
* Make sure to make sensor_msgs a catkin dependency. (#123 <https://github.com/ros/robot_state_publisher/issues/123>)
* Add joint_state_listener to the catkin package LIBRARIES (#112 <https://github.com/ros/robot_state_publisher/issues/112>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, sevangelatos
```
