### PR TITLE
euslime: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2356,6 +2356,12 @@ repositories:
       url: https://github.com/shadow-robot/ethercat_grant.git
       version: melodic-devel
     status: maintained
+  euslime:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/jsk-ros-pkg/euslime-release.git
+      version: 1.0.1-1
   euslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslime` to `1.0.1-1`:

- upstream repository: https://github.com/jsk-ros-pkg/euslime.git
- release repository: https://github.com/jsk-ros-pkg/euslime-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## euslime

```
* First public release for melodic
* Contributors: Yuki Furuta, Guilherme Affonso
```
