### PR TITLE
add python-cvxopt package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1184,6 +1184,8 @@ python-cryptography:
   gentoo: [dev-python/cryptography]
   rhel: [python2-cryptography]
   ubuntu: [python-cryptography]
+python-cvxopt:
+  ubuntu: [python-cvxopt]
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1186,6 +1186,10 @@ python-cryptography:
   ubuntu: [python-cryptography]
 python-cvxopt:
   ubuntu: [python-cvxopt]
+  debian: [python-cvxopt]
+  arch: [python-cvxopt]
+  fedora: [python-cvxopt]
+  macports: [py27-cvxopt]
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1185,11 +1185,11 @@ python-cryptography:
   rhel: [python2-cryptography]
   ubuntu: [python-cryptography]
 python-cvxopt:
-  ubuntu: [python-cvxopt]
-  debian: [python-cvxopt]
   arch: [python-cvxopt]
+  debian: [python-cvxopt]
   fedora: [python-cvxopt]
   macports: [py27-cvxopt]
+  ubuntu: [python-cvxopt]
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]


### PR DESCRIPTION
Hello,

I just created a ros package which depend on the python module [cvxopt,](https://github.com/cvxopt/cvxopt) so it would be great if it was resolved by rosdep.

In the [installation guide](https://cvxopt.org/install/index.html), they recommend using pip or conda for installation, but there is a package available on ubuntu and debian via apt, named python-cvxopt.