### PR TITLE
image_common: 1.12.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -472,6 +472,21 @@ repositories:
       version: kinetic-devel
     status: maintained
   image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: noetic-devel
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_common
+      - image_transport
+      - polled_camera
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/image_common-release.git
+      version: 1.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.12.0-1`:

- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## camera_calibration_parsers

```
* Noetic release image_common (#155 <https://github.com/ros-perception/image_common/issues/155>)
  * noetic - Porting Python to Python3
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * Updated cmake_minimum_required to 3.0.2
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * changed diskutils.core for setuptools
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * ported to noetic image_transport tutorial
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager

```
* Noetic release image_common (#155 <https://github.com/ros-perception/image_common/issues/155>)
  * noetic - Porting Python to Python3
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * Updated cmake_minimum_required to 3.0.2
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * changed diskutils.core for setuptools
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
  * ported to noetic image_transport tutorial
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero
```

## image_common

```
* Noetic release image_common (#155 <https://github.com/ros-perception/image_common/issues/155>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport

```
* Noetic release image_common (#155 <https://github.com/ros-perception/image_common/issues/155>)
* Contributors: Alejandro Hernández Cordero
```

## polled_camera

```
* Noetic release image_common (#155 <https://github.com/ros-perception/image_common/issues/155>)
* Contributors: Alejandro Hernández Cordero
```
