### PR TITLE
hebi_cpp_api 3.2.0-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3400,7 +3400,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
-      version: 3.1.1-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository hebi_cpp_api_ros to 3.2.0-1:

* upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
* release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
* distro file: melodic/distribution.yaml
* bloom version: 0.8.0
* previous version for package: 3.1.1-1

 **hebi_cpp_api** 

* Added experimental high-level "Arm API" to enable easier control of robotic arm systems