### PR TITLE
perception_pcl: 1.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -682,6 +682,26 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: noetic-devel
     status: maintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: melodic-devel
+    release:
+      packages:
+      - pcl_conversions
+      - pcl_ros
+      - perception_pcl
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/perception_pcl-release.git
+      version: 1.7.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: melodic-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `1.7.1-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros-gbp/perception_pcl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
