### PR TITLE
Add pyrealsense2 and open3d pip packages for ubuntu/fedora/debian

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3400,6 +3400,16 @@ python-pyramid:
   fedora: [python-pyramid]
   gentoo: [dev-python/pyramid]
   ubuntu: [python-pyramid]
+python-pyrealsense2-pip:
+  debian:
+    pip:
+      packages: [pyrealsense2]
+  fedora:
+    pip:
+      packages: [pyrealsense2]
+  ubuntu:
+    pip:
+      packages: [pyrealsense2]
 python-pyside:
   arch: [python2-pyside]
   debian: [python-pyside]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2696,6 +2696,16 @@ python-omniorb:
   ubuntu:
     '*': [python-omniorb, python-omniorb-omg, omniidl-python]
     lucid: [python-omniorb2, python-omniorb2-omg, omniidl4-python]
+python-open3d-pip:
+  debian:
+    pip:
+      packages: [open3d-python]
+  fedora:
+    pip:
+      packages: [open3d-python]
+  ubuntu:
+    pip:
+      packages: [open3d-python]
 python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]


### PR DESCRIPTION
Package documentations:
https://pypi.org/project/pyrealsense2/
https://pypi.org/project/open3d-python/

Use case:
We are using realsense cameras in our ros project and open3d for processing the data.

Test on Ubuntu with:
```
$ rosdep update && rosdep resolve open3d-pip pyrealsense2-pip
#ROSDEP[open3d-pip]
#pip
open3d-python
#ROSDEP[pyrealsense2-pip]
#pip
pyrealsense2
```
