### PR TITLE
pointgrey_camera_driver: 0.14.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6981,6 +6981,27 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: lunar-devel
     status: maintained
+  pointgrey_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    release:
+      packages:
+      - image_exposure_msgs
+      - pointgrey_camera_description
+      - pointgrey_camera_driver
+      - statistics_msgs
+      - wfov_camera_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
+      version: 0.14.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    status: maintained
   pose_cov_ops:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.14.0-1`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

```
* Fixed warnings about inconsistent namespace redefinitions for xmlns:xacro.
* Contributors: Tony Baltovski
```

## pointgrey_camera_driver

```
* [pointgrey_camera_driver] Switched bionic to amd64.
* Use path.join instead of manually inserting a /
* Whitespace cleanup
* Add the crunch-bang python line so Atom's syntax highlighting plays nicely
* Rewrite the download_flycap script so that it downloads packages from the correct endpoint. Drop support for Trusty, add future support for Bionic
* Add messages as build dependencies for driver executables (#153 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/153>)
* update to use non deprecated pluginlib macro (#150 <https://github.com/ros-drivers/pointgrey_camera_driver/issues/150>)
* Contributors: Chris I-B, Kevin Allen, Mikael Arguedas, Tony Baltovski
```

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
