### PR TITLE
hector_localization: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3430,6 +3430,22 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
       version: 0.5.1-0
     status: maintained
+  hector_localization:
+    release:
+      packages:
+      - hector_localization
+      - hector_pose_estimation
+      - hector_pose_estimation_core
+      - message_to_tf
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
+      version: catkin
+    status: maintained
   hector_models:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_localization` to `0.3.0-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_localization.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## hector_localization

- No changes

## hector_pose_estimation

```
* hector_pose_estimation: removed trailing / in directory install rule
* Contributors: Johannes Meyer
```

## hector_pose_estimation_core

```
* hector_pose_estimation_core: cleanup of Eigen MatrixBase and QuaternionBase plugins
* hector_pose_estimation_core: refactored vector and matrix classes
  Instead of inheriting from Eigen::Matrix<> types, hector_pose_estimation now simply defines
  typedefs for all kind of use cases. The former SymmetricMatrix_<> and SkewSymmetricMatrix classes
  have been replaced by Eigen::MatrixBase extension (https://eigen.tuxfamily.org/dox-devel/TopicCustomizingEigen.html)
  and by a free function that returns a skew-symmetric matrix.
  The refactoring was required for the release in Ubuntu Xenial and Eigen 3.3. The previous code was
  too fragile in case of Eigen upgrades and did not compile in Xenial due to changes in the Eigen::internal::traits<T>
  interface.
* Contributors: Johannes Meyer
```

## message_to_tf

- No changes
