### PR TITLE
mavros: 1.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7150,7 +7150,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.1.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-1`

## libmavconn

- No changes

## mavros

```
* fixed styling
* fixed indent from using spaces
* updates apmrover2 modes and allows for arduboat mode changes
* mavsafety kill feature for emergency stop
* Include trajectory_msgs in CMakeLists.txt
  This allows build to complete successfully.
* Contributors: Anthony Goeckner, Matt Koos, aykutkabaoglu
```

## mavros_extras

```
* Setting the same transparency for all elements
* Visualization of the direction of the device
* add support for bezier
* Contributors: Alamoris, Martina Rivizzigno
```

## mavros_msgs

- No changes

## test_mavros

- No changes
