### PR TITLE
mavros: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5005,7 +5005,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.1.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-1`

## libmavconn

- No changes

## mavros

```
* fixed styling
* fixed indent from using spaces
* updates apmrover2 modes and allows for arduboat mode changes
* mavsafety kill feature for emergency stop
* Include trajectory_msgs in CMakeLists.txt
  This allows build to complete successfully.
* Contributors: Anthony Goeckner, Matt Koos, aykutkabaoglu
```

## mavros_extras

```
* Setting the same transparency for all elements
* Visualization of the direction of the device
* add support for bezier
* Contributors: Alamoris, Martina Rivizzigno
```

## mavros_msgs

- No changes

## test_mavros

- No changes
