### PR TITLE
interactive_markers: 1.11.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5471,7 +5471,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -5480,7 +5480,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   iot_bridge:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5471,7 +5471,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: kinetic-devel
+      version: indigo-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -5480,7 +5480,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: kinetic-devel
+      version: indigo-devel
     status: maintained
   iot_bridge:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3850,7 +3850,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -3860,7 +3860,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   ipr_extern:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3855,7 +3855,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.11.4-0
+      version: 1.11.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.11.5-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.11.4-0`

## interactive_markers

```
* [feature]     InteractiveMarkerServer::erase(): return false for unknown marker (#43 <https://github.com/ros-visualization/interactive_markers/issues/43>)
* [fix]         Avoid overriding warning status messages (Fixes #34 <https://github.com/ros-visualization/interactive_markers/issues/34>)
* [fix]         Fixed the problem that *.hpp was not installed (#66 <https://github.com/ros-visualization/interactive_markers/issues/66>)
* [fix]         Make the Timer daemon survive /clock jumping back in a playback loop (#47 <https://github.com/ros-visualization/interactive_markers/issues/47>)
* [maintanence] Modernize package.xml and add missing std_msgs in CATKIN_DEPENDS
* [maintanence] Use setuptools instead of distutils (#67 <https://github.com/ros-visualization/interactive_markers/issues/67>)
* [maintanence] Bump cmake version to 3.0.2 (#64 <https://github.com/ros-visualization/interactive_markers/issues/64>)
* [maintanence] Windows compatibility
  * Use C++11 portable sleep (#63 <https://github.com/ros-visualization/interactive_markers/issues/63>)
  * Symbol visibility for shared libraries (#62 <https://github.com/ros-visualization/interactive_markers/issues/62>)
  * Fix install location on Windows (#39 <https://github.com/ros-visualization/interactive_markers/issues/39>)
* Contributors: Alejandro Hernández Cordero, David Gossow, Fabian Maas, Jacob Perron, Robert Haschke, Sean Yen, Shane Loretz, shela
```
