### PR TITLE
laser_filters: 1.8.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -526,6 +526,21 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: melodic-devel
     status: maintained
+  laser_filters:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/laser_filters-release.git
+      version: 1.8.9-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: kinetic-devel
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.9-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## laser_filters

```
* Bump CMake version to avoid CMP0048 warning
* Polygon filter
* Add dynamic reconfigure for scan shadows filter
* Parameter to remove shadow start point in scan shadows filter
* Contributors: Jonathan Binney, Rein Appeldoorn, Yannick_de_Hoop, ahcorde
```
