### PR TITLE
urdf_geometry_parser: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16405,7 +16405,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/urdf_geometry_parser-release.git
-      version: 0.0.3-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_geometry_parser` to `0.1.0-1`:

- upstream repository: https://github.com/ros-controls/urdf_geometry_parser.git
- release repository: https://github.com/ros-gbp/urdf_geometry_parser-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.3-0`

## urdf_geometry_parser

```
* Remove tf2 dependency
* Add license
* Bump CMake version to avoid CMP0048 warning
* Cleanup CMakeLists.txt and package.xml
* Contributors: Bence Magyar, Matt Reynolds, Vincent Rousseau
```
