### PR TITLE
rc_dynamics_api: 0.10.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1671,6 +1671,22 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: crystal-devel
     status: maintained
+  rc_dynamics_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_dynamics_api-release.git
+      version: 0.10.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    status: developed
   rcdiscover:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_dynamics_api` to `0.10.2-1`:

- upstream repository: https://github.com/roboception/rc_dynamics_api.git
- release repository: https://github.com/roboception-gbp/rc_dynamics_api-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rc_dynamics_api

```
* remove build_export_depend on catkin from package.xml
```
