### PR TITLE
four_wheel_steering_msgs: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -289,6 +289,15 @@ repositories:
       version: noetic-devel
     status: maintained
   four_wheel_steering_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `four_wheel_steering_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/ros-drivers/four_wheel_steering_msgs.git
- release repository: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## four_wheel_steering_msgs

```
* Bump CMake version to avoid CMP0048 warning (#4 <https://github.com/ros-drivers/four_wheel_steering_msgs/issues/4>)
* Contributors: Alejandro Hernández Cordero
```
