### PR TITLE
four_wheel_steering_msgs: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2854,7 +2854,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
-      version: 1.0.0-0
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `four_wheel_steering_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/ros-drivers/four_wheel_steering_msgs.git
- release repository: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-0`

## four_wheel_steering_msgs

```
* Bump CMake version to avoid CMP0048 warning (#4 <https://github.com/ros-drivers/four_wheel_steering_msgs/issues/4>)
* Contributors: Alejandro Hernández Cordero
```
