### PR TITLE
rc_genicam_api: 2.3.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1933,6 +1933,22 @@ repositories:
       url: https://github.com/roboception/rc_dynamics_api.git
       version: master
     status: developed
+  rc_genicam_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_genicam_api-release.git
+      version: 2.3.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    status: developed
   rcdiscover:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.3.5-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rc_genicam_api

```
* ensure that downscale factor doesn't lead to division by zero
* remove build_export_depend on catkin from package.xml
```
