### PR TITLE
catkin: 0.8.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -92,7 +92,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.2-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.1-1`

## catkin

```
* use Python 3 shebang (#1076 <https://github.com/ros/catkin/issues/1076>)
* stamp env hook before copying (#1075 <https://github.com/ros/catkin/issues/1075>)
* set egg-base for setuptools packages (#1073 <https://github.com/ros/catkin/issues/1073>)
* [Windows] Accommodate different drives for --root (#1071 <https://github.com/ros/catkin/issues/1071>)
* [Windows] stop setuptools egg packaging (#1070 <https://github.com/ros/catkin/issues/1070>)
```
