### PR TITLE
catkin: 0.7.24-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1027,7 +1027,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.23-1
+      version: 0.7.24-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.24-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.7.23-1`

## catkin

```
* stamp env hook before copying (#1075 <https://github.com/ros/catkin/issues/1075>)
* set egg-base for setuptools packages (#1073 <https://github.com/ros/catkin/issues/1073>) (#1077 <https://github.com/ros/catkin/issues/1077>)
* [Windows] Accommodate different drives for --root (#1071 <https://github.com/ros/catkin/issues/1071>)
* [Windows] stop setuptools egg packaging (#1070 <https://github.com/ros/catkin/issues/1070>)
```
