### PR TITLE
urg_stamped: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1648,6 +1648,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: melodic-devel
     status: maintained
+  urg_stamped:
+    doc:
+      type: git
+      url: https://github.com/seqsense/urg_stamped.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/seqsense/urg_stamped-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/seqsense/urg_stamped.git
+      version: master
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.5-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## urg_stamped

```
* Support Noetic (#61 <https://github.com/seqsense/urg_stamped/issues/61>)
* Contributors: Atsushi Watanabe
```
