### PR TITLE
genmsg: 0.5.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3014,7 +3014,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.15-1
+      version: 0.5.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genmsg` to `0.5.16-1`:

- upstream repository: git@github.com:ros/genmsg.git
- release repository: https://github.com/ros-gbp/genmsg-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.5.15-1`

## genmsg

```
* fix comment handling in service spec string constants (#92 <https://github.com/ros/genmsg/issues/92>)
```
