### PR TITLE
yp-spur: 1.18.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17568,7 +17568,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.18.0-1
+      version: 1.18.1-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.18.1-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.18.0-1`

## ypspur

```
* Update assets to v0.0.8 (#139 <https://github.com/openspur/yp-spur/issues/139>)
* Fix without-device mode (#136 <https://github.com/openspur/yp-spur/issues/136>)
* Add CI job for Ubuntu Focal (#135 <https://github.com/openspur/yp-spur/issues/135>)
* Contributors: Atsushi Watanabe
```
