### PR TITLE
yp-spur: 1.18.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11939,7 +11939,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.18.0-1
+      version: 1.18.1-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.18.1-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.18.0-1`

## ypspur

```
* Update assets to v0.0.8 (#139 <https://github.com/openspur/yp-spur/issues/139>)
* Fix without-device mode (#136 <https://github.com/openspur/yp-spur/issues/136>)
* Add CI job for Ubuntu Focal (#135 <https://github.com/openspur/yp-spur/issues/135>)
* Contributors: Atsushi Watanabe
```
