### PR TITLE
yp-spur: 1.18.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1698,5 +1698,22 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: noetic-devel
     status: maintained
+  yp-spur:
+    doc:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    release:
+      packages:
+      - ypspur
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/openspur/yp-spur-release.git
+      version: 1.18.1-1
+    source:
+      type: git
+      url: https://github.com/openspur/yp-spur.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.18.1-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## ypspur

```
* Update assets to v0.0.8 (#139 <https://github.com/openspur/yp-spur/issues/139>)
* Fix without-device mode (#136 <https://github.com/openspur/yp-spur/issues/136>)
* Add CI job for Ubuntu Focal (#135 <https://github.com/openspur/yp-spur/issues/135>)
* Contributors: Atsushi Watanabe
```
