### PR TITLE
neonavigation: 0.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5872,7 +5872,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.8.2-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.1-1`

## costmap_cspace

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## map_organizer

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## neonavigation_launch

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```

## track_odometry

```
* track_odometry: add option to align all postures to source frame (#447 <https://github.com/at-wat/neonavigation/issues/447>)
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* track_odometry: add enable_tcp_no_delay option to reduce latency (#456 <https://github.com/at-wat/neonavigation/issues/456>)
* track_odometry: use double instead of float (#455 <https://github.com/at-wat/neonavigation/issues/455>)
* Contributors: Atsushi Watanabe, Naotaka Hatao, Yuta Koga
```

## trajectory_tracker

```
* Support Noetic (#461 <https://github.com/at-wat/neonavigation/issues/461>)
* Contributors: Atsushi Watanabe
```
