### PR TITLE
neonavigation_msgs: 0.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -677,6 +677,28 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros1
     status: maintained
+  neonavigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/at-wat/neonavigation_msgs.git
+      version: master
+    release:
+      packages:
+      - costmap_cspace_msgs
+      - map_organizer_msgs
+      - neonavigation_msgs
+      - planner_cspace_msgs
+      - safety_limiter_msgs
+      - trajectory_tracker_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/at-wat/neonavigation_msgs-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/at-wat/neonavigation_msgs.git
+      version: master
+    status: developed
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_msgs` to `0.8.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation_msgs.git
- release repository: https://github.com/at-wat/neonavigation_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## costmap_cspace_msgs

- No changes

## map_organizer_msgs

- No changes

## neonavigation_msgs

- No changes

## planner_cspace_msgs

- No changes

## safety_limiter_msgs

- No changes

## trajectory_tracker_msgs

```
* trajectory_tracker_msgs: add path header in TrajectoryTrackerStatus (#26 <https://github.com/at-wat/neonavigation_msgs/issues/26>)
* Contributors: Naotaka Hatao
```
