### PR TITLE
Added source for euslime

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2362,6 +2362,10 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/jsk-ros-pkg/euslime-release.git
       version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/euslime.git
+      version: master
   euslisp:
     doc:
       type: git


### PR DESCRIPTION
Added source field for the euslime entry in melodic (https://github.com/ros/rosdistro/pull/24337).

If I understand correctly this is needed to perform pre-release tests?