### PR TITLE
Update eigenpy to 2.3.0-3 to include patch for installation to share/cmake

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2303,7 +2303,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 2.3.0-1
+      version: 2.3.0-3
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Implements suggestion by @rhaschke in #24341 - thanks for the detailed analysis!

This PR uses patches to change the `INSTALL_DESTINATION` of `eigenpyConfig.cmake` to `share/cmake/eigenpy`.

It also explicitly sets the `CMAKE_BUILD_TYPE` to `Release`. It appears that the buildfarm by default sets `-DCMAKE_BUILD_TYPE=None`.