### PR TITLE
move_base_flex: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5276,7 +5276,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.3.1-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.3.0-1`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

- No changes

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* Ensure that check_costmap_mutex is destroyed after timer.
* Avoid crash on shutdown by stop shutdown_costmap_timer on destructor
  and explicitly call the costmap_nav_srv destructor
```

## mbf_msgs

- No changes

## mbf_simple_nav

- No changes

## mbf_utility

- No changes

## move_base_flex

- No changes
