### PR TITLE
Update eigenpy to 2.3.0-4 to fix-up patch

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2303,7 +2303,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 2.3.0-3
+      version: 2.3.0-4
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
I didn't realise the variable for `INSTALL_DESTINATION` gets set in two different places - this PR addresses this. I also accidentally installed to `share/cmake/{package}` instead of `share/{package}/cmake`. This should hopefully resolve these final issues.

Fix-up for #24407