### PR TITLE
plotjuggler: 2.6.3-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9947,7 +9947,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.6.2-1
+      version: 2.6.3-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.6.3-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.6.2-1`

## plotjuggler

```
* Fix issue #271 <https://github.com/facontidavide/PlotJuggler/issues/271>
* @veimox added
* Bugfix/executable (#264 <https://github.com/facontidavide/PlotJuggler/issues/264>)
  * created launching script , installing and making use of it in the icon
  * ignoring temporary folders when creating binary locally
  * corrected intsallation of script
  * using PROGRAM to install it with executable permissions
  Co-authored-by: Jorge Rodriguez <mailto:jr@blue-ocean-robotics.com>
* Feature/scalable icon (#265 <https://github.com/facontidavide/PlotJuggler/issues/265>)
  * installing icons in /usr/share and do it at any build type
  * added scalable icon
  * removed old icon
  Co-authored-by: Jorge Rodriguez <mailto:jr@blue-ocean-robotics.com>
* fix default suffix
* Fix bug #258 <https://github.com/facontidavide/PlotJuggler/issues/258>
* Contributors: Davide Faconti, Jorge Rodriguez
```
