### PR TITLE
laser_filters: 1.8.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4530,7 +4530,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.8-1
+      version: 1.8.10-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.10-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.8.8-1`

## laser_filters

```
* radius_outlier_filter: new filter for radius based outlier removal
  Add a new filter to remove measurements that do not have a number of
  neighbors within a certain range.
* Contributors: Jonathan Binney, Nicolas Limpert
```
