### PR TITLE
ros: 1.15.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1030,7 +1030,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.1-1
+      version: 1.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.2-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.15.1-1`

## mk

- No changes

## rosbash

```
* add rosmv shell function to move a file from package to target (#247 <https://github.com/ros/ros/issues/247>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

```
* fix log purge on Windows (#251 <https://github.com/ros/ros/issues/251>)
```

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

- No changes
