### PR TITLE
laser_assembler: 1.7.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -557,6 +557,21 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: melodic-devel
     status: maintained
+  laser_assembler:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_assembler.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/laser_assembler-release.git
+      version: 1.7.8-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_assembler.git
+      version: noetic-devel
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_assembler` to `1.7.8-1`:

- upstream repository: https://github.com/ros-perception/laser_assembler.git
- release repository: https://github.com/ros-gbp/laser_assembler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## laser_assembler

```
* Bump CMake version to avoid CMP0048 warning
* Fix windows build
* Contributors: Jonathan Binney, Sean Yen, ahcorde
```
