### PR TITLE
Add python-sexpdata to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4137,16 +4137,21 @@ python-setuptools:
     zesty: [python-setuptools]
 python-sexpdata:
   debian:
-    '*':
+    '*': [python-sexpdata]
+    jessie:
       pip:
         packages: [sexpdata]
-    buster: [python-sexpdata]
+    stretch:
+      pip:
+        packages: [sexpdata]
   ubuntu:
-    '*':
+    '*': [python-sexpdata]
+    bionic:
       pip:
         packages: [sexpdata]
-    disco: [python-sexpdata]
-    eoan: [python-sexpdata]
+    xenial:
+      pip:
+        packages: [sexpdata]
 python-sh:
   debian: [python-sh]
   fedora: [python-sh]
@@ -5838,9 +5843,6 @@ python3-sexpdata:
   ubuntu:
     '*': [python3-sexpdata]
     bionic:
-      pip:
-        packages: [sexpdata]
-    trusty:
       pip:
         packages: [sexpdata]
     xenial:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4136,9 +4136,17 @@ python-setuptools:
     yakkety: [python-setuptools]
     zesty: [python-setuptools]
 python-sexpdata:
+  debian:
+    '*':
+      pip:
+        packages: [sexpdata]
+    buster: [python-sexpdata]
   ubuntu:
-    pip:
-      packages: [sexpdata]
+    '*':
+      pip:
+        packages: [sexpdata]
+    disco: [python-sexpdata]
+    eoan: [python-sexpdata]
 python-sh:
   debian: [python-sh]
   fedora: [python-sh]
@@ -5818,6 +5826,26 @@ python3-setuptools:
   openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-setuptools]
+python3-sexpdata:
+  debian:
+    '*': [python3-sexpdata]
+    jessie:
+      pip:
+        packages: [sexpdata]
+    stretch:
+      pip:
+        packages: [sexpdata]
+  ubuntu:
+    '*': [python3-sexpdata]
+    bionic:
+      pip:
+        packages: [sexpdata]
+    trusty:
+      pip:
+        packages: [sexpdata]
+    xenial:
+      pip:
+        packages: [sexpdata]
 python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4135,6 +4135,10 @@ python-setuptools:
     xenial_python3: [python3-setuptools]
     yakkety: [python-setuptools]
     zesty: [python-setuptools]
+python-sexpdata:
+  ubuntu:
+    pip:
+      packages: [sexpdata]
 python-sh:
   debian: [python-sh]
   fedora: [python-sh]


### PR DESCRIPTION
Adding [sexpdata](https://pypi.org/project/sexpdata/), a python S-expression parser needed in the recently added [euslime](https://github.com/jsk-ros-pkg/euslime) package. 
https://github.com/ros/rosdistro/pull/24337