### PR TITLE
volksbot_driver: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11570,7 +11570,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/volksbot_driver-release.git
-      version: 1.0.0-3
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/uos/volksbot_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `volksbot_driver` to `1.0.1-1`:

- upstream repository: https://github.com/uos/volksbot_driver.git
- release repository: https://github.com/uos-gbp/volksbot_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.0.0-3`

## volksbot_driver

```
* support for four and six wheels, as well as changing the joint names
* Contributors: Sebastian Pütz
```
