### PR TITLE
[dep] Add some exfat* tools.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -739,6 +739,15 @@ espeak:
   fedora: [espeak]
   gentoo: [app-accessibility/espeak]
   ubuntu: [espeak]
+exfat-fuse:
+  debian: [exfat-fuse]
+  gentoo: [sys-fs/fuse-exfat]
+  ubuntu: [exfat-fuse]
+exfat-utils:
+  arch: [exfat-utils]
+  debian: [exfat-utils]
+  gentoo: [sys-fs/exfat-utils]
+  ubuntu: [exfat-utils]
 f2c:
   arch: [f2c]
   debian: [f2c, libf2c2, libf2c2-dev]


### PR DESCRIPTION
arch
- expat-fuse equivalent not found.
- https://www.archlinux.org/packages/community/x86_64/exfat-utils

Debian jessie onward
- https://packages.debian.org/jessie/exfat-fuse
- https://packages.debian.org/jessie/exfat-utils

gentoo
- https://packages.gentoo.org/packages/sys-fs/fuse-exfat
- https://packages.gentoo.org/packages/sys-fs/exfat-utils

ubuntu
- https://packages.ubuntu.com/xenial/exfat-fuse
- https://packages.ubuntu.com/xenial/exfat-utils