### PR TITLE
kinetic: Update eigenpy to 2.3.1_2

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3131,7 +3131,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 1.6.9-1
+      version: 2.3.1-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
This updates EigenPy on Kinetic to match the 2.3.x release on Melodic. It will fix the current source build failures for Pinocchio on Kinetic.

The release contains the same patches as on Melodic - plus a patch that used to be on the 1.6.9 release to fix lib installation prefix.