### PR TITLE
resource_retriever: 2.2.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1901,7 +1901,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.2.2-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.2.1-1`

## libcurl_vendor

```
* Ignore broken curl-config.cmake (#40 <https://github.com/ros/resource_retriever/issues/40>) (#42 <https://github.com/ros/resource_retriever/issues/42>)
* Contributors: Scott K Logan
```

## resource_retriever

- No changes
