### PR TITLE
osrf_testing_tools_cpp: 1.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -68,6 +68,25 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  osrf_testing_tools_cpp:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    release:
+      packages:
+      - osrf_testing_tools_cpp
+      - test_osrf_testing_tools_cpp
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
+      version: 1.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: master
+    status: maintained
   ros_workspace:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.3.0-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
