### PR TITLE
test_interface_files: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -79,5 +79,21 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: maintained
+  test_interface_files:
+    doc:
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/test_interface_files-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: master
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## test_interface_files

```
* remove absolute paths from installed CMake code (#9 <https://github.com/ros2/test_interface_files/issues/9>)
* add wstring default values with non-ASCII characters (#8 <https://github.com/ros2/test_interface_files/issues/8>)
* Add Arrays.srv (#7 <https://github.com/ros2/test_interface_files/issues/7>)
* add IdlOnlyTypes - even though they are commented out atm (#6 <https://github.com/ros2/test_interface_files/issues/6>)
* Contributors: Dirk Thomas, Jacob Perron
```
