### PR TITLE
add nlohmann-json to rosdistro

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4621,7 +4621,7 @@ nlohmann-json-dev:
   debian: [nlohmann-json-dev]
   gentoo: [dev-cpp/nlohmann_json]
   ubuntu:
-    '*': [nlohmann-json-dev ]
+    '*': [nlohmann-json-dev]
     xenial: null
 nmap:
   archlinux: [nmap]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4617,6 +4617,11 @@ nkf:
   fedora: [nkf]
   gentoo: [app-i18n/nkf]
   ubuntu: [nkf]
+nlohmann-json:
+  debian: [nlohmann-json-dev]
+  fedra: [json]
+  gentoo: [nlohmann_json]
+  ubuntu: [nlohmann-json-dev ]
 nmap:
   archlinux: [nmap]
   debian: [nmap]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4621,7 +4621,9 @@ nlohmann-json:
   debian: [nlohmann-json-dev]
   fedra: [json]
   gentoo: [nlohmann_json]
-  ubuntu: [nlohmann-json-dev ]
+  ubuntu: 
+    '*': [nlohmann-json-dev ]
+    xenial: null
 nmap:
   archlinux: [nmap]
   debian: [nmap]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4617,7 +4617,7 @@ nkf:
   fedora: [nkf]
   gentoo: [app-i18n/nkf]
   ubuntu: [nkf]
-nlohmann-json:
+nlohmann-json-dev:
   debian: [nlohmann-json-dev]
   gentoo: [dev-cpp/nlohmann_json]
   ubuntu: 

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4619,7 +4619,7 @@ nkf:
   ubuntu: [nkf]
 nlohmann-json:
   debian: [nlohmann-json-dev]
-  gentoo: [nlohmann_json]
+  gentoo: [dev-cpp/nlohmann_json]
   ubuntu: 
     '*': [nlohmann-json-dev ]
     xenial: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4619,7 +4619,6 @@ nkf:
   ubuntu: [nkf]
 nlohmann-json:
   debian: [nlohmann-json-dev]
-  fedra: [json]
   gentoo: [nlohmann_json]
   ubuntu: 
     '*': [nlohmann-json-dev ]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4620,7 +4620,7 @@ nkf:
 nlohmann-json-dev:
   debian: [nlohmann-json-dev]
   gentoo: [dev-cpp/nlohmann_json]
-  ubuntu: 
+  ubuntu:
     '*': [nlohmann-json-dev ]
     xenial: null
 nmap:


### PR DESCRIPTION
I want to add nlohmann-json to rosdistro.

Fedra package is here : https://rpms.remirepo.net/rpmphp/zoom.php?rpm=json
Gentoo package is here : https://packages.gentoo.org/packages/dev-cpp/nlohmann_json
Ubuntu package is here : https://packages.ubuntu.com/search?keywords=nlohmann-json-dev
Debian package is here : https://packages.debian.org/stretch/nlohmann-json-dev