### PR TITLE
Update python-hypothesis rule for Ubuntu.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2007,11 +2007,9 @@ python-hypothesis:
   fedora: [python-hypothesis]
   gentoo: [dev-python/hypothesis]
   ubuntu:
-    xenial: [python-hypothesis]
+    '*': [python-hypothesis]
     xenial_python3: [python3-hypothesis]
-    yakkety: [python-hypothesis]
     yakkety_python3: [python3-hypothesis]
-    zesty: [python-hypothesis]
     zesty_python3: [python3-hypothesis]
 python-imageio:
   debian:


### PR DESCRIPTION
The rule python-hypothesis on Ubuntu seems to have not been touched in a while. This refactors the existing entries into a generic rule such that python-hypothesis resolves for newer Ubuntu versions, too.