### PR TITLE
uncrustify_vendor: 1.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -130,5 +130,16 @@ repositories:
       url: https://github.com/ros2/test_interface_files.git
       version: master
     status: maintained
+  uncrustify_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: master
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `uncrustify_vendor` to `1.4.0-1`:

- upstream repository: https://github.com/ament/uncrustify_vendor.git
- release repository: https://github.com/ros2-gbp/uncrustify_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
