### PR TITLE
spdlog_vendor: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -162,6 +162,18 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: maintained
+  spdlog_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/spdlog_vendor-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/spdlog_vendor.git
+      version: master
+    status: maintained
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## spdlog_vendor

```
* suppress sign conversion warning (#7 <https://github.com/ros2/spdlog_vendor/issues/7>)
* Fix linting (#3 <https://github.com/ros2/spdlog_vendor/issues/3>)
* Spdlog vendor update (#2 <https://github.com/ros2/spdlog_vendor/issues/2>)
* Enable linter tests on spdlog_vendor (#1 <https://github.com/ros2/spdlog_vendor/issues/1>)
* Contributors: Anas Abou Allaban, Chris Lalancette, Jorge Perez, Karsten Knese
```
