### PR TITLE
hokuyo3d: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -502,6 +502,21 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  hokuyo3d:
+    doc:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/at-wat/hokuyo3d-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/at-wat/hokuyo3d.git
+      version: master
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hokuyo3d` to `0.2.1-1`:

- upstream repository: https://github.com/at-wat/hokuyo3d.git
- release repository: https://github.com/at-wat/hokuyo3d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## hokuyo3d

```
* Fix bot comment on prerelease test (#52 <https://github.com/at-wat/hokuyo3d/issues/52>)
* Update CI scripts (#49 <https://github.com/at-wat/hokuyo3d/issues/49>)
* Support Boost 1.69 (#48 <https://github.com/at-wat/hokuyo3d/issues/48>)
* Update pointer align style (#47 <https://github.com/at-wat/hokuyo3d/issues/47>)
* Update assets to v0.0.8 (#46 <https://github.com/at-wat/hokuyo3d/issues/46>)
* Update assets to v0.0.7 (#45 <https://github.com/at-wat/hokuyo3d/issues/45>)
* Update assets to v0.0.6 (#44 <https://github.com/at-wat/hokuyo3d/issues/44>)
* Ignore gh-pr-comment failure (#42 <https://github.com/at-wat/hokuyo3d/issues/42>)
* Fix CI bot (#41 <https://github.com/at-wat/hokuyo3d/issues/41>)
* Fix travis build branch (#40 <https://github.com/at-wat/hokuyo3d/issues/40>)
* Contributors: Atsushi Watanabe
```
