### PR TITLE
rosbridge_suite: 0.11.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8847,7 +8847,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.4-1
+      version: 0.11.5-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `0.11.5-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite
- release repository: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.11.4-1`

## rosapi

```
* Python 3 updates/fixes (#460 <https://github.com/RobotWebTools/rosbridge_suite/issues/460>)
  * rosbridge_library, rosbridge_server: Update package format
  Add Python3 conditional dependencies where applicable.
  * rosbridge_library: Fix pngcompression for Python 3
  * rosapi: Use catkin_install_python for scripts
* Contributors: Alexey Rogachevskiy
```

## rosbridge_library

```
* Add script for dockerized development shell (#479 <https://github.com/RobotWebTools/rosbridge_suite/issues/479>)
  * Add script for dockerized development shell
  * Fix queue dropping test
* Subscriber concurrency review (#478 <https://github.com/RobotWebTools/rosbridge_suite/issues/478>)
  * Lock access to SubscriberManager public methods
  Prevent subscribe during unsubscribe critical section.
  * Unsubscribing an unsubscribed topic is an error
  This branch must not be ignored.
  * Cleanup some redundant syntax in subscribers impl
* Fix queue blocking (#464 <https://github.com/RobotWebTools/rosbridge_suite/issues/464>)
  * Unblock QueueMessageHandler.handle_message
  The thread was holding the lock while pushing to a potentially blocking
  function.  Rewrite the logic and use a deque while we're at it.
  * Add test for subscription queue behavior
  Guarantee that the queue drops messages when blocked.
* Python 3 updates/fixes (#460 <https://github.com/RobotWebTools/rosbridge_suite/issues/460>)
  * rosbridge_library, rosbridge_server: Update package format
  Add Python3 conditional dependencies where applicable.
  * rosbridge_library: Fix pngcompression for Python 3
  * rosapi: Use catkin_install_python for scripts
* Fixing wrong header/stamp in published ROS-messsages (#472 <https://github.com/RobotWebTools/rosbridge_suite/issues/472>)
  When publishing a message to ROS (i.e. incoming from rosbridge_server's perspective), timestamps in the Header attributes all point to the same Time object iff the message contains multiple Header attributes (typically the case if a ROS message contains other ROS messages, e.g. ...Array-types) and rosparam use_sim_time is true.
* Contributors: Alexey Rogachevskiy, Matt Vollrath, danielmaier
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* default websocket_external_port to port to mimic behavior in node (#470 <https://github.com/RobotWebTools/rosbridge_suite/issues/470>)
  fixes bug introduced in #468 <https://github.com/RobotWebTools/rosbridge_suite/issues/468>
* Default to supporting local files as we had before Autobahn. (#469 <https://github.com/RobotWebTools/rosbridge_suite/issues/469>)
  For Kinetic 0.10.3 version don't add the allowNullOrigin option.
  For everything else add it and default to True because that is
  consistent with the original behaviour of this package.
  Add websocket_null_origin to launch args
* Python 3 updates/fixes (#460 <https://github.com/RobotWebTools/rosbridge_suite/issues/460>)
  * rosbridge_library, rosbridge_server: Update package format
  Add Python3 conditional dependencies where applicable.
  * rosbridge_library: Fix pngcompression for Python 3
  * rosapi: Use catkin_install_python for scripts
* Fix intermittent test smoke (#473 <https://github.com/RobotWebTools/rosbridge_suite/issues/473>)
  * Run rosbridge_server websocket tests serial
  Running these tests in parallel may make them less reliable.
  * Reduce websocket smoke test load
  Appears to be failing intermittently due to a client issue.
  Co-authored-by: Jihoon Lee <mailto:jihoonlee.in@gmail.com>
* Expose autobahn externalPort parameter (#468 <https://github.com/RobotWebTools/rosbridge_suite/issues/468>)
  * Expose autobahn externalPort parameter
  * Use ws port as default external port
  * Include websocket params in launchfile
* Contributors: Alexey Rogachevskiy, Eduardo Paez, El Jawad Alaa, Matt Vollrath, boilerbots
```

## rosbridge_suite

- No changes
