### PR TITLE
kinetic: Update pinocchio to 2.4.0_2

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9873,7 +9873,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
-      version: 2.4.0-1
+      version: 2.4.0-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
Deactivates unit tests to avoid memory exhaustion on buildfarm.

Related issue: https://github.com/stack-of-tasks/pinocchio/issues/1096