### PR TITLE
melodic: Update pinocchio to 2.4.0_2

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6950,7 +6950,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
-      version: 2.3.1-1
+      version: 2.4.0-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
Deactivates unit tests to avoid memory exhaustion on buildfarm.