### PR TITLE
Use ogre version 1.12 on focal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2790,6 +2790,7 @@ libogre:
   ubuntu:
     artful: [libogre-1.9-dev]
     bionic: [libogre-1.9.0v5]
+    focal: [libogre-1.12]
     lucid: [libogre-dev]
     maverick: [libogre-dev]
     natty: [libogre-dev]
@@ -2822,6 +2823,7 @@ libogre-dev:
   ubuntu:
     artful: [libogre-1.9-dev]
     bionic: [libogre-1.9-dev]
+    focal: [libogre-1.12-dev]
     lucid: [libogre-dev]
     maverick: [libogre-dev]
     natty: [libogre-dev]


### PR DESCRIPTION
I finally managed to get Ogre in Ubuntu updated today and since @rhaschke already ported rviz to support it, it should be used in noetic