### PR TITLE
visualstates: 0.2.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11579,7 +11579,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/VisualStates-release.git
-      version: 0.2.3-3
+      version: 0.2.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/VisualStates.git
+      version: master
   volksbot_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualstates` to `0.2.4-1`:

- upstream repository: https://github.com/JdeRobot/VisualStates.git
- release repository: https://github.com/JdeRobot/VisualStates-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.2.3-3`

## visualstates

```
* Merge pull request #151 <https://github.com/JdeRobot/VisualStates/issues/151> from JdeRobot/dependabot/bundler/docs/rake-tw-12.3
  Update rake requirement from ~> 10.0 to ~> 12.3 in /docs
* Update rake requirement from ~> 10.0 to ~> 12.3 in /docs
  Updates the requirements on [rake](https://github.com/ruby/rake) to permit the latest version.
  - [Release notes](https://github.com/ruby/rake/releases)
  - [Changelog](https://github.com/ruby/rake/blob/master/History.rdoc)
  - [Commits](https://github.com/ruby/rake/compare/v10.5.0...v12.3.3)
  Signed-off-by: dependabot[bot] <mailto:support@github.com>
* Merge pull request #150 <https://github.com/JdeRobot/VisualStates/issues/150> from JdeRobot/fix-setup
  add missing module visualstates.gui.util
* add missing module visualstates.gui.util
* Contributors: JoseMaria Cañas, Okan Asik, Okan Aşık, dependabot[bot]
```
