### PR TITLE
jderobot_camviz: 0.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4028,7 +4028,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/CamViz-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_camviz` to `0.1.0-2`:

- upstream repository: https://github.com/JdeRobot/CamViz.git
- release repository: https://github.com/JdeRobot/CamViz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.1.0-1`

## jderobot_camviz

```
* first public release of camViz for Melodic
* Contributors: Jose Maria Cañas Plaza, Pankhuri Vanjani, Francisco Perez
```
