### PR TITLE
rowma_ros: 0.0.2-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13251,6 +13251,21 @@ repositories:
       url: https://github.com/tork-a/roswww.git
       version: develop
     status: maintained
+  rowma_ros:
+    doc:
+      type: git
+      url: https://github.com/rowma/rowma_ros.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rowma/rowma_ros.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://github.com/rowma/rowma_ros.git
+      version: master
+    status: developed
   rplidar_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rowma_ros` to `0.0.2-2`:

- upstream repository: https://github.com/rowma/rowma_ros
- release repository: https://github.com/rowma/rowma_ros.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rowma_ros

- No changes
