### PR TITLE
rowma_ros: 0.0.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9224,6 +9224,21 @@ repositories:
       type: git
       url: https://github.com/ethz-asl/rotors_simulator.git
       version: feature/gazebo9-autobackport
+  rowma_ros:
+    doc:
+      type: git
+      url: https://github.com/rowma/rowma_ros.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rowma/rowma_ros.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://github.com/rowma/rowma_ros.git
+      version: master
+    status: developed
   rplidar_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rowma_ros` to `0.0.2-2`:

- upstream repository: https://github.com/rowma/rowma_ros
- release repository: https://github.com/rowma/rowma_ros.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rowma_ros

- No changes
