### PR TITLE
jsk_visualization: 2.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4315,7 +4315,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_visualization-release.git
-      version: 2.1.5-0
+      version: 2.1.6-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
     status: developed
   jskeus:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.6-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.1.5-0`

## jsk_interactive

- No changes

## jsk_interactive_marker

```
* Remove unnecessary ROS_INFO (#755 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/755>)
* Contributors: Yuto Uchimi
```

## jsk_interactive_test

- No changes

## jsk_rqt_plugins

```
* fix test failure in jsk_rqt_plugins (#766 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/766>)
  
    * disable jsk_rqt_plugins test in indigo
      this is because indigo does not support matplotlib
      liner_model.RANSACRegressor.
  
* [jsk_rqt_plugins] load rosparam correctly in button_general.py (#746 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/746>)
* Replace image_pipeline with image_publisher (#729 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/729>)
  
    * Replace image_pipeline with image_publisher
      * image_pipeline is a meta package and normal ros packages are not
      intended to depend on meta packages.
  
* Contributors: Ryohei Ueda, Shingo Kitagawa
```

## jsk_rviz_plugins

```
* [jsk_rviz_plugins] Add FontAwesome 5 (#759 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/759>)
  
    * Display FontAwesome 5 icons from pictogram.py and pictogram_all.py
    * Add FontAwesome 5
    * Add property to set position of overlay menu
  
* Add option to specify width and height in VideoCapture plugin (#748 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/748>)
* Add a script that convert String to OverlayText (#753 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/753>)
* fix build failure of OgreSceneManager this block latest Melodic builds (#766 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/766>)
* Add property to set position of overlay menu (#758 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/758>)
* [jsk_rviz_plugins/OverlayImage] Add property to ignore alpha channel of the image (#752 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/752>)
* [motor_states_temperature_decomposer.py] add queue_size (#756 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/756>)
* support jsk_rviz_plugin to be loaded in indigo (#739 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/739>)
* [jsk_rviz_plugins/OverlayImageDisplay] Use memcpy to copy image data (#737 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/737>)
  
    * Use memcpy to copy image data from cv::Mat to QImagee instead of use QImage::setPixel() many times for optimization.
  
* Transport hint for camera info (#736 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/736>)
  
    * Add field to select transport hint of CameraInfo display
      * Use ImageTransport to create subscriber to subscribe image topic in CameraInfoDisplay.
      * Use ImageTransportHintsProperty to choose image transport hints when subscribing image topic to visualize sensor_msgs/CameraInfo.
    * Use ImageTransportHintsProperty in OverlayImageDisplay class
    * Add ImageTransportHintsProperty class
      * ImageTransportHintsProperty is an rviz property class specialized for image_transport::TransportHints.
  
* Add transport hint field to OverlayImage display (#730 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/730>)
  
    * Add transport hint field to OverlayImage display
      * Add an editable enum field to specify transport hint on OverlayImage display.
      * raw, compressed and theora are listed as pre-defined transport  hints.
  
* Unsubscribe image topic when "use image" is unchecked in CameraInfo display (#732 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/732>)
* Fix format specifier (#731 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/731>)
  
    * Use %u instead of %lu to print Ogre::Texture::getWidth() and Ogre::Texture::getHeight() because they return uint32.
  
* Do not subscribe image topic when rviz startups in OverlayImage display (#733 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/733>)
  * Do not subscribe image topic when rviz startups in OverlayImage displayIn order not to subscribe image topic when rviz startups with OverlayImage display disabled, always verify if the display is enabled before the display subscribes topic.
  
    * Unsubscribe image topic when "use image" is unchecked in CameraInfo display
  
* Support classification result visualization with approximate sync (#725 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/725>)
  
    * classification_result_visualizer: add option to use approximate synchronizer
  
* Contributors: Yuki Furuta, Iki Yo, Naoki Mizuno, Naoki Hiraoka, Ryohei Ueda, Shingo Kitagawa, Yuto Uchimi, Iory Yanokura
```

## jsk_visualization

- No changes
