### PR TITLE
openzen_sensor: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6547,7 +6547,7 @@ repositories:
     doc:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git
-      version: 1.0.0
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -6556,7 +6556,7 @@ repositories:
     source:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git
-      version: 1.0.0
+      version: master
     status: developed
   optpp_catkin:
     release:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6543,6 +6543,22 @@ repositories:
       url: https://github.com/ros-perception/openslam_gmapping.git
       version: melodic-devel
     status: unmaintained
+  openzen_sensor:
+    doc:
+      type: git
+      url: https://bitbucket.org/lpresearch/openzenros.git
+      version: 1.0.0
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lp-research/openzen_sensor-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://bitbucket.org/lpresearch/openzenros.git
+      version: 1.0.0
+    status: developed
   optpp_catkin:
     release:
       tags:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6554,7 +6554,6 @@ repositories:
       url: https://github.com/lp-research/openzen_sensor-release.git
       version: 1.0.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git
       version: 1.0.0

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6552,7 +6552,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lp-research/openzen_sensor-release.git
-      version: 1.0.0-1
+      version: 1.0.1-2
     source:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openzen_sensor` to `1.0.0-1`:

- upstream repository: https://bitbucket.org/lpresearch/openzenros.git
- release repository: https://github.com/lp-research/openzen_sensor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## openzen_sensor

```
* Initial Release of OpenZen ROS driver
* Contributors: LP-Research Inc. Team
```
