### PR TITLE
app_manager: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -161,7 +161,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/app_manager-release.git
-      version: 1.1.0-0
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/pr2/app_manager.git


### PR DESCRIPTION
Increasing version of package(s) in repository `app_manager` to `1.1.1-1`:

- upstream repository: https://github.com/pr2/app_manager.git
- release repository: https://github.com/ros-gbp/app_manager-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.1.0-0`

## app_manager

```
* use python3.5 for travis (#18 <https://github.com/pr2/app_manager/issues/18>)
* use app_manager/example-min (#15 <https://github.com/pr2/app_manager/issues/15>)
  
    * example-min.launch location changed due to https://github.com/PR2/app_manager/pull/15
    * use app_manager/example-min, since talker.py was removed from rospy in melodic https://github.com/ros/ros_comm/pull/1847
  
* update document (#14 <https://github.com/pr2/app_manager/issues/14>)
  
    * Add more info for how to start apps, closes https://github.com/PR2/app_manager/issues/13
  
* Fix travis (#16 <https://github.com/pr2/app_manager/issues/16>)
  
    * fix workspace name due to ros-infrastructure/ros_buildfarm#577 <https://github.com/ros-infrastructure/ros_buildfarm/issues/577>
  
* install launch directory (#9 <https://github.com/pr2/app_manager/issues/9>)
* add run_depend of app_manager in README.md (#11 <https://github.com/pr2/app_manager/issues/11>)
* update travis.yml (#10 <https://github.com/pr2/app_manager/issues/10>)
  
    * add empty applist0 directory
      c.f. https://stackoverflow.com/questions/115983/how-can-i-add-an-empty-directory-to-a-git-repository
    * calling self._load() and updating self._file_mtime are never happens, since self.update() is removed in https://github.com/PR2/app_manager/pull/7/files#diff-a8d7b30ba0e424e10aa794dec1928181L98
    * revert code from #7 <https://github.com/pr2/app_manager/issues/7>, which wrongly removed invalid_installed_files
    * example-min.launch file has been moved to subdir since 2012
      
      https://github.com/ros/ros_comm/commit/964da45c6959bf9c2bde8680c69d1ab36e3770b1#diff-03b2e74d781fea8d7240c1fdd29a41a9
  
* Contributors: Kei Okada, Shingo Kitagawa, Takayuki Murooka, Yuki Furuta
```
