### PR TITLE
pacmod_game_control: 3.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6699,7 +6699,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/pacmod_game_control-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pacmod_game_control` to `3.0.2-1`:

- upstream repository: https://github.com/astuff/pacmod_game_control.git
- release repository: https://github.com/astuff/pacmod_game_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `3.0.1-1`

## pacmod_game_control

```
* fix shift command - manual merge due to circleci not communicating correctly
* fix shift command
* Contributors: Amruta Mhaske, bjansky
```
