### PR TITLE
kdl_parser: 1.14.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -566,6 +566,15 @@ repositories:
       version: noetic-devel
     status: maintained
   kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/kdl_parser-release.git
+      version: 1.14.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `1.14.0-1`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros-gbp/kdl_parser-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## kdl_parser

```
* Used keys for Orocos (#38 <https://github.com/ros/kdl_parser/issues/38>)
* Set C++ standard to 14 (#37 <https://github.com/ros/kdl_parser/issues/37>)
* Contributors: Alejandro Hernández Cordero, James Xu, Shane Loretz
```
