### PR TITLE
pr2_robot: 1.6.31-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7304,6 +7304,30 @@ repositories:
       url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
       version: 1.1.7-0
     status: unmaintained
+  pr2_robot:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_robot.git
+      version: kinetic-devel
+    release:
+      packages:
+      - imu_monitor
+      - pr2_bringup
+      - pr2_camera_synchronizer
+      - pr2_computer_monitor
+      - pr2_controller_configuration
+      - pr2_ethercat
+      - pr2_robot
+      - pr2_run_stop_auto_restart
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_robot-release.git
+      version: 1.6.31-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_robot.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_robot` to `1.6.31-1`:

- upstream repository: https://github.com/pr2/pr2_robot.git
- release repository: https://github.com/pr2-gbp/pr2_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## imu_monitor

- No changes

## pr2_bringup

```
* pr2_bringup: test launch files (#255 <https://github.com/pr2/pr2_robot/issues/255>)
  
    * Disable because pr2.launch needs to resolve c1/c2 hostname
  
* rebased version of https://github.com/PR2/pr2_robot/pull/256 (#263 <https://github.com/pr2/pr2_robot/issues/263>)
  
    * Adapt monitoring to upgraded PR2s:
      - no more IPMI
      - new number of CPU cores
      - re-add monitoring of c2
  
* calibrate_pr2: intercept and print exception (#248 <https://github.com/pr2/pr2_robot/issues/248>)
  * This was silently ignored before.
  * White space cleanup
* Param names changed between urg_node and hokuyo_node (#257 <https://github.com/pr2/pr2_robot/issues/257>)
  
    * The new urg_node package is used for the laser scanners in kinetic, but the parameter names are still the one of the hokuyo_node package.
  
* Contributors: Yuki Furuta, Matthieu Herrb, Michael Goerner, Yannick Jonetzko
```

## pr2_camera_synchronizer

- No changes

## pr2_computer_monitor

```
* add --ignore-self arg in ntp_monitor.py (#259 <https://github.com/pr2/pr2_robot/issues/259>)
* fixed CMake errors
* Contributors: David Feil-Seifer, Shingo Kitagawa
```

## pr2_controller_configuration

```
* fixed integer cast to void* warning in pr2_ethercat; fixed broken launchtest for now
* Contributors: David Feil-Seifer
```

## pr2_ethercat

```
* fixed integer cast to void* warning in pr2_ethercat; fixed broken launchtest for now
* Contributors: David Feil-Seifer
```

## pr2_robot

- No changes

## pr2_run_stop_auto_restart

```
* fixed CMake errors
* Contributors: David Feil-Seifer
```
