### PR TITLE
swarmros: 0.3.6-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15154,7 +15154,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
-      version: 0.3.6-0
+      version: 0.3.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swarmros` to `0.3.6-2`:

- upstream repository: https://github.com/amilankovich-slab/swarmros.git
- release repository: https://github.com/amilankovich-slab/swarmros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.3.6-0`
