### PR TITLE
sbg_driver: 2.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14287,7 +14287,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `2.0.3-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.0.2-1`

## sbg_driver

```
* Improve matrix handling
* Fix body velocity computation (Issue #31 <https://github.com/SBG-Systems/sbg_ros_driver/issues/31>)
```
