### PR TITLE
catkin: 0.8.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -92,7 +92,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.1-1
+      version: 0.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.3-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.1-1`

## catkin

```
* also rewrite shebang lines with whitespace in catkin_install_python (#1079 <https://github.com/ros/catkin/issues/1079>)
```
