### PR TITLE
Add a few missing gentoo keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -407,6 +407,7 @@ clang-tidy:
     buster: [clang-tidy]
     stretch: [clang-tidy]
   fedora: [clang-tools-extra]
+  gentoo: [sys-devel/clang]
   osx:
     homebrew:
       packages: [llvm]
@@ -4162,6 +4163,7 @@ libxml2:
 libxml2-utils:
   debian: [libxml2-utils]
   fedora: [libxml2]
+  gentoo: [dev-libs/libxml2]
   openembedded: [libxml2@openembedded-core]
   osx:
     homebrew:


### PR DESCRIPTION
Adds `clang-tidy` and `libxml2-utils` resolutions for Gentoo.