### PR TITLE
hrpsys: 315.15.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3544,6 +3544,21 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hrpsys:
+    doc:
+      type: git
+      url: https://github.com/fkanehiro/hrpsys-base.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/hrpsys-release.git
+      version: 315.15.0-1
+    source:
+      type: git
+      url: https://github.com/fkanehiro/hrpsys-base.git
+      version: master
+    status: maintained
   husky:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.15.0-1`:

- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## hrpsys

- No changes
