### PR TITLE
ros_control: 0.18.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8601,7 +8601,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.17.0-1
+      version: 0.18.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.18.0-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.17.0-1`

## combined_robot_hw

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## combined_robot_hw_tests

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## controller_interface

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## controller_manager

```
* enable spawner to wait indefinitely if requested (#428 <https://github.com/ros-controls/ros_control/issues/428>)
  rospy.wait_for_service does not allow for 0 to wait indefinitely.
  Instead, None has to be passed explicitly.
  By personal request of three maintainers extended to include documentation
  and the alternative argument --no-timeout.
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Michael Görner, Shane Loretz
```

## controller_manager_msgs

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## controller_manager_tests

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## hardware_interface

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## joint_limits_interface

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## ros_control

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## rqt_controller_manager

```
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Shane Loretz
```

## transmission_interface

```
* Add xmlns for URDF, remove xmlns:xacro (#436 <https://github.com/ros-controls/ros_control/issues/436>)
* Fixed compile tests (#434 <https://github.com/ros-controls/ros_control/issues/434>)
* Replace internal::is_permutation with std (#419 <https://github.com/ros-controls/ros_control/issues/419>)
* Bump CMake version to avoid CMP0048 (#427 <https://github.com/ros-controls/ros_control/issues/427>)
* Contributors: Alejandro Hernández Cordero, Matt Reynolds, Shane Loretz
```
