### PR TITLE
sick_scan2: 0.1.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2746,7 +2746,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/SICKAG/sick_scan2-release.git
-      version: 0.1.5-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan2` to `0.1.7-1`:

- upstream repository: https://github.com/SICKAG/sick_scan2.git
- release repository: https://github.com/SICKAG/sick_scan2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.5-1`

## sick_scan2

```
* retrial bloom release
* Merge pull request #8 <https://github.com/SICKAG/sick_scan2/issues/8> from clalancette/fixes
  Fixes for CMakeLists.txt to build on the buildfarm.
* Fixes for CMakeLists.txt to build on the buildfarm.
  A few things done in here:
  1.  Change CMake required version back to 3.5
  2.  Remove unnecessary dependency on pthreads
  3.  Remove duplicate boost dependency.
  4.  Make sure to find_package(diagnostic_updater) before use.
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Trying to figure out problem with the build farm
  build farm reports: 23:10:29 /usr/bin/ld: cannot find -lpthreads
* -pthread option added to build receipt
* Add pthreads dependancy
  This addition is triggered by reading
  'https://stackoverflow.com/questions/31948521/building-error-using-cmake-cannot-find-lpthreads'
* pthread dep. added to CMakeLists.txt
* removed unnecessary dependency from cmakelist.txt
* Contributors: Chris Lalancette, Michael Lehning
```
