### PR TITLE
openrtm_aist: 1.1.2-7 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6552,7 +6552,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.2-3
+      version: 1.1.2-7
+    source:
+      type: git
+      url: https://github.com/tork-a/openrtm_aist-release.git
+      version: release/melodic/openrtm_aist
     status: developed
   openrtm_aist_python:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.2-7`:

- upstream repository: https://github.com/OpenRTM/OpenRTM-aist.git
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.1.2-3`
