### PR TITLE
ros_controllers: 0.16.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8665,7 +8665,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.15.1-1
+      version: 0.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.15.1-1`

## ackermann_steering_controller

```
* Bump CMake version to prevent CMP0048
* Add missing header guards
* Replace header guard with #pragma once
* Prefix every xacro tag with 'xacro:'
* Modernize xacro
  - Remove '--inorder'
  - Use 'xacro' over 'xacro.py'
* swap implementations of read and write methods
  Follows the intended use of hardware_interface::RobotHW,
  see its documentation for details
* Contributors: Franz, Matt Reynolds
```

## diff_drive_controller

```
* Fix warning dynamic_reconfigure
* Bump CMake version to prevent CMP0048
* Add missing header guards
* Replace header guard with #pragma once
* Prefix every xacro tag with 'xacro:'
* Modernize xacro
  - Remove '--inorder'
  - Use 'xacro' over 'xacro.py'
* switch implementation of read and write methods of Diffbot class
* Refactor nan test
  EXPECT_NE(x, bool) -> EXPECT_TRUE/FALSE(x)
  EXPECT_EQ(x, double) -> EXPECT_DOUBLE_EQ(x, double)
  + clang default reformat
* Check for nan cmd_vel
* Contributors: Anas Abou Allaban, Bence Magyar, Franz, Matt Reynolds, Raffaello Bonghi
```

## effort_controllers

```
* Added test for position controller
* Solving issues with large rotational limits
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* fix minor typo in documentation of setGains method
  Changes Get to Set of setGains method documentation
* Contributors: Bence Magyar, F Pucher, Franco Fusco, Matt Reynolds
```

## force_torque_sensor_controller

```
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* Contributors: Matt Reynolds
```

## forward_command_controller

```
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* Contributors: Matt Reynolds
```

## four_wheel_steering_controller

```
* Bump CMake version to prevent CMP0048
* Add missing header guards
* Replace header guard with #pragma once
* Modernize xacro
  - Remove '--inorder'
  - Use 'xacro' over 'xacro.py'
* swap implementations of read and write methods
  Follows the intended use of hardware_interface::RobotHW,
  see its documentation for details
* Contributors: Franz, Matt Reynolds
```

## gripper_action_controller

```
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* Contributors: Matt Reynolds
```

## imu_sensor_controller

```
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* Contributors: Matt Reynolds
```

## joint_state_controller

```
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* Contributors: Matt Reynolds
```

## joint_trajectory_controller

```
* Bump CMake version to prevent CMP0048
* Add #pragma once to new joint_trajectory_controller test
* Replace header guard with #pragma once
* Modernize xacro
  - Remove '--inorder'
  - Use 'xacro' over 'xacro.py'
* Add code_coverage target to CMakeLists.txt
* Contributors: Bence Magyar, Immanuel Martini, Matt Reynolds
```

## position_controllers

```
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* Contributors: Matt Reynolds
```

## ros_controllers

```
* Bump CMake version to prevent CMP0048
* Contributors: Matt Reynolds
```

## rqt_joint_trajectory_controller

```
* Bump CMake version to prevent CMP0048
* Contributors: Matt Reynolds
```

## velocity_controllers

```
* Assuming lower limits are smaller than upper limits
* Solving issues with large rotational limits
* Bump CMake version to prevent CMP0048
* Replace header guard with #pragma once
* Contributors: Franco Fusco, Matt Reynolds
```
