### PR TITLE
Fix/add libqt5-opengl-dev rules for Fedora/RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3411,9 +3411,10 @@ libqt5-opengl:
 libqt5-opengl-dev:
   arch: [qt5-base]
   debian: [libqt5opengl5-dev]
-  fedora: [qt5-qtbase]
+  fedora: [qt5-qtbase-devel]
   freebsd: [qt5-opengl]
   gentoo: ['dev-qt/qtopengl:5']
+  rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [libqt5opengl5-dev]
 libqt5-printsupport:


### PR DESCRIPTION
Fedora: https://apps.fedoraproject.org/packages/qt5-qtbase-devel
RHEL: http://mirror.centos.org/centos/7.7.1908/os/x86_64/Packages/qt5-qtbase-devel-5.9.7-2.el7.x86_64.rpm