### PR TITLE
novatel_oem7_driver: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6139,6 +6139,18 @@ repositories:
       version: master
     status: developed
   novatel_oem7_driver:
+    doc:
+      type: git
+      url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
+      version: master
+    release:
+      packages:
+      - novatel_oem7_driver
+      - novatel_oem7_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6141,7 +6141,7 @@ repositories:
   novatel_oem7_driver:
     doc:
       type: git
-      url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
+      url: https://github.com/novatel/novatel_oem7_driver.git
       version: master
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `1.0.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
