### PR TITLE
ypspur_ros: 0.3.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1855,5 +1855,20 @@ repositories:
       url: https://github.com/openspur/yp-spur.git
       version: master
     status: developed
+  ypspur_ros:
+    doc:
+      type: git
+      url: https://github.com/openspur/ypspur_ros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/openspur/ypspur_ros-release.git
+      version: 0.3.1-3
+    source:
+      type: git
+      url: https://github.com/openspur/ypspur_ros.git
+      version: master
+    status: developed
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.3.1-3`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## ypspur_ros

```
* Fix communication error handling (#64 <https://github.com/openspur/ypspur_ros/issues/64>)
* Drop support for yp-spur<1.17.0 to simplify the code (#63 <https://github.com/openspur/ypspur_ros/issues/63>)
* Add sleep to ensure publishing rosout before exit (#61 <https://github.com/openspur/ypspur_ros/issues/61>)
* Fix coding style (#62 <https://github.com/openspur/ypspur_ros/issues/62>)
* Add post-release test script (#58 <https://github.com/openspur/ypspur_ros/issues/58>)
* Disable CI build on indigo (#59 <https://github.com/openspur/ypspur_ros/issues/59>)
* Contributors: Atsushi Watanabe
```
