### PR TITLE
noetic: Update octomap/octovis to 1.9.5-3

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -808,7 +808,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.5-2
+      version: 1.9.5-3
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -808,7 +808,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.5-3
+      version: 1.9.5-4
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git


### PR DESCRIPTION
Fixes the build failures for projects dependent on octomap, e.g., octovis by using a patch to set the `CMAKE_INSTALL_LIBDIR`.