### PR TITLE
ifm3d_core: 0.17.0-12 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1087,6 +1087,13 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: dashing-devel
     status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.17.0-12
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.17.0-12`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
