### PR TITLE
ifm3d_core: 0.17.0-15 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -856,6 +856,13 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: dashing-devel
     status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.17.0-15
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.17.0-15`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
