### PR TITLE
robot_state_publisher: 1.15.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1057,6 +1057,15 @@ repositories:
       version: kinetic-devel
     status: maintained
   robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/robot_state_publisher-release.git
+      version: 1.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.15.0-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## robot_state_publisher

```
* Remove state_publisher and add in a public default constructor (#87 <https://github.com/ros/robot_state_publisher/issues/87>)
* Added support for custom RobotStatePublisher implementations (API/ABI break) (#115 <https://github.com/ros/robot_state_publisher/issues/115>)
* Bump CMake version to avoid CMP0048 (#136 <https://github.com/ros/robot_state_publisher/issues/136>)
* Add missing test depend rosbag (#135 <https://github.com/ros/robot_state_publisher/issues/135>)
* Used orocos keys (#134 <https://github.com/ros/robot_state_publisher/issues/134>)
* Add joint_state_listener to the catkin package LIBRARIES (#112 <https://github.com/ros/robot_state_publisher/issues/112>) (#114 <https://github.com/ros/robot_state_publisher/issues/114>)
* Make sure to make sensor_msgs a catkin dependency. (#122 <https://github.com/ros/robot_state_publisher/issues/122>)
* update how compiler flags are added (#104 <https://github.com/ros/robot_state_publisher/issues/104>)
* update install destination in CMakeLists.txt (#103 <https://github.com/ros/robot_state_publisher/issues/103>)
* Remove treefksolver completely from the repository. (#100 <https://github.com/ros/robot_state_publisher/issues/100>)
* changed return code from -1 to 1 since its considered a reserved bash exit code (#98 <https://github.com/ros/robot_state_publisher/issues/98>)
* Fixed problem when building static library version (#92 <https://github.com/ros/robot_state_publisher/issues/92>) (#96 <https://github.com/ros/robot_state_publisher/issues/96>)
* Add Ian as a maintainer for robot_state_publisher. (#94 <https://github.com/ros/robot_state_publisher/issues/94>)
* added warning when joint is found in joint message but not in the urdf (#83 <https://github.com/ros/robot_state_publisher/issues/83>)
* added ros_warn if JointStateMessage is older than 30 seconds (#84 <https://github.com/ros/robot_state_publisher/issues/84>)
* Add tcp_no_delay to joint_states subscriber (#80 <https://github.com/ros/robot_state_publisher/issues/80>) (#85 <https://github.com/ros/robot_state_publisher/issues/85>)
* Remove dependency on tf and tf_prefix support (#82 <https://github.com/ros/robot_state_publisher/issues/82>)
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>) (#75 <https://github.com/ros/robot_state_publisher/issues/75>)
* Added c++11 target_compile_options (#78 <https://github.com/ros/robot_state_publisher/issues/78>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, James Xu, Lukas Bulwahn, Martin Pecka, Shane Loretz, betab0t, jgueldenstein
```
