### PR TITLE
rviz: 7.0.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2734,7 +2734,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 7.0.4-1
+      version: 7.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `7.0.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `7.0.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove unnecessary call to render scene (#490 <https://github.com/ros2/rviz/issues/490>) (#514 <https://github.com/ros2/rviz/issues/514>)
* Contributors: Jacob Perron
```

## rviz_default_plugins

```
* Allow the MapDisplay "Update Topic" to be changed. (#517 <https://github.com/ros2/rviz/issues/517>) (#518 <https://github.com/ros2/rviz/issues/518>)
* Fix camera info for camera display (#419 <https://github.com/ros2/rviz/issues/419>) (#500 <https://github.com/ros2/rviz/issues/500>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
