### PR TITLE
ament_index: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -38,6 +38,25 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: master
     status: developed
+  ament_index:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: master
+    release:
+      packages:
+      - ament_index_cpp
+      - ament_index_python
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_index-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: master
+    status: maintained
   ament_lint:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -38,25 +38,6 @@ repositories:
       url: https://github.com/ament/ament_cmake.git
       version: master
     status: developed
-  ament_index:
-    doc:
-      type: git
-      url: https://github.com/ament/ament_index.git
-      version: master
-    release:
-      packages:
-      - ament_index_cpp
-      - ament_index_python
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 0.8.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ament/ament_index.git
-      version: master
-    status: maintained
   ament_cmake_ros:
     doc:
       type: git
@@ -74,6 +55,25 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
+      version: master
+    status: maintained
+  ament_index:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: master
+    release:
+      packages:
+      - ament_index_cpp
+      - ament_index_python
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_index-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_index.git
       version: master
     status: maintained
   ament_lint:


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `0.8.0-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
