### PR TITLE
rqt_moveit: 0.5.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1475,6 +1475,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_logger_level.git
       version: master
     status: maintained
+  rqt_moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_moveit-release.git
+      version: 0.5.8-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: master
+    status: maintained
   rqt_msg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_moveit` to `0.5.8-1`:

- upstream repository: https://github.com/ros-visualization/rqt_moveit.git
- release repository: https://github.com/ros-gbp/rqt_moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_moveit

```
* updated package to format 3
```
