### PR TITLE
fcl_catkin: 0.6.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2542,11 +2542,15 @@ repositories:
       version: master
     status: developed
   fcl_catkin:
+    doc:
+      type: git
+      url: https://github.com/flexible-collision-library/fcl.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.6.0-1
+      version: 0.6.1-2
     status: developed
   fetch_gazebo:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl_catkin` to `0.6.1-2`:

- upstream repository: https://github.com/wxmerkt/fcl_catkin.git
- release repository: https://github.com/wxmerkt/fcl_catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.0-1`
