### PR TITLE
jackal: 0.6.5-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5574,7 +5574,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.6.4-1
+      version: 0.6.5-2
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.6.5-2`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.4-1`

## jackal_control

- No changes

## jackal_description

```
* [jackal_description] Re-added pointgrey_camera_description as run depend.
* Contributors: Tony Baltovski
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
