### PR TITLE
jackal: 0.6.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3979,7 +3979,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.6.4-3
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.6.5-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.4-3`

## jackal_control

- No changes

## jackal_description

```
* [jackal_description] Re-added pointgrey_camera_description as run depend.
* Contributors: Tony Baltovski
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
