### PR TITLE
husky: 0.3.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5010,7 +5010,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.3.5-1
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.3.6-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.5-1`

## husky_base

- No changes

## husky_bringup

- No changes

## husky_control

- No changes

## husky_description

```
* Fixed GazeboRosControlPlugin missing error
* Contributors: lerolynn
```

## husky_desktop

- No changes

## husky_gazebo

- No changes

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* Add the joint_state_publisher_gui dependency
* Contributors: Chris I-B
```
