### PR TITLE
ridgeback_desktop: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8145,11 +8145,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_desktop.git
       version: kinetic-devel
+    status: maintained
   ridgeback_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_desktop` to `0.1.2-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_desktop
- release repository: https://github.com/clearpath-gbp/ridgeback_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.1-1`

## ridgeback_desktop

- No changes

## ridgeback_viz

```
* [ridgeback_viz] Removed joint_state_publisher since joint_state_publisher_gui is generating the same data.
* Fix a deprecation warning with the joint state publisher gui
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```
