### PR TITLE
Add RHEL 8 rules for 4 keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4293,8 +4293,7 @@ log4cplus:
   arch: [log4cplus]
   debian: [liblog4cplus-dev]
   fedora: [log4cplus-devel]
-  rhel:
-    '7': [log4cplus-devel]
+  rhel: [log4cplus-devel]
   ubuntu: [liblog4cplus-dev]
 log4cxx:
   alpine: [log4cxx-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5186,6 +5186,9 @@ python3-asyncssh:
 python3-autobahn:
   debian: [python3-autobahn]
   fedora: [python3-autobahn]
+  rhel:
+    '*': ['python%{python3_pkgversion}-autobahn']
+    '7': null
   ubuntu: [python3-autobahn]
 python3-babeltrace:
   debian: [python3-babeltrace]
@@ -5455,6 +5458,9 @@ python3-matplotlib:
     pip:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
+  rhel:
+    '*': ['python%{python3_pkgversion}-matplotlib']
+    '7': null
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mock:
@@ -5687,6 +5693,9 @@ python3-pyproj:
   debian: [python3-pyproj]
   fedora: [python3-pyproj]
   gentoo: [dev-python/pyproj]
+  rhel:
+    '*': ['python%{python3_pkgversion}-pyproj']
+    '7': null
   ubuntu: [python3-pyproj]
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]


### PR DESCRIPTION
These keys are used across ROS 2 Eloquent.

The three Python packages are available in EPEL 8, but are not available in RHEL 7.

| rosdep key | system package name | src link | pkgs link |
|------------|---------------------|----------|-----------|
| log4cplus | log4cplus-devel | [src](https://src.fedoraproject.org/rpms/log4cplus#bodhi_updates) | |
| python3-autobahn | python%{python3_pkgversion}-autobahn | [src](https://src.fedoraproject.org/rpms/python-autobahn#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python3-autobahn) |
| python3-matplotlib | python%{python3_pkgversion}-matplotlib | [src](https://src.fedoraproject.org/rpms/python-matplotlib#bodhi_updates) | [pkgs](https://apps.fedoraproject.org/packages/python3-matplotlib)
| python3-pyproj | python%{python3_pkgversion}-pyproj | [src](https://src.fedoraproject.org/rpms/pyproj#bodhi_updates) | |

```
$ dnf list -q --showduplicates --available log4cplus-devel \
> python3-autobahn python3-matplotlib python3-pyproj
Available Packages
log4cplus-devel.x86_64                     1.2.0-11.el8                    epel
python3-autobahn.noarch                    19.10.1-3.el8                   epel
python3-matplotlib.x86_64                  3.0.3-3.el8                     epel
python3-pyproj.x86_64                      2.2.1-1.el8                     epel
```