### PR TITLE
ros2_intel_realsense: 2.0.7-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1348,7 +1348,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.16.5-1
+      version: 2.34.0
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git
@@ -2361,19 +2361,21 @@ repositories:
     doc:
       type: git
       url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
+      version: refactor
     release:
       packages:
-      - realsense_camera_msgs
-      - realsense_ros2_camera
+      - realsense_msgs
+      - realsense_ros
+      - realsense_node
+      - realsense_examples
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.4-2
+      version: 2.0.7
     source:
       type: git
       url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
+      version: refactor
     status: maintained
   ros2_object_analytics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_realsense` to `2.0.7-1`:

- upstream repository: https://github.com/intel/ros2_intel_realsense.git
- release repository: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.0.4-2`

Signed-off-by: Sharron LIU <sharron.xr.liu@gmail.com>