### PR TITLE
novatel_oem7_driver: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8685,6 +8685,18 @@ repositories:
       version: master
     status: developed
   novatel_oem7_driver:
+    doc:
+      type: git
+      url: https://github.com/novatel/novatel_oem7_driver.git
+      version: 1.0.0
+    release:
+      packages:
+      - novatel_oem7_driver
+      - novatel_oem7_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8688,7 +8688,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git
-      version: 1.0.0
+      version: master
     release:
       packages:
       - novatel_oem7_driver


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `1.0.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
