### PR TITLE
ros2_intel_realsense: 2.0.7-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2364,12 +2364,14 @@ repositories:
       version: master
     release:
       packages:
-      - realsense_camera_msgs
-      - realsense_ros2_camera
+      - realsense_examples
+      - realsense_msgs
+      - realsense_node
+      - realsense_ros
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.4-2
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/intel/ros2_intel_realsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_realsense` to `2.0.7-1`:

- upstream repository: https://github.com/intel/ros2_intel_realsense.git
- release repository: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.0.4-2`
