### PR TITLE
teleop_tools: 1.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3183,7 +3183,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.1.0-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.2-1`

## joy_teleop

```
* Add the ability to have deadman axes. (#46 <https://github.com/ros-teleop/teleop_tools/issues/46>)
  * Add the ability to have deadman axes.
  Some controllers don't have a convenient shoulder trigger
  button, but do have shoulder "axes".  Allow the axes to
  be used for a deadman trigger, assuming they are pressed
  all the way.  Note that I used a dict for the list of
  axes, as this provides the most convenient way to deal
  with controllers that use 1.0, -1.0, or 0.0 as the "far"
  end of the axis.
  * Make sure to ignore buttons and axes that don't exist.
* Contributors: Chris Lalancette
```

## key_teleop

- No changes

## mouse_teleop

- No changes

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
