### PR TITLE
[rosdep] add python-rpi.gpio-pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3964,6 +3964,16 @@ python-rpi.gpio:
       pip:
         packages: [RPi.GPIO]
     zesty: [python-rpi.gpio]
+python-rpi.gpio-pip:
+  debian:
+    pip:
+      packages: [RPi.GPIO]
+  fedora:
+    pip:
+      packages: [RPi.GPIO]
+  ubuntu:
+    pip:
+      packages: [RPi.GPIO]
 python-rrdtool:
   debian: [python-rrdtool]
   fedora: [rrdtool-python]


### PR DESCRIPTION
deb package python-rpi.gpio is only avialable on arm archs
the pip package RPi.gpio is available on all platforms

We could also change the existing `python-rpi.gpio` key to only map to pip packages (https://github.com/ros/rosdistro/pull/16545#issuecomment-616664611) but the name would be misleading so it looks like adding a `-pip` suffixed key still makes sense