### PR TITLE
Add libbluetooth key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1609,6 +1609,12 @@ libblas-dev:
   gentoo: [virtual/blas]
   openembedded: [openblas@meta-ros]
   ubuntu: [libblas-dev]
+libbluetooth:
+  arch: [bluez]
+  debian: [libbluetooth3]
+  fedora: [bluez-libs]
+  gentoo: [net-wireless/bluez-libs]
+  ubuntu: [libbluetooth3]
 libbluetooth-dev:
   arch: [bluez]
   debian: [libbluetooth-dev]


### PR DESCRIPTION
This is so packages can exec_depend on just the runtime library.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Links:
Arch: https://www.archlinux.org/packages/extra/x86_64/bluez/
Debian: https://packages.debian.org/search?keywords=libbluetooth&searchon=names&suite=all&section=all
Fedora: https://apps.fedoraproject.org/packages/bluez-libs
Gentoo: https://packages.gentoo.org/packages/net-wireless/bluez
Ubuntu: https://packages.ubuntu.com/search?keywords=libbluetooth&searchon=names&suite=all&section=all

The only one that is weird to me is Gentoo; there doesn't seem to be a "bluez-libs" in the package database, but that is the key that is being used for `libbluetooth-dev` as well.  Maybe it is outdated?  Not sure.