### PR TITLE
open_karto: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -829,6 +829,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_msgs.git
       version: melodic-devel
     status: maintained
+  open_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/open_karto.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/open_karto-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/open_karto.git
+      version: melodic-devel
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.2.0-1`:

- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## open_karto

```
* Adds maintainer and branches for melodic
* Merge pull request #14 <https://github.com/ros-perception/open_karto/issues/14> from ros-perception/maintainer-add
  Adding myself as a maintainer for open_karto
* Adding myself as a maintainer for open_karto
* Merge pull request #11 <https://github.com/ros-perception/open_karto/issues/11> from Maidbot/minimum_time_interval
  Process scan if enough time has elapsed since the previous one
* Merge pull request #10 <https://github.com/ros-perception/open_karto/issues/10> from mikepurvis/fix-cpp11
  Use std::isnan/isinf, for C++11 compatibility.
* [Mapper] Take time into account in HasMoveEnough
  The function HasMovedEnough now also returns true if more than MinimumTimeInterval time has elapsed since the previously processed laser scan
* [Mapper] Add new parameter, MinimumTimeInterval
* Use std::isnan/isinf, for C++11 compatibility.
* Merge pull request #8 <https://github.com/ros-perception/open_karto/issues/8> from mig-em/feature/invalidScans1.1.4
  Add invalid scan detection for scanmatcher
* Merge pull request #9 <https://github.com/ros-perception/open_karto/issues/9> from Maidbot/ignore_min_readings
  Ignore readings less than the sensor's minimum range
* [Karto] Also ignore readings less than the minimum range
* Add invalid scan detection for scanmatcher
* Contributors: Luc Bettaieb, Michael Ferguson, Mike Purvis, Russell Toris, Spyros Maniatopoulos, mig-em
```
