### PR TITLE
timed_roslaunch: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10733,6 +10733,22 @@ repositories:
       url: https://github.com/tradr-project/tf_remapper_cpp.git
       version: master
     status: developed
+  timed_roslaunch:
+    doc:
+      type: git
+      url: https://github.com/MoriKen254/timed_roslaunch.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/MoriKen254/timed_roslaunch-release.git
+      version: 0.1.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MoriKen254/timed_roslaunch.git
+      version: melodic-devel
+    status: maintained
   tiny_tf:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `timed_roslaunch` to `0.1.4-1`:

- upstream repository: https://github.com/MoriKen254/timed_roslaunch.git
- release repository: https://github.com/MoriKen254/timed_roslaunch-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
