### PR TITLE
jderobot_assets: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4047,7 +4047,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `1.0.2-1`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.1-1`

## jderobot_assets

```
* Added models needed for drone-gymkhana exercise
* Contributors: Pedro Arias
```
