### PR TITLE
moveit_python: 0.3.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5409,7 +5409,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.3.4-1`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.3-1`

## moveit_python

```
* Fixed error message when removing attached object. (#25 <https://github.com/mikeferguson/moveit_python/issues/25>)
  Co-authored-by: Karl Kangur <mailto:karl.kangur@exwzd.com>
* Merge pull request #24 <https://github.com/mikeferguson/moveit_python/issues/24> from v4hn/pr-master-python3
  python3 compatible API & syntax
* python3 compatible API & syntax
* Contributors: Karl Kangur, Michael Ferguson, v4hn
```
