### PR TITLE
kinetic: abb_driver now hosted in separate repository

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -33,6 +33,16 @@ repositories:
       url: https://github.com/ros-industrial/abb.git
       version: kinetic
     status: developed
+  abb_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb_driver.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb_driver.git
+      version: kinetic-devel
+    status: maintained
   abb_experimental:
     doc:
       type: git


### PR DESCRIPTION
As per subject.

Package has been migrated from original repository to a new one.

Subsequent PRs will also update release location etc.
