### PR TITLE
melodic: abb_driver now hosted in separate repository

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -27,6 +27,16 @@ repositories:
       url: https://github.com/ros-industrial-release/abb-release.git
       version: 1.3.1-1
     status: maintained
+  abb_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb_driver.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb_driver.git
+      version: kinetic-devel
+    status: maintained
   abseil_cpp:
     doc:
       type: git


### PR DESCRIPTION
As per subject.

Package has been migrated from original repository to a new one.

Subsequent PRs will also update release location etc.
