### PR TITLE
slam_karto: 0.8.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1731,6 +1731,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_web.git
       version: master
     status: maintained
+  slam_karto:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/slam_karto-release.git
+      version: 0.8.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/slam_karto.git
+      version: melodic-devel
+    status: maintained
   sparse_bundle_adjustment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_karto` to `0.8.1-1`:

- upstream repository: https://github.com/ros-perception/slam_karto.git
- release repository: https://github.com/ros-gbp/slam_karto-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## slam_karto

```
* set C++11 if std not specified
  This is mainly for building on Lunar
* Contributors: Michael Ferguson
```
