### PR TITLE
Add RHEL 8 rules from PowerTools repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ Keys in the rosdep database are required to come from packages contained in the 
 #### RHEL/CentOS
 
 * CentOS Repositories: base, extras, centos-sclo-rh, or updates
+  * Additionally, for CentOS 8+: AppStream or PowerTools
 * Fedora Project Repositories: epel
 
 #### MacOS

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -288,7 +288,7 @@ boost:
   macports: [boost]
   openembedded: [boost@openembedded-core]
   opensuse: [boost-devel]
-  rhel: [boost-devel]
+  rhel: [boost-devel, 'boost-python%{python3_pkgversion}-devel']
   slackware:
     slackpkg:
       packages: [boost]
@@ -1163,6 +1163,7 @@ graphviz:
 graphviz-dev:
   debian: [libgraphviz-dev]
   fedora: [graphviz-devel]
+  rhel: [graphviz-devel]
   ubuntu: [libgraphviz-dev]
 gringo:
   debian: [gringo]
@@ -1427,6 +1428,7 @@ jasper:
   gentoo: [media-libs/jasper]
   macports: [jasper]
   opensuse: [libjasper-devel]
+  rhel: [jasper-devel]
   slackware:
     slackpkg:
       packages: [jasper]
@@ -1576,12 +1578,14 @@ libavahi-client-dev:
   debian: [libavahi-client-dev]
   fedora: [avahi-devel]
   gentoo: [net-dns/avahi]
+  rhel: [avahi-devel]
   ubuntu: [libavahi-client-dev]
 libavahi-core-dev:
   arch: [avahi]
   debian: [libavahi-core-dev]
   fedora: [avahi-devel]
   gentoo: [net-dns/avahi]
+  rhel: [avahi-devel]
   ubuntu: [libavahi-core-dev]
 libavdevice-dev:
   debian: [libavdevice-dev]
@@ -1596,6 +1600,7 @@ libbison-dev:
   debian: [libbison-dev]
   fedora: [bison-devel]
   gentoo: [sys-devel/bison]
+  rhel: [bison-devel]
   ubuntu:
     precise: [libbison-dev]
     trusty: [libbison-dev]
@@ -1608,12 +1613,14 @@ libblas-dev:
   fedora: [blas-devel]
   gentoo: [virtual/blas]
   openembedded: [openblas@meta-ros]
+  rhel: [blas-devel]
   ubuntu: [libblas-dev]
 libbluetooth-dev:
   arch: [bluez]
   debian: [libbluetooth-dev]
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
+  rhel: [bluez-libs-devel]
   ubuntu: [libbluetooth-dev]
 libboost-atomic:
   debian:
@@ -1899,6 +1906,7 @@ libconfig-dev:
   debian: [libconfig-dev]
   fedora: [libconfig-devel]
   gentoo: ['dev-libs/libconfig[cxx]']
+  rhel: [libconfig-devel]
   ubuntu: [libconfig-dev]
 libconsole-bridge-dev:
   alpine: [console_bridge-dev]
@@ -2092,6 +2100,7 @@ libfltk-dev:
   gentoo: [x11-libs/fltk]
   macports: [fltk]
   opensuse: [fltk-devel]
+  rhel: [fltk-devel]
   slackware: [fltk]
   ubuntu:
     artful: [libfltk1.3-dev]
@@ -2236,8 +2245,7 @@ libgflags-dev:
   fedora: [gflags-devel]
   gentoo: [dev-cpp/gflags]
   openembedded: [gflags@meta-oe]
-  rhel:
-    '7': [gflags-devel]
+  rhel: [gflags-devel]
   ubuntu: [libgflags-dev]
 libgfortran3:
   arch: [gcc-libs]
@@ -2255,6 +2263,7 @@ libglew-dev:
   debian: [libglew-dev]
   fedora: [glew-devel]
   gentoo: [media-libs/glew]
+  rhel: [glew-devel]
   ubuntu:
     artful: [libglew-dev]
     bionic: [libglew-dev]
@@ -2290,6 +2299,7 @@ libglm-dev:
   debian: [libglm-dev]
   fedora: [glm]
   gentoo: [media-libs/glm]
+  rhel: [glm-devel]
   ubuntu: [libglm-dev]
 libglui-dev:
   arch: [glui]
@@ -2317,8 +2327,7 @@ libgoogle-glog-dev:
   fedora: [glog-devel]
   gentoo: [dev-cpp/glog]
   openembedded: [glog@meta-oe]
-  rhel:
-    '7': [glog-devel]
+  rhel: [glog-devel]
   ubuntu: [libgoogle-glog-dev]
 libgpgme-dev:
   alpine: [gpgme-dev]
@@ -2353,6 +2362,7 @@ libgphoto-dev:
   debian: [libgphoto2-dev]
   fedora: [libgphoto2-devel]
   gentoo: [media-gfx/gphoto2]
+  rhel: [libgphoto2-devel]
   ubuntu:
     '*': [libgphoto2-dev]
     precise: [libgphoto2-2-dev]
@@ -2561,6 +2571,7 @@ libjson0-dev:
   debian: [libjson0-dev]
   fedora: [json-c-devel]
   gentoo: ['dev-libs/json-c:0']
+  rhel: [json-c-devel]
   ubuntu: [libjson0-dev]
 libjsoncpp:
   debian: [libjsoncpp1]
@@ -2598,8 +2609,7 @@ liblapack-dev:
   fedora: [lapack-devel]
   gentoo: [virtual/lapack]
   openembedded: [lapack@meta-ros]
-  rhel:
-    '7': [lapack-devel]
+  rhel: [lapack-devel]
   ubuntu: [liblapack-dev]
 liblapacke-dev:
   debian: [liblapacke-dev]
@@ -2625,6 +2635,7 @@ liblttng-ust-dev:
   debian: [liblttng-ust-dev]
   fedora: [lttng-ust]
   gentoo: [dev-util/lttng-ust]
+  rhel: [lttng-ust-devel]
   ubuntu: [liblttng-ust-dev]
 liblzma-dev:
   debian: [liblzma-dev]
@@ -2646,6 +2657,7 @@ libmicrohttpd:
   debian: [libmicrohttpd-dev]
   fedora: [libmicrohttpd-devel]
   gentoo: [net-libs/libmicrohttpd]
+  rhel: [libmicrohttpd-devel]
   ubuntu: [libmicrohttpd-dev]
 libmlpack-dev:
   debian: [libmlpack-dev]
@@ -2675,6 +2687,7 @@ libmp3lame-dev:
   debian: [libmp3lame-dev]
   fedora: [lame-devel]
   gentoo: [media-sound/lame]
+  rhel: [lame-devel]
   ubuntu: [libmp3lame-dev]
 libmpich-dev:
   debian: [libmpich-dev]
@@ -2863,10 +2876,12 @@ libopenal-dev:
   debian: [libopenal-dev]
   fedora: [openal-soft-devel]
   gentoo: [media-libs/openal]
+  rhel: [openal-soft-devel]
   ubuntu: [libopenal-dev]
 libopenblas-dev:
   debian: [libopenblas-dev]
   fedora: [openblas-devel]
+  rhel: [openblas-devel]
   ubuntu: [libopenblas-dev]
 libopencv-contrib-dev:
   arch: [opencv-contrib]
@@ -2890,8 +2905,7 @@ libopenexr-dev:
   debian: [libopenexr-dev]
   fedora: [OpenEXR-devel]
   gentoo: [media-libs/openexr]
-  rhel:
-    '7': [OpenEXR-devel]
+  rhel: [OpenEXR-devel]
   ubuntu: [libopenexr-dev]
 libopenni-dev:
   arch: [openni]
@@ -3005,8 +3019,7 @@ libpcap:
   gentoo: [net-libs/libpcap]
   macports: [libpcap]
   openembedded: [libpcap@openembedded-core]
-  rhel:
-    '7': [libpcap-devel]
+  rhel: [libpcap-devel]
   ubuntu: [libpcap0.8-dev]
 libpcl-all:
   arch: [pcl]
@@ -3302,6 +3315,7 @@ libqhull:
   macports: [qhull]
   openembedded: [qhull@meta-ros]
   opensuse: [qhull-devel]
+  rhel: [qhull-devel]
   slackware: [qhull]
   ubuntu: [libqhull-dev]
 libqrencode:
@@ -3524,6 +3538,7 @@ libqwtplot3d-qt4-dev:
 librabbitmq-dev:
   debian: [librabbitmq-dev]
   fedora: [librabbitmq-devel]
+  rhel: [librabbitmq-devel]
   ubuntu: [librabbitmq-dev]
 libraw1394:
   arch:
@@ -3540,6 +3555,7 @@ libraw1394-dev:
   debian: [libraw1394-dev]
   fedora: [libraw1394-devel]
   gentoo: [sys-libs/libraw1394]
+  rhel: [libraw1394-devel]
   ubuntu: [libraw1394-dev]
 librdkafka-dev:
   debian: [librdkafka-dev]
@@ -3589,6 +3605,7 @@ libsndfile1-dev:
   debian: [libsndfile1-dev]
   fedora: [libsndfile-devel]
   gentoo: [media-libs/libsndfile]
+  rhel: [libsndfile-devel]
   ubuntu: [libsndfile1-dev]
 libsoqt4-dev:
   arch: [soqt]
@@ -3807,6 +3824,7 @@ libturbojpeg:
   freebsd: [libjpeg-turbo]
   gentoo: [media-libs/libjpeg-turbo]
   openembedded: [libjpeq-turbo@openembedded-core]
+  rhel: [turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
     precise: [libturbojpeg, libjpeg-turbo8-dev]
@@ -3931,8 +3949,7 @@ libusb-dev:
   fedora: [libusb-devel]
   gentoo: [virtual/libusb]
   macports: [libusb]
-  rhel:
-    '7': [libusb-devel]
+  rhel: [libusb-devel]
   ubuntu: [libusb-dev]
 libuv-dev:
   debian:
@@ -3959,6 +3976,7 @@ libv4l-dev:
   freebsd: [libv4l]
   gentoo: [media-libs/libv4l]
   opensuse: [libv4l-devel]
+  rhel: [libv4l-devel]
   slackware:
     slackpkg:
       packages: [v4l-utils]
@@ -3981,6 +3999,7 @@ libvpx-dev:
   debian: [libvpx-dev]
   fedora: [libvpx-devel]
   gentoo: [media-libs/libvpx]
+  rhel: [libvpx-devel]
   ubuntu: [libvpx-dev]
 libvtk:
   arch: [vtk]
@@ -4177,6 +4196,7 @@ libxmlrpc-c++:
   debian: [libxmlrpc-c++8-dev]
   fedora: [xmlrpc-c-devel]
   gentoo: ['dev-libs/xmlrpc-c']
+  rhel: [xmlrpc-c-devel]
   ubuntu: [libxmlrpc-c++8-dev]
 libxmu-dev:
   arch: [libxmu]
@@ -4603,6 +4623,7 @@ nasm:
   gentoo: [dev-lang/nasm]
   macports: [nasm]
   opensuse: [nasm]
+  rhel: [nasm]
   ubuntu: [nasm]
 nbtscan:
   arch: [nbtscan]
@@ -4629,6 +4650,7 @@ netpbm:
   gentoo: [media-libs/netpbm]
   macports: [netpbm]
   opensuse: [netpbm]
+  rhel: [netpbm-devel]
   ubuntu: [libnetpbm10-dev]
 network-manager:
   debian: [network-manager]
@@ -4650,6 +4672,7 @@ nkf:
   debian: [nkf]
   fedora: [nkf]
   gentoo: [app-i18n/nkf]
+  rhel: [nkf]
   ubuntu: [nkf]
 nmap:
   archlinux: [nmap]
@@ -4723,6 +4746,7 @@ opencl-headers:
   arch: [opencl-headers]
   debian: [opencl-headers]
   fedora: [opencl-headers]
+  rhel: [opencl-headers]
   ubuntu: [opencl-headers]
 opende:
   arch: [ode]
@@ -4806,6 +4830,7 @@ osmium:
 pandoc:
   debian: [pandoc]
   gentoo: [app-text/pandoc]
+  rhel: [pandoc]
   ubuntu: [pandoc]
 pcre:
   arch: [pcre]
@@ -5020,8 +5045,7 @@ protobuf-dev:
   macports: [protobuf-cpp]
   openembedded: [protobuf@meta-oe]
   opensuse: [protobuf-devel]
-  rhel:
-    '7': [protobuf-devel, protobuf-compiler]
+  rhel: [protobuf-devel, protobuf-compiler]
   slackware: [protobuf]
   ubuntu: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]
 ps-engine:
@@ -5033,6 +5057,7 @@ pstoedit:
   debian: [pstoedit]
   fedora: [pstoedit]
   gentoo: [media-gfx/pstoedit]
+  rhel: [pstoedit]
   ubuntu: [pstoedit]
 psutils:
   debian: [psutils]
@@ -5324,6 +5349,7 @@ sdl2:
   debian: [libsdl2-dev]
   fedora: [SDL2-devel]
   gentoo: [media-libs/libsdl2]
+  rhel: [SDL2-devel]
   ubuntu: [libsdl2-dev]
 sdl2-mixer:
   debian: [libsdl2-mixer-dev]
@@ -5369,6 +5395,7 @@ snappy:
   debian: [libsnappy-dev]
   fedora: [snappy]
   gentoo: [app-arch/snappy]
+  rhel: [snappy-devel]
   ubuntu: [libsnappy-dev]
 socat:
   arch: [socat]
@@ -5474,8 +5501,7 @@ suitesparse:
   gentoo: [sci-libs/suitesparse]
   macports: [SuiteSparse]
   openembedded: [suitesparse-cxsparse@meta-ros, suitesparse-cholmod@meta-ros]
-  rhel:
-    '7': [suitesparse-devel]
+  rhel: [suitesparse-devel]
   ubuntu: [libsuitesparse-dev]
 supervisor:
   arch: [supervisor]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5516,8 +5516,7 @@ python3-packaging:
   debian: [python3-packaging]
   fedora: [python3-packaging]
   gentoo: [dev-python/packaging]
-  rhel:
-    '7': ['python%{python3_pkgversion}-packaging']
+  rhel: ['python%{python3_pkgversion}-packaging']
   ubuntu: [python3-packaging]
 python3-pandas:
   debian: [python3-pandas]
@@ -5877,12 +5876,14 @@ python3-sip:
   ubuntu: [python3-sip-dev]
 python3-sphinx:
   debian: [python3-sphinx]
+  rhel: ['python%{python3_pkgversion}-sphinx']
   ubuntu: [python3-sphinx]
 python3-sphinx-argparse:
   debian: [python3-sphinx-argparse]
   ubuntu: [python3-sphinx-argparse]
 python3-sphinx-rtd-theme:
   debian: [python3-sphinx-rtd-theme]
+  rhel: ['python%{python3_pkgversion}-sphinx_rtd_theme']
   ubuntu: [python3-sphinx-rtd-theme]
 python3-sqlalchemy:
   debian: [python3-sqlalchemy]


### PR DESCRIPTION
This repo is published by RedHat, but it is not enabled by default. It contains quite a few packages that were previously available in the 'base' or 'epel' repos for RHEL 7.

I also explicitly listed the AppStream repo in CONTRIBUTING.md. This repo is required for a basic installation (similar to BaseOS), but I thought it best to list it since we list 'base'.

There aren't any official web databases for RHEL/CentOS packages, so I'll link to the packages sitting in the repository mirrors.

| rosdep key | system package |
|------------|----------------|
| boost | [boost-python%{python3_pkgversion}-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/boost-python3-devel-1.66.0-6.el8.x86_64.rpm) |
| graphviz-dev | [graphviz-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/graphviz-devel-2.40.1-39.el8.x86_64.rpm) |
| jasper | [jasper-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/jasper-devel-2.0.14-4.el8.x86_64.rpm) |
| libavahi-client-dev | [avahi-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/avahi-devel-0.7-19.el8.x86_64.rpm) |
| libavahi-core-dev | [avahi-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/avahi-devel-0.7-19.el8.x86_64.rpm) |
| libbison-dev | [bison-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/bison-devel-3.0.4-10.el8.x86_64.rpm) |
| libblas-dev | [blas-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/blas-devel-3.8.0-8.el8.x86_64.rpm) |
| libbluetooth-dev | [bluez-libs-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/bluez-libs-devel-5.50-1.el8.x86_64.rpm) |
| libconfig-dev | [libconfig-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libconfig-devel-1.5-9.el8.x86_64.rpm) |
| libfltk-dev | [fltk-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/fltk-devel-1.3.4-5.el8.x86_64.rpm) |
| libgflags-dev | [gflags-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/gflags-devel-2.1.2-6.el8.x86_64.rpm) |
| libglew-dev | [glew-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/glew-devel-2.0.0-6.el8.x86_64.rpm) |
| libglm-dev | [glm-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/glm-devel-0.9.8.5-2.el8.noarch.rpm) |
| libgoogle-glog-dev | [glog-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/glog-devel-0.3.5-3.el8.x86_64.rpm) |
| libgphoto-dev | [libgphoto2-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libgphoto2-devel-2.5.16-3.el8.x86_64.rpm) |
| libjson0-dev | [json-c-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/json-c-devel-0.13.1-0.2.el8.x86_64.rpm) |
| liblapack-dev | [lapack-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/lapack-devel-3.8.0-8.el8.x86_64.rpm) |
| liblttng-ust-dev | [lttng-ust-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/lttng-ust-devel-2.8.1-11.el8.x86_64.rpm) |
| libmicrohttpd | [libmicrohttpd-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libmicrohttpd-devel-0.9.59-2.el8.x86_64.rpm) |
| libmp3lame-dev | [lame-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/lame-devel-3.100-6.el8.x86_64.rpm) |
| libopenal-dev | [openal-soft-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/openal-soft-devel-1.18.2-7.el8.x86_64.rpm) |
| libopenblas-dev | [openblas-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/openblas-devel-0.3.3-2.el8.x86_64.rpm) |
| libopenexr-dev | [OpenEXR-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/OpenEXR-devel-2.2.0-11.el8.x86_64.rpm) |
| libpcap | [libpcap-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libpcap-devel-1.9.0-3.el8.x86_64.rpm) |
| libqhull | [qhull-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/qhull-devel-2015.2-5.el8.x86_64.rpm) |
| librabbitmq-dev | [librabbitmq-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/librabbitmq-devel-0.9.0-1.el8.x86_64.rpm) |
| libraw1394-dev | [libraw1394-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libraw1394-devel-2.1.2-5.el8.x86_64.rpm) |
| libsndfile1-dev | [libsndfile-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libsndfile-devel-1.0.28-8.el8.x86_64.rpm) |
| libturbojpeg | [turbojpeg-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/turbojpeg-devel-1.5.3-10.el8.x86_64.rpm) |
| libusb-dev | [libusb-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libusb-devel-0.1.5-12.el8.x86_64.rpm) |
| libv4l-dev | [libv4l-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libv4l-devel-1.14.2-3.el8.x86_64.rpm) |
| libvpx-dev | [libvpx-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/libvpx-devel-1.7.0-6.el8.x86_64.rpm) |
| libxmlrpc-c++ | [xmlrpc-c-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/xmlrpc-c-devel-1.51.0-5.el8.x86_64.rpm) |
| nasm | [nasm](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/nasm-2.13.03-2.el8.x86_64.rpm) |
| netpbm | [netpbm-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/netpbm-devel-10.82.00-6.el8.x86_64.rpm) |
| nkf | [nkf](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/nkf-2.1.4-8.el8.x86_64.rpm) |
| opencl-headers | [opencl-headers](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/opencl-headers-2.2-1.20180306gite986688.el8.noarch.rpm) |
| pandoc | [pandoc](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/pandoc-2.0.6-4.el8.x86_64.rpm) |
| protobuf-dev | [protobuf-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/protobuf-devel-3.5.0-7.el8.x86_64.rpm) |
| protobuf-dev | [protobuf-compiler](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/protobuf-compiler-3.5.0-7.el8.x86_64.rpm) |
| pstoedit | [pstoedit](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/pstoedit-3.70-9.el8.x86_64.rpm) |
| sdl2 | [SDL2-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/SDL2-devel-2.0.8-7.el8.x86_64.rpm) |
| snappy | [snappy-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/snappy-devel-1.1.7-5.el8.x86_64.rpm) |
| suitesparse | [suitesparse-devel](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/suitesparse-devel-4.4.6-11.el8.x86_64.rpm) |
| python3-packaging | [python%{python3_pkgversion}-packaging](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/python3-packaging-16.8-9.el8.noarch.rpm) |
| python3-sphinx | [python%{python3_pkgversion}-sphinx](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/python3-sphinx-1.7.6-1.el8.noarch.rpm) |
| python3-sphinx-rtd-theme | [python%{python3_pkgversion}-sphinx_rtd_theme](http://mirror.centos.org/centos-8/8.1.1911/PowerTools/x86_64/os/Packages/python3-sphinx_rtd_theme-0.3.1-3.el8.noarch.rpm) |

```
$ dnf list -q --showduplicates --available boost-python3-devel \
> graphviz-devel jasper-devel avahi-devel bison-devel blas-devel \
> bluez-libs-devel libconfig-devel fltk-devel gflags-devel glew-devel \
> glm-devel glog-devel libgphoto2-devel json-c-devel lapack-devel \
> lttng-ust-devel libmicrohttpd-devel lame-devel openal-soft-devel \
> openblas-devel OpenEXR-devel libpcap-devel qhull-devel librabbitmq-devel \
> libraw1394-devel libsndfile-devel turbojpeg-devel libusb-devel \
> libv4l-devel libvpx-devel xmlrpc-c-devel nasm netpbm-devel nkf \
> opencl-headers pandoc protobuf-devel protobuf-compiler pstoedit SDL2-devel \
> snappy-devel suitesparse-devel python3-packaging python3-sphinx \
> python3-sphinx_rtd_theme --exclude *.i686
Available Packages
OpenEXR-devel.x86_64                2.2.0-11.el8                     PowerTools
SDL2-devel.x86_64                   2.0.8-7.el8                      PowerTools
avahi-devel.x86_64                  0.7-19.el8                       PowerTools
bison-devel.x86_64                  3.0.4-10.el8                     PowerTools
blas-devel.x86_64                   3.8.0-8.el8                      PowerTools
bluez-libs-devel.x86_64             5.50-1.el8                       PowerTools
boost-python3-devel.x86_64          1.66.0-6.el8                     PowerTools
fltk-devel.x86_64                   1.3.4-5.el8                      PowerTools
gflags-devel.x86_64                 2.1.2-6.el8                      PowerTools
glew-devel.x86_64                   2.0.0-6.el8                      PowerTools
glm-devel.noarch                    0.9.8.5-2.el8                    PowerTools
glog-devel.x86_64                   0.3.5-3.el8                      PowerTools
graphviz-devel.x86_64               2.40.1-39.el8                    PowerTools
jasper-devel.x86_64                 2.0.14-4.el8                     PowerTools
json-c-devel.x86_64                 0.13.1-0.2.el8                   PowerTools
lame-devel.x86_64                   3.100-6.el8                      PowerTools
lapack-devel.x86_64                 3.8.0-8.el8                      PowerTools
libconfig-devel.x86_64              1.5-9.el8                        PowerTools
libgphoto2-devel.x86_64             2.5.16-3.el8                     PowerTools
libmicrohttpd-devel.x86_64          1:0.9.59-2.el8                   PowerTools
libpcap-devel.x86_64                14:1.9.0-3.el8                   PowerTools
librabbitmq-devel.x86_64            0.9.0-1.el8                      PowerTools
libraw1394-devel.x86_64             2.1.2-5.el8                      PowerTools
libsndfile-devel.x86_64             1.0.28-8.el8                     PowerTools
libusb-devel.x86_64                 1:0.1.5-12.el8                   PowerTools
libv4l-devel.x86_64                 1.14.2-3.el8                     PowerTools
libvpx-devel.x86_64                 1.7.0-6.el8                      PowerTools
lttng-ust-devel.x86_64              2.8.1-11.el8                     PowerTools
nasm.x86_64                         2.13.03-2.el8                    PowerTools
netpbm-devel.x86_64                 10.82.00-6.el8                   PowerTools
nkf.x86_64                          1:2.1.4-8.el8                    PowerTools
openal-soft-devel.x86_64            1.18.2-7.el8                     PowerTools
openblas-devel.x86_64               0.3.3-2.el8                      PowerTools
opencl-headers.noarch               2.2-1.20180306gite986688.el8     PowerTools
pandoc.x86_64                       2.0.6-4.el8                      PowerTools
protobuf-compiler.x86_64            3.5.0-7.el8                      PowerTools
protobuf-devel.x86_64               3.5.0-7.el8                      PowerTools
pstoedit.x86_64                     3.70-9.el8                       PowerTools
python3-packaging.noarch            16.8-9.el8                       PowerTools
python3-sphinx.noarch               1:1.7.6-1.el8                    PowerTools
python3-sphinx_rtd_theme.noarch     0.3.1-3.el8                      PowerTools
qhull-devel.x86_64                  2015.2-5.el8                     PowerTools
snappy-devel.x86_64                 1.1.7-5.el8                      PowerTools
suitesparse-devel.x86_64            4.4.6-11.el8                     PowerTools
turbojpeg-devel.x86_64              1.5.3-10.el8                     PowerTools
xmlrpc-c-devel.x86_64               1.51.0-5.el8                     PowerTools
```