### PR TITLE
ros_control: 0.19.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1175,6 +1175,23 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros_control.git
       version: noetic-devel
+    release:
+      packages:
+      - combined_robot_hw
+      - combined_robot_hw_tests
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - controller_manager_tests
+      - hardware_interface
+      - joint_limits_interface
+      - ros_control
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_control-release.git
+      version: 0.19.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.19.0-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

```
* Replace enums with enum classes (#412 <https://github.com/ros-controls/ros_control/issues/412>)
* Contributors: Matt Reynolds
```

## controller_manager

```
* Replace enums with enum classes (#412 <https://github.com/ros-controls/ros_control/issues/412>)
* Contributors: Matt Reynolds
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Disable flaky CLI spawn test (#446 <https://github.com/ros-controls/ros_control/issues/446>)
* Update travis config and rosinstall for noetic (#439 <https://github.com/ros-controls/ros_control/issues/439>)
* Contributors: Bence Magyar
```

## hardware_interface

```
* Remove deprecated ForceTorqueHandle ctor (#437 <https://github.com/ros-controls/ros_control/issues/437>)
* Replace enums with enum classes (#412 <https://github.com/ros-controls/ros_control/issues/412>)
* Use CamelCase for ResourceManagerType typedef (#438 <https://github.com/ros-controls/ros_control/issues/438>)
* Contributors: Matt Reynolds
```

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Replace enums with enum classes (#412 <https://github.com/ros-controls/ros_control/issues/412>)
* Contributors: Matt Reynolds
```
