### PR TITLE
octomap_ros: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6273,7 +6273,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_ros-release.git
-      version: 0.4.0-0
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.4.1-1`:

- upstream repository: https://github.com/OctoMap/octomap_ros.git
- release repository: https://github.com/ros-gbp/octomap_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.4.0-0`

## octomap_ros

```
* Added archive destination for static libraries (#10 <https://github.com/OctoMap/octomap_ros/issues/10>)
* Fix catkin_lint issues and cmake policy CMP0038 (#9 <https://github.com/OctoMap/octomap_ros/issues/9>)
* Update maintainer emails
* Contributors: Andrea Ponza, Armin Hornung, Sebastian Kasperski, Wolfgang Merkt
```
