### PR TITLE
octomap_ros: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -829,6 +829,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_msgs.git
       version: melodic-devel
     status: maintained
+  octomap_ros:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_ros-release.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: melodic-devel
+    status: unmaintained
   open_karto:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.4.1-1`:

- upstream repository: https://github.com/OctoMap/octomap_ros.git
- release repository: https://github.com/ros-gbp/octomap_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## octomap_ros

```
* Added archive destination for static libraries (#10 <https://github.com/OctoMap/octomap_ros/issues/10>)
* Fix catkin_lint issues and cmake policy CMP0038 (#9 <https://github.com/OctoMap/octomap_ros/issues/9>)
* Update maintainer emails
* Contributors: Andrea Ponza, Armin Hornung, Sebastian Kasperski, Wolfgang Merkt
```
