### PR TITLE
octomap_msgs: 0.3.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6248,7 +6248,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_msgs-release.git
-      version: 0.3.3-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `0.3.5-1`:

- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.3-1`

## octomap_msgs

```
* Add myself to maintainers
* Contributors: Wolfgang Merkt
```
