### PR TITLE
octomap_mapping: 0.6.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6233,7 +6233,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_mapping-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.5-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.4-1`

## octomap_mapping

```
* Update maintainer email
* Contributors: Wolfgang Merkt
```

## octomap_server

```
* Add color server nodelet (#68 <https://github.com/OctoMap/octomap_mapping/issues/68>, #67 <https://github.com/OctoMap/octomap_mapping/issues/67>)
* Updated maintainer email
* Contributors: clunietp, Wolfgang Merkt
```
