### PR TITLE
octomap_mapping: 0.6.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -844,6 +844,24 @@ repositories:
       url: https://github.com/OctoMap/octomap.git
       version: devel
     status: maintained
+  octomap_mapping:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: kinetic-devel
+    release:
+      packages:
+      - octomap_mapping
+      - octomap_server
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_mapping-release.git
+      version: 0.6.5-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: kinetic-devel
+    status: maintained
   octomap_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `0.6.5-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping
- release repository: https://github.com/ros-gbp/octomap_mapping-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## octomap_mapping

```
* Update maintainer email
* Contributors: Wolfgang Merkt
```

## octomap_server

```
* Add color server nodelet (#68 <https://github.com/OctoMap/octomap_mapping/issues/68>, #67 <https://github.com/OctoMap/octomap_mapping/issues/67>)
* Updated maintainer email
* Contributors: clunietp, Wolfgang Merkt
```
