### PR TITLE
laser_pipeline: 1.6.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -641,6 +641,21 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  laser_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_pipeline.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/laser_pipeline-release.git
+      version: 1.6.4-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_pipeline.git
+      version: noetic-devel
+    status: maintained
   mcl_3dl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_pipeline` to `1.6.4-1`:

- upstream repository: https://github.com/ros-perception/laser_pipeline.git
- release repository: https://github.com/ros-gbp/laser_pipeline-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
