### PR TITLE
add python3-gi key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5363,6 +5363,12 @@ python3-future:
   fedora: [python3-future]
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
+python3-gi:
+  arch: [python-gobject]
+  debian: [python3-gi]
+  fedora: [pygobject3]
+  gentoo: [dev-python/pygobject]
+  ubuntu: [python3-gi]
 python3-gitlab:
   debian:
     '*': [python3-gitlab]


### PR DESCRIPTION
add python3-gi key

arch: https://www.archlinux.org/packages/extra/x86_64/python-gobject/
debian: https://pkgs.org/download/python3-gi
fedora: https://apps.fedoraproject.org/packages/pygobject3
gentoo: https://packages.gentoo.org/packages/dev-python/pygobject
ubuntu: https://pkgs.org/download/python3-gi
