### PR TITLE
convex_decomposition: 0.1.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -223,6 +223,21 @@ repositories:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
       version: melodic-devel
+  convex_decomposition:
+    doc:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/convex_decomposition-release.git
+      version: 0.1.12-1
+    source:
+      type: git
+      url: https://github.com/ros/convex_decomposition.git
+      version: melodic-devel
+    status: unmaintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `convex_decomposition` to `0.1.12-1`:

- upstream repository: https://github.com/ros/convex_decomposition.git
- release repository: https://github.com/ros-gbp/convex_decomposition-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## convex_decomposition

```
* Merge pull request #8 <https://github.com/ros/convex_decomposition/issues/8> from k-okada/add_travis
  update travis.yml
* Change maintainer to ROS Orphaned Package
* update travis.yml
* mv readme to README.md
* Contributors: Kei Okada
```
