### PR TITLE
laser_proc: 0.1.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -671,6 +671,21 @@ repositories:
       url: https://github.com/ros-perception/laser_pipeline.git
       version: noetic-devel
     status: maintained
+  laser_proc:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/laser_proc-release.git
+      version: 0.1.6-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: melodic-devel
+    status: maintained
   mcl_3dl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `0.1.6-1`:

- upstream repository: git://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros-gbp/laser_proc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## laser_proc

```
* Update required cmake version
* Contributors: Jon Binney
```
