### PR TITLE
osrf_pycommon: 0.1.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -192,6 +192,21 @@ repositories:
       url: https://github.com/IntelRealSense/librealsense.git
       version: ros2debian
     status: maintained
+  osrf_pycommon:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_pycommon-release.git
+      version: 0.1.9-1
+    source:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    status: maintained
   osrf_testing_tools_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `0.1.9-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## osrf_pycommon

```
* install resource marker file for package (#56 <https://github.com/osrf/osrf_pycommon/pull/56>)
```
