### PR TITLE
libyaml_vendor: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -192,6 +192,18 @@ repositories:
       url: https://github.com/IntelRealSense/librealsense.git
       version: ros2debian
     status: maintained
+  libyaml_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/libyaml_vendor-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/libyaml_vendor.git
+      version: foxy
+    status: maintained
   osrf_testing_tools_cpp:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -217,7 +217,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
-      version: foxy
+      version: master
     status: maintained
   osrf_pycommon:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## libyaml_vendor

```
* Add missing export of yaml (#15 <https://github.com/ros2/libyaml_vendor/issues/15>)
* Only propagate CMAKE_BUILD_TYPE for single configuration generators (#13 <https://github.com/ros2/libyaml_vendor/issues/13>)
* Enable linter tests on libyaml_vendor (#8 <https://github.com/ros2/libyaml_vendor/issues/8>)
* Add missing LICENSE file, apache2 (#7 <https://github.com/ros2/libyaml_vendor/issues/7>)
```
