### PR TITLE
python_cmake_module: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -226,6 +226,21 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: maintained
+  python_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/python_cmake_module-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: master
+    status: developed
   ros_workspace:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `python_cmake_module` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/python_cmake_module.git
- release repository: https://github.com/ros2-gbp/python_cmake_module-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
