### PR TITLE
spdlog_vendor: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -257,7 +257,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.1.1-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.1.0-1`

## spdlog_vendor

```
* Silence warning from GNUInstallDirs on Windows. (#10 <https://github.com/ros2/spdlog_vendor/issues/10>)
```
