### PR TITLE
launch: 0.10.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -190,6 +190,28 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  launch:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: master
+    release:
+      packages:
+      - launch
+      - launch_testing
+      - launch_testing_ament_cmake
+      - launch_xml
+      - launch_yaml
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/launch-release.git
+      version: 0.10.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: master
+    status: developed
   librealsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## launch

```
* remove Python 3.5 specific logic (#401 <https://github.com/ros2/launch/issues/401>)
* use typing.TYPE_CHECKING to avoid flake8 failure (#398 <https://github.com/ros2/launch/issues/398>)
* Suppress flake8 A003 warning (#395 <https://github.com/ros2/launch/issues/395>)
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Remove unnecessary overloads (#389 <https://github.com/ros2/launch/issues/389>)
* Simplify type annotation (#388 <https://github.com/ros2/launch/issues/388>)
* Add support for anon substitution (#384 <https://github.com/ros2/launch/issues/384>)
* Make RegisterEventHandler describe its sub-entities (#386 <https://github.com/ros2/launch/issues/386>)
* Fix parsing of cmd line arguments in XML and yaml file (#379 <https://github.com/ros2/launch/issues/379>)
* Only allow ExecuteProcess actions to execute once (#375 <https://github.com/ros2/launch/issues/375>)
* Fix grammar in docstring (#373 <https://github.com/ros2/launch/issues/373>)
* Release loop lock before waiting for it to do work (#369 <https://github.com/ros2/launch/issues/369>)
* Adds Command substitution (#367 <https://github.com/ros2/launch/issues/367>)
* Handle case where output buffer is closed during shutdown (#365 <https://github.com/ros2/launch/issues/365>)
* Use imperative mood in docstrings. (#362 <https://github.com/ros2/launch/issues/362>)
* Contributors: Dirk Thomas, Ivan Santiago Paunovic, Jacob Perron, Jorge Perez, Peter Baughman, Shane Loretz, Steven! Ragnarök, William Woodall
```

## launch_testing

```
* Improve jUnit output for launch tests when run with py.test (#404 <https://github.com/ros2/launch/issues/404>)
* avoid deprecation warning, use from_parent (#402 <https://github.com/ros2/launch/issues/402>)
* Warn that old-style ready_fn and test attributes will be deprecated (#346 <https://github.com/ros2/launch/issues/346>)
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* stop using constructors deprecated in pytest 5.4 (#391 <https://github.com/ros2/launch/issues/391>)
* Add the ability to assert in stdout or stderr. (#378 <https://github.com/ros2/launch/issues/378>)
* Add delay parameter to retry_on_failure decorator (#390 <https://github.com/ros2/launch/issues/390>)
* Make RegisterEventHandler describe its sub-entities (#386 <https://github.com/ros2/launch/issues/386>)
* Import test file without contaminating sys.modules (#360 <https://github.com/ros2/launch/issues/360>)
* Update reference to example launch test file (#363 <https://github.com/ros2/launch/issues/363>)
* Use imperative mood in docstrings. (#362 <https://github.com/ros2/launch/issues/362>)
* Fix a documentation typo. (#361 <https://github.com/ros2/launch/issues/361>)
* Fix junit XML when launch dies early (#358 <https://github.com/ros2/launch/issues/358>)
* Contributors: Chris Lalancette, Dan Rose, Dirk Thomas, Jacob Perron, Michel Hidalgo, Peter Baughman, Steven! Ragnarök
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Use imperative mood in docstrings. (#362 <https://github.com/ros2/launch/issues/362>)
* Contributors: Dirk Thomas, Steven! Ragnarök
```

## launch_yaml

```
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Use imperative mood in docstrings. (#362 <https://github.com/ros2/launch/issues/362>)
* Contributors: Dirk Thomas, Steven! Ragnarök
```
