### PR TITLE
rcl_logging: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -290,6 +290,26 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: master
     status: developed
+  rcl_logging:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    release:
+      packages:
+      - rcl_logging_log4cxx
+      - rcl_logging_noop
+      - rcl_logging_spdlog
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 0.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: master
+    status: maintained
   rcutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `0.4.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rcl_logging_log4cxx

```
* Fix CMake warnings about using uninitialized variables (#30 <https://github.com/ros2/rcl_logging/issues/30>)
* Code style only: wrap after open parenthesis if not in one line (#24 <https://github.com/ros2/rcl_logging/issues/24>)
* Contributors: Dirk Thomas
```

## rcl_logging_noop

```
* Fix CMake warnings about using uninitialized variables (#30 <https://github.com/ros2/rcl_logging/issues/30>)
* Contributors: Dirk Thomas
```

## rcl_logging_spdlog

```
* Export targets in addition to include directories / libraries (#31 <https://github.com/ros2/rcl_logging/issues/31>)
* Make spdlog an exec_depend (#27 <https://github.com/ros2/rcl_logging/issues/27>)
* Code style only: wrap after open parenthesis if not in one line (#24 <https://github.com/ros2/rcl_logging/issues/24>)
* Bypass spdlog singleton registry (#23 <https://github.com/ros2/rcl_logging/issues/23>)
* Contributors: Chris Lalancette, Dirk Thomas, Ivan Santiago Paunovic
```
