### PR TITLE
rosidl: 0.9.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -317,6 +317,33 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: maintained
+  rosidl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: master
+    release:
+      packages:
+      - rosidl_adapter
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_parser
+      - rosidl_runtime_c
+      - rosidl_runtime_cpp
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl-release.git
+      version: 0.9.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: master
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `0.9.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rosidl_adapter

```
* Use f-string (#436 <https://github.com/ros2/rosidl/issues/436>)
* Contributors: Dirk Thomas
```

## rosidl_cmake

```
* Use f-string (#436 <https://github.com/ros2/rosidl/issues/436>)
* Contributors: Dirk Thomas
```

## rosidl_generator_c

```
* Export targets in addition to include directories / libraries (#473 <https://github.com/ros2/rosidl/issues/473>)
* Move non-entry point headers into detail subdirectory (#461 <https://github.com/ros2/rosidl/issues/461>)
* Rename rosidl_generator_c 'namespace' to rosidl_runtime_c (#458 <https://github.com/ros2/rosidl/issues/458>)
* Only export ament_cmake_core instead of ament_cmake (#459 <https://github.com/ros2/rosidl/issues/459>)
* Split rosidl_generator_c and rosidl_generator_cpp in two: rosidl_generator_x and rosidl_runtime_x (#442 <https://github.com/ros2/rosidl/issues/442>)
* Added rosidl_generator_c as a member of group rosidl_runtime_packages (#440 <https://github.com/ros2/rosidl/issues/440>)
* Style update to match uncrustify with explicit language (#439 <https://github.com/ros2/rosidl/issues/439>)
* Code style only: wrap after open parenthesis if not in one line (#435 <https://github.com/ros2/rosidl/issues/435>)
* Use f-string (#436 <https://github.com/ros2/rosidl/issues/436>)
* Move repeated logic for C include prefix into common function (#432 <https://github.com/ros2/rosidl/issues/432>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Jacob Perron
```

## rosidl_generator_cpp

```
* Export targets in addition to include directories / libraries (#473 <https://github.com/ros2/rosidl/issues/473>)
* Move non-entry point headers into detail subdirectory (#461 <https://github.com/ros2/rosidl/issues/461>)
* Only export ament_cmake_core instead of ament_cmake (#459 <https://github.com/ros2/rosidl/issues/459>)
* Rename rosidl_namespace_cpp namespace (#456 <https://github.com/ros2/rosidl/issues/456>)
* Split rosidl_generator_c and rosidl_generator_cpp in two: rosidl_generator_x and rosidl_runtime_x (#442 <https://github.com/ros2/rosidl/issues/442>)
* Add a utility for rigorously initializing a message instance (#448 <https://github.com/ros2/rosidl/issues/448>)
* Avoid setter for empty struct dummy member (#455 <https://github.com/ros2/rosidl/issues/455>)
* Code style only: wrap after open parenthesis if not in one line (#435 <https://github.com/ros2/rosidl/issues/435>)
* Use f-string (#436 <https://github.com/ros2/rosidl/issues/436>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Grey
```

## rosidl_parser

```
* Use f-string (#436 <https://github.com/ros2/rosidl/issues/436>)
* Contributors: Dirk Thomas
```

## rosidl_runtime_c

```
* Rename message_bounds structure for consistency (#475 <https://github.com/ros2/rosidl/issues/475>)
* Rename rosidl_runtime_c__String__bounds to singular (#476 <https://github.com/ros2/rosidl/issues/476>)
* Document string structs and sequence functions (#466 <https://github.com/ros2/rosidl/issues/466>)
* Export targets in addition to include directories / libraries (#465 <https://github.com/ros2/rosidl/issues/465>)
* Rename rosidl_runtime_c_message_initialization to rosidl_runtime_c__message_initialization (#464 <https://github.com/ros2/rosidl/issues/464>)
* Rename rosidl_generator_c 'namespace' to rosidl_runtime_c (#458 <https://github.com/ros2/rosidl/issues/458>)
* Split rosidl_generator_c and rosidl_generator_cpp in two: rosidl_generator_x and rosidl_runtime_x (#442 <https://github.com/ros2/rosidl/issues/442>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Michael Carroll
```

## rosidl_runtime_cpp

```
* Export targets in a addition to include directories / libraries (#471 <https://github.com/ros2/rosidl/issues/471>)
* Rename rosidl_runtime_c_message_initialization to rosidl_runtime_c__message_initialization (#464 <https://github.com/ros2/rosidl/issues/464>)
* Rename rosidl_generator_c 'namespace' to rosidl_runtime_c (#458 <https://github.com/ros2/rosidl/issues/458>)
* Move rosidl_generator_cpp headers (#456 <https://github.com/ros2/rosidl/issues/456>)
* Split rosidl_generator_c and rosidl_generator_cpp in two: rosidl_generator_x and rosidl_runtime_x (#442 <https://github.com/ros2/rosidl/issues/442>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas
```

## rosidl_typesupport_interface

```
* Export targets in addition to include directories / libraries (#471 <https://github.com/ros2/rosidl/issues/471>)
* Contributors: Dirk Thomas
```

## rosidl_typesupport_introspection_c

```
* Export missing targets for single typesupport build, avoid exposing build directories in include dirs (#477 <https://github.com/ros2/rosidl/issues/477>)
* Export targets in addition to include directories / libraries (#471 <https://github.com/ros2/rosidl/issues/471>)
* Fix build with single introspection typesupport (#470 <https://github.com/ros2/rosidl/issues/470>)
* Rename rosidl_runtime_c_message_initialization to rosidl_runtime_c__message_initialization (#464 <https://github.com/ros2/rosidl/issues/464>)
* Move non-entry point headers into detail subdirectory (#461 <https://github.com/ros2/rosidl/issues/461>)
* Rename rosidl_generator_c 'namespace' to rosidl_runtime_c (#458 <https://github.com/ros2/rosidl/issues/458>)
* Split rosidl_generator_c and rosidl_generator_cpp in two: rosidl_generator_x and rosidl_runtime_x (#442 <https://github.com/ros2/rosidl/issues/442>)
* Export typesupport library in a separate cmake variable (#453 <https://github.com/ros2/rosidl/issues/453>)
* Style update to match uncrustify with explicit language (#439 <https://github.com/ros2/rosidl/issues/439>)
* Move repeated logic for C include prefix into common function (#432 <https://github.com/ros2/rosidl/issues/432>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Ivan Santiago Paunovic, Jacob Perron
```

## rosidl_typesupport_introspection_cpp

```
* Export missing targets for single typesupport build, avoid exposing build directories in include dirs (#477 <https://github.com/ros2/rosidl/issues/477>)
* Export targets in addition to include directories / libraries (#471 <https://github.com/ros2/rosidl/issues/471> #473 <https://github.com/ros2/rosidl/issues/473> )
* Fix build with single introspection typesupport (#470 <https://github.com/ros2/rosidl/issues/470>)
* Move non-entry point headers into detail subdirectory (#461 <https://github.com/ros2/rosidl/issues/461>)
* Rename rosidl_generator_c 'namespace' to rosidl_runtime_c (#458 <https://github.com/ros2/rosidl/issues/458>)
* Rename rosidl_namespace_cpp namespace (#456 <https://github.com/ros2/rosidl/issues/456>)
* Splitted rosidl_generator_c and rosidl_generator_cpp in two: rosidl_generator_x and rosidl_runtime_x (#442 <https://github.com/ros2/rosidl/issues/442>)
* Export typesupport library in a separate cmake variable (#453 <https://github.com/ros2/rosidl/issues/453>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Ivan Santiago Paunovic
```
