### PR TITLE
rcpputils: 0.3.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -314,7 +314,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: 0.3.0
+      version: master
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -323,7 +323,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: 0.3.0
+      version: master
     status: developed
   rcutils:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -310,6 +310,21 @@ repositories:
       url: https://github.com/ros2/rcl_logging.git
       version: master
     status: maintained
+  rcpputils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: 0.3.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rcpputils-release.git
+      version: 0.3.0-2
+    source:
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: 0.3.0
+    status: developed
   rcutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `0.3.0-2`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rcpputils

```
* Added shared library to feature list (#58 <https://github.com/ros2/rcpputils/issues/58>)
* export targets in a addition to include directories / libraries (#57 <https://github.com/ros2/rcpputils/issues/57>)
* remove pointer for smart pointer (#56 <https://github.com/ros2/rcpputils/issues/56>)
* Added shared library class description to readme (#53 <https://github.com/ros2/rcpputils/issues/53>)
* Increased shared library tests (#51 <https://github.com/ros2/rcpputils/issues/51>)
* Removed duplicated split function (#54 <https://github.com/ros2/rcpputils/issues/54>)
* Exposed get_env_var (#55 <https://github.com/ros2/rcpputils/issues/55>)
* Added debug version for library names (#52 <https://github.com/ros2/rcpputils/issues/52>)
* Added unload_library method to shared_library (#50 <https://github.com/ros2/rcpputils/issues/50>)
* Included abstraction for rcutils::shared_library (#49 <https://github.com/ros2/rcpputils/issues/49>)
* Add more documentation and include doxyfile (#46 <https://github.com/ros2/rcpputils/issues/46>)
* Update README.md with license and build badges. (#45 <https://github.com/ros2/rcpputils/issues/45>)
* Update README to mention assertion helper functions (#43 <https://github.com/ros2/rcpputils/issues/43>)
* Add rcpputils::fs::file_size and rcpputils::fs::is_directory (#41 <https://github.com/ros2/rcpputils/issues/41>)
* Make assert functions accept an optional string. (#42 <https://github.com/ros2/rcpputils/issues/42>)
* Add functions for C++ assertions (#31 <https://github.com/ros2/rcpputils/issues/31>)
* remove reference for pointer traits (#38 <https://github.com/ros2/rcpputils/issues/38>)
* code style only: wrap after open parenthesis if not in one line (#36 <https://github.com/ros2/rcpputils/issues/36>)
* Bug fixes for rcpputils::fs API (#35 <https://github.com/ros2/rcpputils/issues/35>)
  * Ensure rcpputils::fs::create_directories works with absolute paths.
  * Implement temp_directory_path() for testing purposes.
  * Fix rcpputils::fs::path::parent_path() method.
* Add build and test workflow (#33 <https://github.com/ros2/rcpputils/issues/33>)
* Add linting workflow (#32 <https://github.com/ros2/rcpputils/issues/32>)
* Fix filesystem helpers for directory manipulation. (#30 <https://github.com/ros2/rcpputils/issues/30>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Emerson Knapp, Karsten Knese, Michel Hidalgo, Zachary Michaels
```
