### PR TITLE
ros2_tracing: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -345,6 +345,21 @@ repositories:
       url: https://github.com/ros2/rmw.git
       version: master
     status: maintained
+  ros2_tracing:
+    release:
+      packages:
+      - tracetools
+      - tracetools_read
+      - tracetools_trace
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: foxy
+    status: developed
   ros_workspace:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `1.0.0-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## tracetools

```
* Export -rdynamic using ament_export_link_flags and modern CMake
* Contributors: Christophe Bedard, Dirk Thomas
```

## tracetools_trace

```
* Start a session daemon if there isn't one before setting up tracing
* Contributors: Christophe Bedard
```
