### PR TITLE
open_karto: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -946,7 +946,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/open_karto-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros-perception/open_karto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.2.1-1`:

- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.0-1`

## open_karto

```
* bump version to silence CMP0048
* Merge pull request #19 <https://github.com/ros-perception/open_karto/issues/19> from moriarty/patch-1
  Melodic: build status badges Indigo is EOL.
* Melodic: build status badges Indigo is EOL.
* Merge pull request #18 <https://github.com/ros-perception/open_karto/issues/18> from ms-iot/windows_port
  [Windows][melodic] Fix Windows build break
* Changing maintainer email
* Fix windows build.
* Contributors: Alex Moriarty, Luc Bettaieb, Michael Ferguson, Sean Yen
```
