### PR TITLE
fastcdr: 1.0.13-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -183,6 +183,8 @@ repositories:
       url: https://github.com/ros2-gbp/fastcdr-release.git
       version: 1.0.13-1
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
       version: v1.0.13

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -176,6 +176,17 @@ repositories:
       url: https://github.com/ros2/eigen3_cmake_module.git
       version: master
     status: maintained
+  fastcdr:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/fastcdr-release.git
+      version: 1.0.13-1
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-CDR.git
+      version: v1.0.13
+    status: maintained
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `fastcdr` to `1.0.13-1`:

- upstream repository: https://github.com/eProsima/Fast-CDR.git
- release repository: https://github.com/ros2-gbp/fastcdr-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
