### PR TITLE
mbf_recovery_behaviors: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5089,6 +5089,24 @@ repositories:
       url: https://github.com/mavlink/mavros.git
       version: master
     status: developed
+  mbf_recovery_behaviors:
+    doc:
+      type: git
+      url: https://github.com/uos/mbf_recovery_behaviors.git
+      version: master
+    release:
+      packages:
+      - mbf_recovery_behaviors
+      - moveback_recovery
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/mbf_recovery_behaviors.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/uos/mbf_recovery_behaviors.git
+      version: master
+    status: developed
   mcl_3dl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mbf_recovery_behaviors` to `0.1.0-1`:

- upstream repository: https://github.com/uos/mbf_recovery_behaviors.git
- release repository: https://github.com/uos-gbp/mbf_recovery_behaviors.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## mbf_recovery_behaviors

```
* initial version 0.1.0
* Contributors: Sebastian Pütz
```

## moveback_recovery

```
* initial version 0.1.0 containing the moveback_recovery
* Contributors: Sebastian Pütz
```
