### PR TITLE
uos_tools: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11259,6 +11259,28 @@ repositories:
       url: https://github.com/ros-geographic-info/unique_identifier.git
       version: master
     status: maintained
+  uos_tools:
+    doc:
+      type: git
+      url: https://github.com/uos/uos_tools.git
+      version: master
+    release:
+      packages:
+      - uos_common_urdf
+      - uos_diffdrive_teleop
+      - uos_freespace
+      - uos_gazebo_worlds
+      - uos_maps
+      - uos_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/uos-tools.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/uos/uos_tools.git
+      version: master
+    status: maintained
   ur_robot_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uos_tools` to `1.0.0-1`:

- upstream repository: https://github.com/uos/uos_tools.git
- release repository: https://github.com/uos-gbp/uos-tools.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## uos_common_urdf

```
* Initial version 1.0.0
* Contributors: André Potenza, Jochen Sprickerhof, Martin Günther, Sebastian Pütz, Michael Görner, Tristan Igelbrink
```

## uos_diffdrive_teleop

```
* Initial version 1.0.0
* Contributors: Jochen Sprickerhof, Martin Günther, Michael Görner, MikyasDesta, Sebastian Pütz, Tristan Igelbrink
```

## uos_freespace

```
* Initial version 1.0.0
* Contributors: Jochen Sprickerhof, Marcel Wiegand, Martin Günther, Michael Görner, Peter Purnyn, Sebastian Pütz, Tristan Igelbrink
```

## uos_gazebo_worlds

```
* Initial version 1.0.0
* Contributors: Jochen Sprickerhof, Martin Günther, Michael Görner, Michael Stypa, Sebastian Pütz, Tristan Igelbrink
```

## uos_maps

```
* Initial version 1.0.0
* Contributors: Jochen Sprickerhof, Michael Görner, Sebastian Pütz, Tristan Igelbrink
```

## uos_tools

```
* Initial version 1.0.0
* Contributors: Jochen Sprickerhof, Martin Günther, Sebastian Pütz, Tristan Igelbrink, Michael Görner
```
