### PR TITLE
class_loader: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -145,6 +145,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/class_loader-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: ros2
+    status: maintained
   console_bridge_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.0.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## class_loader

```
* Export CMake targets in a addition to include directories / libraries. (#147 <https://github.com/ros/class_loader/issues/147>)
* Fixed references to poco in error strings. (#144 <https://github.com/ros/class_loader/issues/144>)
* Removed poco dependency. Shared library management is now provided by rcpputils. (#139 <https://github.com/ros/class_loader/issues/139>)
* Add missing LICENSE file, matching 3-clause BSD (#137 <https://github.com/ros/class_loader/issues/137>)
* Code style change: wrap after open parenthesis if not in one line (#138 <https://github.com/ros/class_loader/issues/138>)
* Fix Travis on macOS. (#135 <https://github.com/ros/class_loader/issues/135>)
* Use .empty() to check for an empty string. (#132 <https://github.com/ros/class_loader/issues/132>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Dirk Thomas, Jorge Perez
```
