### PR TITLE
warehouse_ros: 0.9.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17020,7 +17020,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/warehouse_ros-release.git
-      version: 0.9.3-1
+      version: 0.9.4-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.4-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.9.3-1`

## warehouse_ros

```
* Cleanup: fix catkin_lint warnings, remove obsolete test folder
* Fix unused-parameter warnings (#44 <https://github.com/ros-planning/warehouse_ros/issues/44>)
* Bump required cmake version (#45 <https://github.com/ros-planning/warehouse_ros/issues/45>)
* Contributors: Michael Görner, Robert Haschke
```
