### PR TITLE
warehouse_ros: 0.9.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2022,6 +2022,21 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: noetic
     status: maintained
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros-release.git
+      version: 0.9.4-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: kinetic-devel
+    status: maintained
   webkit_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `0.9.4-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros-gbp/warehouse_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## warehouse_ros

```
* Cleanup: fix catkin_lint warnings, remove obsolete test folder
* Fix unused-parameter warnings (#44 <https://github.com/ros-planning/warehouse_ros/issues/44>)
* Bump required cmake version (#45 <https://github.com/ros-planning/warehouse_ros/issues/45>)
* Contributors: Michael Görner, Robert Haschke
```
