### PR TITLE
pluginlib: 2.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -304,6 +304,22 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: maintained
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/pluginlib-release.git
+      version: 2.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: ros2
+    status: maintained
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `2.5.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## pluginlib

```
* Export CMake targets in a addition to include directories / libraries. (#188 <https://github.com/ros/pluginlib/issues/188>)
* Use rcpputils for library names. (#186 <https://github.com/ros/pluginlib/issues/186>)
* Fix filesystem linking on clang9. (#183 <https://github.com/ros/pluginlib/issues/183>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Emerson Knapp
```
