### PR TITLE
unique_identifier_msgs: 2.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3441,7 +3441,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.1.1-1`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.1.0-1`

## unique_identifier_msgs

```
* Enable linter tests on unique_identifier_msgs (#5 <https://github.com/ros2/unique_identifier_msgs/issues/5>)
* Contributors: Jorge Perez
```
