### PR TITLE
openslam_gmapping: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -952,6 +952,21 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  openslam_gmapping:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/openslam_gmapping.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/openslam_gmapping-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/openslam_gmapping.git
+      version: melodic-devel
+    status: unmaintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openslam_gmapping` to `0.2.1-1`:

- upstream repository: https://github.com/ros-perception/openslam_gmapping
- release repository: https://github.com/ros-gbp/openslam_gmapping-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## openslam_gmapping

```
* CMakeLists.txt: fix install command (install libs, install includes to corrrect position as well as hxx (#30 <https://github.com/ros-perception/openslam_gmapping/issues/30>)
* Contributors: Kei Okada
```
