### PR TITLE
ivcon: 0.1.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -576,6 +576,21 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: noetic
     status: maintained
+  ivcon:
+    doc:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ivcon-release.git
+      version: 0.1.7-1
+    source:
+      type: git
+      url: https://github.com/ros/ivcon.git
+      version: melodic-devel
+    status: unmaintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ivcon` to `0.1.7-1`:

- upstream repository: https://github.com/ros/ivcon.git
- release repository: https://github.com/ros-gbp/ivcon-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ivcon

```
* Merge pull request #6 <https://github.com/ros/ivcon/issues/6> from k-okada/add_travis
  Add travis.yml
* update maintainer to ROS Orphaned Package Maintainers
* mv readme -> README.md
* update travis.yml
* Contributors: Kei Okada
```
