### PR TITLE
Add flac to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -800,6 +800,12 @@ ffmpeg2theora:
   fedora: [ffmpeg2theora]
   gentoo: [media-video/ffmpeg2theora]
   ubuntu: [ffmpeg2theora]
+flac:
+  arch: [flac]
+  debian: [flac]
+  fedora: [flac]
+  gentoo: [media-libs/flac]
+  ubuntu: [flac]
 flex:
   arch: [flex]
   debian: [flex]


### PR DESCRIPTION
I add `flac` package to base.yaml

Links:
arch: https://www.archlinux.org/packages/extra/x86_64/flac/
debian: https://packages.debian.org/buster/flac
fedra: https://apps.fedoraproject.org/packages/mingw-flac
gentoo: https://packages.gentoo.org/packages/media-libs/flac
ubuntu: https://packages.ubuntu.com/bionic/flac
@k-okada 