### PR TITLE
interactive_markers: 1.12.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -576,6 +576,22 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: noetic
     status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_markers-release.git
+      version: 1.12.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: noetic-devel
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.12.0-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## interactive_markers

```
* [maintanence] fix signed / unsigned warning
* [maintanence] Migration to tf2
* Contributors: Robert Haschke
```
