### PR TITLE
moveit: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5362,6 +5362,7 @@ repositories:
       - moveit_ros_control_interface
       - moveit_ros_manipulation
       - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
       - moveit_ros_perception
       - moveit_ros_planning
       - moveit_ros_planning_interface
@@ -5374,7 +5375,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.0.3-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.2-1`

## chomp_motion_planner

```
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Windows build fixes
  * Fix header inclusion and other MSVC build errors (#1636 <https://github.com/ros-planning/moveit/issues/1636>)
  * Remove GCC extensions (#1583 <https://github.com/ros-planning/moveit/issues/1583>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]   Fix possible division-by-zero (#1809 <https://github.com/ros-planning/moveit/issues/1809>)
* Contributors: Max Krichenbauer, Robert Haschke, Sean Yen, Yu, Yan
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

```
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_commander

```
* [feature] Expose reference_point_position parameter in getJacobian() (#1595 <https://github.com/ros-planning/moveit/issues/1595>)
* [maint]   Improve Python 3 compatibility (#1870 <https://github.com/ros-planning/moveit/issues/1870>)
  * Replaced StringIO with BytesIO for python msg serialization
  * Use py_bindings_tools::ByteString as byte-based serialization buffer on C++ side
* [fix]     Fix service call to utilize original name space (#1959 <https://github.com/ros-planning/moveit/issues/1959>)
* [maint]   Windows compatibility: fallback to using pyreadline (#1635 <https://github.com/ros-planning/moveit/issues/1635>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]     Fix planning scene interface not respecting custom namespace (#1815 <https://github.com/ros-planning/moveit/issues/1815>)
* [maint]   moveit_commander: python3 import fixes (#1786 <https://github.com/ros-planning/moveit/issues/1786>)
* [fix]     python planning_scene_interface: fix attaching objects (#1624 <https://github.com/ros-planning/moveit/issues/1624>)
* [feature] Select time parametrization algorithm in retime_trajectory (#1508 <https://github.com/ros-planning/moveit/issues/1508>)
* Contributors: Bjar Ne, Felix von Drigalski, Masaki Murooka, Pavel-P, Raphael Druon, Robert Haschke, Ryodo Tanaka, Sean Yen, v4hn
```

## moveit_controller_manager_example

```
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen
```

## moveit_core

```
* [feature] Allow to filter for joint when creating a RobotTrajectory message (#1927 <https://github.com/ros-planning/moveit/issues/1927>)
* [fix]     Fix RobotState::copyFrom()
* [fix]     Fix segfault in totg (#1861 <https://github.com/ros-planning/moveit/issues/1861>)
* [fix]     Handle incomplete group states
* [fix]     Fix issue in totg giving invalid accelerations (#1729 <https://github.com/ros-planning/moveit/issues/1729>)
* [feature] New isValidVelocityMove() for checking time between two waypoints given velocity (#684 <https://github.com/ros-planning/moveit/issues/684>)
* [maint]   Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [fix]     Fix Condition for adding current DistanceResultData to DistanceMap (#1968 <https://github.com/ros-planning/moveit/issues/1968>)
* [maint]   Fix various build issues on Windows (#1880 <https://github.com/ros-planning/moveit/issues/1880>)
  * remove GCC extensions (#1583 <https://github.com/ros-planning/moveit/issues/1583>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]     Delete attached body before adding a new one with same id (#1821 <https://github.com/ros-planning/moveit/issues/1821>)
* [maint]   Provide UniquePtr macros (#1771 <https://github.com/ros-planning/moveit/issues/1771>)
* [maint]   Updated deprecation method: MOVEIT_DEPRECATED -> [[deprecated]] (#1748 <https://github.com/ros-planning/moveit/issues/1748>)
* [feature] Add RobotTrajectory::getDuration() (#1554 <https://github.com/ros-planning/moveit/issues/1554>)
* Contributors: Ayush Garg, Dale Koenig, Dave Coleman, Felix von Drigalski, Jafar Abdi, Jeroen, Michael Görner, Mike Lautman, Niklas Fiedler, Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_experimental

```
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen
```

## moveit_fake_controller_manager

```
* [fix]   Handle "default" parameter in MoveitControllerManagers
  MoveIt{Fake|Simple}ControllerManager::getControllerState() now correctly returns current state
* [fix]   Handle incomplete group states
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen, Yu, Yan, Luca Lach
```

## moveit_kinematics

```
* [feature] KDL IK: constrain wiggled joints to limits (#1953 <https://github.com/ros-planning/moveit/issues/1953>)
* [feature] IKFast: optional prefix for link names (#1599 <https://github.com/ros-planning/moveit/issues/1599>)
  If you pass a link_prefix parameter in your kinematics.yaml, this string is prepended to the base and tip links.
  It allows multi-robot setups (e.g. dual-arm) and still instantiate the same solver for both manipulators.
* [feature] IKFast: increase verbosity of generated script (#1434 <https://github.com/ros-planning/moveit/issues/1434>)
* [maint]   Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint]   Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint]   Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [feature] IKFast: implement Translation*AxisAngle4D IK type (#1823 <https://github.com/ros-planning/moveit/issues/1823>)
* [fix]     Fix possible division-by-zero (#1809 <https://github.com/ros-planning/moveit/issues/1809>)
* Contributors: Christian Henkel, Martin Günther, Max Krichenbauer, Michael Görner, Robert Haschke, Sean Yen, Yu, Yan, jschleicher
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen
```

## moveit_planners_ompl

```
* [maint] Cleanup OMPL dynamic reconfigure config (#1649 <https://github.com/ros-planning/moveit/issues/1649>)
  * Reduce minimum number of waypoints in solution to 2
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Michael Görner, Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* [feature] MoveIt benchmark improvements (#1510 <https://github.com/ros-planning/moveit/issues/1510>)
  * Add pseudo experiment all_experiments to allow comparing all entries
  * Expose loadBenchmarkQueryData() for setting up custom queries
  * Add benchmark entry for comparing the 'final' result trajectory
  * Add trajectory similarity function to measure repeatability
  * Address requested changes
  * Fill empty fields in all_experiments
  * Improve variable and function names
  * Add helper function computeTrajectoryDistance()
* [maint]   Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint]   Windows build fixes
  * Fix header inclusion and other MSVC build errors (#1636 <https://github.com/ros-planning/moveit/issues/1636>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Henning Kayser, Michael Görner, Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_ros_control_interface

```
* [maint]   Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint]   Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [feature] Add support for pos_vel_controllers and pos_vel_acc_controllers (#1806 <https://github.com/ros-planning/moveit/issues/1806>)
* Contributors: Robert Haschke, Sandro Magalhães, Sean Yen
```

## moveit_ros_manipulation

```
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_ros_move_group

```
* [maint] Move get_planning_scene service into PlanningSceneMonitor for reusability (#1854 <https://github.com/ros-planning/moveit/issues/1854>)
* [maint] Cleanup move_group capabilities (#1515 <https://github.com/ros-planning/moveit/issues/1515>)
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_ros_occupancy_map_monitor

```
* [fix]   Add error message on failure to initialize occupancy map monitor (#1873 <https://github.com/ros-planning/moveit/issues/1873>)
* [fix]   Update occupancy grid when loaded from file (#1594 <https://github.com/ros-planning/moveit/issues/1594>)
* [maint] Apply clang-tidy fix (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Windows build fixes
  * Fix header inclusion and other MSVC build errors (#1636 <https://github.com/ros-planning/moveit/issues/1636>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint] move occupancy_map_monitor into its own package (#1533 <https://github.com/ros-planning/moveit/issues/1533>)
* Contributors: Bjar Ne, Dale Koenig, Raphael Druon, Robert Haschke, Sean Yen, Simon Schmeisser, Yu, Yan, jschleicher
```

## moveit_ros_perception

```
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build fixes
  * Fix header inclusion and other MSVC build errors (#1636 <https://github.com/ros-planning/moveit/issues/1636>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint] Allow subclassing of point_containment_filter::ShapeMask. (#1457 <https://github.com/ros-planning/moveit/issues/1457>)
* [fix]   depth_image_octomap_updater: reset depth transfer function to standard values (#1661 <https://github.com/ros-planning/moveit/issues/1661>)
* [fix]   depth_image_octomap_updater: correctly set properties of debug images (#1652 <https://github.com/ros-planning/moveit/issues/1652>)
* [maint] Move occupancy_map_monitor into its own package (#1533 <https://github.com/ros-planning/moveit/issues/1533>)
* Contributors: Martin Pecka, Matthias Nieuwenhuisen, Robert Haschke, Sean Yen, Yu, Yan, jschleicher
```

## moveit_ros_planning

```
* [fix]     CurrentStateMonitor: Initialize velocity/effort with unset dynamics
* [fix]     Fix spurious warning message (# IK attempts) (#1876 <https://github.com/ros-planning/moveit/issues/1876>)
* [maint]   Move get_planning_scene service into PlanningSceneMonitor for reusability (#1854 <https://github.com/ros-planning/moveit/issues/1854>)
* [feature] Forward controller names to TrajectoryExecutionManager
* [fix]     Always copy dynamics if enabled in CurrentStateMonitor (#1676 <https://github.com/ros-planning/moveit/issues/1676>)
* [feature] TrajectoryMonitor: zero sampling frequency disables trajectory recording (#1542 <https://github.com/ros-planning/moveit/issues/1542>)
* [feature] Add user warning when planning fails with multiple constraints (#1443 <https://github.com/ros-planning/moveit/issues/1443>)
* [maint]   Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint]   Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint]   Windows build fixes
  * Fix header inclusion and other MSVC build errors (#1636 <https://github.com/ros-planning/moveit/issues/1636>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
  * Favor ros::Duration.sleep over sleep. (#1634 <https://github.com/ros-planning/moveit/issues/1634>)
  * Remove GCC extensions (#1583 <https://github.com/ros-planning/moveit/issues/1583>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]     Fix potential memory leak in RDFLoader (#1828 <https://github.com/ros-planning/moveit/issues/1828>)
  [maint]   Use smart pointers to avoid explicit new/delete
* [fix]     TrajectoryExecutionManager: fix race condition (#1709 <https://github.com/ros-planning/moveit/issues/1709>)
* [fix]     Correctly propagate error if time parameterization fails (#1562 <https://github.com/ros-planning/moveit/issues/1562>)
* [maint]   move occupancy_map_monitor into its own package (#1533 <https://github.com/ros-planning/moveit/issues/1533>)
* [feature] PlanExecution: return executed trajectory (#1538 <https://github.com/ros-planning/moveit/issues/1538>)
* Contributors: Felix von Drigalski, Henning Kayser, Max Krichenbauer, Michael Görner, Robert Haschke, Sean Yen, Yu, Yan, jschleicher, livanov93, Luca Lach
```

## moveit_ros_planning_interface

```
* [feature] MoveGroupInterface: Add execution methods for moveit_msgs::RobotTrajectory (#1955 <https://github.com/ros-planning/moveit/issues/1955>)
* [feature] Allow to instantiate a PlanningSceneInterface w/ and w/o a running move_group node
* [fix]     Release Python GIL for C++ calls (#1947 <https://github.com/ros-planning/moveit/issues/1947>)
* [feature] Expose reference_point_position parameter in getJacobian() (#1595 <https://github.com/ros-planning/moveit/issues/1595>)
* [feature] MoveGroupInterface: Expose constructPickGoal and constructPlaceGoal (#1498 <https://github.com/ros-planning/moveit/issues/1498>)
* [feature] python MoveGroupInterface: Added custom time limit for wait_for_servers() (#1444 <https://github.com/ros-planning/moveit/issues/1444>)
* [maint]   Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint]   Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint]   Improve Python 3 compatibility (#1870 <https://github.com/ros-planning/moveit/issues/1870>)
  * Replaced StringIO with BytesIO for python msg serialization
  * Use py_bindings_tools::ByteString as byte-based serialization buffer on C++ side
* [feature] Export moveit_py_bindings_tools library
* [maint]   Fix various build issues on Windows
  * Use .pyd as the output suffix for Python module on Windows. (#1637 <https://github.com/ros-planning/moveit/issues/1637>)
  * Favor ros::Duration.sleep over sleep. (#1634 <https://github.com/ros-planning/moveit/issues/1634>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint]   Updated deprecation method: MOVEIT_DEPRECATED -> [[deprecated]] (#1748 <https://github.com/ros-planning/moveit/issues/1748>)
* [maint]   eigenpy: switched to system package (#1737 <https://github.com/ros-planning/moveit/issues/1737>)
* [featue]  PlanningSceneInterface: wait for its two services
* [feature] Select time parametrization algorithm in retime_trajectory (#1508 <https://github.com/ros-planning/moveit/issues/1508>)
* Contributors: Bjar Ne, Felix von Drigalski, Kunal Tyagi, Luca Rinelli, Masaki Murooka, Michael Görner, Niklas Fiedler, Robert Haschke, Sean Yen, Yu, Yan, mvieth, v4hn
```

## moveit_ros_robot_interaction

```
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* Contributors: Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_ros_visualization

```
* [fix]     MotionPlanningDisplay: change internal shortcut Ctrl+R to Ctrl+I (#1967 <https://github.com/ros-planning/moveit/issues/1967>)
* [fix]     Remove PlanningSceneInterface from rviz display, but use its PlanningSceneMonitor instead
* [fix]     Fix segfault in RobotStateVisualization (#1941 <https://github.com/ros-planning/moveit/issues/1941>)
* [feature] Provide visual feedback on success of requestPlanningSceneState()
* [feature] Wait for get_planning_scene in background (#1934 <https://github.com/ros-planning/moveit/issues/1934>)
* [feature] Reduce step size for pose-adapting widgets
* [fix]     Reset scene_marker when disabling motion planning panel
* [fix]     Enable/disable motion planning panel with display
* [fix]     Enable/disable pose+scale group box when collision object is selected/deselected
* [fix]     Correctly populate the list of scene objects in the motion planning panel
* [feature] Resize scene marker with collision object
* [feature] Show attached bodies in trajectory trail (#1766 <https://github.com/ros-planning/moveit/issues/1766>)
* [fix]     Fix REALTIME trajectory playback (#1683 <https://github.com/ros-planning/moveit/issues/1683>)
* [maint]   Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint]   Notice changes in rviz planning panel requiring saving (#1991 <https://github.com/ros-planning/moveit/issues/1991>)
* [maint]   Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint]   Improve Python 3 compatibility (#1870 <https://github.com/ros-planning/moveit/issues/1870>)
  * Replaced StringIO with BytesIO for python msg serialization
  * Use py_bindings_tools::ByteString as byte-based serialization buffer on C++ side
* [maint]   Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]     Fix pruning of enclosed nodes when rendering octomap in RViz (#1685 <https://github.com/ros-planning/moveit/issues/1685>)
* [fix]     Fix missing scene_manager initialization in OcTreeRender's  constructor (#1817 <https://github.com/ros-planning/moveit/issues/1817>)
* [feature] new Joints tab in RViz motion panel (#1308 <https://github.com/ros-planning/moveit/issues/1308>)
* [feature] Add <previous> robot state to RViz motion panel (#1742 <https://github.com/ros-planning/moveit/issues/1742>)
* Contributors: Bjar Ne, Dale Koenig, MarqRazz, Max Krichenbauer, Michael Görner, Robert Haschke, RyodoTanaka, Sean Yen, Takara Kasai, Yannick Jonetzko, Yu, Yan, v4hn
```

## moveit_ros_warehouse

```
* [maint] Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]   Fix potential use of uninitialized variable (#1818 <https://github.com/ros-planning/moveit/issues/1818>)
* Contributors: Max Krichenbauer, Robert Haschke, Sean Yen, Yu, Yan
```

## moveit_runtime

- No changes

## moveit_setup_assistant

```
* [feature] Allow loading of additional kinematics parameters file (#1997 <https://github.com/ros-planning/moveit/issues/1997>)
* [feature] Allow adding initial poses to fake_controllers.yaml (#1892 <https://github.com/ros-planning/moveit/issues/1892>)
* [feature] Display robot poses on selection, not only on click (#1930 <https://github.com/ros-planning/moveit/issues/1930>)
* [fix]     Fix invalid iterator (#1623 <https://github.com/ros-planning/moveit/issues/1623>)
* [maint]   Apply clang-tidy fix to entire code base (#1394 <https://github.com/ros-planning/moveit/issues/1394>)
* [maint]   Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint]   Windows build fixes
  * Fix header inclusion and other MSVC build errors (#1636 <https://github.com/ros-planning/moveit/issues/1636>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
  * Favor ros::Duration.sleep over sleep. (#1634 <https://github.com/ros-planning/moveit/issues/1634>)
  * Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [feature] Add support for pos_vel_controllers and pos_vel_acc_controllers (#1806 <https://github.com/ros-planning/moveit/issues/1806>)
* [feature] Add joint state controller config by default (#1024 <https://github.com/ros-planning/moveit/issues/1024>)
* Contributors: AndyZe, Daniel Wang, Felix von Drigalski, Jafar Abdi, Max Krichenbauer, Michael Görner, Mohmmad Ayman, Robert Haschke, Sandro Magalhães, Sean Yen, Simon Schmeisser, Tejas Kumar Shastha, Yu, Yan, v4hn
```

## moveit_simple_controller_manager

```
* [fix]   Handle "default" parameter in MoveitControllerManagers
  MoveIt{Fake|Simple}ControllerManager::getControllerState() now correctly returns current state
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Windows build: Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]   ControllerManager: wait for done-callback (#1783 <https://github.com/ros-planning/moveit/issues/1783>)
* Contributors: Robert Haschke, Sean Yen, Luca Lach
```
