### PR TITLE
rviz: 1.13.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10002,7 +10002,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.9-2
+      version: 1.13.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.11-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.13.9-2`

## rviz

```
* [feature] Provide load_config and save_config ROS services
* [maint]   clang-tidy fixes (#1494 <https://github.com/ros-visualization/rviz/issues/1494>)
* Contributors: Robert B Anderson, Robert Haschke
```
