### PR TITLE
foonathan_memory_vendor: 0.6.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -234,6 +234,17 @@ repositories:
       url: https://github.com/eProsima/Fast-CDR.git
       version: v1.0.13
     status: maintained
+  foonathan_memory_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
+      version: 0.6.0-1
+    source:
+      type: git
+      url: https://github.com/eProsima/foonathan_memory_vendor.git
+      version: master
+    status: maintained
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `foonathan_memory_vendor` to `0.6.0-1`:

- upstream repository: https://github.com/eProsima/foonathan_memory_vendor.git
- release repository: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
