### PR TITLE
tinyxml_vendor: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -684,6 +684,18 @@ repositories:
       url: https://github.com/ros2/tinyxml2_vendor.git
       version: master
     status: maintained
+  tinyxml_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
+      version: master
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml_vendor` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/tinyxml_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
