### PR TITLE
robot_calibration: 0.6.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11598,7 +11598,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.6.3-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.6.2-1`

## robot_calibration

```
* kinetic requires C++11, but doesn't specify it (#85 <https://github.com/mikeferguson/robot_calibration/issues/85>)
* note topics being published/subscribed
* some fixes for magnetometer cal (#84 <https://github.com/mikeferguson/robot_calibration/issues/84>)
  * the spinOnce was needed
  * exit properly on CTRL-C
* add magnetometer calibration node (#83 <https://github.com/mikeferguson/robot_calibration/issues/83>)
* remove readme, top level one has docs
* add travis and code coverage (#80 <https://github.com/mikeferguson/robot_calibration/issues/80>)
* export feature_finders lib
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
