### PR TITLE
mesh_tools: 1.0.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5190,7 +5190,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/mesh-tools.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/uos/mesh_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mesh_tools` to `1.0.0-2`:

- upstream repository: https://github.com/uos/mesh_tools.git
- release repository: https://github.com/uos-gbp/mesh-tools.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-1`

## hdf5_map_io

```
* release version 1.0.0
```

## label_manager

```
* release version 1.0.0
```

## mesh_msgs

```
* release version 1.0.0
```

## mesh_msgs_hdf5

```
* release version 1.0.0
```

## mesh_msgs_transform

```
* release version 1.0.0
```

## mesh_tools

```
* release version 1.0.0
```

## rviz_map_plugin

```
* release version 1.0.0
```

## rviz_mesh_plugin

```
* release version 1.0.0
```
