### PR TITLE
yaml_cpp_vendor: 7.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -765,5 +765,17 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  yaml_cpp_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+      version: 7.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/yaml_cpp_vendor.git
+      version: master
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `7.0.1-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## yaml_cpp_vendor

- No changes
