### PR TITLE
hrpsys: 315.15.0-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3567,7 +3567,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/hrpsys-release.git
-      version: 315.15.0-3
+      version: 315.15.0-5
     source:
       type: git
       url: https://github.com/fkanehiro/hrpsys-base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hrpsys` to `315.15.0-5`:

- upstream repository: https://github.com/fkanehiro/hrpsys-base.git
- release repository: https://github.com/tork-a/hrpsys-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `315.15.0-3`

## hrpsys

- No changes
