### PR TITLE
audio_common: 0.3.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -45,6 +45,27 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  audio_common:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: master
+    release:
+      packages:
+      - audio_capture
+      - audio_common
+      - audio_common_msgs
+      - audio_play
+      - sound_play
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/audio_common-release.git
+      version: 0.3.5-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/audio_common.git
+      version: master
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.5-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

- No changes

## sound_play

```
* Merge pull request #133 <https://github.com/ros-drivers/audio_common/issues/133> from knorth55/noetic-build
* remove unnecessary shebang
* use setuptools instead of distutils.core
* use package format=3 for python3
* refactor CMakeLists.txt
* use catkin_install_python for python shebang
* Merge pull request #135 <https://github.com/ros-drivers/audio_common/issues/135> from knorth55/add-travis
* disable sound_play test
* Contributors: Shingo Kitagawa
```
