### PR TITLE
audio_common: 0.3.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -768,7 +768,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.5-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.4-1`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

- No changes

## sound_play

```
* Merge pull request #133 <https://github.com/ros-drivers/audio_common/issues/133> from knorth55/noetic-build
* remove unnecessary shebang
* use setuptools instead of distutils.core
* use package format=3 for python3
* refactor CMakeLists.txt
* use catkin_install_python for python shebang
* Merge pull request #135 <https://github.com/ros-drivers/audio_common/issues/135> from knorth55/add-travis
* disable sound_play test
* Contributors: Shingo Kitagawa
```
