### PR TITLE
[rosdep] Add python-influxdb

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2091,8 +2091,13 @@ python-impacket:
   fedora: [python-impacket]
   ubuntu: [python-impacket]
 python-influxdb:
-  debian: [python-influxdb]
-  ubuntu: [python-influxdb]
+  debian:
+    buster: [python-influxdb]
+    jessie: [python-influxdb]
+  ubuntu:
+    bionic: [python-influxdb]
+    disco: [python-influxdb]
+    xenial: [python-influxdb]
 python-inject-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2090,6 +2090,9 @@ python-impacket:
   debian: [python-impacket]
   fedora: [python-impacket]
   ubuntu: [python-impacket]
+python-influxdb:
+  debian: [python-influxdb]
+  ubuntu: [python-influxdb]
 python-inject-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
* debian: https://packages.debian.org/search?keywords=python-influxdb
* ubuntu: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python-influxdb&searchon=names