### PR TITLE
fastrtps: 2.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -241,6 +241,8 @@ repositories:
       url: https://github.com/ros2-gbp/fastrtps-release.git
       version: 2.0.0-2
     source:
+      test_commits: false
+      test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-RTPS.git
       version: 9c28edc805863117d500ebb7aef86d509471ebd8

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -234,6 +234,17 @@ repositories:
       url: https://github.com/eProsima/Fast-CDR.git
       version: v1.0.13
     status: maintained
+  fastrtps:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/fastrtps-release.git
+      version: 2.0.0-2
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-RTPS.git
+      version: 9c28edc805863117d500ebb7aef86d509471ebd8
+    status: maintained
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `2.0.0-2`:

- upstream repository: https://github.com/eProsima/Fast-RTPS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
