### PR TITLE
webrtc_ros: 59.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17225,7 +17225,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/webrtc_ros-release.git
-      version: 59.0.3-0
+      version: 59.0.4-1
     source:
       type: git
       url: https://github.com/RobotWebTools/webrtc_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `webrtc_ros` to `59.0.4-1`:

- upstream repository: https://github.com/RobotWebTools/webrtc_ros.git
- release repository: https://github.com/RobotWebTools-release/webrtc_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `59.0.3-0`

## webrtc

```
* No changes
```

## webrtc_ros

```
* Add ICE to server (#44 <https://github.com/RobotWebTools/webrtc_ros/issues/44>)
* Implement logic to resize or drop frames on demand
* Get rid of jQuery
* Ignore invalid ICE candidates
  This resolves an issue with Firefox.
* Update JavaScript client code for latest browser compatibility
* Contributors: Michael Sobrepera, Timo Röhling
```
