### PR TITLE
kdl_parser: 2.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -283,6 +283,22 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/kdl_parser-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: ros2
+    status: maintained
   launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `2.3.0-1`:

- upstream repository: https://github.com/ros2/kdl_parser.git
- release repository: https://github.com/ros2-gbp/kdl_parser-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## kdl_parser

```
* export targets in a addition to include directories / libraries (#6 <https://github.com/ros2/kdl_parser/issues/6>)
* code style only: wrap after open parenthesis if not in one line (#5 <https://github.com/ros2/kdl_parser/issues/5>)
* Contributors: Dirk Thomas
```
