### PR TITLE
Add python3-lttng rule for Fedora 32+

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5441,6 +5441,10 @@ python3-lark-parser:
     xenial: [python3-lark-parser]
 python3-lttng:
   debian: [python3-lttng]
+  fedora:
+    '*': [python3-lttng]
+    '30': null
+    '31': null
   ubuntu: [python3-lttng]
 python3-lxml:
   debian: [python3-lxml]


### PR DESCRIPTION
The most recent update to `lttng-tools` in Fedora 32 enabled the python3 subpackage: https://src.fedoraproject.org/rpms/lttng-tools/c/564506f5eb91bab2fc35187a1d5b235b79d92317?branch=master

Here is the Fedora 32 build in Koji, where you can see that the python3 subpackage was built: https://koji.fedoraproject.org/koji/buildinfo?buildID=1458623

As of now, the new subpackage has not been built in Fedora 30 or 31.

```
$ dnf list -q --available --showduplicates python3-lttng
Available Packages
python3-lttng.x86_64                    2.11.1-1.fc32                    fedora
```