### PR TITLE
neonavigation: 0.8.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5970,7 +5970,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.8.4-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.8.3-1`

## costmap_cspace

```
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

```
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* Contributors: Atsushi Watanabe
```

## map_organizer

```
* Remove old workaround for debian stretch build (#473 <https://github.com/at-wat/neonavigation/issues/473>)
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

```
* Remove old workaround for debian stretch build (#473 <https://github.com/at-wat/neonavigation/issues/473>)
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

```
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

```
* Remove old workaround for debian stretch build (#473 <https://github.com/at-wat/neonavigation/issues/473>)
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* Contributors: Atsushi Watanabe
```

## track_odometry

```
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* Contributors: Atsushi Watanabe
```

## trajectory_tracker

```
* Clean unused dependencies (#472 <https://github.com/at-wat/neonavigation/issues/472>)
* trajectory_tracker: add missing dep to std_srvs (#470 <https://github.com/at-wat/neonavigation/issues/470>)
* Contributors: Atsushi Watanabe
```
