### PR TITLE
ros_testing: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -722,6 +722,25 @@ repositories:
       url: https://github.com/ros2/ros2cli.git
       version: master
     status: maintained
+  ros_testing:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: master
+    release:
+      packages:
+      - ros2test
+      - ros_testing
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_testing-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: master
+    status: maintained
   ros_workspace:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.2.1-1`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/ros2-gbp/ros_testing-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## ros2test

```
* More verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Contributors: Dirk Thomas
```

## ros_testing

- No changes
