### PR TITLE
message_filters: 3.2.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -384,6 +384,22 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: master
     status: maintained
+  message_filters:
+    doc:
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_message_filters-release.git
+      version: 3.2.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: master
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `3.2.3-2`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## message_filters

```
* allow custom qos for message filters
```
