### PR TITLE
launch_ros: 0.10.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -330,10 +330,11 @@ repositories:
       packages:
       - launch_ros
       - launch_testing_ros
+      - ros2launch
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.10.0-1
+      version: 0.10.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.10.0-2`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.10.0-1`

## launch_ros

```
* Avoid using sys.argv in rclpy.init (#144 <https://github.com/ros2/launch_ros/issues/144>)
* Deprecated 'node_executable' parameter and replace with 'executable' (#140 <https://github.com/ros2/launch_ros/issues/140>)
* Bump node_name warning stacklevel (#138 <https://github.com/ros2/launch_ros/issues/138>)
* More verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Enable implicit ROS startup by launch_ros actions  (#128 <https://github.com/ros2/launch_ros/issues/128>)
* Add warning message when launching Non-Uniquely Named Nodes (#127 <https://github.com/ros2/launch_ros/issues/127>)
* Rename node-related parameters (#122 <https://github.com/ros2/launch_ros/issues/122>)
* Fix LoadComposableNodes action so that loading happens asynchronously (#113 <https://github.com/ros2/launch_ros/issues/113>)
* Fix frontend topic remapping (#111 <https://github.com/ros2/launch_ros/issues/111>)
* Check for shutdown while waiting for a service response to avoid hang during shutdown (#104 <https://github.com/ros2/launch_ros/issues/104>)
* Fix misleading deprecated warnings when using launch arguments (#106 <https://github.com/ros2/launch_ros/issues/106>)
* Use imperative mood in constructor docstrings (#103 <https://github.com/ros2/launch_ros/issues/103>)
* Maintain order of parameters regarding name and from (#99 <https://github.com/ros2/launch_ros/issues/99>)
* Allow separate launch composition (#77 <https://github.com/ros2/launch_ros/issues/77>)
* Fix push-ros-namespace in xml/yaml launch files (#100 <https://github.com/ros2/launch_ros/issues/100>)
* Pass the node-name attribute through the substitution parser (#101 <https://github.com/ros2/launch_ros/issues/101>)
* Add pid to launch_ros node name as suffix (#98 <https://github.com/ros2/launch_ros/issues/98>)
* Contributors: Brian Ezequiel Marchi, Brian Marchi, Dirk Thomas, Eric Fang, Grey, Ivan Santiago Paunovic, Jacob Perron, Miaofei Mei, Michel Hidalgo, Shane Loretz, Steven! Ragnarök, William Woodall
```

## launch_testing_ros

```
* Deprecated 'node_executable' parameter and replace with 'executable' (#140 <https://github.com/ros2/launch_ros/issues/140>)
* Avoid deprecation warning, use from_parent (#141 <https://github.com/ros2/launch_ros/issues/141>)
* Show error strings as part of the flake8 test (#135 <https://github.com/ros2/launch_ros/issues/135>)
* Remove unused 'launch' import (#133 <https://github.com/ros2/launch_ros/issues/133>)
* Enable implicit ROS startup by launch_ros actions  (#128 <https://github.com/ros2/launch_ros/issues/128>)
* Fix launch_testing_ros example (#121 <https://github.com/ros2/launch_ros/issues/121>)
* Contributors: Dirk Thomas, Jacob Perron, Michel Hidalgo
```

## ros2launch

```
* Deprecated 'node_executable' parameter and replace with 'executable' (#140 <https://github.com/ros2/launch_ros/issues/140>)
* More verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Enable implicit ROS startup by launch_ros actions  (#128 <https://github.com/ros2/launch_ros/issues/128>)
* Rename node-related parameters (#122 <https://github.com/ros2/launch_ros/issues/122>)
* Legal tab completion of launch files (#126 <https://github.com/ros2/launch_ros/issues/126>)
* Fix linter by removing unused import (#110 <https://github.com/ros2/launch_ros/issues/110>)
* Fix misleading deprecated warnings when using launch arguments (#106 <https://github.com/ros2/launch_ros/issues/106>)
* Use imperative mood in constructor docstrings (#103 <https://github.com/ros2/launch_ros/issues/103>)
* Contributors: Dirk Thomas, Emerson Knapp, Ivan Santiago Paunovic, Jacob Perron, Michel Hidalgo, Shane Loretz, Steven! Ragnarök
```
