### PR TITLE
Fix 3 Fedora 32 rules for Noetic

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -282,7 +282,10 @@ boost:
     squeeze: [libboost1.42-all-dev]
     stretch: [libboost-all-dev]
     wheezy: [libboost-all-dev]
-  fedora: [boost-devel, boost-python2-devel, boost-python3-devel]
+  fedora:
+    '*': [boost-devel, boost-python3-devel]
+    '30': [boost-devel, boost-python2-devel, boost-python3-devel]
+    '31': [boost-devel, boost-python2-devel, boost-python3-devel]
   freebsd: [py27-boost-libs]
   gentoo: ['dev-libs/boost[python]']
   macports: [boost]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5393,7 +5393,7 @@ python3-future:
 python3-gi:
   arch: [python-gobject]
   debian: [python3-gi]
-  fedora: [pygobject3]
+  fedora: [python3-gobject]
   gentoo: [dev-python/pygobject]
   ubuntu: [python3-gi]
 python3-gitlab:
@@ -5584,7 +5584,10 @@ python3-pep8:
     buster: [python3-pep8]
     jessie: [python3-pep8]
     stretch: [python3-pep8]
-  fedora: [python3-pep8]
+  fedora:
+    '*': null
+    '30': [python3-pep8]
+    '31': [python3-pep8]
   gentoo: [dev-python/pep8]
   openembedded: [python3-pep8@meta-ros]
   osx:


### PR DESCRIPTION
Three changes:
* boost-python2-devel is no longer present in Fedora 32+
* pygobject3 refers to the Python 2 package for pygobject version 3, not the Python 3 package
* The deprecated pep8 package has been completely removed from Fedora in 32+

https://src.fedoraproject.org/rpms/boost#bodhi_updates
https://src.fedoraproject.org/rpms/pygobject3#bodhi_updates
https://src.fedoraproject.org/rpms/python-pep8#bodhi_updates

```
dnf list -q --available --showduplicates boost-python2-devel \
> python3-gobject python3-pep8
Available Packages
python3-gobject.x86_64                   3.36.0-2.fc32                   fedora
```