### PR TITLE
robot_state_publisher: 2.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -747,7 +747,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: :{version}
+      version: ros2
     status: maintained
   ros2_tracing:
     release:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -737,6 +737,18 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: master
     status: developed
+  robot_state_publisher:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_state_publisher-release.git
+      version: 2.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: :{version}
+    status: maintained
   ros2_tracing:
     release:
       packages:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -738,6 +738,10 @@ repositories:
       version: master
     status: developed
   robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: ros2
     release:
       tags:
         release: release/foxy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.4.0-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.4`
- previous version for package: `null`

## robot_state_publisher

```
* Replace deprecated launch_ros usage (#137 <https://github.com/ros/robot_state_publisher/issues/137>)
* code style only: wrap after open parenthesis if not in one line (#129 <https://github.com/ros/robot_state_publisher/issues/129>)
* Refactor the ROS 2 code to be more modern (#126 <https://github.com/ros/robot_state_publisher/issues/126>)
* Switch to using TARGET_FILE to find the binary targets on Windows.
* Fix tests on Windows.
* Make the error message much nicer on Windows.
* robot_state_publisher_node -> robot_state_publisher
* Fix test build on Windows.
* Get rid of redundant declaration.
* Guard against negative publish_frequencies.
* Switch to modern launch_testing ReadyToTest.
* Add testing to robot_state_publisher.
* Update some example launch files.
* Implement the ability to change the parameters on the fly.
* Fix silly bug while computing the publish interval.
* Refactor to have a "setup" function during the constructor and later on during the parameter setup.
* Mark things as explicit and final.
* Update the documentation.
* Make robot_state_publisher composable.
* Contributors: Chris Lalancette, Dirk Thomas, Jacob Perron
```
