### PR TITLE
resource_retriever: 2.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -647,6 +647,25 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: master
     status: maintained
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: ros2
+    release:
+      packages:
+      - libcurl_vendor
+      - resource_retriever
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/resource_retriever-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: ros2
+    status: maintained
   rmw:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.3.0-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## libcurl_vendor

```
* Ignore broken curl-config.cmake (#40 <https://github.com/ros/resource_retriever/issues/40>)
* Update curl reference from 7.57 to 7.58 (#36 <https://github.com/ros/resource_retriever/issues/36>)
* Contributors: Nathan Brooks, Scott K Logan
```

## resource_retriever

```
* Towards Quality Level 1 - Added common_linters and fixed tests  (#43 <https://github.com/ros/resource_retriever/issues/43>)
* use ament_export_targets() (#41 <https://github.com/ros/resource_retriever/issues/41>)
* Catch ament_index_cpp::PackageNotFoundError (#32 <https://github.com/ros/resource_retriever/issues/32>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Shane Loretz
```
