### PR TITLE
interactive_markers: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -312,6 +312,22 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/interactive_markers-release.git
+      version: 2.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: ros2
+    status: maintained
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.1.0-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## interactive_markers

```
* avoid new deprecations (#69 <https://github.com/ros-visualization/interactive_markers/issues/69>)
* Merge pull request #60 <https://github.com/ros-visualization/interactive_markers/issues/60> from ros-visualization/revert-58-bsd3clause_fixup
* Revert "Cleanup bsd 3 clause license usage"
* Merge pull request #58 <https://github.com/ros-visualization/interactive_markers/issues/58> from ros-visualization/bsd3clause_fixup
* code style only: wrap after open parenthesis if not in one line (#57 <https://github.com/ros-visualization/interactive_markers/issues/57>)
* Cleanup bsd 3 clause license usage
* Contributors: Dirk Thomas, Tully Foote, William Woodall
```
