### PR TITLE
laser_geometry: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -360,6 +360,22 @@ repositories:
       url: https://github.com/ros2/kdl_parser.git
       version: ros2
     status: maintained
+  laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_geometry-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: ros2
+    status: maintained
   launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.2.0-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## laser_geometry

```
* use ament_export_targets()
* code style only: wrap after open parenthesis if not in one line (#52 <https://github.com/ros-perception/laser_geometry/issues/52>)
* use target_include_directories
* Drop CMake extras redundant with eigen3_cmake_module. (#50 <https://github.com/ros-perception/laser_geometry/issues/50>)
* Contributors: Dirk Thomas, Jonathan Binney, Karsten Knese, Michel Hidalgo
```
