### PR TITLE
plotjuggler: 2.6.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9986,7 +9986,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.6.3-2
+      version: 2.6.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.6.4-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.6.3-2`

## plotjuggler

```
* Fix the damn icons
* marl updated
* fix issue #281 <https://github.com/facontidavide/PlotJuggler/issues/281>
* catch exception in marl
* fix backward-cpp
* Implement feature #274 <https://github.com/facontidavide/PlotJuggler/issues/274>
* Implement feature #269 <https://github.com/facontidavide/PlotJuggler/issues/269>
* Contributors: Davide Faconti
```
