### PR TITLE
rosbag2: 0.2.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -950,6 +950,36 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: maintained
+  rosbag2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
+    release:
+      packages:
+      - ros2bag
+      - rosbag2
+      - rosbag2_compression
+      - rosbag2_converter_default_plugins
+      - rosbag2_cpp
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_test_common
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      - zstd_vendor
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.2.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: master
+    status: developed
   rosidl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.5-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## ros2bag

```
* add topic remapping option to rosbag2 play (#388 <https://github.com/ros2/rosbag2/issues/388>)
* Add loop option to rosbag play (#361 <https://github.com/ros2/rosbag2/issues/361>)
* Expose topic filter to command line (addresses #342 <https://github.com/ros2/rosbag2/issues/342>) (#363 <https://github.com/ros2/rosbag2/issues/363>)
* Override QoS Profiles in CLI - Playback (#356 <https://github.com/ros2/rosbag2/issues/356>)
* Refactor utility functions in ros2bag (#358 <https://github.com/ros2/rosbag2/issues/358>)
* Add QoS Profile override to CLI (#347 <https://github.com/ros2/rosbag2/issues/347>)
* Transaction based sqlite3 inserts (#225 <https://github.com/ros2/rosbag2/issues/225>)
* include hidden topics (#332 <https://github.com/ros2/rosbag2/issues/332>)
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Add playback rate command line arg (#304 <https://github.com/ros2/rosbag2/issues/304>)
* [compression] Enable compression through ros2bag cli (#263 <https://github.com/ros2/rosbag2/issues/263>)
* switch to not deprecated API (#261 <https://github.com/ros2/rosbag2/issues/261>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Anas Abou Allaban, Dirk Thomas, Karsten Knese, Mabel Zhang, Sriram Raghunathan, Zachary Michaels, ketatam
```

## rosbag2

```
* Make rosbag2 a metapackage (#241 <https://github.com/ros2/rosbag2/issues/241>)
* Contributors: Anas Abou Allaban, Karsten Knese, Prajakta Gokhale
```

## rosbag2_compression

```
* Don't fail build if lsan isn't available. (#397 <https://github.com/ros2/rosbag2/issues/397>)
* Correctly set all test dependencies. (#392 <https://github.com/ros2/rosbag2/issues/392>)
* Deduplicate code in SequentialCompressionReader. (#372 <https://github.com/ros2/rosbag2/issues/372>)
* Add filter for reading selective topics. (#302 <https://github.com/ros2/rosbag2/issues/302>)
* Add QoS profiles field to metadata struct and provide serialization utilities. (#330 <https://github.com/ros2/rosbag2/issues/330>)
* Fix compression log logic. (#320 <https://github.com/ros2/rosbag2/issues/320>)
* Fix throw in playback of split+compressed bagfiles. (#294 <https://github.com/ros2/rosbag2/issues/294>)
* Refactor Compression Reader/Writers to use the CompressionFactory. (#315 <https://github.com/ros2/rosbag2/issues/315>)
* Add compression factory implementation. (#313 <https://github.com/ros2/rosbag2/issues/313>)
* Include stdexcept. (#314 <https://github.com/ros2/rosbag2/issues/314>)
* Add compression factory stubs. (#311 <https://github.com/ros2/rosbag2/issues/311>)
* Replace rcutils_get_file_size with rcpputils::fs::file_size. (#291 <https://github.com/ros2/rosbag2/issues/291>)
* [compression] Enable compression through ros2bag cli. (#263 <https://github.com/ros2/rosbag2/issues/263>)
* [compression] Close storage before compression. (#284 <https://github.com/ros2/rosbag2/issues/284>)
* Improve logging in rosbag2_compression. (#287 <https://github.com/ros2/rosbag2/issues/287>)
* Change validation functions to accept output type of ZSTD_getFrameContentSize. (#285 <https://github.com/ros2/rosbag2/issues/285>)
* code style only: wrap after open parenthesis if not in one line. (#280 <https://github.com/ros2/rosbag2/issues/280>)
* Add more assertions on rosbag2_compression. (#279 <https://github.com/ros2/rosbag2/issues/279>)
* [compression] Add SequentialCompressionWriter. (#260 <https://github.com/ros2/rosbag2/issues/260>)
* Add a SequentialCompressionReader. (#258 <https://github.com/ros2/rosbag2/issues/258>)
* Move compression artifacts from rosbag2_cpp to rosbag2_compression. (#257 <https://github.com/ros2/rosbag2/issues/257>)
* remove rosbag2 filesystem helper. (#249 <https://github.com/ros2/rosbag2/issues/249>)
* [Compression - 8] Enable reader to read from compressed files/messages. (#246 <https://github.com/ros2/rosbag2/issues/246>)
* [compression] Follow ROS2 style conventions better and throw eagerly. (#245 <https://github.com/ros2/rosbag2/issues/245>)
* [Compression] Use vector resize instead of reserve. (#243 <https://github.com/ros2/rosbag2/issues/243>)
* [Compression - 6] Add Zstd file decompression implementation. (#230 <https://github.com/ros2/rosbag2/issues/230>)
* Check output of fread/fwrite in compression. (#237 <https://github.com/ros2/rosbag2/issues/237>)
* Fix compress uri. (#234 <https://github.com/ros2/rosbag2/issues/234>)
* [Compression - 5] Add Zstd file compression. (#220 <https://github.com/ros2/rosbag2/issues/220>)
* [Compression - 4] Add decompressor interface. (#219 <https://github.com/ros2/rosbag2/issues/219>)
* Contributors: Anas Abou Allaban, Dirk Thomas, Emerson Knapp, Karsten Knese, Mabel Zhang, Scott K Logan, Thomas Moulard, Zachary Michaels
```

## rosbag2_converter_default_plugins

```
* Fixed string related with poco (#374 <https://github.com/ros2/rosbag2/issues/374>)
* rename rosidl_generator_cpp namespace to rosidl_runtime_cpp (#366 <https://github.com/ros2/rosbag2/issues/366>)
* added rosidl_runtime c and cpp depencencies (#310 <https://github.com/ros2/rosbag2/issues/310>)
* Replace poco dependency by rcutils (#322 <https://github.com/ros2/rosbag2/issues/322>)
* code style only: wrap after open parenthesis if not in one line (#280 <https://github.com/ros2/rosbag2/issues/280>)
* Make rosbag2 a metapackage (#241 <https://github.com/ros2/rosbag2/issues/241>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Karsten Knese
```

## rosbag2_cpp

```
* Don't fail build if lsan isn't available (#397 <https://github.com/ros2/rosbag2/issues/397>)
* Expose BaseReaderInterface's BagMetadata  (#377 <https://github.com/ros2/rosbag2/issues/377>)
* Expose topic filter to command line (addresses #342 <https://github.com/ros2/rosbag2/issues/342>) (#363 <https://github.com/ros2/rosbag2/issues/363>)
* Deduplicate code in SequentialCompressionReader (#372 <https://github.com/ros2/rosbag2/issues/372>)
* rename rosidl_generator_c namespace to rosidl_runtime_c (#368 <https://github.com/ros2/rosbag2/issues/368>)
* rename rosidl_generator_cpp namespace to rosidl_runtime_cpp (#366 <https://github.com/ros2/rosbag2/issues/366>)
* added rosidl_runtime c and cpp depencencies (#310 <https://github.com/ros2/rosbag2/issues/310>)
* Replace poco dependency by rcutils (#322 <https://github.com/ros2/rosbag2/issues/322>)
* resolve relative file paths (#345 <https://github.com/ros2/rosbag2/issues/345>)
* Add filter for reading selective topics (#302 <https://github.com/ros2/rosbag2/issues/302>)
* default max bag size to 0 (#344 <https://github.com/ros2/rosbag2/issues/344>)
* Transaction based sqlite3 inserts (#225 <https://github.com/ros2/rosbag2/issues/225>)
* Add QoS to metadata (re-do #330 <https://github.com/ros2/rosbag2/issues/330>) (#335 <https://github.com/ros2/rosbag2/issues/335>)
* Revert "Add QoS profiles field to metadata struct and provide serialization utilities (#330 <https://github.com/ros2/rosbag2/issues/330>)" (#334 <https://github.com/ros2/rosbag2/issues/334>)
* Add QoS profiles field to metadata struct and provide serialization utilities (#330 <https://github.com/ros2/rosbag2/issues/330>)
* Replace rcutils_get_file_size with rcpputils::fs::file_size (#291 <https://github.com/ros2/rosbag2/issues/291>)
* code style only: wrap after open parenthesis if not in one line (#280 <https://github.com/ros2/rosbag2/issues/280>)
* Fix ros2 bag play on split bags (#268 <https://github.com/ros2/rosbag2/issues/268>)
* [compression] Add SequentialCompressionWriter (#260 <https://github.com/ros2/rosbag2/issues/260>)
* Add unit test for SequentialReader when metadata file does not exist (#254 <https://github.com/ros2/rosbag2/issues/254>)
* Move compression artifacts from rosbag2_cpp to rosbag2_compression (#257 <https://github.com/ros2/rosbag2/issues/257>)
* Fix uncrustify warnings (#256 <https://github.com/ros2/rosbag2/issues/256>)
* remove rosbag2 filesystem helper (#249 <https://github.com/ros2/rosbag2/issues/249>)
* [Compression - 8] Enable reader to read from compressed files/messages (#246 <https://github.com/ros2/rosbag2/issues/246>)
* Make rosbag2 a metapackage (#241 <https://github.com/ros2/rosbag2/issues/241>)
* Contributors: Alejandro Hernández Cordero, Anas Abou Allaban, Dirk Thomas, Emerson Knapp, Karsten Knese, Mabel Zhang, Scott K Logan, Sriram Raghunathan, Zachary Michaels
```

## rosbag2_storage

```
* Read serialized qos profiles out of the metadata (#359 <https://github.com/ros2/rosbag2/issues/359>)
* Add filter for reading selective topics (#302 <https://github.com/ros2/rosbag2/issues/302>)
* Transaction based sqlite3 inserts (#225 <https://github.com/ros2/rosbag2/issues/225>)
* Add QoS profiles field to metadata struct and provide serialization utilities (#330 <https://github.com/ros2/rosbag2/issues/330>)
* code style only: wrap after open parenthesis if not in one line (#280 <https://github.com/ros2/rosbag2/issues/280>)
* remove rosbag2 filesystem helper (#249 <https://github.com/ros2/rosbag2/issues/249>)
* [Compression - 7] Add compression metadata (#221 <https://github.com/ros2/rosbag2/issues/221>)
* Sanitize bagfile splitting CLI input (#226 <https://github.com/ros2/rosbag2/issues/226>)
* Move get_storage_identifier and get_bagfile_size (#209 <https://github.com/ros2/rosbag2/issues/209>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Anas Abou Allaban, Dirk Thomas, Emerson Knapp, Karsten Knese, Mabel Zhang, Prajakta Gokhale, Sriram Raghunathan, Zachary Michaels
```

## rosbag2_storage_default_plugins

```
* Add filter for reading selective topics (#302 <https://github.com/ros2/rosbag2/issues/302>)
* Transaction based sqlite3 inserts (#225 <https://github.com/ros2/rosbag2/issues/225>)
* Add QoS profiles field to metadata struct and provide serialization utilities (#330 <https://github.com/ros2/rosbag2/issues/330>)
* Replace rcutils_get_file_size with rcpputils::fs::file_size (#291 <https://github.com/ros2/rosbag2/issues/291>)
* code style only: wrap after open parenthesis if not in one line (#280 <https://github.com/ros2/rosbag2/issues/280>)
* Improve SQLite error messages (#269 <https://github.com/ros2/rosbag2/issues/269>)
* remove rosbag2 filesystem helper (#249 <https://github.com/ros2/rosbag2/issues/249>)
* Sanitize bagfile splitting CLI input (#226 <https://github.com/ros2/rosbag2/issues/226>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Dirk Thomas, Emerson Knapp, Karsten Knese, Mabel Zhang, Prajakta Gokhale, Sriram Raghunathan, Zachary Michaels
```

## rosbag2_test_common

```
* use serialized message (#386 <https://github.com/ros2/rosbag2/issues/386>)
* QoS Profile Overrides - Player (#353 <https://github.com/ros2/rosbag2/issues/353>)
* Intelligently subscribe to topics according to their QoS profiles (#355 <https://github.com/ros2/rosbag2/issues/355>)
* Override Subscriber QoS - Record (#346 <https://github.com/ros2/rosbag2/issues/346>)
* fix cyclone tests (#338 <https://github.com/ros2/rosbag2/issues/338>)
* code style only: wrap after open parenthesis if not in one line (#280 <https://github.com/ros2/rosbag2/issues/280>)
* Enhance E2E tests in Windows (#278 <https://github.com/ros2/rosbag2/issues/278>)
* Add splitting e2e tests (#247 <https://github.com/ros2/rosbag2/issues/247>)
* Make rosbag2 a metapackage (#241 <https://github.com/ros2/rosbag2/issues/241>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Anas Abou Allaban, Dirk Thomas, Emerson Knapp, Karsten Knese, Zachary Michaels
```

## rosbag2_tests

```
* Expose topic filter to command line (addresses #342 <https://github.com/ros2/rosbag2/issues/342>) (#363 <https://github.com/ros2/rosbag2/issues/363>)
* Fix rosbag2_tests resource files and play_end_to_end test (#362 <https://github.com/ros2/rosbag2/issues/362>)
* Replace poco dependency by rcutils (#322 <https://github.com/ros2/rosbag2/issues/322>)
* resolve relative file paths (#345 <https://github.com/ros2/rosbag2/issues/345>)
* Transaction based sqlite3 inserts (#225 <https://github.com/ros2/rosbag2/issues/225>)
* Replace rcutils_get_file_size with rcpputils::fs::file_size (#291 <https://github.com/ros2/rosbag2/issues/291>)
* [compression] Enable compression through ros2bag cli (#263 <https://github.com/ros2/rosbag2/issues/263>)
* Wait for metadata to be written to disk (#283 <https://github.com/ros2/rosbag2/issues/283>)
* Refactor record_fixture to use rcpputils::fs::path (#286 <https://github.com/ros2/rosbag2/issues/286>)
* code style only: wrap after open parenthesis if not in one line (#280 <https://github.com/ros2/rosbag2/issues/280>)
* Enhance E2E tests in Windows (#278 <https://github.com/ros2/rosbag2/issues/278>)
* Add splitting e2e tests (#247 <https://github.com/ros2/rosbag2/issues/247>)
* remove rosbag2 filesystem helper (#249 <https://github.com/ros2/rosbag2/issues/249>)
* Make rosbag2 a metapackage (#241 <https://github.com/ros2/rosbag2/issues/241>)
* [Compression - 7] Add compression metadata (#221 <https://github.com/ros2/rosbag2/issues/221>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Alejandro Hernández Cordero, Anas Abou Allaban, Dirk Thomas, Karsten Knese, Mabel Zhang, Sriram Raghunathan, Zachary Michaels
```

## rosbag2_transport

```
* add topic remapping option to rosbag2 play (#388 <https://github.com/ros2/rosbag2/issues/388>)
* add missing test dependency (#392 <https://github.com/ros2/rosbag2/issues/392>)
* use serialized message (#386 <https://github.com/ros2/rosbag2/issues/386>)
* Adaptive playback qos based on recorded metadata (#364 <https://github.com/ros2/rosbag2/issues/364>)
* Add loop option to rosbag play (#361 <https://github.com/ros2/rosbag2/issues/361>)
* Move qos utilities to their own compilation unit (#379 <https://github.com/ros2/rosbag2/issues/379>)
* Expose BaseReaderInterface's BagMetadata  (#377 <https://github.com/ros2/rosbag2/issues/377>)
* Expose topic filter to command line (addresses #342 <https://github.com/ros2/rosbag2/issues/342>) (#363 <https://github.com/ros2/rosbag2/issues/363>)
* Fix Action CI tests to pass reliably (#376 <https://github.com/ros2/rosbag2/issues/376>)
* Update GenericSubscription's handle_message signature (#373 <https://github.com/ros2/rosbag2/issues/373>)
* Bridge CLI with transport (#370 <https://github.com/ros2/rosbag2/issues/370>)
* Override QoS Profiles in CLI - Playback (#356 <https://github.com/ros2/rosbag2/issues/356>)
* QoS Profile Overrides - Player (#353 <https://github.com/ros2/rosbag2/issues/353>)
* Fix rosbag2_tests resource files and play_end_to_end test (#362 <https://github.com/ros2/rosbag2/issues/362>)
* use ament_export_targets() (#360 <https://github.com/ros2/rosbag2/issues/360>)
* Intelligently subscribe to topics according to their QoS profiles (#355 <https://github.com/ros2/rosbag2/issues/355>)
* Add QoS Profile override to CLI (#347 <https://github.com/ros2/rosbag2/issues/347>)
* Override Subscriber QoS - Record (#346 <https://github.com/ros2/rosbag2/issues/346>)
* Replace poco dependency by rcutils (#322 <https://github.com/ros2/rosbag2/issues/322>)
* Test all RMW implementations for rosbag2_transport (#349 <https://github.com/ros2/rosbag2/issues/349>)
* Add filter for reading selective topics (#302 <https://github.com/ros2/rosbag2/issues/302>)
* Disable adaptive qos subscription for now  (#348 <https://github.com/ros2/rosbag2/issues/348>)
* Subscribe to topics using the common offered QoS (#343 <https://github.com/ros2/rosbag2/issues/343>)
* Transaction based sqlite3 inserts (#225 <https://github.com/ros2/rosbag2/issues/225>)
* Allow GenericPublisher / GenericSubscription to take a QoS profile (#337 <https://github.com/ros2/rosbag2/issues/337>)
* Query offered QoS profiles for a topic and store in metadata (#333 <https://github.com/ros2/rosbag2/issues/333>)
* Add QoS profiles field to metadata struct and provide serialization utilities (#330 <https://github.com/ros2/rosbag2/issues/330>)
* include hidden topics (#332 <https://github.com/ros2/rosbag2/issues/332>)
* Add playback rate command line arg (#304 <https://github.com/ros2/rosbag2/issues/304>)
* Removed rosidl_generator_cpp in rosbag2_transport because it's not used (#321 <https://github.com/ros2/rosbag2/issues/321>)
* Fix race condition in transport recorder (#303 <https://github.com/ros2/rosbag2/issues/303>)
* [compression] Enable compression through ros2bag cli (#263 <https://github.com/ros2/rosbag2/issues/263>)
* code style only: wrap after open parenthesis if not in one line (#280 <https://github.com/ros2/rosbag2/issues/280>)
* Make rosbag2 a metapackage (#241 <https://github.com/ros2/rosbag2/issues/241>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Alejandro Hernández Cordero, Anas Abou Allaban, Dirk Thomas, Emerson Knapp, Karsten Knese, Mabel Zhang, Sriram Raghunathan, Zachary Michaels, carlossvg, ketatam
```

## shared_queues_vendor

```
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Karsten Knese
```

## sqlite3_vendor

```
* fix CMake warning about using uninitialized variables (#382 <https://github.com/ros2/rosbag2/issues/382>)
* Add project() to sqlite3_cmakelists.txt (#324 <https://github.com/ros2/rosbag2/issues/324>)
* make sqlite3_vendor an ament package (#252 <https://github.com/ros2/rosbag2/issues/252>)
* make ros tooling working group maintainer (#211 <https://github.com/ros2/rosbag2/issues/211>)
* Contributors: Dirk Thomas, Karsten Knese, Mikael Arguedas, brawner
```

## zstd_vendor

```
* [Compression - 5] Add Zstd file compression (#220 <https://github.com/ros2/rosbag2/issues/220>)
* Contributors: Anas Abou Allaban, Zachary Michaels
```
