### PR TITLE
Add RHEL rules for 4 Python packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4706,6 +4706,9 @@ python-tk:
   arch: [python2, tk]
   debian: [python-tk]
   fedora: [python2-tkinter]
+  rhel:
+    '*': [python2-tkinter]
+    '7': [tkinter]
   ubuntu:
     '*': [python-tk]
     bionic_python3: [python3-tk]
@@ -4950,6 +4953,7 @@ python-virtualenv:
   fedora: [python-virtualenv]
   gentoo: [dev-python/virtualenv]
   rhel:
+    '*': [python2-virtualenv]
     '7': [python-virtualenv]
   ubuntu: [python-virtualenv]
 python-visual:
@@ -5240,6 +5244,9 @@ python3-boto3:
   debian: [python3-boto3]
   fedora: [python3-boto3]
   opensuse: [python3-boto3]
+  rhel:
+    '*': ['python%{python3_pkgversion}-boto3']
+    '7': null
   ubuntu: [python3-boto3]
 python3-bson:
   debian: [python3-bson]
@@ -6003,6 +6010,9 @@ python3-twisted:
   debian: [python3-twisted]
   fedora: [python3-twisted]
   gentoo: [dev-python/twisted]
+  rhel:
+    '*': ['python%{python3_pkgversion}-twisted']
+    '7': null
   ubuntu: [python3-twisted]
 python3-vcstool:
   debian:


### PR DESCRIPTION
I've stumbled across these missing rules while working with ROS 2 on CentOS.

There aren't any official web databases for RHEL/CentOS packages, so I'll link to the packages sitting in the repository mirrors.

For EPEL, I've linked to the web database.

#### From AppStream
* [`python2-tkinter`](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python2-tkinter-2.7.16-12.module_el8.1.0+219+cf9e6ac9.x86_64.rpm)
* [`python2-virtualenv`](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python2-virtualenv-15.1.0-19.module_el8.1.0+219+cf9e6ac9.noarch.rpm)

#### From EPEL:
* `python%{python3_pkgversion}-boto3`: https://apps.fedoraproject.org/packages/python3-boto3
* `python%{python3_pkgversion}-twisted`: https://apps.fedoraproject.org/packages/python3-twisted

```
$ dnf list -q --available --showduplicates python2-tkinter \
> python2-virtualenv python3-boto3 python3-twisted
Available Packages
python2-tkinter.x86_64       2.7.16-12.module_el8.1.0+219+cf9e6ac9    AppStream
python2-virtualenv.noarch    15.1.0-19.module_el8.1.0+219+cf9e6ac9    AppStream
python3-boto3.noarch         1.10.21-1.el8                            epel     
python3-twisted.x86_64       19.10.0-2.el8                            epel
```