### PR TITLE
mir_robot: 1.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5311,10 +5311,11 @@ repositories:
       - mir_msgs
       - mir_navigation
       - mir_robot
+      - sdc21x0
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.5-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.4-1`

## mir_actions

- No changes

## mir_description

```
* Switch from Gazebo GPU laser to normal laser plugin
  The GPU laser plugin has caused multiple people problems before, because
  it is not compatible with all GPUS: #1 <https://github.com/dfki-ric/mir_robot/issues/1>
  #32 <https://github.com/dfki-ric/mir_robot/issues/32>
  #46 <https://github.com/dfki-ric/mir_robot/issues/46>
  #52 <https://github.com/dfki-ric/mir_robot/issues/52>
  The normal laser plugin directly uses the physics engine, so it doesn't
  depend on any specific GPU. Also, it doesn't slow down the simulation
  noticeably (maybe 1-2%).
* Contributors: Martin Günther
```

## mir_driver

```
* Add optional prefix parameter to fake_mir_joint_publisher (#47 <https://github.com/dfki-ric/mir_robot/issues/47>)
* tf_remove_child_frames: Don't publish empty TFs
* Add sdc21x0 package, MC/currents topic
* Contributors: Martin Günther, Nils Niemann
```

## mir_dwb_critics

```
* mir_dwb_critics: Add plot_dwb_scores.py
* mir_dwb_critics: Improve print_dwb_scores output
* added PathDistPrunedCritic for dwb (#42 <https://github.com/dfki-ric/mir_robot/issues/42>)
  which works exactly like the original PathDistCritic, except that it
  searches for a local minimum in the distance from the global path to the robots
  current position. It then prunes the global_path from the start up to
  this point, therefore approximately cutting of a segment of the path
  that the robot already followed.
* Contributors: Martin Günther, Nils Niemann
```

## mir_gazebo

- No changes

## mir_msgs

- No changes

## mir_navigation

```
* Rename hector_mapping.launch, add dependency
* genmprim.py: Improve plotting
* genmprim.py: Make executable
* SBPL: Reduce allocated_time + initial_epsilon params
  This leads to shorter planning times, but will perhaps fail on larger
  maps.
* Update mprim file to mir-software 2.0.17
  This was updated in 2.0.17 and hasn't changed through 2.6 at least.
* Add genmprim_unicycle matlab + python script, fix mprim file
* Adjust dwb params: split_path, finer trajectories (#43 <https://github.com/dfki-ric/mir_robot/issues/43>)
  - use split_path option to enforce following complex paths
  - more trajectory samples over a smaller simulated time. This fixes a
  problem where the robot would stop too far away from the goal, as all
  possible trajectories either overshot the goal, or were too short to
  reach into the next gridcell of the critics.
  - remove Oscillation critic (never helped)
* added PathDistPrunedCritic for dwb (#42 <https://github.com/dfki-ric/mir_robot/issues/42>)
  which works exactly like the original PathDistCritic, except that it
  searches for a local minimum in the distance from the global path to the robots
  current position. It then prunes the global_path from the start up to
  this point, therefore approximately cutting of a segment of the path
  that the robot already followed.
* Add default local_planner to move_base launch file
  This makes the hector_mapping Gazebo demo work with the instructions
  from the README (see #32 <https://github.com/dfki-ric/mir_robot/issues/32>).
* Contributors: Martin Günther, Nils Niemann
```

## mir_robot

- No changes

## sdc21x0

```
* Add sdc21x0 package, MC/currents topic
* Contributors: Martin Günther
* Add sdc21x0 package, MC/currents topic
* Contributors: Martin Günther
```
