### PR TITLE
gazebo_ros_pkgs: 2.8.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2960,7 +2960,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.8.6-1
+      version: 2.8.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.8.7-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.4`
- previous version for package: `2.8.6-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* gazebo_ros_wheel_slip: remove unused member data (#1084 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1084>)
* gazebo_ros_wheel_slip plugin (#995 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/995>)
  Uses dynamic_reconfigure to set wheel slip parameters.
  Requires gazebo 9.5.
  * don't overwrite initial slip values
  * Add test world using trisphere_cycles
* portable installation fix. (#1061 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1061>)
* Measure IMU orientation with respect to world (#1051 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1051>)
  Report the IMU orientation from the sensor plugin with respect to the world frame.
  This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html
  In order to not break existing behavior, users should opt-in by adding a new SDF tag.
* Contributors: Jacob Perron, Sean Yen, Steven Peters
```

## gazebo_ros

```
* add node required to empty world (#1078 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1078>)
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* Contributors: Mabel Zhang
```

## gazebo_ros_control

```
* gazebo_ros_control: catch all pluginlib exceptions (#1062 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1062>)
* Contributors: Max Schwarz
```

## gazebo_ros_pkgs

- No changes
