### PR TITLE
Drop ogre rules for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2829,7 +2829,6 @@ libogre:
   gentoo: [dev-games/ogre]
   macports: [ogre]
   opensuse: [ogre-devel]
-  rhel: [ogre-devel]
   slackware: [ogre]
   ubuntu:
     artful: [libogre-1.9-dev]
@@ -2861,7 +2860,6 @@ libogre-dev:
   gentoo: [dev-games/ogre]
   macports: [ogre]
   opensuse: [ogre-devel]
-  rhel: [ogre-devel]
   slackware: [ogre]
   ubuntu:
     artful: [libogre-1.9-dev]


### PR DESCRIPTION
I can't find an `ogre-devel` package in any supported repositories for RHEL 7 or 8. I think the rules were added a really long time ago.