### PR TITLE
Update 3 python 2 rules for RHEL 8

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -372,7 +372,7 @@ python:
   macports: [python26, python_select]
   openembedded: [python@openembedded-core]
   opensuse: [python-devel]
-  rhel: [python-devel]
+  rhel: [python2-devel]
   slackware:
     slackpkg:
       packages: [python]
@@ -3202,7 +3202,7 @@ python-pycryptodome:
   osx:
     pip:
       packages: [pycryptodome]
-  rhel: [python-pycryptodomex]
+  rhel: [python2-pycryptodomex]
   ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]
@@ -5151,7 +5151,9 @@ python-yaml:
     pip:
       depends: [yaml]
       packages: [PyYAML]
-  rhel: [PyYAML]
+  rhel:
+    '*': [python2-pyyaml]
+    '7': [PyYAML]
   slackware: [PyYAML]
   ubuntu:
     artful: [python-yaml]


### PR DESCRIPTION
These three existing rules for Python 2 packages in RHEL need to be updated to work with RHEL 8.

In RHEL 7, a `python2-foo` package would provide a virtual `python-foo` package for compatibility. This isn't true in RHEL 8 for the few Python 2 packages that are part of the distro. However, `python-foo` packages in RHEL 7 typically provide a `python2-foo` virtual package for _forward_ compatibility, so sometimes we can still use a single rule for RHEL 7 and 8.

This was the case for `python2-devel`, but doesn't hold true for `PyYAML`, which doesn't have a very consistent track record for naming in Fedora and RHEL (`PyYAML`/`python*-PyYAML`/`python*-pyyaml`/`python*-yaml`). I found no overlap in the virtual packages either.

On CentOS 7, this is the best way I can find to demonstrate the virtual providers:
```
$ sudo yum -q install python2-devel python2-pycryptodomex PyYAML
Package python-devel-2.7.5-88.el7.x86_64 already installed and latest version
Package python2-pycryptodomex-3.9.7-1.el7.x86_64 already installed and latest version
Package PyYAML-3.10-11.el7.x86_64 already installed and latest version
```

On CentOS 8:
```
$ sudo dnf install python2-devel python2-pycryptodomex python2-pyyaml
Package python2-devel-2.7.16-12.module_el8.1.0+219+cf9e6ac9.x86_64 is already installed.
Package python2-pycryptodomex-3.9.7-1.el8.x86_64 is already installed.
Package python2-pyyaml-3.12-16.module_el8.1.0+219+cf9e6ac9.x86_64 is already installed.
```