### PR TITLE
Remove RHEL 8 rules for several Python 2 keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -231,7 +231,8 @@ paramiko:
   osx:
     pip:
       packages: [paramiko]
-  rhel: [python-paramiko]
+  rhel:
+    '7': [python-paramiko]
   ubuntu: [python-paramiko]
 pi-ina219-pip:
   debian:
@@ -2059,7 +2060,8 @@ python-imaging:
   osx:
     pip:
       packages: [Pillow]
-  rhel: [python-imaging]
+  rhel:
+    '7': [python-imaging]
   slackware:
     slackpkg:
       packages: [python-pillow]
@@ -2371,7 +2373,8 @@ python-matplotlib:
     pip:
       depends: [pkg-config, freetype, libpng12-dev]
       packages: [matplotlib]
-  rhel: [python-matplotlib]
+  rhel:
+    '7': [python-matplotlib]
   slackware: [matplotlib]
   ubuntu:
     artful: [python-matplotlib]
@@ -2866,7 +2869,8 @@ python-paramiko:
   osx:
     pip:
       packages: [paramiko]
-  rhel: [python-paramiko]
+  rhel:
+    '7': [python-paramiko]
   slackware: [paramiko]
   ubuntu: [python-paramiko]
 python-parse:
@@ -3827,7 +3831,8 @@ python-rosdep-modules:
   osx:
     pip:
       packages: [rosdep]
-  rhel: ['python-rosdep']
+  rhel:
+    '7': [python-rosdep]
   slackware:
     pip:
       packages: [rosdep]


### PR DESCRIPTION
Though RHEL 8 contains a select few Python 2 packages right now, it probably won't pick up any new ones, so these rules are never expected to be correct looking forward from RHEL 7.

```
$ sudo dnf -q list python{,2}-{paramiko,imaging,matplotlib,rosdep}
Error: No matching Packages to list
```