### PR TITLE
Add several missing Python rules for RHEL 7 + 8

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -484,6 +484,7 @@ python-argparse:
   osx:
     pip:
       packages: [argparse]
+  rhel: [python2]
   slackware:
     pip:
       packages: [argparse]
@@ -743,6 +744,9 @@ python-cairo:
   freebsd: [py27-cairo]
   gentoo: [dev-python/pycairo]
   opensuse: [python-cairo]
+  rhel:
+    '*': [python2-cairo]
+    '7': [pycairo]
   slackware:
     slackpkg:
       packages: [pycairo]
@@ -1102,6 +1106,9 @@ python-coverage:
   osx:
     pip:
       packages: [coverage]
+  rhel:
+    '*': [python2-coverage]
+    '7': [python-coverage]
   slackware: [coverage]
   ubuntu:
     artful: [python-coverage]
@@ -1279,6 +1286,8 @@ python-defusedxml:
   osx:
     pip:
       packages: [defusedxml]
+  rhel:
+    '7': [python2-defusedxml]
   slackware:
     pip:
       packages: [defusedxml]
@@ -1381,6 +1390,8 @@ python-empy:
   osx:
     pip:
       packages: [empy]
+  rhel:
+    '7': [python2-empy]
   slackware:
     pip:
       packages: [empy]
@@ -1766,6 +1777,8 @@ python-gnupg:
   freebsd: [py27-python-gnupg]
   gentoo: [dev-python/python-gnupg]
   openembedded: [python-gnupg@meta-ros]
+  rhel:
+    '7': [python2-gnupg]
   ubuntu: [python-gnupg]
 python-google-cloud-bigquery-pip:
   debian:
@@ -2559,6 +2572,8 @@ python-netifaces:
   osx:
     pip:
       packages: [netifaces]
+  rhel:
+    '7': [python-netifaces]
   slackware: [netifaces]
   ubuntu:
     artful: [python-netifaces]
@@ -2614,6 +2629,7 @@ python-nose:
   osx:
     pip:
       packages: [nose]
+  rhel: [python2-nose]
   slackware: [nose]
   ubuntu:
     artful: [python-nose]
@@ -2752,6 +2768,8 @@ python-opencv:
   gentoo: ['media-libs/opencv[python]']
   openembedded: [opencv@meta-oe]
   opensuse: [python-opencv]
+  rhel:
+    '7': [opencv-python]
   slackware: [opencv]
   ubuntu: [python-opencv]
 python-opengl:
@@ -2765,6 +2783,8 @@ python-opengl:
   osx:
     pip:
       packages: [PyOpenGL]
+  rhel:
+    '7': [PyOpenGL]
   slackware: [PyOpenGL]
   ubuntu:
     artful: [python-opengl]
@@ -3231,6 +3251,8 @@ python-pydot:
   osx:
     pip:
       packages: [pydot]
+  rhel:
+    '7': [python2-pydot]
   slackware: [pydot]
   ubuntu: [python-pydot]
 python-pyexiv2:
@@ -3283,6 +3305,8 @@ python-pygraphviz:
   osx:
     pip:
       packages: [pygraphviz]
+  rhel:
+    '7': [python2-pygraphviz]
   slackware: [pygraphviz]
   ubuntu: [python-pygraphviz]
 python-pyinotify:
@@ -3785,6 +3809,8 @@ python-rosdep:
   osx:
     pip:
       packages: [rosdep]
+  rhel:
+    '7': [python2-rosdep]
   slackware:
     pip:
       packages: [rosdep]
@@ -3840,6 +3866,8 @@ python-rosdistro:
     macports: [py27-rosdistro]
     pip:
       packages: [rosdistro]
+  rhel:
+    '7': [python2-rosdistro]
   ubuntu:
     artful: [python-rosdistro]
     lucid: [python-rosdistro]
@@ -3868,6 +3896,8 @@ python-rosinstall:
   fedora: [python-rosinstall]
   gentoo: [dev-python/rosinstall]
   macports: [p27-rosinstall]
+  rhel:
+    '7': [python-rosinstall]
   ubuntu:
     '*': [python-rosinstall]
     trusty_python3: [python3-rosinstall]
@@ -3879,6 +3909,8 @@ python-rosinstall-generator:
   fedora: [python-rosinstall_generator]
   gentoo: [dev-python/rosinstall_generator]
   macports: [py27-rosinstall-generator]
+  rhel:
+    '7': [python2-rosinstall_generator]
   ubuntu:
     lucid: [python-rosinstall-generator]
     maverick: [python-rosinstall-generator]
@@ -3907,6 +3939,8 @@ python-rospkg:
   osx:
     pip:
       packages: [rospkg]
+  rhel:
+    '7': [python2-rospkg]
   slackware:
     pip:
       packages: [rospkg]
@@ -3935,6 +3969,8 @@ python-rospkg-modules:
   osx:
     pip:
       packages: [rospkg]
+  rhel:
+    '7': [python2-rospkg]
   slackware:
     pip:
       packages: [rospkg]
@@ -4134,6 +4170,7 @@ python-setuptools:
   osx:
     pip:
       packages: [setuptools]
+  rhel: [python2-setuptools]
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
@@ -5108,6 +5145,8 @@ python-wxtools:
   freebsd: [py27-wxPython30]
   gentoo: [dev-python/wxpython]
   openembedded: [wxpython@meta-oe]
+  rhel:
+    '7': [wxPython]
   ubuntu: [python-wxtools]
 python-xdot:
   debian: [xdot]
@@ -5193,6 +5232,7 @@ python3:
   debian: [python3-dev]
   fedora: [python3-devel]
   gentoo: [dev-lang/python]
+  rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
 python3-asyncssh:
   debian: [python3-asyncssh]
@@ -5263,6 +5303,7 @@ python3-catkin-pkg:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]
+  rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg]
 python3-catkin-pkg-modules:
   debian: [python3-catkin-pkg-modules]
@@ -5288,6 +5329,7 @@ python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]
   gentoo: [dev-python/coverage]
+  rhel: ['python%{python3_pkgversion}-coverage']
   ubuntu: [python3-coverage]
 python3-cryptography:
   debian: [python3-cryptography]
@@ -5298,6 +5340,7 @@ python3-defusedxml:
   debian: [python3-defusedxml]
   fedora: [python3-defusedxml]
   gentoo: [dev-python/defusedxml]
+  rhel: ['python%{python3_pkgversion}-defusedxml']
   ubuntu: [python3-defusedxml]
 python3-dev:
   debian: [python3-dev]
@@ -5560,6 +5603,7 @@ python3-paramiko:
   debian: [python3-paramiko]
   fedora: [python3-paramiko]
   gentoo: [dev-python/paramiko]
+  rhel: ['python%{python3_pkgversion}-paramiko']
   ubuntu: [python3-paramiko]
 python3-pcg-gazebo-pip:
   debian:
@@ -5824,6 +5868,7 @@ python3-rosdep:
   debian: [python3-rosdep]
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
+  rhel: ['python%{python3_pkgversion}-rosdep']
   ubuntu: [python3-rosdep]
 python3-rosdep-modules:
   debian: [python3-rosdep-modules]
@@ -5853,6 +5898,7 @@ python3-rospkg:
   osx:
     pip:
       packages: [rospkg]
+  rhel: ['python%{python3_pkgversion}-rospkg']
   slackware:
     pip:
       packages: [rospkg]
@@ -5872,6 +5918,7 @@ python3-rospkg-modules:
   osx:
     pip:
       packages: [rospkg]
+  rhel: ['python%{python3_pkgversion}-rospkg']
   slackware:
     pip:
       packages: [rospkg]


### PR DESCRIPTION
Some of these keys are used in basic ROS 1 packages, and some are used in ROS 2.

Take note that where the package name in the table doesn't match the rule being added precisely, it is probably because the package listed provides a virtual package by the name listed in the rule. The only time I did this was to keep the RHEL 7 and RHEL 8 rules combined into a single rule.

There aren't any official web databases for RHEL/CentOS packages, so I'll link to the packages sitting in the repository mirrors.

| rosdep key | RHEL 7 package | RHEL 8 package |
|------------|----------------|----------------|
| python-argparse | [python](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/python-2.7.5-88.el7.x86_64.rpm) | [python2](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python2-2.7.16-12.module_el8.1.0+219+cf9e6ac9.x86_64.rpm) |
| python-cairo | [pycairo](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/pycairo-1.8.10-8.el7.x86_64.rpm) | [python2-cairo](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python2-cairo-1.16.3-6.module_el8.0.0+36+bb6a76a2.x86_64.rpm) |
| python-coverage | [python-coverage](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/python-coverage-3.6-0.5.b3.el7.x86_64.rpm) | [python2-coverage](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python2-coverage-4.5.1-4.module_el8.1.0+219+cf9e6ac9.x86_64.rpm) |
| python-defusedxml | [python2-defusedxml](https://src.fedoraproject.org/rpms/python-defusedxml#bodhi_updates) |
| python-empy | [python2-empy](https://src.fedoraproject.org/rpms/python-empy#bodhi_updates) |
| python-gnupg | [python2-gnupg](https://src.fedoraproject.org/rpms/python-gnupg#bodhi_updates) |
| python-netifaces | [python-netifaces](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/python-netifaces-0.10.4-3.el7.x86_64.rpm) |
| python-nose | [python-nose](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/python-nose-1.3.7-1.el7.noarch.rpm) | [python2-nose](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python2-nose-1.3.7-30.module_el8.1.0+219+cf9e6ac9.noarch.rpm) |
| python-opencv | [opencv-python](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/opencv-python-2.4.5-3.el7.x86_64.rpm) |
| python-opengl | [PyOpenGL](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/PyOpenGL-3.0.1-6.el7.noarch.rpm) |
| python-pydot | [python2-pydot](https://src.fedoraproject.org/rpms/pydot#bodhi_updates) |
| python-pygraphviz | [python2-pygraphviz](https://src.fedoraproject.org/rpms/python-pygraphviz#bodhi_updates) |
| python-rosdep | [python2-rosdep](https://src.fedoraproject.org/rpms/python-rosdep#bodhi_updates) |
| python-rosdistro | [python2-rosdistro](https://src.fedoraproject.org/rpms/python-rosdistro#bodhi_updates) |
| python-rosinstall | [python-rosinstall](https://src.fedoraproject.org/rpms/python-rosinstall#bodhi_updates) |
| python-rosinstall_generator | [python2-rosinstall_generator](https://src.fedoraproject.org/rpms/python-rosinstall_generator#bodhi_updates) |
| python-rospkg | [python2-rospkg](https://src.fedoraproject.org/rpms/python-rospkg#bodhi_updates) |
| python-rospkg-modules | [python2-rospkg](https://src.fedoraproject.org/rpms/python-rospkg#bodhi_updates) |
| python-setuptools | [python-setuptools](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/python-setuptools-0.9.8-7.el7.noarch.rpm) | [python2-setuptools](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python2-setuptools-39.0.1-11.module_el8.1.0+219+cf9e6ac9.noarch.rpm) |
| python-wxtools | [wxPython](https://src.fedoraproject.org/rpms/wxPython#bodhi_updates) |
| python3 | [python3-devel](http://mirror.centos.org/centos/7.8.2003/os/x86_64/Packages/python3-devel-3.6.8-13.el7.x86_64.rpm) | [python36-devel](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python36-devel-3.6.8-2.module_el8.1.0+245+c39af44f.x86_64.rpm) |
| python3-catkin-pkg | [python36-catkin_pkg](https://src.fedoraproject.org/rpms/python-catkin_pkg#bodhi_updates) | [python3-catkin_pkg](https://src.fedoraproject.org/rpms/python-catkin_pkg#bodhi_updates) |
| python3-coverage | [python36-coverage](https://src.fedoraproject.org/rpms/python3-coverage#bodhi_updates) | [python3-coverage](http://mirror.centos.org/centos/8.1.1911/AppStream/x86_64/os/Packages/python3-coverage-4.5.1-7.el8.x86_64.rpm) |
| python3-defusedxml | [python36-defusedxml](https://src.fedoraproject.org/rpms/python-defusedxml#bodhi_updates) | [python3-defusedxml](https://src.fedoraproject.org/rpms/python-defusedxml#bodhi_updates) |
| python3-paramiko | [python36-paramiko](https://src.fedoraproject.org/rpms/python-paramiko#bodhi_updates) | [python3-paramiko](https://src.fedoraproject.org/rpms/python-paramiko#bodhi_updates) |
| python3-rosdep | [python36-rosdep](https://src.fedoraproject.org/rpms/python-rosdep#bodhi_updates) | [python3-rosdep](https://src.fedoraproject.org/rpms/python-rosdep#bodhi_updates) |
| python3-rospkg | [python36-rospkg](https://src.fedoraproject.org/rpms/python-rospkg#bodhi_updates) | [python3-rospkg](https://src.fedoraproject.org/rpms/python-rospkg#bodhi_updates) |
| python3-rospkg-modules | [python36-rospkg](https://src.fedoraproject.org/rpms/python-rospkg#bodhi_updates) | [python3-rospkg](https://src.fedoraproject.org/rpms/python-rospkg#bodhi_updates) |

CentOS 7:
```
$ yum list -q --available --showduplicates --exclude='*.i686' python pycairo \
> python-coverage python2-defusedxml python2-empy python2-gnupg \
> python-netifaces python-nose opencv-python PyOpenGL python2-pydot \
> python2-pygraphviz python2-rosdep python2-rosdistro python-rosinstall \
> python2-rosinstall_generator python2-rospkg python-setuptools wxPython \
> python3-devel python36-catkin_pkg python36-coverage \
> python36-defusedxml python36-paramiko python36-rosdep python36-rospkg
Available Packages
PyOpenGL.noarch                                3.0.1-6.el7                 base
opencv-python.x86_64                           2.4.5-3.el7                 base
pycairo.x86_64                                 1.8.10-8.el7                base
python.x86_64                                  2.7.5-88.el7                base
python-coverage.x86_64                         3.6-0.5.b3.el7              base
python-netifaces.x86_64                        0.10.4-3.el7                base
python-nose.noarch                             1.3.7-1.el7                 base
python-rosinstall.noarch                       0.7.7-1.el7                 epel
python-setuptools.noarch                       0.9.8-7.el7                 base
python2-defusedxml.noarch                      0.5.0-2.el7                 epel
python2-empy.noarch                            3.3.3-2.el7                 epel
python2-gnupg.noarch                           0.4.3-1.el7                 epel
python2-pydot.noarch                           1.0.28-13.el7               epel
python2-pygraphviz.x86_64                      1.3-2.rc2.el7.2             epel
python2-rosdep.noarch                          0.17.1-1.el7                epel
python2-rosdistro.noarch                       0.7.5-1.el7                 epel
python2-rosinstall_generator.noarch            0.1.18-1.el7                epel
python2-rospkg.noarch                          1.1.10-1.el7                epel
python3-devel.x86_64                           3.6.8-13.el7                base
python36-catkin_pkg.noarch                     0.4.14-1.el7                epel
python36-coverage.x86_64                       4.0.3-5.el7                 epel
python36-defusedxml.noarch                     0.5.0-2.el7                 epel
python36-paramiko.noarch                       2.1.1-0.10.el7              epel
python36-rosdep.noarch                         0.17.1-1.el7                epel
python36-rospkg.noarch                         1.1.10-1.el7                epel
wxPython.x86_64                                2.8.12.0-9.el7              epel
```

CentOS 8:
```
dnf list -q --available --showduplicates --exclude='*.i686' python2 \
> python2-cairo python2-coverage python2-nose python2-setuptools \
> python36-devel python3-catkin_pkg python3-coverage python3-defusedxml \
> python3-paramiko python3-rosdep python3-rospkg
Available Packages
python2.x86_64               2.7.16-12.module_el8.1.0+219+cf9e6ac9    AppStream
python2-cairo.x86_64         1.16.3-6.module_el8.0.0+36+bb6a76a2      AppStream
python2-coverage.x86_64      4.5.1-4.module_el8.1.0+219+cf9e6ac9      AppStream
python2-nose.noarch          1.3.7-30.module_el8.1.0+219+cf9e6ac9     AppStream
python2-setuptools.noarch    39.0.1-11.module_el8.1.0+219+cf9e6ac9    AppStream
python3-catkin_pkg.noarch    0.4.14-1.el8                             epel     
python3-coverage.x86_64      4.5.1-7.el8                              AppStream
python3-defusedxml.noarch    0.6.0-1.el8                              epel     
python3-paramiko.noarch      2.4.3-1.el8                              epel     
python3-rosdep.noarch        0.17.1-1.el8                             epel     
python3-rospkg.noarch        1.1.10-1.el8                             epel     
python36-devel.x86_64        3.6.8-2.module_el8.1.0+245+c39af44f      AppStream
```