### PR TITLE
Add several RHEL base rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1340,6 +1340,7 @@ hddtemp:
   macports: [python27]
   openembedded: [hddtemp@meta-oe]
   opensuse: [hddtemp]
+  rhel: [hddtemp]
   slackware: [hddtemp]
   ubuntu: [hddtemp]
 hdf5:
@@ -1647,6 +1648,7 @@ libboost-atomic-dev:
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
   ubuntu: [libboost-atomic-dev]
 libboost-chrono:
   debian:
@@ -1663,6 +1665,7 @@ libboost-chrono-dev:
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
   ubuntu: [libboost-chrono-dev]
 libboost-date-time:
   debian:
@@ -1679,6 +1682,7 @@ libboost-date-time-dev:
   debian: [libboost-date-time-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
   ubuntu: [libboost-date-time-dev]
 libboost-dev:
   debian: [libboost-dev]
@@ -1700,6 +1704,7 @@ libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
   fedora: [boost-devel]
   gentoo: ['dev-libs/boost[python]']
+  rhel: [boost-devel]
   ubuntu: [libboost-filesystem-dev]
 libboost-iostreams:
   debian:
@@ -1716,6 +1721,7 @@ libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
   ubuntu: [libboost-iostreams-dev]
 libboost-program-options:
   debian:
@@ -1780,6 +1786,7 @@ libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
   ubuntu: [libboost-random-dev]
 libboost-regex:
   debian:
@@ -1796,6 +1803,7 @@ libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
   ubuntu: [libboost-regex-dev]
 libboost-system:
   debian:
@@ -1834,6 +1842,7 @@ libboost-thread-dev:
   debian: [libboost-thread-dev]
   fedora: [boost-devel]
   gentoo: ['dev-libs/boost[threads]']
+  rhel: [boost-devel]
   ubuntu: [libboost-thread-dev]
 libcairo2-dev:
   arch: [cairo]
@@ -3902,6 +3911,7 @@ liburdfdom-dev:
   gentoo: [dev-libs/urdfdom]
   openembedded: [urdfdom@meta-ros]
   opensuse: [urdfdom-devel]
+  rhel: [urdfdom-devel]
   slackware: [urdfdom]
   ubuntu: [liburdfdom-dev]
 liburdfdom-headers-dev:
@@ -3912,6 +3922,7 @@ liburdfdom-headers-dev:
   gentoo: [dev-libs/urdfdom_headers]
   openembedded: [urdfdom-headers@meta-ros]
   opensuse: [urdfdom-headers-devel]
+  rhel: [urdfdom-headers-devel]
   slackware: [urdfdom_headers]
   ubuntu: [liburdfdom-headers-dev]
 liburdfdom-tools:
@@ -4277,6 +4288,7 @@ libzstd-dev:
   debian: [libzstd-dev]
   fedora: [libzstd-devel]
   gentoo: [app-arch/zstd]
+  rhel: [libzstd-devel]
   ubuntu:
     '*': [libzstd-dev]
     xenial: [libzstd1-dev]
@@ -5274,6 +5286,7 @@ sbcl:
   gentoo: [dev-lisp/sbcl]
   macports: [sbcl]
   opensuse: [sbcl]
+  rhel: [sbcl]
   slackware: [sbcl]
   ubuntu: [sbcl]
 scons:


### PR DESCRIPTION
There aren't any official web databases for RHEL/CentOS packages, so I'll link to the packages sitting in the repository mirrors where appropriate.

| rosdep key | system package |
|------------|----------------|
| hddtemp | [hddtemp](https://src.fedoraproject.org/rpms/hddtemp#bodhi_updates) |
| libboost-atomic-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-chrono-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-date-time-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-filesystem-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-iostreams-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-random-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-regex-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| libboost-thread-dev | [boost-devel](http://mirror.centos.org/centos-7/7.7.1908/os/x86_64/Packages/boost-devel-1.53.0-27.el7.x86_64.rpm) |
| liburdfdom-dev | [urdfdom-devel](https://src.fedoraproject.org/rpms/urdfdom#bodhi_updates) |
| liburdfdom-headers-dev | [urdfdom-headers-devel](https://src.fedoraproject.org/rpms/urdfdom-headers#bodhi_updates) |
| libzstd-dev | [libzstd-devel](https://src.fedoraproject.org/rpms/zstd#bodhi_updates) |
| sbcl | [sbcl](https://src.fedoraproject.org/rpms/sbcl#bodhi_updates) |

```
$ yum list -q available --showduplicates --exclude='*.i686' hddtemp \
> boost-devel urdfdom-devel urdfdom-headers-devel libzstd-devel sbcl
Available Packages
boost-devel.x86_64                        1.53.0-28.el7                    base
hddtemp.x86_64                            0.3-0.31.beta15.el7              epel
libzstd-devel.x86_64                      1.4.4-1.el7                      epel
sbcl.x86_64                               1.4.0-1.el7                      epel
urdfdom-devel.x86_64                      0.3.0-5.el7                      epel
urdfdom-headers-devel.noarch              0.3.0-2.el7                      epel
```