### PR TITLE
rviz: 8.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1205,6 +1205,31 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: master
     status: developed
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: foxy
+    release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz-release.git
+      version: 8.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: foxy
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.0.0-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.5`
- previous version for package: `null`

## rviz2

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Made some code style changes. (#504 <https://github.com/ros2/rviz/issues/504>)
* Contributors: Dirk Thomas
```

## rviz_assimp_vendor

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Suppressed an upstream cmake warning in assimp. (#534 <https://github.com/ros2/rviz/issues/534>)
* Contributors: William Woodall
```

## rviz_common

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Removed duplicate include dirs and link libraries. (#533 <https://github.com/ros2/rviz/issues/533>)
* Added missing export of urdf. (#529 <https://github.com/ros2/rviz/issues/529>)
* Made changes to avoid newly deprecated functions in rclcpp. (#528 <https://github.com/ros2/rviz/issues/528>)
* Changed to use ``ament_export_targets()``. (#525 <https://github.com/ros2/rviz/issues/525>)
* Updated deprecated enums in rviz_common. (#510 <https://github.com/ros2/rviz/issues/510>)
* Solved a compiler warning in Ubuntu Focal. (#503 <https://github.com/ros2/rviz/issues/503>)
* Removed an uncessary call to render scene. (#490 <https://github.com/ros2/rviz/issues/490>)
* Made some code style changes. (#504 <https://github.com/ros2/rviz/issues/504>)
* Fixed a bug encountered when included as a sub-project. (#475 <https://github.com/ros2/rviz/issues/475>)
* Contributors: Dan Rose, Dirk Thomas, Ivan Santiago Paunovic, Jacob Perron, William Woodall, brawner
```

## rviz_default_plugins

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Removed duplicate include dirs and link libraries. (#533 <https://github.com/ros2/rviz/issues/533>)
* Updated includes to use non-entry point headers from detail subdir. (#526 <https://github.com/ros2/rviz/issues/526>)
* Changed to use ``ament_export_targets()``. (#525 <https://github.com/ros2/rviz/issues/525>)
* Changed to use the clock from the node in tools. (#519 <https://github.com/ros2/rviz/issues/519>)
* Changed to allow the MapDisplay "Update Topic" to be changed. (#517 <https://github.com/ros2/rviz/issues/517>)
  The major reason for this is so that the "Update Topic"
  (and more importantly the QoS profile) is saved when clicking
  "Save Config" in RViz2.  The more minor reason is that a user
  *might* want to use a different topic for this.  We still
  auto-populate this field with <topic_name>_updates by default,
  but the user can now override it.
* Made some code style changes. (#504 <https://github.com/ros2/rviz/issues/504>)
* Fixed camera info for camera display. (#419 <https://github.com/ros2/rviz/issues/419>)
* Fixed wrong resource group for robot links. (#495 <https://github.com/ros2/rviz/issues/495>)
* Changed default goal to ``goal_pose`` and not just in default rviz. (#491 <https://github.com/ros2/rviz/issues/491>)
* Fixed a bug by setting the clock type if Marker ``frame_locked`` is true. (#482 <https://github.com/ros2/rviz/issues/482>)
  Fixes #479 <https://github.com/ros2/rviz/issues/479>
* Fixed the map display for moving TF frame. (#483 <https://github.com/ros2/rviz/issues/483>)
  Instead of the current time, use Time(0) to get the latest available transform as a fallback.
  This is the same logic that is applied in RViz from ROS 1.
  Resolves #332 <https://github.com/ros2/rviz/issues/332>
* Migrated pose with covariance display. (#471 <https://github.com/ros2/rviz/issues/471>)
* Fixed build when included as a sub-project. (#475 <https://github.com/ros2/rviz/issues/475>)
* Added icon copyrights + PoseWithCovariance icon. (#430 <https://github.com/ros2/rviz/issues/430>)
* Contributors: Chris Lalancette, Dan Rose, Dirk Thomas, Jacob Perron, Martin Idel, Michel Hidalgo, Steven Macenski, chapulina
```

## rviz_ogre_vendor

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Switched to the CMake Patch module. (#509 <https://github.com/ros2/rviz/issues/509>)
* Contributors: Dan Rose, Mikael Arguedas
```

## rviz_rendering

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Removed duplicate include dirs and link libraries. (#533 <https://github.com/ros2/rviz/issues/533>)
* Changed to use ``ament_export_targets()``. (#525 <https://github.com/ros2/rviz/issues/525>)
* Made some code style changes. (#504 <https://github.com/ros2/rviz/issues/504>)
* Migrated the pose with covariance display. (#471 <https://github.com/ros2/rviz/issues/471>)
* Fixed the build when included as a sub-project. (#475 <https://github.com/ros2/rviz/issues/475>)
* Contributors: Dan Rose, Dirk Thomas, Martin Idel
```

## rviz_rendering_tests

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Made some code style changes. (#504 <https://github.com/ros2/rviz/issues/504>)
* Fixed the build when included as a sub-project. (#475 <https://github.com/ros2/rviz/issues/475>)
* Contributors: Dan Rose, Dirk Thomas
```

## rviz_visual_testing_framework

```
* Note from wjwwood: I've chosen bump the major version this time, even though the API was not broken strictly speaking, partly because of some potentially disruptive build system changes and partially in preparation for ROS Foxy, to allow for new minor/patch versions in the previous ROS release Eloquent.
* Changed to use ``ament_export_targets()``. (#525 <https://github.com/ros2/rviz/issues/525>)
* Made some code style changes. (#504 <https://github.com/ros2/rviz/issues/504>)
* Changed to install RViz configs for visual tests. (#487 <https://github.com/ros2/rviz/issues/487>) (#498 <https://github.com/ros2/rviz/issues/498>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas
```
