### PR TITLE
geometric_shapes: 0.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3098,7 +3098,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.6.1-0
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.6.2-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.6.1-0`

## geometric_shapes

```
* [maint]   clang-tidy fixes in headers (#139 <https://github.com/ros-planning/geometric_shapes/issues/139>)
* [fix]     Various fixes + performance improvements (#109 <https://github.com/ros-planning/geometric_shapes/issues/109>, #126 <https://github.com/ros-planning/geometric_shapes/issues/126>, #107 <https://github.com/ros-planning/geometric_shapes/issues/107>, #108 <https://github.com/ros-planning/geometric_shapes/issues/108>)
  * Use Eigen::Isometry3d::linear() instead of rotation()
  * Normalize the direction vector passed to Body::intersectsRay() (#115 <https://github.com/ros-planning/geometric_shapes/issues/115>)
  * Improved test coverage
* [feature] Added support for non-uniform scaling and padding of shapes. (#103 <https://github.com/ros-planning/geometric_shapes/issues/103>)
* [maint]   Made bodies::samplePointInside() const. (#133 <https://github.com/ros-planning/geometric_shapes/issues/133>)
* [fix]     Throw runtime exception when a shape or body should have a negative dimension. (#106 <https://github.com/ros-planning/geometric_shapes/issues/106>)
* [maint]   Prefer std::make_shared (#116 <https://github.com/ros-planning/geometric_shapes/issues/116>)
* [maint]   clang-tidy fixes (#114 <https://github.com/ros-planning/geometric_shapes/issues/114>)
* [fix]     Use covariant returns for clone() (#102 <https://github.com/ros-planning/geometric_shapes/issues/102>)
* [feature] Added bodies::Body::computeBoundingBox (aligned box version). (#104 <https://github.com/ros-planning/geometric_shapes/issues/104>)
* [maint]   Windows compatibility: fix ASSIMP libraries path (#101 <https://github.com/ros-planning/geometric_shapes/issues/101>)
* [fix]     Body::containsPoint(): always include surface points (#97 <https://github.com/ros-planning/geometric_shapes/issues/97>)
* Contributors: Martin Pecka, Alejandro Hernández Cordero, Bryce Willey, Michael Görner, Mike Lautman, Robert Haschke, RoboticsYY, Sean Yen, Tyler Weaver
```
