### PR TITLE
jsk_common_msgs: 4.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -647,6 +647,28 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: noetic-devel
     status: maintained
+  jsk_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
+    release:
+      packages:
+      - jsk_common_msgs
+      - jsk_footstep_msgs
+      - jsk_gui_msgs
+      - jsk_hark_msgs
+      - posedetection_msgs
+      - speech_recognition_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_common_msgs-release.git
+      version: 4.3.2-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+      version: master
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common_msgs` to `4.3.2-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common_msgs
- release repository: https://github.com/tork-a/jsk_common_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## jsk_common_msgs

- No changes

## jsk_footstep_msgs

- No changes

## jsk_gui_msgs

- No changes

## jsk_hark_msgs

- No changes

## posedetection_msgs

```
* fix for noetic, need to use OpenCV2 instead of OpenCV (#26 <https://github.com/jsk-ros-pkg/jsk_common_msgs/issues/26>)
  
    * add noetic test to travis.yml, update jsk_travis 0.5.10
  
* Contributors: Kei Okada
```

## speech_recognition_msgs

- No changes
