### PR TITLE
rosdep: Added libopencv-imgproc-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2920,7 +2920,11 @@ libopencv-dev:
   rhel: [opencv-devel]
   ubuntu: [libopencv-dev]
 libopencv-imgproc-dev:
+  arch: [opencv]
   debian: [libopencv-imgproc-dev]
+  fedora: [opencv-devel]
+  gentoo: [media-libs/opencv]
+  rhel: [opencv-devel]
   ubuntu: [libopencv-imgproc-dev]
 libopenexr-dev:
   arch: [openexr]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2919,6 +2919,9 @@ libopencv-dev:
   openembedded: [opencv@meta-oe]
   rhel: [opencv-devel]
   ubuntu: [libopencv-dev]
+libopencv-imgproc-dev:
+  debian: [libopencv-imgproc-dev]
+  ubuntu: [libopencv-imgproc-dev]
 libopenexr-dev:
   arch: [openexr]
   debian: [libopenexr-dev]


### PR DESCRIPTION
Added libopencv-imgproc-dev rosdep key for

-  [Debian](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libopencv-imgproc-dev)

-  [Ubuntu](https://packages.ubuntu.com/search?keywords=+libopencv-imgproc-dev&searchon=names&suite=all&section=all)

Not found for Fedora and Gentoo.