### PR TITLE
pilz_robots: 0.5.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7049,7 +7049,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.14-1
+      version: 0.5.15-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.15-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.5`
- previous version for package: `0.5.14-1`

## pilz_control

```
* Introduce goal_time_tolerance to PJTC function is_executing
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_status_indicator_rqt

- No changes

## pilz_testutils

```
* add timeout to AsyncTest::barricade()
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

```
* Fix coverage generation for pilz_utils
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Add support for starting the robot without modbus
* sto for hw definition is now called safety_hw everywhere
* Moved system_info_node to prbt_support
* Adopted default configuration for launchfiles
* Renaming of STO into RUN_PERMITTED
* Enable starting ROS without modbus connection
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* Use default hardware setup in moveit_planning_execution.launch
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

```
* Add support for starting the robot without modbus
* Rename argument enable_safety_interface to iso10218_support.
* Moved system_info_node here from prbt_hardware_support
* Adopted default configuration for launchfiles
* Add README
* Enable starting ROS without connecting to safety controller
* Contributors: Pilz GmbH and Co. KG
```
