### PR TITLE
rviz: 1.13.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10057,7 +10057,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.11-1
+      version: 1.13.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.12-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.5`
- previous version for package: `1.13.11-1`

## rviz

```
* [maint] clang-format (#1502 <https://github.com/ros-visualization/rviz/issues/1502>)
* [maint] Modernize python tests + examples
* [maint] Fix clang compiler warnings
* [maint] clang-tidy
* [maint] Require C++11
* Contributors: Robert Haschke
```
