### PR TITLE
plotjuggler: 2.7.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1460,6 +1460,21 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: dashing
     status: maintained
+  plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 2.7.0-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.7.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## plotjuggler

```
* Merge branch 'ros2' of https://github.com/facontidavide/PlotJuggler into ros2
* added github actions for ros2
* last fixes to DataStreamROS2
* implemented DataLoadRosBag2
* compile with ament/colcon
* Contributors: Davide Faconti
```
