### PR TITLE
rmw_dds_common: 0.1.0-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -868,7 +868,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 0.1.0-2
+      version: 0.1.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `0.1.0-3`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.0-2`

## rmw_dds_common

```
* Export targets in addition to include directories / libraries (#15 <https://github.com/ros2/rmw_dds_common/issues/15>)
* Increasing code coverage (#14 <https://github.com/ros2/rmw_dds_common/issues/14>)
* security-context -> enclave (#13 <https://github.com/ros2/rmw_dds_common/issues/13>)
* Make rmw_dds_common use rosidl_generator_interfaces normally (#12 <https://github.com/ros2/rmw_dds_common/issues/12>)
* Changed rosidl_generator_cpp with rosidl_runtime_cpp (#10 <https://github.com/ros2/rmw_dds_common/issues/10>)
* Fix windows warning (#7 <https://github.com/ros2/rmw_dds_common/issues/7>)
* First implementation (#4 <https://github.com/ros2/rmw_dds_common/issues/4>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Ivan Santiago Paunovic, Mikael Arguedas
```
