### PR TITLE
rcl_interfaces: 0.9.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -688,7 +688,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 0.9.0-1
+      version: 0.9.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `0.9.0-2`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-1`

## action_msgs

- No changes

## builtin_interfaces

- No changes

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

```
* Remove commented code line (#99 <https://github.com/ros2/rcl_interfaces/issues/99>)
* Remove unused IntraProcessMessage (#89 <https://github.com/ros2/rcl_interfaces/issues/89>)
* Contributors: Dirk Thomas, Stephen Brawner
```

## rosgraph_msgs

- No changes

## statistics_msgs

```
* Add new messages for topic statistics (#98 <https://github.com/ros2/rcl_interfaces/issues/98>)
* Contributors: Prajakta Gokhale
```

## test_msgs

```
* Remove unused local variable (#96 <https://github.com/ros2/rcl_interfaces/issues/96>)
* Contributors: Dirk Thomas
```
