### PR TITLE
common_interfaces: 0.9.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -183,7 +183,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 0.9.0-1
+      version: 0.9.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `0.9.0-2`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-1`
