### PR TITLE
example_interfaces: 0.8.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -277,7 +277,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.8.0-1
+      version: 0.8.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `example_interfaces` to `0.8.0-2`:

- upstream repository: https://github.com/ros2/example_interfaces.git
- release repository: https://github.com/ros2-gbp/example_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.0-1`
