### PR TITLE
neonavigation: 0.8.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5970,7 +5970,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.8.4-1
+      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.8.5-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.4-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

```
* Revert "Remove old workaround for debian stretch build (#473 <https://github.com/at-wat/neonavigation/issues/473>)" (#478 <https://github.com/at-wat/neonavigation/issues/478>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

```
* Revert "Remove old workaround for debian stretch build (#473 <https://github.com/at-wat/neonavigation/issues/473>)" (#478 <https://github.com/at-wat/neonavigation/issues/478>)
* Contributors: Atsushi Watanabe
```

## planner_cspace

- No changes

## safety_limiter

```
* Revert "Remove old workaround for debian stretch build (#473 <https://github.com/at-wat/neonavigation/issues/473>)" (#478 <https://github.com/at-wat/neonavigation/issues/478>)
* Contributors: Atsushi Watanabe
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
