### PR TITLE
geometry2: 0.13.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -376,7 +376,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.0-1
+      version: 0.13.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.0-2`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.13.0-1`

## examples_tf2_py

```
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Contributors: Dirk Thomas
```

## geometry2

```
* Uncommented tf2_bullet and tf2_tools (#260 <https://github.com/ros2/geometry2/issues/260>)
* Contributors: Alejandro Hernández Cordero
```

## tf2

```
* Added doxyfiles and sphinx Makefiles (#257 <https://github.com/ros2/geometry2/issues/257>)
* Fix displayTimePoint truncation error (#253 <https://github.com/ros2/geometry2/issues/253>)
* rename rosidl_generator_cpp namespace to rosidl_runtime_cpp (#248 <https://github.com/ros2/geometry2/issues/248>)
* Use the new rcutils_strerror function. (#239 <https://github.com/ros2/geometry2/issues/239>)
* Remove unnecessary semicolons. (#235 <https://github.com/ros2/geometry2/issues/235>)
* Export all tf2 dependencies. (#238 <https://github.com/ros2/geometry2/issues/238>)
* Fix a deprecated copy warning by implementing the assignment operator (#201 <https://github.com/ros2/geometry2/issues/201>)
* tf2 add windows cmath constants (#217 <https://github.com/ros2/geometry2/issues/217>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Dirk Thomas, Hunter L. Allen, Michel Hidalgo, brawner
```

## tf2_bullet

```
* Added doxyfiles and sphinx Makefiles (#257 <https://github.com/ros2/geometry2/issues/257>)
* Porting tf2_bullet to ros2 (#205 <https://github.com/ros2/geometry2/issues/205>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_eigen

```
* Added doxyfiles and sphinx Makefiles (#257 <https://github.com/ros2/geometry2/issues/257>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_geometry_msgs

```
* Added doxyfiles and sphinx Makefiles (#257 <https://github.com/ros2/geometry2/issues/257>)
* add missing test dependency (#256 <https://github.com/ros2/geometry2/issues/256>)
* use target_include_directories (#231 <https://github.com/ros2/geometry2/issues/231>)
* installed python tf2_geometry_msgs (#207 <https://github.com/ros2/geometry2/issues/207>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Karsten Knese
```

## tf2_kdl

```
* Added doxyfiles and sphinx Makefiles (#257 <https://github.com/ros2/geometry2/issues/257>)
* installed python tf2_kdl and ported tf2_kdl tests (#206 <https://github.com/ros2/geometry2/issues/206>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_msgs

```
* Added linter test to tf2_msgs (#209 <https://github.com/ros2/geometry2/issues/209>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_py

```
* Fix build error in Focal (#241 <https://github.com/ros2/geometry2/issues/241>)
* Style cleanup on tf2_py.cpp (#222 <https://github.com/ros2/geometry2/issues/222>)
* Contributors: Alejandro Hernández Cordero, Ivan Santiago Paunovic
```

## tf2_ros

```
* Added doxyfiles and sphinx Makefiles (#257 <https://github.com/ros2/geometry2/issues/257>)
* avoid more deprecations (#255 <https://github.com/ros2/geometry2/issues/255>)
* create_timer takes shared pointers (#251 <https://github.com/ros2/geometry2/issues/251>)
* Improve tf2_echo and tf2_monitor messages while waiting for data (#254 <https://github.com/ros2/geometry2/issues/254>)
* Add missing visibility header include (#246 <https://github.com/ros2/geometry2/issues/246>)
* Fix -Wrange-loop-construct (#245 <https://github.com/ros2/geometry2/issues/245>)
  ```
  --- stderr: tf2_ros
  /opt/ros/master/src/ros2/geometry2/tf2_ros/test/test_buffer.cpp:84:21: warning: loop variable 'elem' creates a copy from type 'const std::pair<const unsigned long, std::function<void (const unsigned long &)> >' [-Wrange-loop-construct]
  for (const auto elem : timer_to_callback_map\_) {
  ^
  /opt/ros/master/src/ros2/geometry2/tf2_ros/test/test_buffer.cpp:84:10: note: use reference type 'const std::pair<const unsigned long, std::function<void (const unsigned long &)> > &' to prevent copying
  for (const auto elem : timer_to_callback_map\_) {
  ^~~~~~~~~~~~~~~~~
  &
  1 warning generated.
  ---
  ```
* Remove TODO (#234 <https://github.com/ros2/geometry2/issues/234>)
  The TODO is done; The publisher is using QoS durability setting 'transient local' which is the closest thing to the 'latched' concept in ROS 1.
  Signed-off-by: Jacob Perron <mailto:jacob@openrobotics.org>
* Remove virtual keyword from overridden functions (#214 <https://github.com/ros2/geometry2/issues/214>)
  Signed-off-by: Hunter L. Allen <mailto:hunterlallen@protonmail.com>
* message filter fix (#216 <https://github.com/ros2/geometry2/issues/216>)
  * Fixed meesage_filter add method
  * removed using builtin_interfaces::msg::Time in tf2_ros
* Porting more tests to tf2_ros (#202 <https://github.com/ros2/geometry2/issues/202>)
  * Added more tests to tf2_ros
  * improving tf2_ros time_reset_test
  * tf2_ros fixed failed test_buffer_client.cpp
  * added some EXPECT to listener unittest
  * reviews
  * Update listener_unittest.cpp
  * fixed tf2_ros time_reset_test
  * tf2_ros removed ROS launch files
  * Added TODO to fix test_buffer_client in CI
  * tf2_ros added feedback
* Add static transform component (#182 <https://github.com/ros2/geometry2/issues/182>)
  * Create a static transform component for composition
  Signed-off-by: Hunter L. Allen <mailto:hunterlallen@protonmail.com>
  * Suffix node name with randomly generated alpha-numeric string
  Signed-off-by: Hunter L. Allen <mailto:hunterlallen@protonmail.com>
  * Fix windows build
  Signed-off-by: Hunter L. Allen <mailto:hunterlallen@protonmail.com>
  * Switch to much more readable and more performant implementation by @clalancette
  Signed-off-by: Hunter L. Allen <mailto:hunterlallen@protonmail.com>
* Adding support for view_frame (#192 <https://github.com/ros2/geometry2/issues/192>)
  * Adding tf2_tools support for view_frames
  * Changelog
  * tf2_tools 0.12.1 package version
  * tf2_tools common linters
  * tf2_tools changelog Forthcoming
  * tf2_tools log error and destroy client and node when a exception raised
  * tf2_tools 0.12.4 package version
  * tf2_tools revert some changes
  * tf2_tools - reduce changes
  * tf2_tools: finally block and passing the time instead of the node
  * tf2_tools: buffer with less arguments
  * tf2_tools: Fix condition
* Contributors: Alejandro Hernández Cordero, Dan Rose, Hunter L. Allen, Jacob Perron, Karsten Knese, Shane Loretz, William Woodall
```

## tf2_sensor_msgs

```
* use target_include_directories (#231 <https://github.com/ros2/geometry2/issues/231>)
* Export tf2_sensor_msgs package dependency on Eigen3. (#211 <https://github.com/ros2/geometry2/issues/211>)
* Contributors: Karsten Knese, Michel Hidalgo
```

## tf2_tools

```
* Added doxyfiles and sphinx Makefiles (#257 <https://github.com/ros2/geometry2/issues/257>)
* tf2_tools update the shebang line (#226 <https://github.com/ros2/geometry2/issues/226>)
* Adding support for view_frame (#192 <https://github.com/ros2/geometry2/issues/192>)
* Contributors: Alejandro Hernández Cordero
```
