### PR TITLE
demos: 0.9.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -246,7 +246,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.9.0-1
+      version: 0.9.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.9.0-2`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

```
* Replace deprecated launch_ros usage (#437 <https://github.com/ros2/demos/issues/437>)
* Update launch_ros action usage (#431 <https://github.com/ros2/demos/issues/431>)
* code style only: wrap after open parenthesis if not in one line (#429 <https://github.com/ros2/demos/issues/429>)
* Contributors: Dirk Thomas, Jacob Perron
```

## demo_nodes_cpp

```
* avoid new deprecations (#442 <https://github.com/ros2/demos/issues/442>)
* use serialized message (#441 <https://github.com/ros2/demos/issues/441>)
* Replace deprecated launch_ros usage (#437 <https://github.com/ros2/demos/issues/437>)
* code style only: wrap after open parenthesis if not in one line (#429 <https://github.com/ros2/demos/issues/429>)
* Use spin_until_future_complete instead of spin_some in parameters_event demo (#427 <https://github.com/ros2/demos/issues/427>)
* change the logging demo test for updated console format (#421 <https://github.com/ros2/demos/issues/421>)
* [demo_nodes_cpp]  Add XML launch demos (#419 <https://github.com/ros2/demos/issues/419>)
* Contributors: Dirk Thomas, Ivan Santiago Paunovic, Jacob Perron, Karsten Knese, Steven Macenski, William Woodall, Yutaka Kondo
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Contributors: Dirk Thomas
```

## dummy_map_server

- No changes

## dummy_robot_bringup

```
* Add XML and YAML launch scripts for dummy_robot_bringup (#440 <https://github.com/ros2/demos/issues/440>)
* Switch dummy_robot_bringup to use parameter for rsp. (#426 <https://github.com/ros2/demos/issues/426>)
* Switch back to robot_state_publisher for the node name.
* Switch dummy_robot_bringup to use parameter for rsp.
* Contributors: Chris Lalancette, Jacob Perron, p-vega
```

## dummy_sensors

- No changes

## image_tools

```
* Replace deprecated launch_ros usage (#437 <https://github.com/ros2/demos/issues/437>)
* Fix frame_id  (#433 <https://github.com/ros2/demos/issues/433>)
* Update launch_ros action usage (#431 <https://github.com/ros2/demos/issues/431>)
* code style only: wrap after open parenthesis if not in one line (#429 <https://github.com/ros2/demos/issues/429>)
* Contributors: Dirk Thomas, Gonzo, Jacob Perron
```

## intra_process_demo

```
* Fix pendulum_control tests to use stdout stream. (#430 <https://github.com/ros2/demos/issues/430>)
* Contributors: Chris Lalancette
```

## lifecycle

```
* Replace deprecated launch_ros usage (#437 <https://github.com/ros2/demos/issues/437>)
* Update launch_ros action usage (#431 <https://github.com/ros2/demos/issues/431>)
* code style only: wrap after open parenthesis if not in one line (#429 <https://github.com/ros2/demos/issues/429>)
* Contributors: Dirk Thomas, Jacob Perron
```

## logging_demo

```
* Set logging format in tests to avoid drift when defaults change. (#420 <https://github.com/ros2/demos/issues/420>)
* Contributors: Steven! Ragnarök
```

## pendulum_control

```
* avoid new deprecations (#442 <https://github.com/ros2/demos/issues/442>)
* fix CMake warning about using uninitialized variables (#439 <https://github.com/ros2/demos/issues/439>)
* Fix pendulum_control tests to use stdout stream. (#430 <https://github.com/ros2/demos/issues/430>)
* code style only: wrap after open parenthesis if not in one line (#429 <https://github.com/ros2/demos/issues/429>)
* Contributors: Chris Lalancette, Dirk Thomas, William Woodall
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Demo to show the working of the incompatible_qos event callbacks. (#416 <https://github.com/ros2/demos/issues/416>)
* code style only: wrap after open parenthesis if not in one line (#429 <https://github.com/ros2/demos/issues/429>)
* Contributors: Dirk Thomas, Jaison Titus
```

## quality_of_service_demo_py

```
* Demo to show the working of the incompatible_qos event callbacks. (#416 <https://github.com/ros2/demos/issues/416>)
* Use imperative mood in docstring. (#422 <https://github.com/ros2/demos/issues/422>)
* Contributors: Jaison Titus, Steven! Ragnarök
```

## topic_monitor

```
* more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* Contributors: Dirk Thomas
```
