### PR TITLE
navigation_msgs: 2.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -559,7 +559,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.0.2-1
+      version: 2.0.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `2.0.2-2`:

- upstream repository: https://github.com/ros-planning/navigation_msgs
- release repository: https://github.com/ros2-gbp/navigation_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.2-1`

## map_msgs

- No changes

## move_base_msgs

```
* port move_base_msgs to ROS2 actions (#10 <https://github.com/ros-planning/navigation_msgs/issues/10>)
* Contributors: Steven Macenski
```
