### PR TITLE
Add python3-prometheus-client rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5667,6 +5667,9 @@ python3-pkg-resources:
   openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
+python3-prometheus-client:
+  debian: [python3-prometheus-client]
+  ubuntu: [python3-prometheus-client]
 python3-psutil:
   alpine: [py3-psutil]
   arch: [python-psutil]


### PR DESCRIPTION
Using in a robot application to report battery percentage to a Prometheus database as part of a monitoring solution for a robot's main compute.

Ubuntu: https://packages.ubuntu.com/focal/python3-prometheus-client
Debian: https://packages.debian.org/buster/python3-prometheus-client
Not available in Fedora/RedHat

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>