### PR TITLE
code_coverage: 0.4.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1966,7 +1966,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mikeferguson/code_coverage-gbp.git
-      version: 0.4.0-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/code_coverage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.4.2-1`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.0-1`

## code_coverage

```
* Add option for specifying extra flags to genhtml (#20 <https://github.com/mikeferguson/code_coverage/issues/20>)
  This modification allows you to add flags to the genhtml step so that you can do things like output the lcov report with demangled C++ function names, e.g.:
  catkin_make -DGENHTML_EXTRA_FLAGS="--demangle-cpp" -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug test1_coverage_report
* Add catkin_make build step in usage example (#19 <https://github.com/mikeferguson/code_coverage/issues/19>)
* bump cmake version for noetic
* Contributors: Immanuel Martini, Michael Ferguson, mschickler
```
