### PR TITLE
Add rosdep Python 3 keys for scikit-learn (sklearn) and tqdm

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5765,6 +5765,14 @@ python3-sip:
   fedora: [python3-sip]
   gentoo: [dev-python/sip]
   ubuntu: [python3-sip-dev]
+python3-sklearn:
+  debian: [python3-sklearn]
+  fedora: [python3-scikit-learn]
+  gentoo: [sci-libs/scikits_learn]
+  osx:
+    pip:
+      packages: [scikit-learn]
+  ubuntu: [python3-sklearn]
 python3-sphinx:
   debian: [python3-sphinx]
   ubuntu: [python3-sphinx]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5819,17 +5819,14 @@ python3-tornado:
   ubuntu: [python3-tornado]
 python3-tqdm:
   alpine: [py3-tqdm]
-  debian:
-    stretch: [python3-tqdm]
+  debian: [python3-tqdm]
   fedora: [python3-tqdm]
   osx:
     pip:
       packages: [tqdm]
   ubuntu:
-    bionic: [python3-tqdm]
-    eoan: [python3-tqdm]
-    focal: [python3-tqdm]
-    groovy: [python3-tqdm]
+    '*': [python3-tqdm]
+    xenial: null
 python3-triangle-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5817,6 +5817,19 @@ python3-tornado:
       packages: [tornado]
   rhel: ['python%{python3_pkgversion}-tornado']
   ubuntu: [python3-tornado]
+python3-tqdm:
+  alpine: [py3-tqdm]
+  debian:
+    stretch: [python3-tqdm]
+  fedora: [python3-tqdm]
+  osx:
+    pip:
+      packages: [tqdm]
+  ubuntu:
+    bionic: [python3-tqdm]
+    eoan: [python3-tqdm]
+    focal: [python3-tqdm]
+    groovy: [python3-tqdm]
 python3-triangle-pip:
   debian:
     pip:


### PR DESCRIPTION
1. scikit-learn
Package names taken from the official installation instructions (https://scikit-learn.org/stable/install.html)

2. tqdm
Alpine: https://pkgs.alpinelinux.org/packages?name=py3-tqdm
Debian: https://packages.debian.org/stretch/python3-tqdm
Fedora: https://fedora.pkgs.org/30/fedora-x86_64/python3-tqdm-4.28.1-3.fc30.noarch.rpm.html
Ubuntu: https://packages.ubuntu.com/search?keywords=python3-tqdm
PyPi: https://pypi.org/project/tqdm


 