### PR TITLE
ros2_tracing: 1.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -946,15 +946,22 @@ repositories:
       version: ros2
     status: maintained
   ros2_tracing:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: foxy
     release:
       packages:
+      - ros2trace
       - tracetools
+      - tracetools_launch
       - tracetools_read
+      - tracetools_test
       - tracetools_trace
       tags:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `1.0.0-2`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.0-1`

## tracetools

```
* Export -rdynamic using ament_export_link_flags and modern CMake
* Contributors: Christophe Bedard, Dirk Thomas
```

## tracetools_launch

```
* Document what kind of lib_name LdPreload expects
* Add logs for LdPreload action on success or failure
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Add test_depend on python3-pytest-cov for tracetools_test
* Call ament_add_pytest_test only once for tracetools_test
* Move test_utils from tracetools to tracetools_test
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Start a session daemon if there isn't one before setting up tracing
* Contributors: Christophe Bedard
```
