### PR TITLE
python_qt_binding: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -649,6 +649,22 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: master
     status: developed
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/python_qt_binding-release.git
+      version: 1.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    status: maintained
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.4-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## python_qt_binding

```
* remove obsolete function used for backward compatibility (#88 <https://github.com/ros-visualization/python_qt_binding/issues/88>)
* disable Shiboken with CMake < 3.14 (#87 <https://github.com/ros-visualization/python_qt_binding/issues/87>)
* fix case of CMake function (#86 <https://github.com/ros-visualization/python_qt_binding/issues/86>)
* restore QUIET which was reverted in #79 <https://github.com/ros-visualization/python_qt_binding/issues/79>
* use PySide2 and Shiboken2 targets for variables (#79 <https://github.com/ros-visualization/python_qt_binding/issues/79>)
* Contributors: Dirk Thomas, Hermann von Kleist
```
