### PR TITLE
qt_gui_core: 1.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -665,6 +665,29 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: crystal-devel
     status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/qt_gui_core-release.git
+      version: 1.0.8-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: crystal-devel
+    status: maintained
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.0.8-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## qt_dotgraph

```
* please flake8 (#207 <https://github.com/ros-visualization/qt_gui_core/issues/207>)
* use the portable way to decide the line break (#200 <https://github.com/ros-visualization/qt_gui_core/issues/200>)
* make tests more flexible in terms of whitespaces (#191 <https://github.com/ros-visualization/qt_gui_core/issues/191>, #193 <https://github.com/ros-visualization/qt_gui_core/issues/193>)
* Contributors: Dirk Thomas, Ivan Santiago Paunovic, Sean Yen
```

## qt_gui

```
* qt_gui: use native default icon theme if suitable (#202 <https://github.com/ros-visualization/qt_gui_core/issues/202>)
* fix title bar buttons rendering on macOS (#205 <https://github.com/ros-visualization/qt_gui_core/issues/205>)
* fix platform check for macOS in themeSearchPaths patching (#204 <https://github.com/ros-visualization/qt_gui_core/issues/204>)
* auto adjust main window if standalone (#199 <https://github.com/ros-visualization/qt_gui_core/issues/199>)
* Contributors: Alexander Gutenkunst, Anton Matosov, Max Schwarz
```

## qt_gui_app

- No changes

## qt_gui_cpp

```
* quiet upstream Qt5 warnings (#210 <https://github.com/ros-visualization/qt_gui_core/issues/210>)
* fix project name in log message (#208 <https://github.com/ros-visualization/qt_gui_core/issues/208>)
* fixed namespace in typesystem.xml (#201 <https://github.com/ros-visualization/qt_gui_core/issues/201>)
* Contributors: Dan Rose, Hermann von Kleist, Jacob Perron
```

## qt_gui_py_common

```
* fix CMake warning about using uninitialized variables (#215 <https://github.com/ros-visualization/qt_gui_core/issues/215>)
* Contributors: Dirk Thomas
```
