### PR TITLE
rqt: 1.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1269,6 +1269,28 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: master
     status: developed
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt-release.git
+      version: 1.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.0.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_gui

```
* allow definition of settings file (#216 <https://github.com/ros-visualization/rqt/issues/216>)
* Contributors: Alexander Gutenkunst
```

## rqt_gui_cpp

```
* avoid new deprecations (#225 <https://github.com/ros-visualization/rqt/issues/225>)
* replace deprecated usage of rclcpp::is_initialized() (#215 <https://github.com/ros-visualization/rqt/issues/215>)
* Contributors: Jacob Perron, William Woodall
```

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
