### PR TITLE
rmw_cyclonedds: 0.6.0-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -909,7 +909,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.6.0-2
+      version: 0.6.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.6.0-3`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.6.0-2`

## rmw_cyclonedds_cpp

```
* Fix how topic name should be when not using ros topic name conventions (#177 <https://github.com/ros2/rmw_cyclonedds/issues/177>)
* Initialize participant on first use and destroy participant after last node is destroyed (#176 <https://github.com/ros2/rmw_cyclonedds/issues/176>)
* Fix error message (#175 <https://github.com/ros2/rmw_cyclonedds/issues/175>)
  Only generate "Recompile with '-DENABLESECURITY=ON' error when
  ROS_SECURITY_STRATEGY="Enforce"
* Cast size_t to uint32_t explicitly (#171 <https://github.com/ros2/rmw_cyclonedds/issues/171>)
* Rename rosidl_message_bounds_t (#166 <https://github.com/ros2/rmw_cyclonedds/issues/166>)
* Add support for taking a sequence of messages (#148 <https://github.com/ros2/rmw_cyclonedds/issues/148>)
* Implement with_info version of take (#161 <https://github.com/ros2/rmw_cyclonedds/issues/161>)
* Fill in message_info timestamps (#163 <https://github.com/ros2/rmw_cyclonedds/issues/163>)
* Fix build warnings (#162 <https://github.com/ros2/rmw_cyclonedds/issues/162>)
* Switch to one participant per context model (#145 <https://github.com/ros2/rmw_cyclonedds/issues/145>)
* Fix serialization on non-32-bit, big-endian systems (#159 <https://github.com/ros2/rmw_cyclonedds/issues/159>)
* Correct fallthrough macro (#154 <https://github.com/ros2/rmw_cyclonedds/issues/154>)
* Register RMW output filters.
* Implement safer align_ function (#141 <https://github.com/ros2/rmw_cyclonedds/issues/141>)
* Make case fallthrough explicit (#153 <https://github.com/ros2/rmw_cyclonedds/issues/153>)
* Implement rmw_set_log_severity (#149 <https://github.com/ros2/rmw_cyclonedds/issues/149>)
* security-context -> enclave (#146 <https://github.com/ros2/rmw_cyclonedds/issues/146>)
* Rename rosidl_generator_c namespace to rosidl_runtime_c (#150 <https://github.com/ros2/rmw_cyclonedds/issues/150>)
* Added rosidl_runtime c and cpp dependencies (#138 <https://github.com/ros2/rmw_cyclonedds/issues/138>)
* Remove cyclonedds_cmake_module (#139 <https://github.com/ros2/rmw_cyclonedds/issues/139>)
* Enable use of DDS security (#123 <https://github.com/ros2/rmw_cyclonedds/issues/123>)
* Clean up package xml dependencies (#132 <https://github.com/ros2/rmw_cyclonedds/issues/132>)
* API changes to sync with one Participant per Context change in rmw_fastrtps (#106 <https://github.com/ros2/rmw_cyclonedds/issues/106>)
* Support for ON_REQUESTED_INCOMPATIBLE_QOS and ON_OFFERED_INCOMPATIBLE_QOS events (#125 <https://github.com/ros2/rmw_cyclonedds/issues/125>)
* Uncrustify (#124 <https://github.com/ros2/rmw_cyclonedds/issues/124>)
* Prevent undefined behavior when serializing empty vector (#122 <https://github.com/ros2/rmw_cyclonedds/issues/122>)
* Add rmw_*_event_init() functions (#115 <https://github.com/ros2/rmw_cyclonedds/issues/115>)
* Contributors: Alejandro Hernández Cordero, Dan Rose, Dirk Thomas, Erik Boasson, Ingo Lütkebohle, Ivan Santiago Paunovic, Karsten Knese, Miaofei Mei, Michael Carroll, Michel Hidalgo, Mikael Arguedas, Sid Faber, dodsonmg
```
