### PR TITLE
ros_ethercat_eml: 0.3.2-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8790,6 +8790,16 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: melodic
     status: maintained
+  ros_ethercat_eml:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/shadow-robot/ros_ethercat_eml-release.git
+      version: 0.3.2-5
+    source:
+      type: git
+      url: https://github.com/shadow-robot/ros_ethercat_eml.git
+      version: melodic-devel
   ros_monitoring_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ethercat_eml` to `0.3.2-5`:

- upstream repository: https://github.com/shadow-robot/ros_ethercat_eml.git
- release repository: https://github.com/shadow-robot/ros_ethercat_eml-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ros_ethercat_eml

```
* Cosmetic fix
* Remove License pdf to solve double license issue. Add disclaimer.
```
