### PR TITLE
jderobot_drones: 1.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4099,7 +4099,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.2-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.3.1-1`

## drone_wrapper

```
* New velocity control. Masks modified. The drone now keeps it position when velocities are zero.
* Added position control.
* Added mixed control.
* Take off modified: now is done by mixed control. Time to take off reduced. Take off height can be configurable.
* Added all args to script. Needed to pass arguments to exercises.
* Contributors: diegomrt, Pedro Arias
```

## jderobot_drones

```
* New version of drone_wrapper with controls improved.
* New version of rqt_drone_teleop with a new GUI.
* Contributors: diegomrt, Pedro Arias
```

## rqt_drone_teleop

```
* New GUI for rqt_drone_teleop plugin. Added position and velocity info.
* Contributors: diegomrt, Pedro Arias
```

## rqt_ground_robot_teleop

- No changes
