### PR TITLE
sros2: 0.9.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1328,6 +1328,25 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: master
     status: maintained
+  sros2:
+    doc:
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    release:
+      packages:
+      - sros2
+      - sros2_cmake
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/sros2-release.git
+      version: 0.9.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: master
+    status: developed
   test_interface_files:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.9.0-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## sros2

```
* Use matching validity dates for cert and permissions (#205 <https://github.com/ros2/sros2/issues/205>)
* permission signing should use permissions_ca (#204 <https://github.com/ros2/sros2/issues/204>)
* Rename keystore root env from ROS_SECURITY_ROOT_DIRECTORY to ROS_SECURITY_KEYSTORE (#200 <https://github.com/ros2/sros2/issues/200>)
* API cleanup
  * remove function leftover from old generation strategy (#207 <https://github.com/ros2/sros2/issues/207>)
  * remove distribute_key completely (#197 <https://github.com/ros2/sros2/issues/197>)
  * api: reorganize policy generation API (#196 <https://github.com/ros2/sros2/issues/196>)
  * api: reorganize artifact generation API (#195 <https://github.com/ros2/sros2/issues/195>)
  * api: reorganize key API (#192 <https://github.com/ros2/sros2/issues/192>)
  * api: reorganize permission API (#191 <https://github.com/ros2/sros2/issues/191>)
  * api: reorganize policy API (#190 <https://github.com/ros2/sros2/issues/190>)
  * api: reorganize keystore API (#188 <https://github.com/ros2/sros2/issues/188>)
* Security enclaves:
  * Use security contexts (#177 <https://github.com/ros2/sros2/issues/177>)
  * security-context -> enclave (#198 <https://github.com/ros2/sros2/issues/198>)
  * Update generate_policy verb for enclaves (#203 <https://github.com/ros2/sros2/issues/203>)
  * reenable test_generate_policy_no_policy_file (#206 <https://github.com/ros2/sros2/issues/206>)
* [ci] Add GitHub actions for linting and source-build CI (#178 <https://github.com/ros2/sros2/issues/178>)
* [test] use test_msgs instead of std message packages (#181 <https://github.com/ros2/sros2/issues/181>)
* [test] more verbose test_flake8 error messages (same as ros2/launch_ros#135 <https://github.com/ros2/launch_ros/issues/135>)
* [bookkeeping] Update maintainer to point to ros-security mailing list + fix package.xml (#179 <https://github.com/ros2/sros2/issues/179>)
* Symlink CA certs instead of copy (#176 <https://github.com/ros2/sros2/issues/176>)
* update from ros2cli API:
  * pass argv in add_arguments to add_subparsers_on_demand (#175 <https://github.com/ros2/sros2/issues/175>)
  * switch to not deprecated API (#174 <https://github.com/ros2/sros2/issues/174>)
  * Use ros2cli.node.NodeStrategy consistently. (#173 <https://github.com/ros2/sros2/issues/173>)
* Contributors: Dirk Thomas, Ivan Santiago Paunovic, Kyle Fazzari, Michel Hidalgo, Mikael Arguedas, Ruffin
```

## sros2_cmake

```
* Rename keystore root env from ROS_SECURITY_ROOT_DIRECTORY to ROS_SECURITY_KEYSTORE (#200 <https://github.com/ros2/sros2/issues/200>)
* Security enclaves:
  * security-context -> enclave (#198 <https://github.com/ros2/sros2/issues/198>)
  * Update sros2_cmake to use security contexts (#177 <https://github.com/ros2/sros2/issues/177>)
* Update maintainer to point to ros-security mailing list + fix package.xml (#179 <https://github.com/ros2/sros2/issues/179>)
* Contributors: Ivan Santiago Paunovic, Mikael Arguedas, Ruffin
```
