### PR TITLE
urdf: 2.3.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1459,7 +1459,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.3.0-2`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.0-1`

## urdf

```
* Export targets in a addition to include directories / libraries. (#10 <https://github.com/ros2/urdf/issues/10>)
* Force explicit language for uncrustify. (#9 <https://github.com/ros2/urdf/issues/9>)
* Code style only: wrap after open parenthesis if not in one line. (#8 <https://github.com/ros2/urdf/issues/8>)
* Contributors: Dirk Thomas
```
