### PR TITLE
rqt_console: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1291,6 +1291,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt.git
       version: crystal-devel
     status: maintained
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_console-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: dashing-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_console

```
* fix division in Python 3 (#18 <https://github.com/ros-visualization/rqt_console/issues/18>)
* fix highlight filter by message (#17 <https://github.com/ros-visualization/rqt_console/issues/17>)
* fix exclude messages (#11 <https://github.com/ros-visualization/rqt_console/issues/11>)
* add context menu for hiding and showing columns (#13 <https://github.com/ros-visualization/rqt_console/issues/13>)
* remove topics concept which has been removed in ROS 2 (#16 <https://github.com/ros-visualization/rqt_console/issues/16>)
* fix handle_pause_clicked doesn't need args (#15 <https://github.com/ros-visualization/rqt_console/issues/15>)
```
