### PR TITLE
kdl_parser: 2.3.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -422,7 +422,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `2.3.0-2`:

- upstream repository: https://github.com/ros2/kdl_parser.git
- release repository: https://github.com/ros2-gbp/kdl_parser-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.0-1`

## kdl_parser

```
* export targets in a addition to include directories / libraries (#6 <https://github.com/ros2/kdl_parser/issues/6>)
* code style only: wrap after open parenthesis if not in one line (#5 <https://github.com/ros2/kdl_parser/issues/5>)
* Contributors: Dirk Thomas
```
