### PR TITLE
rqt_plot: 1.0.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1306,6 +1306,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: dashing-devel
     status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_plot-release.git
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    status: maintained
   rqt_py_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.0.7-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_plot

```
* fix KeyError when curves are removed concurrently (#37 <https://github.com/ros-visualization/rqt_plot/issues/37>)
```
