### PR TITLE
rqt_topic: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1351,6 +1351,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: crystal-devel
     status: maintained
+  rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_topic-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: dashing-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_topic

```
* set qos_profile (#14 <https://github.com/ros-visualization/rqt_topic/issues/14>)
```
