### PR TITLE
rqt_graph: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1306,6 +1306,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: dashing-devel
     status: maintained
+  rqt_graph:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_graph-release.git
+      version: 1.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: crystal-devel
+    status: maintained
   rqt_plot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.0.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_graph

```
* skip removal of non-present tf connections (#40 <https://github.com/ros-visualization/rqt_graph/issues/40>)
```
