### PR TITLE
rqt_robot_steering: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1367,6 +1367,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: crystal-devel
     status: maintained
+  rqt_robot_steering:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    status: maintained
   rqt_service_caller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros2-gbp/rqt_robot_steering-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
