### PR TITLE
rqt_srv: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1427,6 +1427,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_shell.git
       version: crystal-devel
     status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_srv-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    status: maintained
   rqt_top:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_srv` to `1.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_srv.git
- release repository: https://github.com/ros2-gbp/rqt_srv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_srv

```
* Fixing CMakeLists.txt (#3 <https://github.com/ros-visualization/rqt_srv/issues/3>)
* Contributors: Mike Lautman
```
