### PR TITLE
rosdep: added python3-docutils

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5389,6 +5389,11 @@ python3-docker:
   rhel:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
+python3-docutils:
+  debian:
+    buster: [python3-docutils]
+  ubuntu:
+    focal: [python3-docutils]
 python3-empy:
   debian:
     buster: [python3-empy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5390,10 +5390,10 @@ python3-docker:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
 python3-docutils:
-  debian:
-    buster: [python3-docutils]
-  ubuntu:
-    focal: [python3-docutils]
+  arch: [python-docutils]
+  debian: [python3-docutils]
+  fedora: [python3-docutils]
+  ubuntu: [python3-docutils]
 python3-empy:
   debian:
     buster: [python3-empy]


### PR DESCRIPTION
Added python3-docutils dependency for
Debian buster:

https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=python3-docutils

Ubuntu focal:

https://packages.ubuntu.com/search?keywords=python3-docutils&searchon=names