### PR TITLE
ros_canopen: 0.8.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8622,7 +8622,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.8.3-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.2-1`

## can_msgs

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_402

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_chain_node

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_master

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_motor_node

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## ros_canopen

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## socketcan_bridge

```
* add includes to <memory>
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Mathias Lüdtke, ahcorde
```

## socketcan_interface

```
* Fixed Boost link in test-dispacher
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* do not print ERROR in candump
* Contributors: Mathias Lüdtke, ahcorde
```
