### PR TITLE
ros_canopen: 0.8.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1369,6 +1369,30 @@ repositories:
       url: https://github.com/ros/ros.git
       version: noetic-devel
     status: maintained
+  ros_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: melodic
+    release:
+      packages:
+      - can_msgs
+      - canopen_402
+      - canopen_chain_node
+      - canopen_master
+      - canopen_motor_node
+      - ros_canopen
+      - socketcan_bridge
+      - socketcan_interface
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_canopen-release.git
+      version: 0.8.3-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: melodic-devel
+    status: maintained
   ros_comm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.8.3-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## can_msgs

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_402

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_chain_node

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_master

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## canopen_motor_node

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## ros_canopen

```
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: ahcorde
```

## socketcan_bridge

```
* add includes to <memory>
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Mathias Lüdtke, ahcorde
```

## socketcan_interface

```
* Fixed Boost link in test-dispacher
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Bump CMake version to avoid CMP0048 warning
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* do not print ERROR in candump
* Contributors: Mathias Lüdtke, ahcorde
```
