### PR TITLE
Use Ogre 1.9 in Ubuntu Focal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2842,6 +2842,7 @@ libogre:
   ubuntu:
     artful: [libogre-1.9-dev]
     bionic: [libogre-1.9.0v5]
+    focal: [libogre-1.9.0v5]
     lucid: [libogre-dev]
     maverick: [libogre-dev]
     natty: [libogre-dev]
@@ -2873,6 +2874,7 @@ libogre-dev:
   ubuntu:
     artful: [libogre-1.9-dev]
     bionic: [libogre-1.9-dev]
+    focal: [libogre-1.9-dev]
     lucid: [libogre-dev]
     maverick: [libogre-dev]
     natty: [libogre-dev]


### PR DESCRIPTION
Alternative to https://github.com/ros/rosdistro/pull/24448

* https://packages.ubuntu.com/focal/libogre-1.9-dev
* https://packages.ubuntu.com/focal/libogre-1.9.0v5


Ping @wjwwood @simonschmeisser , look ok?
