### PR TITLE
stage: 4.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2129,6 +2129,17 @@ repositories:
       url: https://github.com/ros-planning/srdfdom.git
       version: noetic-devel
     status: maintained
+  stage:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/stage-release.git
+      version: 4.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-gbp/stage-release.git
+      version: release/noetic/stage
+    status: maintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage` to `4.3.0-1`:

- upstream repository: https://github.com/rtv/Stage.git
- release repository: https://github.com/ros-gbp/stage-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
