### PR TITLE
libyaml_vendor: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -524,7 +524,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-1`

## libyaml_vendor

```
* Quality declaration for external dependency libyaml (#14 <https://github.com/ros2/libyaml_vendor/issues/14>)
* Add missing Contributing.md file (#17 <https://github.com/ros2/libyaml_vendor/issues/17>)
* Export modern CMake interface target (#16 <https://github.com/ros2/libyaml_vendor/issues/16>)
* Contributors: Dirk Thomas, Jorge Perez
```
