### PR TITLE
stage_ros: 1.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2140,6 +2140,22 @@ repositories:
       url: https://github.com/ros-gbp/stage-release.git
       version: release/noetic/stage
     status: maintained
+  stage_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/stage_ros-release.git
+      version: 1.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-simulation/stage_ros.git
+      version: lunar-devel
+    status: unmaintained
   std_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stage_ros` to `1.8.0-1`:

- upstream repository: https://github.com/ros-simulation/stage_ros.git
- release repository: https://github.com/ros-gbp/stage_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## stage_ros

```
* Now uses Stage's native event loop properly and added reassuring startup output.
* Added a GUI section so that the world starts in a good place.
* Fixed issue such that ranger intensity values are no longer clipped to 256
  See: #31 <https://github.com/ros-simulation/stage_ros/issues/31>
* Contributors: Richard Vaughan, Shane Loretz, William Woodall, gerkey
```
