### PR TITLE
rviz: 8.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1505,7 +1505,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.0.0-2
+      version: 8.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.0.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `8.0.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Make rviz_assimp_vendor hack specific to Ubuntu Focal. (#536 <https://github.com/ros2/rviz/issues/536>)
  Signed-off-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: Chris Lalancette
```

## rviz_common

- No changes

## rviz_default_plugins

```
* Added dependency on ogre to fix building on the buildfarm (#544 <https://github.com/ros2/rviz/issues/544>)
* Refactored test fixtures to reduce memory usage while compiling (#540 <https://github.com/ros2/rviz/pull/540>)
* Contributors: Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
