### PR TITLE
Fix libvlc rosdep key in Ubuntu/Debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4001,7 +4001,6 @@ libv4l-dev:
 libvlc:
   debian:
     '*': [libvlc5, vlc-bin]
-    buster: [libvlc5, vlc-nox]
     jessie: [libvlc5, vlc-nox]
   fedora: [vlc-core]
   gentoo: [media-video/vlc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3999,10 +3999,22 @@ libv4l-dev:
       packages: [v4l-utils]
   ubuntu: [libv4l-dev]
 libvlc:
-  debian: [libvlc5, vlc-nox]
+  debian:
+    '*': [libvlc5, vlc-bin]
+    buster: [libvlc5, vlc-nox]
+    jessie: [libvlc5, vlc-nox]
   fedora: [vlc-core]
   gentoo: [media-video/vlc]
-  ubuntu: [libvlc5, vlc-nox]
+  ubuntu:
+    '*': [libvlc5, vlc-bin]
+    precise: [libvlc5, vlc-nox]
+    saucy: [libvlc5, vlc-nox]
+    trusty: [libvlc5, vlc-nox]
+    utopic: [libvlc5, vlc-nox]
+    vivid: [libvlc5, vlc-nox]
+    wily: [libvlc5, vlc-nox]
+    xenial: [libvlc5, vlc-nox]
+    yakkety: [libvlc5, vlc-nox]
 libvlc-dev:
   debian: [libvlc-dev]
   fedora: [libvlc-devel]


### PR DESCRIPTION
In Ubuntu Zesty and later and Debian Stretch and later, the `vlc-nox`
package has been deprecated and turned into a transitional dummy package
that cannot be installed.  It has been replaced by the `vlc-bin` package.
For reference:
- https://packages.ubuntu.com/zesty/allpackages
- https://packages.debian.org/stretch/vlc-nox

This updates the `libvlc` rosdep key to install the correct packages
in the appropriate versions of Ubuntu and Debian.

Signed-off-by: P. J. Reed <preed@swri.org>