### PR TITLE
rosbag2: 0.2.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1106,7 +1106,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.6-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.2.5-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Remove relative include paths in rosbag2_compression tests. (#405 <https://github.com/ros2/rosbag2/issues/405>)
* Contributors: Karsten Knese, Zachary Michaels
```

## rosbag2_converter_default_plugins

```
* Correct usage of rcpputils::SharedLibrary loading. (#400 <https://github.com/ros2/rosbag2/issues/400>)
* Contributors: Karsten Knese
```

## rosbag2_cpp

```
* Correct usage of rcpputils::SharedLibrary loading. (#400 <https://github.com/ros2/rosbag2/issues/400>)
* Contributors: Karsten Knese
```

## rosbag2_storage

```
* Correct usage of rclcpp::SharedLibrary loading. (#400 <https://github.com/ros2/rosbag2/issues/400>)
* Contributors: Karsten Knese
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* Correct usage of rcpputils::SharedLibrary loading. (#400 <https://github.com/ros2/rosbag2/issues/400>)
* Contributors: Karsten Knese
```

## rosbag2_transport

```
* Correct usage of rcpputils::SharedLibrary loading. (#400 <https://github.com/ros2/rosbag2/issues/400>)
* Contributors: Karsten Knese
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
