### PR TITLE
mcl_3dl: 0.2.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7179,7 +7179,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.2.4-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.3-1`

## mcl_3dl

```
* Fix resampling failure of last particle (#313 <https://github.com/at-wat/mcl_3dl/issues/313>)
* Retry gpg keyserver on prerelease test (#312 <https://github.com/at-wat/mcl_3dl/issues/312>)
* Add filter class for Vec3 (#311 <https://github.com/at-wat/mcl_3dl/issues/311>)
* Refactor math functions (#310 <https://github.com/at-wat/mcl_3dl/issues/310>)
* Fix deprecation warning (#309 <https://github.com/at-wat/mcl_3dl/issues/309>)
* Split parameter loader code (#307 <https://github.com/at-wat/mcl_3dl/issues/307>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```
