### PR TITLE
osrf_pycommon: 0.1.10-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -593,7 +593,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 0.1.9-1
+      version: 0.1.10-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `0.1.10-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.9-1`

## osrf_pycommon

```
* fixed simple deprecation warnings (issue #61 <https://github.com/osrf/osrf_pycommon/issues/61>) (#63 <https://github.com/osrf/osrf_pycommon/issues/63>)
* Also run tests with Python 3.7 and 3.8 (#60 <https://github.com/osrf/osrf_pycommon/issues/60>)
* Remove old py2 platforms, add Suite3 option with Ubuntu Focal (#58 <https://github.com/osrf/osrf_pycommon/issues/58>)
* Contributors: Shane Loretz, Zahi Kakish
```
