### PR TITLE
launch: 0.10.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -460,7 +460,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.10.0-1`

## launch

```
* removed deprecated loop parameter call (#387 <https://github.com/ros2/launch/issues/387>) (#410 <https://github.com/ros2/launch/issues/410>)
* Contributors: Zahi Kakish
```

## launch_testing

```
* fixed depcrecation warning of imp to importlib (issue #387 <https://github.com/ros2/launch/issues/387>) (#407 <https://github.com/ros2/launch/issues/407>)
* wait_for_ouput() repr includes actual text (#408 <https://github.com/ros2/launch/issues/408>)
* Contributors: Shane Loretz, Zahi Kakish
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
