### PR TITLE
rcpputils: 0.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -800,7 +800,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 0.3.0-2
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.0-2`

## rcpputils

```
* Fix Action CI by using released upload-artifact instead of master (#61 <https://github.com/ros2/rcpputils/issues/61>)
* Quality declaration (#47 <https://github.com/ros2/rcpputils/issues/47>)
* Contributors: Emerson Knapp, brawner
```
