### PR TITLE
gazebo_ros_pkgs: 2.5.20-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3922,7 +3922,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.5.19-1
+      version: 2.5.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.5.20-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.5.19-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Fix destructor of gazebo_ros_diff_drive.cpp (#1019 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1019>)
* Publish camera info in gazebo_ros_depth_camera plugin (#798 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/798>)
* Contributors: Ongun Kanat, RemiRigal
```

## gazebo_ros

```
* Add required parameter to empty_world nodes (#1074 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1074>)
* Reorder fields initialization to match initialization order in .h file (#987 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/987>)
  This change fixes -Wreorder warnings. More on -Wreorder:
  https://stackoverflow.com/questions/1828037/whats-the-point-of-g-wreorder
* Contributors: Mabel Zhang, aeneev
```

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
