### PR TITLE
gazebo_ros_pkgs: 3.4.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -777,7 +777,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.4.3-1
+      version: 3.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.4.4-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.4.3-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Backport Gazebo11/Bionic fix for boost variant (#1103 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1103>)
* Measure IMU orientation with respect to world (#1058 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1058>)
  Report the IMU orientation from the sensor plugin with respect to the world frame.
  This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html
  In order to not break existing behavior, users should opt-in by adding a new SDF tag.
* Contributors: Jose Luis Rivero, Steven Peters, Jacob Perron
```

## gazebo_ros

```
* wait for service with variable timeout (#1090 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1090>)
* Contributors: Karsten Knese, Louise Poubel
```

## gazebo_ros_pkgs

- No changes
