### PR TITLE
rqt_reconfigure: 0.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1935,6 +1935,11 @@ repositories:
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_reconfigure-release.git
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.5.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_reconfigure

```
* Fix node selection from command line (#77 <https://github.com/cottsay/rqt_reconfigure/issues/77>)
* Handle non-ASCII characters in log messages in Python 2 (#72 <https://github.com/cottsay/rqt_reconfigure/issues/72>)
* Don't process scroll events unless specifically focused (#73 <https://github.com/cottsay/rqt_reconfigure/issues/73>)
* Implement a custom YAML constructor for dyn_re Config (#74 <https://github.com/cottsay/rqt_reconfigure/issues/74>)
* Fix loopback propagation for sub-groups of 'apply' groups (#75 <https://github.com/cottsay/rqt_reconfigure/issues/75>)
* Update package build to support ROS Noetic (#70 <https://github.com/cottsay/rqt_reconfigure/issues/70>)
* Fix YAML dependency python version (#78 <https://github.com/cottsay/rqt_reconfigure/issues/78>)
* Add sorting for tabs (#62 <https://github.com/cottsay/rqt_reconfigure/issues/62>)
* Contributors: Alejandro Hernández Cordero, Flova, Scott K Logan
```
