### PR TITLE
ros2_intel_realsense: 2.0.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -984,6 +984,26 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: ros2
     status: maintained
+  ros2_intel_realsense:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: 2.0.8
+    release:
+      packages:
+      - realsense_examples
+      - realsense_msgs
+      - realsense_node
+      - realsense_ros
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
+      version: 2.0.8-1
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: 2.0.8
+    status: maintained
   ros2_tracing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_realsense` to `2.0.8-1`:

- upstream repository: https://github.com/intel/ros2_intel_realsense.git
- release repository: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
