### PR TITLE
rqt_virtual_joy: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9940,7 +9940,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/aquahika/rqt_virtual_joystick.git
-      version: 0.1.1
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -9950,7 +9950,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/aquahika/rqt_virtual_joystick.git
-      version: 0.1.0
+      version: melodic-devel
     status: maintained
   rqt_web:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9936,6 +9936,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: master
     status: maintained
+  rqt_virtual_joy:
+    doc:
+      type: git
+      url: https://github.com/aquahika/rqt_virtual_joystick.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aquahika/rqt_virtual_joystick-release.git
+      version: 0.1.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aquahika/rqt_virtual_joystick.git
+      version: 0.1.0
+    status: maintained
   rqt_web:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_virtual_joy` to `0.1.2-1`:

- upstream repository: https://github.com/aquahika/rqt_virtual_joystick.git
- release repository: https://github.com/aquahika/rqt_virtual_joystick-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_virtual_joy

```
* First Release
* Contributors: Hikaru Sugiura
```
