### PR TITLE
ros_control: 0.18.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8704,7 +8704,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.18.0-1
+      version: 0.18.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.18.1-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.18.0-1`

## combined_robot_hw

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* Contributors: Matt Reynolds
```

## combined_robot_hw_tests

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* Contributors: Matt Reynolds
```

## controller_interface

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* Contributors: Matt Reynolds
```

## controller_manager

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* Contributors: Matt Reynolds
```

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* Contributors: Matt Reynolds
```

## hardware_interface

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* [hardware_interface::RobotHW] doc: update read and write, fix: group names (#444 <https://github.com/ros-controls/ros_control/issues/444>)
* Contributors: Franz, Matt Reynolds
```

## joint_limits_interface

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* Contributors: Matt Reynolds
```

## ros_control

- No changes

## rqt_controller_manager

```
* Fix rqt displaying and handling of 'initialized' controllers (#450 <https://github.com/ros-controls/ros_control/issues/450>)
  This changes two minor behaviors:
  - Now shows 'initialized' controllers as red again
  - Now shows context menus for initialized controllers
  Fixes ros-controls/ros_control#445 <https://github.com/ros-controls/ros_control/issues/445>
* Contributors: RobertWilbrandt
```

## transmission_interface

```
* Add function specifiers and modernize constructors (#430 <https://github.com/ros-controls/ros_control/issues/430>)
  * Add override specifiers & default constructors
  * Delete ControllerBase copy & move ctors
  * Remove unnecessary default constructors
  * Modernize additional constructors
  * Revert ImuSensorHandle::Data::Data() = default
  * Remove unnecessary default overridden constructors
  * Remove semicolon after function body
* Contributors: Matt Reynolds
```
