### PR TITLE
euslime: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2371,11 +2371,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jsk-ros-pkg/euslime-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/euslime.git
       version: master
+    status: developed
   euslisp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslime` to `1.0.2-1`:

- upstream repository: https://github.com/jsk-ros-pkg/euslime.git
- release repository: https://github.com/jsk-ros-pkg/euslime-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-1`

## euslime

```
* Fix build according to catkin setup
* Contributors: Guilherme Affonso
```
