### PR TITLE
rosdep: Added graphicsmagick-libmagick-dev-compat

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1152,12 +1152,12 @@ gradle:
   ubuntu: [gradle]
 graphicsmagick:
   arch: [graphicsmagick]
-  debian: [libgraphicsmagick++1-dev]
+  debian: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
   fedora: [GraphicsMagick-c++-devel]
   gentoo: [virtual/imagemagick-tools]
   macports: [GraphicsMagick]
   rhel: [GraphicsMagick-c++-devel]
-  ubuntu: [libgraphicsmagick++1-dev]
+  ubuntu: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
 graphviz:
   arch: [graphviz]
   debian: [graphviz]


### PR DESCRIPTION
This package is needed for the find_package(ImageMagick COMPONENTS Magick++ REQUIRED) command to work without making a custom cmake file in cmake_modules.
The reference for FindImageMagick is here: https://cmake.org/cmake/help/v3.0/module/FindImageMagick.html
This package is available for:
Ubuntu: https://packages.ubuntu.com/bionic/graphicsmagick-libmagick-dev-compat
Debian: https://packages.debian.org/buster/graphicsmagick-libmagick-dev-compat

Did not find any correspondent package for the remaining OS.