### PR TITLE
rosauth: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1541,6 +1541,13 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: melodic-devel
     status: maintained
+  rosauth:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/gt-rail-release/rosauth-release.git
+      version: 1.0.1-1
+    status: maintained
   rosbag_migration_rule:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `1.0.1-1`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/gt-rail-release/rosauth-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rosauth

```
* Fix buffer overrun (#19 <https://github.com/GT-RAIL/rosauth/issues/19>)
* enable Windows build (#25 <https://github.com/GT-RAIL/rosauth/issues/25>)
* Contributors: Atsushi Watanabe, James Xu
```
