### PR TITLE
Fix a few Fedora rules, add a missing one

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2340,7 +2340,7 @@ libglib-dev:
 libglm-dev:
   arch: [glm]
   debian: [libglm-dev]
-  fedora: [glm]
+  fedora: [glm-devel]
   gentoo: [media-libs/glm]
   rhel: [glm-devel]
   ubuntu: [libglm-dev]
@@ -2676,7 +2676,7 @@ liblinphone-dev:
 liblttng-ust-dev:
   arch: [lttng-ust]
   debian: [liblttng-ust-dev]
-  fedora: [lttng-ust]
+  fedora: [lttng-ust-devel]
   gentoo: [dev-util/lttng-ust]
   rhel: [lttng-ust-devel]
   ubuntu: [liblttng-ust-dev]
@@ -4874,6 +4874,7 @@ osmium:
   ubuntu: [libosmium-dev]
 pandoc:
   debian: [pandoc]
+  fedora: [pandoc]
   gentoo: [app-text/pandoc]
   rhel: [pandoc]
   ubuntu: [pandoc]
@@ -5439,7 +5440,7 @@ smbclient:
 snappy:
   arch: [snappy]
   debian: [libsnappy-dev]
-  fedora: [snappy]
+  fedora: [snappy-devel]
   gentoo: [app-arch/snappy]
   rhel: [snappy-devel]
   ubuntu: [libsnappy-dev]


### PR DESCRIPTION
These changes were all suggested by @sloretz in #24539

- glm: https://src.fedoraproject.org/rpms/glm#bodhi_updates
- lttng-ust: https://src.fedoraproject.org/rpms/lttng-ust#bodhi_updates
- pandoc: https://src.fedoraproject.org/rpms/pandoc#bodhi_updates
- snappy: https://src.fedoraproject.org/rpms/snappy#bodhi_updates

```
$ dnf list -q --exclude='*.i686' glm-devel lttng-ust-devel pandoc snappy-devel
Available Packages
glm-devel.noarch                        0.9.9.6-3.fc32                  updates
lttng-ust-devel.x86_64                  2.11.0-4.fc32                   fedora 
pandoc.x86_64                           2.7.3-3.fc32                    fedora 
snappy-devel.x86_64                     1.1.8-2.fc32                    fedora
```