### PR TITLE
angles: 1.12.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -145,6 +145,22 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/angles-release.git
+      version: 1.12.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.12.3-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## angles

```
* Update the angle normalization function to a simpler implementation (#19 <https://github.com/ros/angles/issues/19>) (#21 <https://github.com/ros/angles/issues/21>)
  * Update the angle normalization function for a simpler alternative
  * Simplify 2*pi angle wrapping.
  * Simplify/fasten the C++ implementation of angle normalization (removes one fmod call)
* Contributors: Alexis Paques
```
