### PR TITLE
neonavigation_rviz_plugins: 0.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8488,7 +8488,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
-      version: 0.3.0-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_rviz_plugins` to `0.3.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation_rviz_plugins.git
- release repository: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.0-0`

## neonavigation_rviz_plugins

- No changes

## trajectory_tracker_rviz_plugins

```
* Drop ROS Indigo and Ubuntu Trusty support (#6 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/6>)
* Update license information (#5 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/5>)
* Contributors: Atsushi Watanabe
```
