### PR TITLE
neonavigation_rviz_plugins: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6011,7 +6011,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
-      version: 0.3.0-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_rviz_plugins` to `0.3.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation_rviz_plugins.git
- release repository: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.0-0`

## neonavigation_rviz_plugins

- No changes

## trajectory_tracker_rviz_plugins

```
* Drop ROS Indigo and Ubuntu Trusty support (#6 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/6>)
* Update license information (#5 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/5>)
* Contributors: Atsushi Watanabe
```
