### PR TITLE
neonavigation_rviz_plugins: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -966,6 +966,24 @@ repositories:
       url: https://github.com/at-wat/neonavigation_msgs.git
       version: master
     status: developed
+  neonavigation_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/at-wat/neonavigation_rviz_plugins.git
+      version: master
+    release:
+      packages:
+      - neonavigation_rviz_plugins
+      - trajectory_tracker_rviz_plugins
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/at-wat/neonavigation_rviz_plugins.git
+      version: master
+    status: developed
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation_rviz_plugins` to `0.3.1-1`:

- upstream repository: https://github.com/at-wat/neonavigation_rviz_plugins.git
- release repository: https://github.com/at-wat/neonavigation_rviz_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## neonavigation_rviz_plugins

- No changes

## trajectory_tracker_rviz_plugins

```
* Drop ROS Indigo and Ubuntu Trusty support (#6 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/6>)
* Update license information (#5 <https://github.com/at-wat/neonavigation_rviz_plugins/issues/5>)
* Contributors: Atsushi Watanabe
```
