### PR TITLE
joystick_drivers: 2.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -413,6 +413,26 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: ros2
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    release:
+      packages:
+      - joy
+      - joy_linux
+      - sdl2_vendor
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/joystick_drivers-release.git
+      version: 2.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    status: maintained
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `2.4.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## joy

```
* Cross platform joystick support for ROS 2 (#157 <https://github.com/ros-drivers/joystick_drivers/issues/157>)
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Merge pull request #158 <https://github.com/ros-drivers/joystick_drivers/issues/158> from clalancette/ros1-cleanups
* Greatly simplify the sticky_buttons support.
* Small fixes to rumble support.
* Use C++ style casts.
* Use empty instead of length.
* joy_def_ff -> joy_dev_ff
* Cleanup header includes.
* Use size_t appropriately.
* NULL -> nullptr everywhere.
* Style cleanup in joy_node.cpp.
* Merge pull request #154 <https://github.com/ros-drivers/joystick_drivers/issues/154> from zchen24/master
* Minor: moved default to right indent level
* Contributors: Chris Lalancette, Joshua Whitley, Zihan Chen
```

## joy_linux

```
* Cross platform joystick support for ROS 2 (#157 <https://github.com/ros-drivers/joystick_drivers/issues/157>)
* Contributors: Chris Lalancette
```

## sdl2_vendor

```
* Cross platform joystick support for ROS 2 (#157 <https://github.com/ros-drivers/joystick_drivers/issues/157>)
* Contributors: Chris Lalancette
```
