### PR TITLE
teleop_twist_joy: 2.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1615,6 +1615,22 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: master
     status: developed
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: dashing
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
+      version: 2.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: dashing
+    status: maintained
   teleop_twist_keyboard:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.2.2-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## teleop_twist_joy

```
* Export interfaces for Shared Lib on Windows.
* Make teleop_twist_joy composable.
* Reenable cppcheck.
* Rename teleop_twist_joy.h to teleop_twist_joy.hpp
* Get some basic tests running (#10 <https://github.com/ros2/teleop_twist_joy/issues/10>)
* Port config and launch to ROS 2 (#11 <https://github.com/ros2/teleop_twist_joy/issues/11>)
* Contributors: Chris Lalancette, Scott K Logan, seanyen
```
