### PR TITLE
pj_msgs: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7092,6 +7092,17 @@ repositories:
       url: https://github.com/SeaosRobotics/pipeline_planner_open.git
       version: master
     status: maintained
+  pj_msgs:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros1
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler_msgs-release.git
+      version: 0.1.0-1
+    status: developed
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pj_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/facontidavide/plotjuggler_msgs.git
- release repository: https://github.com/facontidavide/plotjuggler_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
