### PR TITLE
pj_msgs: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9959,6 +9959,17 @@ repositories:
       url: https://github.com/SeaosRobotics/pipeline_planner_open.git
       version: master
     status: maintained
+  pj_msgs:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros1
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler_msgs-release.git
+      version: 0.1.0-1
+    status: developed
   platform_automation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pj_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/facontidavide/plotjuggler_msgs.git
- release repository: https://github.com/facontidavide/plotjuggler_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
