### PR TITLE
pcl_msgs: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -654,6 +654,13 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: master
     status: maintained
+  pcl_msgs:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/pcl_msgs-release.git
+      version: 1.0.0-1
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/ros-perception/pcl_msgs
- release repository: https://github.com/ros2-gbp/pcl_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## pcl_msgs

```
* Trim README
* ros2 port of pcl_msgs (#11 <https://github.com/ros-perception/pcl_msgs/issues/11>)
  * Migrated From ROS1 to ROS2
  * Update CHANGELOG.rst
  * Migrated pcl_msgs from ROS1 to ROS2
  * Updated Readme.md
  Added Migration changes information and How to build and test information.
  * Update README.md
  * Update README.md
  * Update README.md
* Migrated From ROS1 to ROS2 (#10 <https://github.com/ros-perception/pcl_msgs/issues/10>)
  * Migrated From ROS1 to ROS2
  * Update CHANGELOG.rst
  * Migrated pcl_msgs from ROS1 to ROS2
* Add service file to update filename
* Contributors: Kentaro Wada, Paul Bovbel, Sandip Rakhasiya
```
