### PR TITLE
rqt_rviz: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2039,6 +2039,18 @@ repositories:
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git
       version: master
     status: maintained
+  rqt_rviz:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_rviz-release.git
+      version: 0.6.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_rviz.git
+      version: lunar-devel
+    status: maintained
   rqt_service_caller:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_rviz` to `0.6.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_rviz.git
- release repository: https://github.com/ros-gbp/rqt_rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## rqt_rviz

```
* Noetic release (#11 <https://github.com/ros-visualization/rqt_rviz/issues/11>)
  * Bump CMake version to avoid CMP0048 warning
  * Use setuptools instead of distutils
* Use std::vector for variable length arrays. (#10 <https://github.com/ros-visualization/rqt_rviz/issues/10>)
  * Use std::vector for variable length arrays. (#3 <https://github.com/ros-visualization/rqt_rviz/issues/3>)
  Some compiler doesn't support variable length arrays feature like G++. Rework the code to use std::vector instead for between cross-compiling.
  * Fix build break in CI.
* Contributors: Alejandro Hernández Cordero, Sean Yen [MSFT]
```
