### PR TITLE
rmw: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -908,7 +908,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 0.9.0-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-1`

## rmw

```
* Remove MANUAL_BY_NODE liveliness API (#227 <https://github.com/ros2/rmw/issues/227>)
* Improved Quality declarations (#225 <https://github.com/ros2/rmw/issues/225>)
* Quality declarations for rmw and rmw_implementation_cmake (#205 <https://github.com/ros2/rmw/issues/205>)
* Add tests for untested public functionality (#203 <https://github.com/ros2/rmw/issues/203>)
* Contributors: Alejandro Hernández Cordero, Ivan Santiago Paunovic, Stephen Brawner
```

## rmw_implementation_cmake

```
* Improved Quality declarations (#225 <https://github.com/ros2/rmw/issues/225>)
* Quality declarations for rmw and rmw_implementation_cmake (#205 <https://github.com/ros2/rmw/issues/205>)
* Contributors: Alejandro Hernández Cordero, Stephen Brawner
```
