### PR TITLE
rmw_connext: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -927,7 +927,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 0.9.1-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## rmw_connext_cpp

```
* Remove MANUAL_BY_NODE liveliness API (#423 <https://github.com/ros2/rmw_connext/issues/423>)
* Contributors: Ivan Santiago Paunovic
```

## rmw_connext_shared_cpp

```
* Remove MANUAL_BY_NODE liveliness API (#423 <https://github.com/ros2/rmw_connext/issues/423>)
* Contributors: Ivan Santiago Paunovic
```
