### PR TITLE
rclpy: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -820,7 +820,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.9.1-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## rclpy

```
* Remove MANUAL_BY_NODE liveliness API (#556 <https://github.com/ros2/rclpy/issues/556>)
* Fix bug that not to get expected data because use less timeout (#548 <https://github.com/ros2/rclpy/issues/548>)
* Contributors: Barry Xu, Ivan Santiago Paunovic
```
