### PR TITLE
rosbag2: 0.2.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1162,7 +1162,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.2.6-1
+      version: 0.2.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.2.7-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.6-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* Fix splitting tests on windows (#407 <https://github.com/ros2/rosbag2/issues/407>)
* Fix #381 <https://github.com/ros2/rosbag2/issues/381> unstable play_end_to_end test (#396 <https://github.com/ros2/rosbag2/issues/396>)
* Contributors: Karsten Knese, Mabel Zhang
```

## rosbag2_transport

```
* Remove MANUAL_BY_NODE liveliness usage (#406 <https://github.com/ros2/rosbag2/issues/406>)
* Contributors: Ivan Santiago Paunovic
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
