### PR TITLE
rmw_fastrtps: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -981,7 +981,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 0.9.1-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## rmw_fastrtps_cpp

```
* Remove API related to manual by node liveliness.  (#379 <https://github.com/ros2/rmw_fastrtps/issues/379>)
* Update quality declarations on feature testing. (#380 <https://github.com/ros2/rmw_fastrtps/issues/380>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_fastrtps_dynamic_cpp

```
* Fix single rmw build for rmw_fastrtps_dynamic_cpp. (#381 <https://github.com/ros2/rmw_fastrtps/issues/381>)
* Remove API related to manual by node liveliness. (#379 <https://github.com/ros2/rmw_fastrtps/issues/379>)
* Contributors: Ivan Santiago Paunovic
```

## rmw_fastrtps_shared_cpp

```
* Remove API related to manual by node liveliness. (#379 <https://github.com/ros2/rmw_fastrtps/issues/379>)
* Update quality declarations on feature testing. (#380 <https://github.com/ros2/rmw_fastrtps/issues/380>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```
