### PR TITLE
ros_workspace: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1140,7 +1140,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 0.8.0-4
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.0-4`

## ros_workspace

```
* Extend library path to have multiarch directory (#18 <https://github.com/ros2/ros_workspace/issues/18>)
* Enable Windows build. (#17 <https://github.com/ros2/ros_workspace/issues/17>)
* Contributors: Jacob Perron, Sean Yen
```
