### PR TITLE
rqt_robot_monitor: 0.5.11-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2003,7 +2003,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_monitor-release.git
-      version: 0.5.10-2
+      version: 0.5.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_monitor` to `0.5.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_monitor.git
- release repository: https://github.com/ros-gbp/rqt_robot_monitor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.10-2`

## rqt_robot_monitor

```
* add Python 3 conditional dependencies
```
