### PR TITLE
costmap_converter: 0.0.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -268,7 +268,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/costmap_converter-release.git
-      version: 0.0.12-1
+      version: 0.0.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_converter` to `0.0.13-1`:

- upstream repository: https://github.com/rst-tu-dortmund/costmap_converter.git
- release repository: https://github.com/rst-tu-dortmund/costmap_converter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.12-1`

## costmap_converter

```
* Changed minimum CMake version to 3.1
* Fixed wrong return type of method pointToNeighborCells
* OpenCV 4 compatibility fix (Thanks to daviddudas)
* Contributors: Christoph Rösmann, daviddudas
```
