### PR TITLE
control_box_rst: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -215,6 +215,22 @@ repositories:
       url: https://github.com/ros/common_tutorials.git
       version: noetic-devel
     status: maintained
+  control_box_rst:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/control_box_rst-release.git
+      version: 0.0.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: noetic-devel
+    status: developed
   control_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_box_rst` to `0.0.5-1`:

- upstream repository: https://github.com/rst-tu-dortmund/control_box_rst.git
- release repository: https://github.com/rst-tu-dortmund/control_box_rst-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## control_box_rst

```
* Changed minimum CMake version to 3.1
* Add default parameter to SolverIpopt::initialize() in case Ipopt is not found..
* Removed obsolete gmock include
* Fix setLastControlRef and graph consistency.
* Internal libgtest target renamed. Fixed compilation issue for yaml-cpp test
* Contributors: Christoph Rösmann, Maximilian Krämer
```
