### PR TITLE
visualization_tutorials: 0.10.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2346,6 +2346,29 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: noetic
     status: maintained
+  visualization_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    release:
+      packages:
+      - interactive_marker_tutorials
+      - librviz_tutorial
+      - rviz_plugin_tutorials
+      - rviz_python_tutorial
+      - visualization_marker_tutorials
+      - visualization_tutorials
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/visualization_tutorials-release.git
+      version: 0.10.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/visualization_tutorials.git
+      version: kinetic-devel
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.4-1`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## interactive_marker_tutorials

```
* Updated to use ``catkin_install_python()`` (#59 <https://github.com/ros-visualization/visualization_tutorials/issues/59>)
* Updated required CMake version to avoid CMP0048 warning (#57 <https://github.com/ros-visualization/visualization_tutorials/issues/57>)
* Removed unused ``saveMarker()`` (#47 <https://github.com/ros-visualization/visualization_tutorials/issues/47>)
* Contributors: Alejandro Hernández Cordero, Bence Magyar, Shane Loretz
```

## librviz_tutorial

```
* Updated required CMake version to avoid CMP0048 warning (#57 <https://github.com/ros-visualization/visualization_tutorials/issues/57>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_plugin_tutorials

```
* Updated to use ``catkin_install_python()`` (#59 <https://github.com/ros-visualization/visualization_tutorials/issues/59>)
* Updated required CMake version to avoid CMP0048 warning (#57 <https://github.com/ros-visualization/visualization_tutorials/issues/57>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz
```

## rviz_python_tutorial

```
* Updated RViz import (#60 <https://github.com/ros-visualization/visualization_tutorials/issues/60>)
* Updated to use ``catkin_install_python()`` (#59 <https://github.com/ros-visualization/visualization_tutorials/issues/59>)
* Updated required CMake version to avoid CMP0048 warning (#57 <https://github.com/ros-visualization/visualization_tutorials/issues/57>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz
```

## visualization_marker_tutorials

```
* Updated required CMake version to avoid CMP0048 warning (#57 <https://github.com/ros-visualization/visualization_tutorials/issues/57>)
* Updated to use ``ros::Duration`` for sleeping to gain cross-platform support (#48 <https://github.com/ros-visualization/visualization_tutorials/issues/48>)
* Contributors: Alejandro Hernández Cordero, Sean Yen [MSFT]
```

## visualization_tutorials

```
* Updated required CMake version to avoid CMP0048 warning (#57 <https://github.com/ros-visualization/visualization_tutorials/issues/57>)
* Contributors: Alejandro Hernández Cordero
```
