### PR TITLE
Add python-rtree and python3-rtree to index

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4030,6 +4030,9 @@ python-rrdtool:
     raring: [python-rrdtool]
     saucy: [python-rrdtool]
     trusty: [python-rrdtool]
+python-rtree:
+  debian: [python-rtree]
+  ubuntu: [python-rtree]
 python-ruamel.yaml:
   debian:
     buster: [python-ruamel.yaml]
@@ -5944,6 +5947,9 @@ python3-rospkg-modules:
     pip:
       packages: [rospkg]
   ubuntu: [python3-rospkg-modules]
+python3-rtree:
+  debian: [python3-rtree]
+  ubuntu: [python3-rtree]
 python3-ruamel.yaml:
   debian:
     buster: [python3-ruamel.yaml]


### PR DESCRIPTION
This PR adds the rosdep keys to install `python-rtree` and `python3-rtree`.
References to these packages can be found below:

`python-rtree`
* Debian: https://packages.debian.org/buster/python-rtree
* Ubuntu: https://packages.ubuntu.com/bionic/python-rtree

`python3-rtree`
* Debian: https://packages.debian.org/buster/python3-rtree
* Ubuntu: https://packages.ubuntu.com/bionic/python3-rtree