### PR TITLE
Add bokeh to index

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -670,6 +670,13 @@ python-bluez:
   gentoo: [dev-python/pybluez]
   rhel: [python-bluez]
   ubuntu: [python-bluez]
+python-bokeh-pip:
+  debian:
+    pip:
+      packages: [bokeh]
+  ubuntu:
+    pip:
+      packages: [bokeh]
 python-boltons:
   debian:
     '*': [python-boltons]
@@ -720,13 +727,6 @@ python-box2d:
   debian: [python-box2d]
   fedora: [pybox2d]
   ubuntu: [python-box2d]
-python-bokeh-pip:
-  debian:
-    pip:
-      packages: [bokeh]
-  ubuntu:
-    pip:
-      packages: [bokeh]
 python-breathe:
   debian: [python-breathe]
   fedora: [python-breathe]
@@ -5286,6 +5286,13 @@ python3-backoff-pip:
   ubuntu:
     pip:
       packages: [backoff]
+python3-bokeh-pip:
+  debian:
+    pip:
+      packages: [bokeh]
+  ubuntu:
+    pip:
+      packages: [bokeh]
 python3-boto3:
   debian: [python3-boto3]
   fedora: [python3-boto3]
@@ -5294,13 +5301,6 @@ python3-boto3:
     '*': ['python%{python3_pkgversion}-boto3']
     '7': null
   ubuntu: [python3-boto3]
-python3-bokeh-pip:
-  debian:
-    pip:
-      packages: [bokeh]
-  ubuntu:
-    pip:
-      packages: [bokeh]
 python3-bson:
   debian: [python3-bson]
   fedora: [python3-bson]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -720,6 +720,13 @@ python-box2d:
   debian: [python-box2d]
   fedora: [pybox2d]
   ubuntu: [python-box2d]
+python-bokeh-pip:
+  debian:
+    pip:
+      packages: [bokeh]
+  ubuntu:
+    pip:
+      packages: [bokeh]
 python-breathe:
   debian: [python-breathe]
   fedora: [python-breathe]
@@ -5287,6 +5294,13 @@ python3-boto3:
     '*': ['python%{python3_pkgversion}-boto3']
     '7': null
   ubuntu: [python3-boto3]
+python3-bokeh-pip:
+  debian:
+    pip:
+      packages: [bokeh]
+  ubuntu:
+    pip:
+      packages: [bokeh]
 python3-bson:
   debian: [python3-bson]
   fedora: [python3-bson]


### PR DESCRIPTION
Add the `bokeh` interactive visualization library to index list.

Reference to the package on PyPi: https://pypi.org/project/bokeh/

The keys added where named `python-bokeh-pip` and python3-bokeh-pip`.