### PR TITLE
geometry2: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -543,7 +543,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.7.1-1`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.0-1`

## geometry2

- No changes

## tf2

```
* Fix to improper ring_45 test, where 'anchor' frame for both inverse and normal transform was frame 'b' instead of frame 'a', thus creating a problem
* Don't insert a TF frame is one of the same timestamp already exists, instead just overwrite it.
* [Noetic] Add tf2::Stamped<T>::operator=() to fix warnings downstream (#453 <https://github.com/ros/geometry2/issues/453>)
  * Add tf2::Stamped<T>::operator=()
* [noetic] cherry-pick Windows fixes from melodic-devel (#450 <https://github.com/ros/geometry2/issues/450>)
  * [Windows][melodic-devel] Fix install locations (#442 <https://github.com/ros/geometry2/issues/442>)
  * fixed install locations of tf2
  * [windows][melodic] more portable fixes. (#443 <https://github.com/ros/geometry2/issues/443>)
  * more portable fixes.
* Contributors: Patrick Beeson, Robert Haschke, Sean Yen, Shane Loretz
```

## tf2_bullet

```
* [noetic] cherry-pick Windows fixes from melodic-devel (#450 <https://github.com/ros/geometry2/issues/450>)
  * [Windows][melodic-devel] Fix install locations (#442 <https://github.com/ros/geometry2/issues/442>)
  * fixed install locations of tf2
  * [windows][melodic] more portable fixes. (#443 <https://github.com/ros/geometry2/issues/443>)
  * more portable fixes.
* Contributors: Sean Yen
```

## tf2_eigen

```
* malcolm: add depends tf2 to catkin_package (#428 <https://github.com/ros/geometry2/issues/428>)
* Contributors: Malcolm Mielle
```

## tf2_geometry_msgs

```
* import setup from setuptools instead of distutils-core (#449 <https://github.com/ros/geometry2/issues/449>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_kdl

```
* import setup from setuptools instead of distutils-core (#449 <https://github.com/ros/geometry2/issues/449>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_msgs

- No changes

## tf2_py

```
* [noetic] cherry-pick Windows fixes from melodic-devel (#450 <https://github.com/ros/geometry2/issues/450>)
  * [Windows][melodic-devel] Fix install locations (#442 <https://github.com/ros/geometry2/issues/442>)
  * fixed install locations of tf2
  * [windows][melodic] more portable fixes. (#443 <https://github.com/ros/geometry2/issues/443>)
  * more portable fixes.
* import setup from setuptools instead of distutils-core (#449 <https://github.com/ros/geometry2/issues/449>)
* Contributors: Alejandro Hernández Cordero, Sean Yen
```

## tf2_ros

```
* StatisTransformBroadcaster: simplify/modernize code
* [noetic] cherry-pick Windows fixes from melodic-devel (#450 <https://github.com/ros/geometry2/issues/450>)
  * [Windows][melodic-devel] Fix install locations (#442 <https://github.com/ros/geometry2/issues/442>)
  * fixed install locations of tf2
  * [windows][melodic] more portable fixes. (#443 <https://github.com/ros/geometry2/issues/443>)
  * more portable fixes.
* import setup from setuptools instead of distutils-core (#449 <https://github.com/ros/geometry2/issues/449>)
* Contributors: Alejandro Hernández Cordero, Robert Haschke, Sean Yen
```

## tf2_sensor_msgs

```
* import setup from setuptools instead of distutils-core (#449 <https://github.com/ros/geometry2/issues/449>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_tools

- No changes
