### PR TITLE
four_wheel_steering_msgs: 1.1.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -394,7 +394,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
-      version: 1.1.0-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `four_wheel_steering_msgs` to `1.1.1-2`:

- upstream repository: https://github.com/ros-drivers/four_wheel_steering_msgs.git
- release repository: https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## four_wheel_steering_msgs

```
* Update maintainer email
* Contributors: Vincent Rousseau
```
