### PR TITLE
rtmros_hironx: 2.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10035,6 +10035,26 @@ repositories:
       url: https://github.com/start-jsk/rtmros_common.git
       version: master
     status: maintained
+  rtmros_hironx:
+    doc:
+      type: git
+      url: https://github.com/start-jsk/rtmros_hironx.git
+      version: indigo-devel
+    release:
+      packages:
+      - hironx_calibration
+      - hironx_moveit_config
+      - hironx_ros_bridge
+      - rtmros_hironx
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/rtmros_hironx-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/start-jsk/rtmros_hironx.git
+      version: indigo-devel
+    status: developed
   rtshell:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_hironx` to `2.2.0-1`:

- upstream repository: https://github.com/start-jsk/rtmros_hironx.git
- release repository: https://github.com/tork-a/rtmros_hironx-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## hironx_calibration

```
* force set ORBgiopMaxMsgSize=2147483648  for hironx_client.py (#540 <https://github.com/start-jsk/rtmros_hironx/issues/540>)
  
    * force build depend hironx_moveit_config, so that hrpsys(plain cmake) runs before hironx_calibration
  
* Contributors: Kei Okada
```

## hironx_moveit_config

- No changes

## hironx_ros_bridge

```
* force set ORBgiopMaxMsgSize=2147483648  for hironx_client.py (#540 <https://github.com/start-jsk/rtmros_hironx/issues/540>)
  
    * increase test_no_moveit
    * hot fix for https://github.com/start-jsk/rtmros_hironx/issues/539
      On 16.04 (omniorb4-dev 4.1) if we start openhrp-model-loader with   <env name="ORBgiopMaxMsgSize" value="2147483648" /> all connection(?) conect respenct giopMaxMsgSize
      But on 18.04 (omniorb4-dev 4.2) wnneed to set ORBgiopMaxMsgSize=2147483648  for each clients
  
* [hironx_ros_bridge] Enable to run CollisionDetector RTC by setting conf (Robot.conf) (#535 <https://github.com/start-jsk/rtmros_hironx/issues/535>)
  
    * [hironx_ros_bridge] Simplify CollisionDetector disabling specific to HIRONX
    * [hironx_ros_bridge] Generalize disabling/enabling RTCs from conf
    * [hironx_ros_bridge] Enable to run CollisionDetector RTC by setting conf (Robot.conf)
    * [hironx_ros_bridge] Add test to check if CollisionDetector is disabled with default conf
    * [hironx_ros_bridge] Add test to disable/enable RTCs from conf
  
* Contributors: Kei Okada, Shun Hasegawa
```

## rtmros_hironx

- No changes
