### PR TITLE
rc_common_msgs: 0.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7987,7 +7987,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_common_msgs-release.git
-      version: 0.4.1-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/roboception/rc_common_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_common_msgs` to `0.5.0-1`:

- upstream repository: https://github.com/roboception/rc_common_msgs.git
- release repository: https://github.com/roboception-gbp/rc_common_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.1-1`

## rc_common_msgs

```
* Added array key/value list for extra data to CameraParam message and removed 'noise' field (will be provided in extra_data)
```
