### PR TITLE
laser_filtering: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -762,6 +762,25 @@ repositories:
       url: https://github.com/ros-perception/laser_assembler.git
       version: noetic-devel
     status: maintained
+  laser_filtering:
+    doc:
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: noetic
+    release:
+      packages:
+      - laser_filtering
+      - map_laser
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wu-robotics/laser_filtering_release.git
+      version: 0.0.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/laser_filtering.git
+      version: noetic
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filtering` to `0.0.5-1`:

- upstream repository: https://github.com/DLu/laser_filtering.git
- release repository: https://github.com/wu-robotics/laser_filtering_release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
