### PR TITLE
perception_pcl: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -661,6 +661,25 @@ repositories:
       url: https://github.com/ros2-gbp/pcl_msgs-release.git
       version: 1.0.0-2
     status: maintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: foxy-devel
+    release:
+      packages:
+      - pcl_conversions
+      - perception_pcl
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/perception_pcl-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: foxy-devel
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `2.2.0-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros2-gbp/perception_pcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
