### PR TITLE
marti_common: 2.13.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7073,7 +7073,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.13.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.12.0-1`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Fix build with GEOS 3.8 (#576 <https://github.com/swri-robotics/marti_common/issues/576>)
* Contributors: Ben Wolsieffer
```

## swri_image_util

```
* Rename swri_image_util test (#575 <https://github.com/swri-robotics/marti_common/issues/575>)
* Contributors: P. J. Reed
```

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

```
* Fix build with Boost >=1.69 (#574 <https://github.com/swri-robotics/marti_common/issues/574>)
* Contributors: Ben Wolsieffer
```

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

```
* Add overload of generateObstacleData for tracked objects (#578 <https://github.com/swri-robotics/marti_common/issues/578>)
* Contributors: Matthew Bries <mailto:matthew.bries@swri.org>
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Fix build with Boost >=1.69 (#574 <https://github.com/swri-robotics/marti_common/issues/574>)
* Contributors: Ben Wolsieffer
```

## swri_yaml_util

- No changes
