### PR TITLE
marti_common: 3.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1388,7 +1388,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.2.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.1.0-1`

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Fix build with GEOS 3.8 (#576 <https://github.com/swri-robotics/marti_common/issues/576>) (#577 <https://github.com/swri-robotics/marti_common/issues/577>)
  Co-authored-by: Ben Wolsieffer <mailto:benwolsieffer@gmail.com>
* Contributors: P. J. Reed
```

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_route_util

```
* Add overload of generateObstacleData for tracked objects (Dashing) (#579 <https://github.com/swri-robotics/marti_common/issues/579>)
* Contributors: Matthew Bries
```

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes
