### PR TITLE
joystick_drivers: 2.4.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -442,7 +442,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `2.4.1-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.4.0-1`

## joy

```
* Small fixes for uncrustify on Foxy. (#171 <https://github.com/ros-drivers/joystick_drivers/issues/171>)
* Contributors: Chris Lalancette
```

## joy_linux

```
* Small fixes for uncrustify on Foxy. (#171 <https://github.com/ros-drivers/joystick_drivers/issues/171>)
* Contributors: Chris Lalancette
```

## sdl2_vendor

- No changes
