### PR TITLE
visualization_tutorials: 0.10.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11810,7 +11810,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.10.3-0
+      version: 0.10.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.10.5-1`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.10.3-0`

## interactive_marker_tutorials

- No changes

## librviz_tutorial

- No changes

## rviz_plugin_tutorials

- No changes

## rviz_python_tutorial

```
* Revert "Update RViz import (#60 <https://github.com/ros-visualization/visualization_tutorials/issues/60>)"
  This reverts commit 60eba95a7f1fd7042778e62521000f5519d04537.
* Contributors: William Woodall
```

## visualization_marker_tutorials

- No changes

## visualization_tutorials

- No changes
