### PR TITLE
mapviz: 2.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1129,6 +1129,28 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
     status: maintained
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: dashing-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/mapviz-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: dashing-devel
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.0.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## mapviz

```
* Port mapviz to ROS 2 (#672 <https://github.com/swri-robotics/mapviz/issues/672>)
* Remove OpenGL warning (#667 <https://github.com/swri-robotics/mapviz/issues/667>)
* Resolves segfault issue on ClearHistory() function call (#651 <https://github.com/swri-robotics/mapviz/issues/651>)
* Fix plug-in config panel to scroll per-pixel instead of per-item, allowing configuration of plug-ins that have config settings that are too large to fit in the panel all at once. (#646 <https://github.com/swri-robotics/mapviz/issues/646>)
* Contributors: Daniel D'Souza, Marc Alban, Matthew Bries, Matthew Grogan, P. J. Reed, Jason Gassaway, John Reyes, Jacob Hassold, Kevin Nickels, Roger Strain
```

## mapviz_interfaces

```
* Port mapviz to ROS 2 (#672 <https://github.com/swri-robotics/mapviz/issues/672>)
* Contributors: P. J. Reed
```

## mapviz_plugins

```
* Port mapviz to ROS 2 (#672 <https://github.com/swri-robotics/mapviz/issues/672>)
* Contributors: Daniel D'Souza, Matthew Bries, Matthew Grogan, P. J. Reed, Jason Gassaway, John Reyes, Jacob Hassold, Kevin Nickels, Roger Strain
```

## multires_image

```
* Port mapviz to ROS 2 (#672 <https://github.com/swri-robotics/mapviz/issues/672>)
* Remove OpenGL warning (#667 <https://github.com/swri-robotics/mapviz/issues/667>)
* Contributors: Daniel D'Souza, P. J. Reed, Jacob Hassold, Kevin Nickels, Roger Strain
```

## tile_map

```
* Port mapviz to ROS 2 (#672 <https://github.com/swri-robotics/mapviz/issues/672>)
* Remove OpenGL warning (#667 <https://github.com/swri-robotics/mapviz/issues/667>)
* Contributors: Daniel D'Souza, P. J. Reed, Jacob Hassold, Kevin Nickels, Roger Strain, Matthew Bries
```
