### PR TITLE
visualization_tutorials: 0.11.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2415,7 +2415,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/visualization_tutorials.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       packages:
       - interactive_marker_tutorials
@@ -2432,7 +2432,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/visualization_tutorials.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   warehouse_ros:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2427,7 +2427,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.10.4-1
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.11.0-1`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.10.4-1`

## interactive_marker_tutorials

- No changes

## librviz_tutorial

- No changes

## rviz_plugin_tutorials

- No changes

## rviz_python_tutorial

- No changes

## visualization_marker_tutorials

- No changes

## visualization_tutorials

- No changes
