### PR TITLE
launch_ros: 0.10.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -516,7 +516,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.10.0-2
+      version: 0.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.10.1-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.10.0-2`

## launch_ros

```
* Fix new flake8 errors (#148 <https://github.com/ros2/launch_ros/issues/148>)
* Contributors: Michel Hidalgo
```

## launch_testing_ros

- No changes

## ros2launch

```
* argcomplete is optional (#147 <https://github.com/ros2/launch_ros/issues/147>)
* Contributors: Alejandro Hernández Cordero
```
