### PR TITLE
system_modes: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1641,6 +1641,24 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: master
     status: developed
+  system_modes:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: 0.2.0
+    release:
+      packages:
+      - system_modes
+      - system_modes_examples
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/microROS/system_modes-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/microROS/system_modes.git
+      version: 0.2.0
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.2.0-1`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
