### PR TITLE
fmilibrary_vendor: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -375,6 +375,12 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  fmilibrary_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/boschresearch/fmilibrary_vendor-release.git
+      version: 0.2.0-1
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/boschresearch/fmilibrary_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## fmilibrary_vendor

```
* Updated to FMILibrary version 2.1 and new location on GitHub.
```
