### PR TITLE
rclc: 0.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1787,6 +1787,25 @@ repositories:
       url: https://github.com/ros2/rcl_logging.git
       version: eloquent
     status: maintained
+  rclc:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: 0.1.1
+    release:
+      packages:
+      - rclc
+      - rclc_examples
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/micro-ROS/rclc-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: 0.1.1
+    status: developed
   rclcpp:
     doc:
       type: git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1791,7 +1791,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: 0.1.1
+      version: master
     release:
       packages:
       - rclc
@@ -1804,7 +1804,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: 0.1.1
+      version: master
     status: developed
   rclcpp:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `0.1.1-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/micro-ROS/rclc-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rclc

```
* Initial release
```

## rclc_examples

```
* Initial release
```
