### PR TITLE
behaviotree_cpp_v3: 3.5.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1045,7 +1045,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
-      version: 3.4.0-1
+      version: 3.5.0-2
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviotree_cpp_v3` to `3.5.0-2`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.4.0-1`

## behaviortree_cpp_v3

```
* added IfThenElse and  WhileDoElse
* issue #190 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/190>
* unit test added
* reverting to a better solution
* RemappedSubTree added
* Fix issue #188 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/188>
* added function const std::string& key (issue #183 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/183>)
* Contributors: Davide Faconti, mailto:daf@blue-ocean-robotics.com
* added IfThenElse and  WhileDoElse
* issue #190 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/190>
* unit test added
* reverting to a better solution
* RemappedSubTree added
* Fix issue #188 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/188>
* added function const std::string& key (issue #183 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/183>)
* Contributors: Davide Faconti, mailto:daf@blue-ocean-robotics.com
```
