### PR TITLE
catkin: 0.8.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -128,7 +128,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.1-1
+      version: 0.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.4-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.1-1`

## catkin

```
* fix GTest detection when cmake-extras is installed (#1091 <https://github.com/ros/catkin/issues/1091>)
* fix gtest_source_paths (#1088 <https://github.com/ros/catkin/issues/1088>)
* fix -egg-base path to point to the build space (#1090 <https://github.com/ros/catkin/issues/1090>)
```
