### PR TITLE
catkin: 0.7.25-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1037,7 +1037,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.23-1
+      version: 0.7.25-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.25-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.23-1`

## catkin

```
* fix GTest detection when cmake-extras is installed (#1091 <https://github.com/ros/catkin/issues/1091>)
* fix gtest_source_paths (#1088 <https://github.com/ros/catkin/issues/1088>)
* fix -egg-base path to point to the build space (#1090 <https://github.com/ros/catkin/issues/1090>)
* also rewrite shebang lines with whitespace in catkin_install_python (#1079 <https://github.com/ros/catkin/issues/1079>)
```
