### PR TITLE
rc_visard: 3.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11258,6 +11258,7 @@ repositories:
       - rc_hand_eye_calibration_client
       - rc_pick_client
       - rc_roi_manager_gui
+      - rc_silhouettematch_client
       - rc_tagdetect_client
       - rc_visard
       - rc_visard_description
@@ -11265,7 +11266,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 2.7.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `3.0.1-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.7.0-1`

## rc_hand_eye_calibration_client

- No changes

## rc_pick_client

- No changes

## rc_roi_manager_gui

- No changes

## rc_silhouettematch_client

```
* add missing msg dependencies
```

## rc_tagdetect_client

- No changes

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

- No changes
