### PR TITLE
filters: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -359,6 +359,22 @@ repositories:
       url: https://github.com/eProsima/Fast-RTPS.git
       version: 9c28edc805863117d500ebb7aef86d509471ebd8
     status: maintained
+  filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/filters-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    status: maintained
   foonathan_memory_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `2.0.0-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros2-gbp/filters-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## filters

```
* Fix a bug in the tests.
* Fixes for Foxy uncrustify.
* Address peer review comments.
* Enforce proper code style.
* Cleanup types and literals.
* Lint all sources.
* Address pending review comments.
* Misc boost fixes
* Fix wrong include guard
* FilterBase<T> to avoid name hiding
* Include what is used
* Alphabetize package deps
* Get rid of unnecessary retval
* Include what is used
* remove unnecessary ';'
* Use empty() instead of size() == 0
* Instal -> Install
* Add ament_package()
* Port filters to ROS Eloquent
* [noetic] deprecate h for hpp (#34 <https://github.com/ros/filters/issues/34>)
* [noetic] Delete unused code (#33 <https://github.com/ros/filters/issues/33>)
* Bump CMake version to avoid CMP0048
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Michel Hidalgo, Shane Loretz
```
