### PR TITLE
executive_smach: 2.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -379,6 +379,20 @@ repositories:
       version: master
     status: developed
   executive_smach:
+    doc:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: noetic-devel
+    release:
+      packages:
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/executive_smach-release.git
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach` to `2.5.0-1`:

- upstream repository: https://github.com/ros/executive_smach.git
- release repository: https://github.com/ros-gbp/executive_smach-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## executive_smach

```
* Python 3 compatibility #71 <https://github.com/ros/executive_smach/issues/71>
* Bump CMake version to avoid CMP0048 warning
* Contributors: Shane Loretz, ahcorde
```

## smach

```
* Python 3 compatibility #71 <https://github.com/ros/executive_smach/issues/71>
* Use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Update state.py Docstrings' @type descriptions #59 <https://github.com/ros/executive_smach/issues/59>
* Typo set_shutdown_cb() --> set_shutdown_check() #56 <https://github.com/ros/executive_smach/issues/56>
* Contributors: Isaac I.Y. Saito, Joseph Coombe, Shane Loretz, ahcorde, cclauss
```

## smach_msgs

```
* Python 3 compatibility #71 <https://github.com/ros/executive_smach/issues/71>
* Bump CMake version to avoid CMP0048 warning
* Contributors: Shane Loretz, ahcorde
```

## smach_ros

```
* Python 3 compatibility #71 <https://github.com/ros/executive_smach/issues/71>
* Bump CMake version to avoid CMP0048 warning
* Contributors: Shane Loretz, ahcorde
```
