### PR TITLE
image_transport_plugins: 1.14.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -673,6 +673,27 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: noetic
     status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: noetic-devel
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/image_transport_plugins-release.git
+      version: 1.14.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: noetic-devel
+    status: unmaintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `1.14.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros-gbp/image_transport_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## compressed_depth_image_transport

```
* Bump CMake version to avoid CMP0048 warning (#53 <https://github.com/ros-perception/image_transport_plugins/issues/53>)
* Add depth compression by RVL #42 <https://github.com/ros-perception/image_transport_plugins/issues/42>
* Fix binary install locations for Windows build #34 <https://github.com/ros-perception/image_transport_plugins/issues/34>
* Add legacy constants when using opencv4 #32 <https://github.com/ros-perception/image_transport_plugins/issues/32>
* Contributors: Alejandro Hernández Cordero, David Gossow, Hans Gaiser, Sean Yen, Shuntaro Yamazaki
```

## compressed_image_transport

```
* Bump CMake version to avoid CMP0048 warning (#53 <https://github.com/ros-perception/image_transport_plugins/issues/53>)
* add params for jpeg compression #35 <https://github.com/ros-perception/image_transport_plugins/issues/35>
* fixed warning when resubscribing #25 <https://github.com/ros-perception/image_transport_plugins/issues/25>
* Fix binary install locations for Windows build #34 <https://github.com/ros-perception/image_transport_plugins/issues/34>
* Add legacy constants when using opencv4 #32 <https://github.com/ros-perception/image_transport_plugins/issues/32>
* fixed warning 'Tried to advertise a service that is already advertised in this node'
* Contributors: Alejandro Hernández Cordero, David Gossow, Hans Gaiser, Sean Yen, Till Grenzdörffer, Yuki Furuta
```

## image_transport_plugins

```
* Bump CMake version to avoid CMP0048 warning (#53 <https://github.com/ros-perception/image_transport_plugins/issues/53>)
* Contributors: Alejandro Hernández Cordero
```

## theora_image_transport

```
* Bump CMake version to avoid CMP0048 warning (#53 <https://github.com/ros-perception/image_transport_plugins/issues/53>)
* Fix binary install locations for Windows build #34 <https://github.com/ros-perception/image_transport_plugins/issues/34>
* Contributors: Alejandro Hernández Cordero, David Gossow, Sean Yen
```
