### PR TITLE
rqt_common_plugins indigo-EOL branch

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13668,7 +13668,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: indigo-EOL
+      version: indigo-devel
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -13677,7 +13677,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: indigo-EOL
+      version: indigo-devel
     status: developed
   rqt_console:
     doc:

--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -13668,7 +13668,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: master
+      version: indigo-EOL
     release:
       tags:
         release: release/indigo/{package}/{version}
@@ -13677,7 +13677,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: master
+      version: indigo-EOL
     status: developed
   rqt_console:
     doc:


### PR DESCRIPTION
https://github.com/ros-visualization/rqt_common_plugins/pull/459#issuecomment-604547280

https://github.com/ros-visualization/rqt_common_plugins/tree/indigo-EOL

AFAIK this avoids breaking users building indigo from source using the --upstream-development flag. There won't be any upstream development in an EOL distro, so I've used the branch name `indigo-EOL` instead of the usual `indigo-devel`. 