### PR TITLE
neonavigation: 0.8.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8448,7 +8448,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.8.5-1
+      version: 0.8.6-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.8.6-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.5-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

```
* neonavigation_launch: revert exec_depend to trajectory_tracker_rviz_plugins (#491 <https://github.com/at-wat/neonavigation/issues/491>)
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

- No changes

## planner_cspace

```
* Fix duplicated tf timestamp (#494 <https://github.com/at-wat/neonavigation/issues/494>)
* planner_cspace: add wait to navigation tests (#492 <https://github.com/at-wat/neonavigation/issues/492>)
* planner_cspace: simplify path switch detection condition (#488 <https://github.com/at-wat/neonavigation/issues/488>)
* planner_cspace: fix uninitialized variable (#486 <https://github.com/at-wat/neonavigation/issues/486>)
* planner_cspace: enable replan when robot reaches the switchback point (#449 <https://github.com/at-wat/neonavigation/issues/449>)
* planner_cspace: fix test_debug_outputs initial wait (#485 <https://github.com/at-wat/neonavigation/issues/485>)
* Contributors: Atsushi Watanabe, Kazuki Takahashi
```

## safety_limiter

- No changes

## track_odometry

```
* Fix duplicated tf timestamp (#494 <https://github.com/at-wat/neonavigation/issues/494>)
* track_odometry: increase transform timeout in tests (#490 <https://github.com/at-wat/neonavigation/issues/490>)
* Contributors: Atsushi Watanabe
```

## trajectory_tracker

```
* Fix duplicated tf timestamp (#494 <https://github.com/at-wat/neonavigation/issues/494>)
* Contributors: Atsushi Watanabe
```
