### PR TITLE
Add rosdep rule for python-pytest-cov

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3544,6 +3544,12 @@ python-pytest:
   fedora: [python-pytest]
   gentoo: [dev-python/pytest]
   ubuntu: [python-pytest]
+python-pytest-cov:
+  arch: [python2-pytest-cov]
+  debian: [python-pytest-cov]
+  fedora: [python-pytest-cov]
+  gentoo: [dev-python/pytest-cov]
+  ubuntu: [python-pytest-cov]
 python-pytest-dependency-pip:
   debian:
     pip:


### PR DESCRIPTION
For generating coverage reports using [ros_pytest](http://wiki.ros.org/ros_pytest).

Arch: https://www.archlinux.org/packages/community/any/python-pytest-cov/
Debian: https://packages.debian.org/search?keywords=python-pytest-cov
Fedora: https://apps.fedoraproject.org/packages/python-pytest-cov
Gentoo: https://packages.gentoo.org/packages/dev-python/pytest-cov
Ubuntu: https://packages.ubuntu.com/bionic/python-pytest-cov
