### PR TITLE
pilz_robots: 0.5.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7058,7 +7058,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.15-1
+      version: 0.5.16-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.16-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.15-1`

## pilz_control

```
* Update and apply clang-format (#387)
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_status_indicator_rqt

- No changes

## pilz_testutils

```
* Update and apply clang-format (#387)
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

```
* Update and apply clang-format (#387)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

```
* Update and apply clang-format (#387)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_hardware_support

```
* Update and apply clang-format (#387)
* Make test-subfolder-names consistent (#380)
* Extend stop1 acceptance test (#378)
* Fix namespace in launch-file (#383)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

```
* Update and apply clang-format (#387)
* Make test-subfolder-names consistent (#380)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_moveit_config

- No changes

## prbt_support

```
* Fix include_directories for prbt_support tests (#390)
* Update and apply clang-format (#387)
* Make test-subfolder-names consistent (#380)
* Fix/joint limits acceptance test (#381)
* Contributors: Pilz GmbH and Co. KG
```
