### PR TITLE
fmi_adapter_ros2: 0.1.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -375,6 +375,24 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
+  fmi_adapter_ros2:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: master
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
+      version: 0.1.8-1
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: master
+    status: developed
   fmilibrary_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.8-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/boschresearch/fmi_adapter_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## fmi_adapter

```
* Prepared for Foxy release.
```

## fmi_adapter_examples

```
* Prepared for Foxy release.
```
