### PR TITLE
hector_slam: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3510,7 +3510,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam` to `0.4.1-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.0-1`

## hector_compressed_map_transport

- No changes

## hector_geotiff

- No changes

## hector_geotiff_plugins

- No changes

## hector_imu_attitude_to_tf

- No changes

## hector_imu_tools

- No changes

## hector_map_server

- No changes

## hector_map_tools

- No changes

## hector_mapping

```
* Remove unnecessary boost signals find_package
  With Boost >1.69 hector_mapping won't build. Furthermore, hector_mapping doesn't use signals anywhere.
* Contributors: Sam Pfeiffer
```

## hector_marker_drawing

- No changes

## hector_nav_msgs

- No changes

## hector_slam

- No changes

## hector_slam_launch

- No changes

## hector_trajectory_server

- No changes
