### PR TITLE
geometry: 1.13.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -585,7 +585,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.13.0-1
+      version: 1.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.13.1-1`:

- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.13.0-1`

## eigen_conversions

```
* Format 2 and build_export_depend orocos kdl (#210 <https://github.com/ros/geometry/issues/210>)
* Contributors: Shane Loretz
```

## geometry

- No changes

## kdl_conversions

```
* Format 2 and build_export_depend orocos kdl (#210 <https://github.com/ros/geometry/issues/210>)
* Contributors: Shane Loretz
```

## tf

```
* Fix ring45 test expectations (#211 <https://github.com/ros/geometry/issues/211>)
  Copying https://github.com/ros/geometry2/commit/04625380bdff3f3e9e860fc0e85f71674ddd1587
* import setup from setuptools instead of distutils-core (#209 <https://github.com/ros/geometry/issues/209>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz
```

## tf_conversions

```
* Format 2 and build_export_depend orocos kdl (#210 <https://github.com/ros/geometry/issues/210>)
* import setup from setuptools instead of distutils-core (#209 <https://github.com/ros/geometry/issues/209>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz
```
