### PR TITLE
rosdep: add Ignition Citadel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2616,11 +2616,11 @@ libignition-math6-dev:
     buster: [libignition-math6-dev]
   ubuntu:
     focal: [libignition-math6-dev]
-libignition-math6-eigen3:
+libignition-math6-eigen3-dev:
   debian:
-    buster: [libignition-math6-eigen3]
+    buster: [libignition-math6-eigen3-dev]
   ubuntu:
-    focal: [libignition-math6-eigen3]
+    focal: [libignition-math6-eigen3-dev]
 libignition-msgs5:
   debian:
     buster: [libignition-msgs5]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1389,50 +1389,80 @@ ifstat:
   gentoo: [net-analyzer/ifstat]
   ubuntu: [ifstat]
 ignition-citadel:
-  ubuntu: [ignition-citadel]
-  debian: [ignition-citadel]
+  debian:
+    buster: [ignition-citadel]
+  ubuntu:
+    focal: [ignition-citadel]
 ignition-cmake2:
-  ubuntu: [libignition-cmake2-dev]
-  debian: [libignition-cmake2-dev]
+  debian:
+    buster: [libignition-cmake2-dev]
+  ubuntu:
+    focal: [libignition-cmake2-dev]
 ignition-common3:
-  ubuntu: [libignition-common3-dev]
-  debian: [libignition-common3-dev]
+  debian:
+    buster: [libignition-common3-dev]
+  ubuntu:
+    focal: [libignition-common3-dev]
 ignition-fuel-tools4:
-  ubuntu: [libignition-fuel-tools4-dev]
-  debian: [libignition-fuel-tools4-dev]
+  debian:
+    buster: [libignition-fuel-tools4-dev]
+  ubuntu:
+    focal: [libignition-fuel-tools4-dev]
 ignition-gazebo3:
-  ubuntu: [libignition-gazebo3-dev]
-  debian: [libignition-gazebo3-dev]
+  debian:
+    buster: [libignition-gazebo3-dev]
+  ubuntu:
+    focal: [libignition-gazebo3-dev]
 ignition-gui3:
-  ubuntu: [libignition-gui3-dev]
-  debian: [libignition-gui3-dev]
+  debian:
+    buster: [libignition-gui3-dev]
+  ubuntu:
+    focal: [libignition-gui3-dev]
 ignition-launch2:
-  ubuntu: [libignition-launch2-dev]
-  debian: [libignition-launch2-dev]
+  debian:
+    buster: [libignition-launch2-dev]
+  ubuntu:
+    focal: [libignition-launch2-dev]
 ignition-math6:
-  ubuntu: [libignition-math6-dev]
-  debian: [libignition-math6-dev]
+  debian:
+    buster: [libignition-math6-dev]
+  ubuntu:
+    focal: [libignition-math6-dev]
 ignition-msgs5:
-  ubuntu: [libignition-msgs5-dev]
-  debian: [libignition-msgs5-dev]
+  debian:
+    buster: [libignition-msgs5-dev]
+  ubuntu:
+    focal: [libignition-msgs5-dev]
 ignition-physics2:
-  ubuntu: [libignition-physics2-dev]
-  debian: [libignition-physics2-dev]
+  debian:
+    buster: [libignition-physics2-dev]
+  ubuntu:
+    focal: [libignition-physics2-dev]
 ignition-plugin1:
-  ubuntu: [libignition-plugin1-dev]
-  debian: [libignition-plugin1-dev]
+  debian:
+    buster: [libignition-plugin1-dev]
+  ubuntu:
+    focal: [libignition-plugin1-dev]
 ignition-rendering3:
-  ubuntu: [libignition-rendering3-dev]
-  debian: [libignition-rendering3-dev]
+  debian:
+    buster: [libignition-rendering3-dev]
+  ubuntu:
+    focal: [libignition-rendering3-dev]
 ignition-sensors3:
-  ubuntu: [libignition-sensors3-dev]
-  debian: [libignition-sensors3-dev]
+  debian:
+    buster: [libignition-sensors3-dev]
+  ubuntu:
+    focal: [libignition-sensors3-dev]
 ignition-tools1:
-  ubuntu: [libignition-tools1-dev]
-  debian: [libignition-tools1-dev]
+  debian:
+    buster: [libignition-tools1-dev]
+  ubuntu:
+    focal: [libignition-tools1-dev]
 ignition-transport8:
-  ubuntu: [libignition-transport8-dev]
-  debian: [libignition-transport8-dev]
+  debian:
+    buster: [libignition-transport8-dev]
+  ubuntu:
+    focal: [libignition-transport8-dev]
 imagemagick:
   arch: [imagemagick]
   debian: [imagemagick]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2611,6 +2611,11 @@ libignition-math6:
     buster: [libignition-math6]
   ubuntu:
     focal: [libignition-math6]
+libignition-math6-eigen3:
+  debian:
+    buster: [libignition-math6-eigen3]
+  ubuntu:
+    focal: [libignition-math6-eigen3]
 libignition-math6-dev:
   debian:
     buster: [libignition-math6-dev]
@@ -2641,11 +2646,11 @@ libignition-plugin1:
     buster: [libignition-plugin1]
   ubuntu:
     focal: [libignition-plugin1]
-libignition-plugin1-dev:
+libignition-plugin-dev:
   debian:
-    buster: [libignition-plugin1-dev]
+    buster: [libignition-plugin-dev]
   ubuntu:
-    focal: [libignition-plugin1-dev]
+    focal: [libignition-plugin-dev]
 libignition-rendering3:
   debian:
     buster: [libignition-rendering3]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1393,76 +1393,11 @@ ignition-citadel:
     buster: [ignition-citadel]
   ubuntu:
     focal: [ignition-citadel]
-ignition-cmake2:
+ignition-tools:
   debian:
-    buster: [libignition-cmake2-dev]
+    buster: [ignition-tools]
   ubuntu:
-    focal: [libignition-cmake2-dev]
-ignition-common3:
-  debian:
-    buster: [libignition-common3-dev]
-  ubuntu:
-    focal: [libignition-common3-dev]
-ignition-fuel-tools4:
-  debian:
-    buster: [libignition-fuel-tools4-dev]
-  ubuntu:
-    focal: [libignition-fuel-tools4-dev]
-ignition-gazebo3:
-  debian:
-    buster: [libignition-gazebo3-dev]
-  ubuntu:
-    focal: [libignition-gazebo3-dev]
-ignition-gui3:
-  debian:
-    buster: [libignition-gui3-dev]
-  ubuntu:
-    focal: [libignition-gui3-dev]
-ignition-launch2:
-  debian:
-    buster: [libignition-launch2-dev]
-  ubuntu:
-    focal: [libignition-launch2-dev]
-ignition-math6:
-  debian:
-    buster: [libignition-math6-dev]
-  ubuntu:
-    focal: [libignition-math6-dev]
-ignition-msgs5:
-  debian:
-    buster: [libignition-msgs5-dev]
-  ubuntu:
-    focal: [libignition-msgs5-dev]
-ignition-physics2:
-  debian:
-    buster: [libignition-physics2-dev]
-  ubuntu:
-    focal: [libignition-physics2-dev]
-ignition-plugin1:
-  debian:
-    buster: [libignition-plugin1-dev]
-  ubuntu:
-    focal: [libignition-plugin1-dev]
-ignition-rendering3:
-  debian:
-    buster: [libignition-rendering3-dev]
-  ubuntu:
-    focal: [libignition-rendering3-dev]
-ignition-sensors3:
-  debian:
-    buster: [libignition-sensors3-dev]
-  ubuntu:
-    focal: [libignition-sensors3-dev]
-ignition-tools1:
-  debian:
-    buster: [libignition-tools1-dev]
-  ubuntu:
-    focal: [libignition-tools1-dev]
-ignition-transport8:
-  debian:
-    buster: [libignition-transport8-dev]
-  ubuntu:
-    focal: [libignition-transport8-dev]
+    focal: [ignition-tools]
 imagemagick:
   arch: [imagemagick]
   debian: [imagemagick]
@@ -2616,6 +2551,136 @@ libicu-dev:
   fedora: [libicu-devel]
   gentoo: [dev-libs/icu]
   ubuntu: [libicu-dev]
+libignition-cmake2-dev:
+  debian:
+    buster: [libignition-cmake2-dev]
+  ubuntu:
+    focal: [libignition-cmake2-dev]
+libignition-common3:
+  debian:
+    buster: [libignition-common3]
+  ubuntu:
+    focal: [libignition-common3]
+libignition-common3-dev:
+  debian:
+    buster: [libignition-common3-dev]
+  ubuntu:
+    focal: [libignition-common3-dev]
+libignition-fuel-tools4:
+  debian:
+    buster: [libignition-fuel-tools4]
+  ubuntu:
+    focal: [libignition-fuel-tools4]
+libignition-fuel-tools4-dev:
+  debian:
+    buster: [libignition-fuel-tools4-dev]
+  ubuntu:
+    focal: [libignition-fuel-tools4-dev]
+libignition-gazebo3:
+  debian:
+    buster: [libignition-gazebo3]
+  ubuntu:
+    focal: [libignition-gazebo3]
+libignition-gazebo3-dev:
+  debian:
+    buster: [libignition-gazebo3-dev]
+  ubuntu:
+    focal: [libignition-gazebo3-dev]
+libignition-gui3:
+  debian:
+    buster: [libignition-gui3]
+  ubuntu:
+    focal: [libignition-gui3]
+libignition-gui3-dev:
+  debian:
+    buster: [libignition-gui3-dev]
+  ubuntu:
+    focal: [libignition-gui3-dev]
+libignition-launch2:
+  debian:
+    buster: [libignition-launch2]
+  ubuntu:
+    focal: [libignition-launch2]
+libignition-launch2-dev:
+  debian:
+    buster: [libignition-launch2-dev]
+  ubuntu:
+    focal: [libignition-launch2-dev]
+libignition-math6:
+  debian:
+    buster: [libignition-math6]
+  ubuntu:
+    focal: [libignition-math6]
+libignition-math6-dev:
+  debian:
+    buster: [libignition-math6-dev]
+  ubuntu:
+    focal: [libignition-math6-dev]
+libignition-msgs5:
+  debian:
+    buster: [libignition-msgs5]
+  ubuntu:
+    focal: [libignition-msgs5]
+libignition-msgs5-dev:
+  debian:
+    buster: [libignition-msgs5-dev]
+  ubuntu:
+    focal: [libignition-msgs5-dev]
+libignition-physics2:
+  debian:
+    buster: [libignition-physics2]
+  ubuntu:
+    focal: [libignition-physics2]
+libignition-physics2-dev:
+  debian:
+    buster: [libignition-physics2-dev]
+  ubuntu:
+    focal: [libignition-physics2-dev]
+libignition-plugin1:
+  debian:
+    buster: [libignition-plugin1]
+  ubuntu:
+    focal: [libignition-plugin1]
+libignition-plugin1-dev:
+  debian:
+    buster: [libignition-plugin1-dev]
+  ubuntu:
+    focal: [libignition-plugin1-dev]
+libignition-rendering3:
+  debian:
+    buster: [libignition-rendering3]
+  ubuntu:
+    focal: [libignition-rendering3]
+libignition-rendering3-dev:
+  debian:
+    buster: [libignition-rendering3-dev]
+  ubuntu:
+    focal: [libignition-rendering3-dev]
+libignition-sensors3:
+  debian:
+    buster: [libignition-sensors3]
+  ubuntu:
+    focal: [libignition-sensors3]
+libignition-sensors3-dev:
+  debian:
+    buster: [libignition-sensors3-dev]
+  ubuntu:
+    focal: [libignition-sensors3-dev]
+libignition-tools-dev:
+  debian:
+    buster: [libignition-tools-dev]
+  ubuntu:
+    focal: [libignition-tools-dev]
+libignition-transport8:
+  debian:
+    buster: [libignition-transport8]
+  ubuntu:
+    focal: [libignition-transport8]
+libignition-transport8-dev:
+  debian:
+    buster: [libignition-transport8-dev]
+  ubuntu:
+    focal: [libignition-transport8-dev]
 libimage-exiftool-perl:
   arch: [perl-image-exiftool]
   debian: [libimage-exiftool-perl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1388,6 +1388,51 @@ ifstat:
   fedora: [ifstat]
   gentoo: [net-analyzer/ifstat]
   ubuntu: [ifstat]
+ignition-citadel:
+  ubuntu: [ignition-citadel]
+  debian: [ignition-citadel]
+ignition-cmake2:
+  ubuntu: [libignition-cmake2-dev]
+  debian: [libignition-cmake2-dev]
+ignition-common3:
+  ubuntu: [libignition-common3-dev]
+  debian: [libignition-common3-dev]
+ignition-fuel-tools4:
+  ubuntu: [libignition-fuel-tools4-dev]
+  debian: [libignition-fuel-tools4-dev]
+ignition-gazebo3:
+  ubuntu: [libignition-gazebo3-dev]
+  debian: [libignition-gazebo3-dev]
+ignition-gui3:
+  ubuntu: [libignition-gui3-dev]
+  debian: [libignition-gui3-dev]
+ignition-launch2:
+  ubuntu: [libignition-launch2-dev]
+  debian: [libignition-launch2-dev]
+ignition-math6:
+  ubuntu: [libignition-math6-dev]
+  debian: [libignition-math6-dev]
+ignition-msgs5:
+  ubuntu: [libignition-msgs5-dev]
+  debian: [libignition-msgs5-dev]
+ignition-physics2:
+  ubuntu: [libignition-physics2-dev]
+  debian: [libignition-physics2-dev]
+ignition-plugin1:
+  ubuntu: [libignition-plugin1-dev]
+  debian: [libignition-plugin1-dev]
+ignition-rendering3:
+  ubuntu: [libignition-rendering3-dev]
+  debian: [libignition-rendering3-dev]
+ignition-sensors3:
+  ubuntu: [libignition-sensors3-dev]
+  debian: [libignition-sensors3-dev]
+ignition-tools1:
+  ubuntu: [libignition-tools1-dev]
+  debian: [libignition-tools1-dev]
+ignition-transport8:
+  ubuntu: [libignition-transport8-dev]
+  debian: [libignition-transport8-dev]
 imagemagick:
   arch: [imagemagick]
   debian: [imagemagick]
@@ -5391,6 +5436,7 @@ sdformat:
     artful: [libsdformat6-dev]
     bionic: [libsdformat6-dev]
     cosmic: [libsdformat6-dev]
+    focal: [libsdformat9-dev]
     precise: [sdformat]
     quantal: [sdformat]
     raring: [sdformat]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2611,16 +2611,16 @@ libignition-math6:
     buster: [libignition-math6]
   ubuntu:
     focal: [libignition-math6]
-libignition-math6-eigen3:
-  debian:
-    buster: [libignition-math6-eigen3]
-  ubuntu:
-    focal: [libignition-math6-eigen3]
 libignition-math6-dev:
   debian:
     buster: [libignition-math6-dev]
   ubuntu:
     focal: [libignition-math6-dev]
+libignition-math6-eigen3:
+  debian:
+    buster: [libignition-math6-eigen3]
+  ubuntu:
+    focal: [libignition-math6-eigen3]
 libignition-msgs5:
   debian:
     buster: [libignition-msgs5]
@@ -2641,11 +2641,6 @@ libignition-physics2-dev:
     buster: [libignition-physics2-dev]
   ubuntu:
     focal: [libignition-physics2-dev]
-libignition-plugin1:
-  debian:
-    buster: [libignition-plugin1]
-  ubuntu:
-    focal: [libignition-plugin1]
 libignition-plugin-dev:
   debian:
     buster: [libignition-plugin-dev]


### PR DESCRIPTION
Some of these keys are already being used by the [ros_ign](https://github.com/osrf/ros_ign/) packages to bloom it into https://packages.osrfoundation.org:

https://github.com/osrf/osrf-rosdep/blob/master/ignition/ignition.yaml

---

This is a follow up to #24646 