### PR TITLE
ros_comm: 1.15.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1592,7 +1592,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.4-1
+      version: 1.15.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.5-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.15.4-1`

## message_filters

```
* clear message queue on simtime jumping back (#1518 <https://github.com/ros/ros_comm/issues/1518>)
```

## ros_comm

- No changes

## rosbag

```
* add option to repeat latched messages at the start of bag splits (#1850 <https://github.com/ros/ros_comm/issues/1850>)
* fix bag migration failures caused by typo in connection_header assignment (#1952 <https://github.com/ros/ros_comm/issues/1952>)
```

## rosbag_storage

```
* fix brief description comments after members (#1920 <https://github.com/ros/ros_comm/issues/1920>)
```

## roscpp

```
* check if async socket connect is success or failure before TransportTCP::read() and TransportTCP::write() (#1954 <https://github.com/ros/ros_comm/issues/1954>)
* fix bug that connection drop signal related funtion throw a bad_weak exception (#1940 <https://github.com/ros/ros_comm/issues/1940>)
* multiple latched publishers per process on the same topic (#1544 <https://github.com/ros/ros_comm/issues/1544>)
* fix negative numbers in ros statistics (#1531 <https://github.com/ros/ros_comm/issues/1531>)
* remove extra n in ROS_DEBUG (#1925 <https://github.com/ros/ros_comm/issues/1925>)
```

## rosgraph

- No changes

## roslaunch

```
* add --sigint-timeout and --sigterm-timeout parameters (#1937 <https://github.com/ros/ros_comm/issues/1937>)
* roslaunch-check: search dir recursively (#1914 <https://github.com/ros/ros_comm/issues/1914>)
* sort printed nodes by namespace alphabetically (#1934 <https://github.com/ros/ros_comm/issues/1934>)
* remove pycrypto import (not used) (#1922 <https://github.com/ros/ros_comm/issues/1922>)
```

## roslz4

```
* use undefined dynamic_lookup on macOS (#1923 <https://github.com/ros/ros_comm/issues/1923>)
```

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

- No changes

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* avoid infinite recursion in rosrun tab completion when rosbash is not installed (#1948 <https://github.com/ros/ros_comm/issues/1948>)
* fix bare pointer in topic_tools::ShapeShifter (#1722 <https://github.com/ros/ros_comm/issues/1722>)
```

## xmlrpcpp

```
* check if enough FDs are free, instead counting the total free FDs (#1929 <https://github.com/ros/ros_comm/issues/1929>)
```
