### PR TITLE
control_msgs: 2.3.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -222,6 +222,21 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: maintained
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 2.3.0-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: foxy-devel
+    status: maintained
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `2.3.0-2`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## control_msgs

```
* Implement "flexible joint states" message: add DynamicJointState message
* add description of JointControllerState.msg (#30 <https://github.com/ros-controls/control_msgs/issues/30>) (#39 <https://github.com/ros-controls/control_msgs/issues/39>)
* Contributors: Bence Magyar
```
