### PR TITLE
moveit_opw_kinematics_plugin: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5447,6 +5447,17 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: melodic-devel
     status: maintained
+  moveit_opw_kinematics_plugin:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
+      version: melodic-devel
+    status: developed
   moveit_pr2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_opw_kinematics_plugin` to `0.2.1-1`:

- upstream repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
- release repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
