### PR TITLE
moveit_opw_kinematics_plugin: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7687,6 +7687,17 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: jade-devel
     status: maintained
+  moveit_opw_kinematics_plugin:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
+      version: kinetic-devel
+    status: developed
   moveit_pr2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_opw_kinematics_plugin` to `0.1.1-1`:

- upstream repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
- release repository: https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
