### PR TITLE
nmc_nlp_lite-release: 0.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6075,6 +6075,19 @@ repositories:
       type: git
       url: https://github.com/NiryoRobotics/niryo_one_ros_simulation.git
       version: master
+  nmc_nlp_lite-release:
+    doc:
+      type: git
+      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
+      version: 0.0.3
+    release:
+      packages:
+      - nmc_nlp_lite
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
+      version: 0.0.3-1
+    status: maintained
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmc_nlp_lite-release` to `0.0.3-1`:

- upstream repository: file:///mnt/c/inetpub_nlp/wwwroot/LN_home/SDK/catkin_ws/src/nmc_nlp_lite
- release repository: https://github.com/nmcbins/nmc_nlp_lite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
