### PR TITLE
nmc_nlp_lite-release: 0.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6078,8 +6078,8 @@ repositories:
   nmc_nlp_lite-release:
     doc:
       type: git
-      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
-      version: 0.0.5
+      url: https://github.com/nmcbins/nmc_nlp_lite_ros.git
+      version: master
     release:
       packages:
       - nmc_nlp_lite

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6075,6 +6075,18 @@ repositories:
       type: git
       url: https://github.com/NiryoRobotics/niryo_one_ros_simulation.git
       version: master
+  nmc_nlp_lite-release:
+    doc:
+      type: git
+      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
+      version: 0.0.5
+    release:
+      packages:
+      - nmc_nlp_lite
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
+      version: 0.0.5-1
   nmea_comms:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmc_nlp_lite-release` to `0.0.5-1`:

- upstream repository: file:///mnt/c/inetpub_nlp/wwwroot/LN_home/SDK/catkin_ws/src/nmc_nlp_lite
- release repository: https://github.com/nmcbins/nmc_nlp_lite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
