### PR TITLE
mrpt2: 2.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1017,6 +1017,21 @@ repositories:
       url: https://github.com/ros/message_runtime.git
       version: kinetic-devel
     status: maintained
+  mrpt2:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/mrpt/mrpt.git
+      version: master
+    status: developed
   navigation:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1020,7 +1020,7 @@ repositories:
   mrpt2:
     doc:
       type: git
-      url: https://github.com/MRPT/mrpt.git
+      url: https://github.com/mrpt/mrpt.git
       version: master
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.0.3-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
