### PR TITLE
rclc: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -871,6 +871,25 @@ repositories:
       url: https://github.com/ros2/rcl_logging.git
       version: master
     status: maintained
+  rclc:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: master
+    release:
+      packages:
+      - rclc
+      - rclc_examples
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/micro-ROS/rclc-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: master
+    status: developed
   rclcpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `0.1.1-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/micro-ROS/rclc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rclc

```
* Initial release
```

## rclc_examples

```
* Initial release
```
