### PR TITLE
Add RHEL rules for 6 keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1695,6 +1695,7 @@ libboost-dev:
   debian: [libboost-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
   ubuntu: [libboost-dev]
 libboost-filesystem:
   debian:
@@ -2633,6 +2634,7 @@ libjsoncpp:
   debian: [libjsoncpp1]
   fedora: [jsoncpp]
   gentoo: [dev-libs/jsoncpp]
+  rhel: [jsoncpp]
   ubuntu:
     artful: [libjsoncpp1]
     bionic: [libjsoncpp1]
@@ -2650,6 +2652,7 @@ libjsoncpp-dev:
   debian: [libjsoncpp-dev]
   fedora: [jsoncpp-devel]
   gentoo: [dev-libs/jsoncpp]
+  rhel: [jsoncpp-devel]
   ubuntu: [libjsoncpp-dev]
 libkdtree++-dev:
   debian: [libkdtree++-dev]
@@ -2801,6 +2804,7 @@ libncurses-dev:
   fedora: [ncurses-devel]
   gentoo: [sys-libs/ncurses]
   macports: [ncurses]
+  rhel: [nucrses-devel]
   ubuntu: [libncurses5-dev]
 libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
@@ -4238,6 +4242,7 @@ libxi-dev:
   debian: [libxi-dev]
   fedora: [libXi-devel]
   gentoo: [x11-libs/libXi]
+  rhel: [libXi-devel]
   ubuntu: [libxi-dev]
 libxinerama-dev:
   arch: [libxinerama]
@@ -4286,6 +4291,7 @@ libxmu-dev:
   debian: [libxmu-dev]
   fedora: [libXmu-devel]
   gentoo: [x11-libs/libXmu]
+  rhel: [libXmu-devel]
   ubuntu: [libxmu-dev]
 libxrandr:
   arch: [libxrandr]


### PR DESCRIPTION
There aren't any official web databases for RHEL/CentOS packages, so I'll link to the packages sitting in the repository mirrors where appropriate.

For EPEL packages, I linked to the Fedora package database.

These are all new dependencies that appeared in ROS 2 Eloquent.

| rosdep key | system package |
|------------|----------------|
| libboost-dev | [boost-devel](http://mirror.centos.org/centos-7/7/os/x86_64/Packages/boost-devel-1.53.0-28.el7.x86_64.rpm) |
| libjsoncpp | [jsoncpp](https://apps.fedoraproject.org/packages/jsoncpp) |
| libjsoncpp-dev | [jsoncpp-devel](https://apps.fedoraproject.org/packages/jsoncpp-devel) |
| libncurses-dev | [nucrses-devel](http://mirror.centos.org/centos-7/7/os/x86_64/Packages/ncurses-devel-5.9-14.20130511.el7_4.x86_64.rpm) |
| libxi-dev | [libXi-devel](http://mirror.centos.org/centos-7/7/os/x86_64/Packages/libXi-devel-1.7.9-1.el7.x86_64.rpm) |
| libxmu-dev | [libXmu-devel](http://mirror.centos.org/centos-7/7/os/x86_64/Packages/libXmu-devel-1.1.2-2.el7.x86_64.rpm) |

```
yum list -q --showduplicates --exclude='*.i686' available boost-devel \
> jsoncpp jsoncpp-devel ncurses-devel libXi-devel libXmu-devel
Available Packages
boost-devel.x86_64                   1.53.0-28.el7                         base
jsoncpp.x86_64                       0.10.5-2.el7                          epel
jsoncpp-devel.x86_64                 0.10.5-2.el7                          epel
libXi-devel.x86_64                   1.7.9-1.el7                           base
libXmu-devel.x86_64                  1.1.2-2.el7                           base
ncurses-devel.x86_64                 5.9-14.20130511.el7_4                 base
```