### PR TITLE
ros1_bridge: 0.9.0-2 in Foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1120,6 +1120,22 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: ros2
     status: maintained
+  ros1_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros1_bridge-release.git
+      version: 0.9.0-2
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    status: maintained
   ros2_intel_realsense:
     doc:
       type: git


### PR DESCRIPTION
Turning off 'test_commits' the same as Eloquent.