### PR TITLE
Unrelease mavlink in Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -931,11 +931,6 @@ repositories:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/noetic/mavlink
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2020.5.5-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
@voon FYI undoing https://github.com/ros/rosdistro/pull/24720 . Mind making a new mavlink release with https://github.com/mavlink/mavlink-gbp-release/pull/10? All mavlink binary jobs are failing, and have never passed.

* http://build.ros.org/view/Nbin_ufv8_uFv8/job/Nbin_ufv8_uFv8__mavlink__ubuntu_focal_arm64__binary/
* http://build.ros.org/view/Nbin_ufhf_uFhf/job/Nbin_ufhf_uFhf__mavlink__ubuntu_focal_armhf__binary/
* http://build.ros.org/view/Nbin_uF64/job/Nbin_uF64__mavlink__ubuntu_focal_amd64__binary/
* http://build.ros.org/view/Nbin_dbv8_dBv8/job/Nbin_dbv8_dBv8__mavlink__debian_buster_arm64__binary/
* http://build.ros.org/view/Nbin_db_dB64/job/Nbin_db_dB64__mavlink__debian_buster_amd64__binary/



