### PR TITLE
gazebo_ros_pkgs: 2.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -464,6 +464,18 @@ repositories:
       version: master
     status: maintained
   gazebo_ros_pkgs:
+    release:
+      packages:
+      - gazebo_dev
+      - gazebo_msgs
+      - gazebo_plugins
+      - gazebo_ros
+      - gazebo_ros_control
+      - gazebo_ros_pkgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
+      version: 2.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.9.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## gazebo_dev

```
* Gazebo 11 for Noetic (#1094 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1094>)
* Bump CMake version to avoid CMP0048 warning (#1066 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1066>)
* Contributors: Alejandro Hernández Cordero, chapulina
```

## gazebo_msgs

```
* Bump CMake version to avoid CMP0048 warning (#1066 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1066>)
* add additional light options to 'set_light_properties' service (#874 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/874>)
  The optional 'Light' properties 'cast_shadows', 'specular', 'direction',
  and 'pose' are not optional any more. These properties are now set via the
  corresponding fields in the ROS message. By default, this will be 0.
  https://github.com/ros-simulation/gazebo_ros_pkgs/pull/874
* Contributors: Alejandro Hernández Cordero, Christian Rauch
```

## gazebo_plugins

```
* gazebo_ros_wheel_slip plugin (Noetic) (#1081 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1081>)
  Uses dynamic_reconfigure to set wheel slip parameters.
  Requires gazebo 9.5.
  * don't overwrite initial slip values
  * Add test world using trisphere_cycles
  * gazebo_ros_wheel_slip: remove unused member data
* Fix bug in clipping of block laser depth values (#902 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/902>)
  * Fix bug in block laser with large min range
  * Add block laser clipping test
  * REP-117 clipping
  Ranges were clipped to maxRange - minRange when they should have been
  clipped to only maxRange
* resolve marker orientation error, remove error mgss (#1096 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1096>)
* Add option to publish depth images in 16UC1 (#862 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/862>)
* [Noetic] changes to make it work with Python3 (#1069 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1069>)
* Generate normals with depth images (#1095 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1095>)
* [noetic] cherry-pick portable installation fixes. (#1089 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1089>)
  * cherry-pick portable installation fixes.
  * removing pub_joint_trajectory_test
* Adpated to OpenCV4 (#1068 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1068>)
* Include preprocessor conditions to avoid compile OnNewNormalsFrame and OnNewReflectanceFrame (#1071 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1071>)
* [Gazebo9] Added reflectance callback to publish reflectance image in ROS  (#1046 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1046>)
  * Added reflectance callback to publish reflectance image in ROS
  * removed debug trace ros_depth_camera
  * update reflectance_plugin tag from material to reflectance_map
  * fixed index variable
  * Added documentation and override
  * updating reflectance_map tags
* IMU sensor: comply with REP 145 by default
  Change default value of initialOrientationAsReference to false
  and print deprecation warning if user explicitly sets it to true.
* Measure IMU orientation with respect to world (#1051 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1051>)
  Report the IMU orientation from the sensor plugin with respect to the world frame.
  This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html
  In order to not break existing behavior, users should opt-in by adding a new SDF tag.
* [Gazebo 9] Created a MarkerArray to publish normals in ROS (#1047 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1047>)
  * created a MarkerArray to publish normals in ROS
  * Added visualization msgs dependencie depthcamerasensor
  * Added feedback
  * populate point cloud when normals is activated
  * argument to reduce the amount of normals to publish
  * reduced computation in normals publisher
* Fix a problem twice named with ros namespace. (#920 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/920>)
  gazebo_ros_imu_sensor: robotNamespace is no longer duplicate inside topics
* gazebo_plugins: export plugin path in package.xml (#923 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/923>)
* Fix destructor of gazebo_ros_diff_drive.cpp (#1021 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1021>)
  Fix issue referenced in #123 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/123> where the destructor of ROS DiffDrive plugin causes gzserver to crash on model deletion.
* [Windows][melodic-devel] more Windows build break fix (#975 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/975>)
  * Fix CMake install error for Windows build.
  * conditionally include <sys/time.h>
* Use ignition::math::Rand utility for portability. (#878 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/878>)
* Contributors: Alejandro Hernández Cordero, Ben Wolsieffer, Jacob Perron, RemiRigal, Sam Pfeiffer, Sean Yen, Shane Loretz, Steven Peters, deltaMASH, iche033
```

## gazebo_ros

```
* [Noetic] changes to make it work with Python3 (#1069 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1069>)
  * Noetic - changes to make it work with Python3
* add node required to noetic (#1082 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1082>)
* add additional light options to 'set_light_properties' service (#874 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/874>)
  The optional 'Light' properties 'cast_shadows', 'specular', 'direction',
  and 'pose' are not optional any more. These properties are now set via the
  corresponding fields in the ROS message. By default, this will be 0.
  https://github.com/ros-simulation/gazebo_ros_pkgs/pull/874
* spawn_model: Fix urlparse imports for Python 3
* spawn_model: Ensure that "model_xml" is a string, required for Python 3
* catkin_find gazebo plugin from bin folder. (#993 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/993>)
* [Windows][melodic-devel] more Windows build break fix (#975 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/975>)
  * Fix CMake install error for Windows build.
  * conditionally include <sys/time.h>
* provide Windows implemenation for setenv. (#879 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/879>)
* implement basic gazebo scripts to support launch file on Windows build. (#880 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/880>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Kartik Mohta, Mabel Zhang, Sean Yen
```

## gazebo_ros_control

```
* restrict Windows header namespace. (#1023 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1023>)
* [Windows][melodic-devel] more Windows build break fix (#975 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/975>)
  * Fix CMake install error for Windows build.
  * conditionally include <sys/time.h>
* Contributors: Sean Yen
```

## gazebo_ros_pkgs

```
* Bump CMake version to avoid CMP0048 warning (#1066 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1066>)
* Contributors: Alejandro Hernández Cordero
```
