### PR TITLE
rosdep: MQTT C++ development package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4875,6 +4875,7 @@ mosquitto-dev:
   ubuntu: [libmosquitto-dev]
 mosquittopp-dev:
   debian: [libmosquittopp-dev]
+  fedora: [mosquitto-devel]
   ubuntu: [libmosquittopp-dev]
 mpg123:
   arch: [mpg123]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4873,6 +4873,9 @@ mosquitto-dev:
   debian: [libmosquitto-dev]
   fedora: [mosquitto-devel]
   ubuntu: [libmosquitto-dev]
+mosquittopp-dev:
+  debian: [libmosquittopp-dev]
+  ubuntu: [libmosquittopp-dev]
 mpg123:
   arch: [mpg123]
   debian: [mpg123]


### PR DESCRIPTION
Adding the C++ dev package for MQTT. Though, it looks like Fedora has the C++ development files in `mosquitto-devel` so alternatively the existing key can be updated to include the C++ packages.
```
mosquitto-dev:
  debian: [libmosquitto-dev, libmosquittopp-dev]
  fedora: [mosquitto-devel]
  ubuntu: [libmosquitto-dev, libmosquittopp-dev]
```

https://packages.ubuntu.com/search?suite=xenial&searchon=names&keywords=libmosquittopp-dev
https://packages.debian.org/search?keywords=libmosquittopp-dev&searchon=names&suite=stable&section=all
https://apps.fedoraproject.org/packages/mosquitto-devel/contents

