### PR TITLE
geometry2: 0.13.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -447,7 +447,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.1-1
+      version: 0.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.13.1-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Modify error message to not match the pattern for Jenkins MSBuild errors (#265 <https://github.com/ros2/geometry2/issues/265>)
* Contributors: Dirk Thomas
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* Explicitly add DLL directories for Windows before importing (#266 <https://github.com/ros2/geometry2/issues/266>)
* Contributors: Jacob Perron
```

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
