### PR TITLE
rosidl_python: 0.9.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1360,7 +1360,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## rosidl_generator_py

```
* Explicitly add DLL directories for Windows before importing (#113 <https://github.com/ros2/rosidl_python/issues/113>)
* Force extension points to be registered in order (#112 <https://github.com/ros2/rosidl_python/issues/112>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron
```
