### PR TITLE
image_pipeline: 1.15.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3749,7 +3749,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.14.0-1
+      version: 1.15.0-1
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.15.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.14.0-1`

## camera_calibration

```
* Fix import path on camera_calibrator.py (#509 <https://github.com/ros-perception/image_pipeline/issues/509>)
* Fixes #501 <https://github.com/ros-perception/image_pipeline/issues/501>: self.size is set before dumping calibration parameters in calibrator.py do_calibration(self, dump) (#502 <https://github.com/ros-perception/image_pipeline/issues/502>)
  Not sure how this one made it through. Thanks for the fix!
* Contributors: Gonçalo Camelo Neves Pereira, Stewart Jamieson
```

## depth_image_proc

```
* updated install locations for better portability. (#500 <https://github.com/ros-perception/image_pipeline/issues/500>)
* Contributors: Sean Yen
```

## image_pipeline

- No changes

## image_proc

```
* updated install locations for better portability. (#500 <https://github.com/ros-perception/image_pipeline/issues/500>)
* Contributors: Sean Yen
```

## image_publisher

```
* updated install locations for better portability. (#500 <https://github.com/ros-perception/image_pipeline/issues/500>)
* Contributors: Sean Yen
```

## image_rotate

```
* updated install locations for better portability. (#500 <https://github.com/ros-perception/image_pipeline/issues/500>)
* Contributors: Sean Yen
```

## image_view

```
* image_view: add missing dependency to gencfg header (#532 <https://github.com/ros-perception/image_pipeline/issues/532>)
* clone cv_ptr->image before set queued_image (#526 <https://github.com/ros-perception/image_pipeline/issues/526>)
* [image_view] Add dynamic reconfigure to image_nodelet.cpp in melodic (#504 <https://github.com/ros-perception/image_pipeline/issues/504>)
* updated install locations for better portability. (#500 <https://github.com/ros-perception/image_pipeline/issues/500>)
* Contributors: Atsushi Watanabe, Kei Okada, Naoya Yamaguchi, Sean Yen
```

## stereo_image_proc

```
* updated install locations for better portability. (#500 <https://github.com/ros-perception/image_pipeline/issues/500>)
* Contributors: Sean Yen
```
