### PR TITLE
rclc: 0.1.2-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2071,7 +2071,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/micro-ROS/rclc-release.git
-      version: 0.1.1-1
+      version: 0.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `0.1.2-2`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/micro-ROS/rclc-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.1-1`

## rclc

```
* Fixed compiler errors for bloom release
```

## rclc_examples

```
* Fixed compiler errors for bloom release
```
