### PR TITLE
Replace the pip python-rtree dependency for the apt package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2969,11 +2969,11 @@ python-pcapy:
 python-pcg-gazebo-pip:
   debian:
     pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
+      depends: [libspatialindex-dev, geos, pybind11-dev, python-rtree]
       packages: [pcg-gazebo]
   ubuntu:
     pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
+      depends: [libspatialindex-dev, geos, pybind11-dev, python-rtree]
       packages: [pcg-gazebo]
 python-pep8:
   arch: [python2-pep8]
@@ -5677,11 +5677,11 @@ python3-paramiko:
 python3-pcg-gazebo-pip:
   debian:
     pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
+      depends: [libspatialindex-dev, geos, pybind11-dev, python3-rtree]
       packages: [pcg-gazebo]
   ubuntu:
     pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
+      depends: [libspatialindex-dev, geos, pybind11-dev, python3-rtree]
       packages: [pcg-gazebo]
 python3-pep8:
   alpine: [py3-pycodestyle]


### PR DESCRIPTION
The current `pip` package for `rtree` is currently leading to problems regarding it's non-Python dependencies. This PR sets the `apt` packages for `rtree`  as dependencies for the `pcg-gazebo` installations.