### PR TITLE
vision_opencv: 1.15.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2542,7 +2542,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/vision_opencv-release.git
-      version: 1.14.0-1
+      version: 1.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `1.15.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros-gbp/vision_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.14.0-1`

## cv_bridge

```
* [Noetic] Use opencv3 on buster (#330 <https://github.com/ros-perception/vision_opencv/issues/330>)
* more portable fixes. (#328 <https://github.com/ros-perception/vision_opencv/issues/328>)
* Contributors: Sean Yen, Shane Loretz
```

## image_geometry

- No changes

## vision_opencv

- No changes
