### PR TITLE
rosidl: 0.9.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1305,7 +1305,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## rosidl_adapter

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_parser

- No changes

## rosidl_runtime_c

```
* Update API documentation (#488 <https://github.com/ros2/rosidl/issues/488>)
* Add tests (#484 <https://github.com/ros2/rosidl/issues/484>)
* Add feature documentation (#482 <https://github.com/ros2/rosidl/issues/482>)
* Contributors: brawner
```

## rosidl_runtime_cpp

```
* Update API documentation (#488 <https://github.com/ros2/rosidl/issues/488>)
* Add tests (#484 <https://github.com/ros2/rosidl/issues/484>)
* Add feature documentation (#482 <https://github.com/ros2/rosidl/issues/482>)
* Contributors: brawner
```

## rosidl_typesupport_interface

```
* Update API documentation (#488 <https://github.com/ros2/rosidl/issues/488>)
* Add tests (#484 <https://github.com/ros2/rosidl/issues/484>)
* Add feature documentation (#482 <https://github.com/ros2/rosidl/issues/482>)
* Contributors: brawner
```

## rosidl_typesupport_introspection_c

```
* Force extension points to be registered in order (#485 <https://github.com/ros2/rosidl/issues/485>)
* Contributors: Ivan Santiago Paunovic
```

## rosidl_typesupport_introspection_cpp

```
* Force extension points to be registered in order (#485 <https://github.com/ros2/rosidl/issues/485>)
* Contributors: Ivan Santiago Paunovic
```
