### PR TITLE
gazebo_ros_pkgs: 2.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -475,7 +475,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.9.0-1
+      version: 2.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.9.1-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.9.0-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* Noetic patch for Opencv libraries (#1106 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1106>)
  * Need to include calib3d for undistort method
  * Add opencv cmake support where needed
* Contributors: Jose Luis Rivero
```

## gazebo_ros

- No changes

## gazebo_ros_control

- No changes

## gazebo_ros_pkgs

- No changes
