### PR TITLE
urdf_sim_tutorial: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2494,6 +2494,22 @@ repositories:
       url: https://github.com/ros-controls/urdf_geometry_parser.git
       version: kinetic-devel
     status: developed
+  urdf_sim_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
+      version: 0.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_sim_tutorial.git
+      version: master
+    status: maintained
   urdf_tutorial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_sim_tutorial` to `0.5.0-1`:

- upstream repository: https://github.com/ros/urdf_sim_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_sim_tutorial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## urdf_sim_tutorial

```
* Bump CMake version to avoid CMP0048 warning #6 <https://github.com/ros/urdf_sim_tutorial/issues/6>
* Contributors: David V. Lu!!, ahcorde
```
