### PR TITLE
actionlib: 1.13.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -37,7 +37,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.13.0-1
+      version: 1.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.13.1-1`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.13.0-1`

## actionlib

```
* Fix tiny typo. (#165 <https://github.com/ros/actionlib/issues/165>)
* Add deleted copy constructor. (#160 <https://github.com/ros/actionlib/issues/160>)
* roscpp ActionClient subscription queue size should be consistent with rospy. (#162 <https://github.com/ros/actionlib/issues/162>)
* import setup from setuptools instead of distutils-core (#163 <https://github.com/ros/actionlib/issues/163>)
* Contributors: Alejandro Hernández Cordero, Ivor Wanders, jschleicher, tomoya
```

## actionlib_tools

```
* Remove scripts using wx (#166 <https://github.com/ros/actionlib/issues/166>)
* Contributors: Shane Loretz
```
