### PR TITLE
ridgeback: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8217,7 +8217,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.2.3-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.3.0-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.3-1`

## ridgeback_control

```
* Fix the default device for the PS4 controller to match with the updated udev rules for bionic
* Contributors: Chris I-B
```

## ridgeback_description

- No changes

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
