### PR TITLE
metapackages: 1.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1029,6 +1029,20 @@ repositories:
       type: git
       url: https://github.com/ros/metapackages.git
       version: noetic-devel
+    release:
+      packages:
+      - desktop
+      - desktop_full
+      - perception
+      - robot
+      - ros_base
+      - ros_core
+      - simulators
+      - viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/metapackages-release.git
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `1.5.0-1`:

- upstream repository: https://github.com/ros/metapackages.git
- release repository: https://github.com/ros-gbp/metapackages-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
