### PR TITLE
rqt_graph: 0.4.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2010,7 +2010,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_graph-release.git
-      version: 0.4.12-1
+      version: 0.4.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `0.4.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros-gbp/rqt_graph-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.12-1`

## rqt_graph

```
* use catkin_install_python() (#43 <https://github.com/ros-visualization/rqt_graph/issues/43>)
```
