### PR TITLE
Added bullet extras for debian and ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -321,9 +321,11 @@ bullet:
     '*': [libbullet-dev]
     trusty_python3: [libbullet-dev]
 bullet-extras:
+  arch: [bullet]
   debian: [libbullet-extras-dev]
-  ubuntu:
-    '*': [libbullet-extras-dev]
+  fedora: [bullet-extras]
+  gentoo: [sci-physics/bullet]
+  ubuntu: [libbullet-extras-dev]
 bzip2:
   alpine: [bzip2-dev]
   arch: [bzip2]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -320,6 +320,10 @@ bullet:
   ubuntu:
     '*': [libbullet-dev]
     trusty_python3: [libbullet-dev]
+bullet-extras:
+  debian: [libbullet-extras-dev]
+  ubuntu:
+    '*': [libbullet-extras-dev]
 bzip2:
   alpine: [bzip2-dev]
   arch: [bzip2]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -38,6 +38,10 @@ bullet:
   osx:
     homebrew:
       packages: [bullet]
+bullet-extras:
+  osx:
+    homebrew:
+      packages: [bullet]
 bzip2:
   osx:
     homebrew:


### PR DESCRIPTION
The Bullet Collision library contains some useful extra features like Inverse Dynamics, file serialization, and some packaged versions of HACD/Convex decomposition. These extras aren't installed by default, so I've added them here.
 
* Debian: https://packages.debian.org/unstable/libbullet-extras-dev
* Ubuntu: https://packages.ubuntu.com/bionic/libs/libbullet-extras-dev