### PR TITLE
rqt_logger_level: 0.4.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2058,7 +2058,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_logger_level-release.git
-      version: 0.4.9-1
+      version: 0.4.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.9-1`

## rqt_logger_level

```
* use catkin_install_python() (#8 <https://github.com/ros-visualization/rqt_logger_level/issues/8>)
```
