### PR TITLE
Add RHEL 8 rule for spdlog

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5534,8 +5534,7 @@ spdlog:
   debian: [libspdlog-dev]
   fedora: [spdlog-devel]
   gentoo: [dev-libs/spdlog]
-  rhel:
-    '7': [spdlog-devel]
+  rhel: [spdlog-devel]
   ubuntu: [libspdlog-dev]
 speech-dispatcher:
   debian: [speech-dispatcher]


### PR DESCRIPTION
This package is now available in EPEL 8: https://src.fedoraproject.org/rpms/spdlog#bodhi_updates