### PR TITLE
moveit_msgs: 0.10.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5441,7 +5441,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.10.0-0
+      version: 0.10.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.10.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.10.0-0`

## moveit_msgs

```
* [feature] Add messages to plan for sequences (#65 <https://github.com/ros-planning/moveit_msgs/issues/65>)
* [feature] Jog arm backport (#70 <https://github.com/ros-planning/moveit_msgs/issues/70>)
* [improve] Correct typos/better phrasing in Place.action & Add missing word to CollisionObject.msg (#52 <https://github.com/ros-planning/moveit_msgs/issues/52>)
* [improve] Add comment all scene components returned if no components specified (#51 <https://github.com/ros-planning/moveit_msgs/issues/51>)
* [maintenance] Bump cmake version (#67 <https://github.com/ros-planning/moveit_msgs/issues/67>)
* [maintenance] Fix catkin_lint issues (#56 <https://github.com/ros-planning/moveit_msgs/issues/56>)
* Contributors: Bence Magyar, Bryce Willey, Christian Henkel, Felix von Drigalski, Jens P, Markus Vieth, Michael Görner, Robert Haschke, Tyler Weaver
```
