### PR TITLE
iris_lama_ros: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3975,6 +3975,13 @@ repositories:
       url: https://github.com/eupedrosa/iris_lama-release.git
       version: 1.0.0-1
     status: developed
+  iris_lama_ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/eupedrosa/iris_lama_ros-release.git
+      version: 1.0.0-1
+    status: developed
   ivcon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama_ros` to `1.0.0-1`:

- upstream repository: https://github.com/iris-ua/iris_lama_ros.git
- release repository: https://github.com/eupedrosa/iris_lama_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## iris_lama_ros

```
* First official release.
```
