### PR TITLE
ros1_bridge: 0.9.0-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1129,7 +1129,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.9.0-3
+      version: 0.9.0-4
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.9.0-4`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-3`

## ros1_bridge

```
* Avoid new deprecations (#255 <https://github.com/ros2/ros1_bridge/issues/255>)
* Updates since changes to message_info in rclcpp (#253 <https://github.com/ros2/ros1_bridge/issues/253>)
* Assert ROS 1 nodes' stdout (#247 <https://github.com/ros2/ros1_bridge/issues/247>)
* Ignore actionlib_msgs deprecation warning (#245 <https://github.com/ros2/ros1_bridge/issues/245>)
* Drop workaround for https://github.com/ros2/rmw_fastrtps/issues/265. (#233 <https://github.com/ros2/ros1_bridge/issues/233>)
* Code style only: wrap after open parenthesis if not in one line (#238 <https://github.com/ros2/ros1_bridge/issues/238>)
* Contributors: Dirk Thomas, Jacob Perron, Michel Hidalgo, William Woodall
```
