### PR TITLE
catkin: 0.8.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -128,7 +128,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.4-1
+      version: 0.8.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.5-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.4-1`

## catkin

```
* stop catkin from trying to find C++ libraries if not needed (#1083 <https://github.com/ros/catkin/issues/1083>)
* [Windows] make more relocatable wrapper (#1086 <https://github.com/ros/catkin/issues/1086>)
* suppress FPHSA name mismatch for empy (#1093 <https://github.com/ros/catkin/issues/1093>)
```
