### PR TITLE
bond_core: 1.8.5-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -847,7 +847,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.8.5-1
+      version: 1.8.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.5-2`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.8.5-1`

## bond

```
* Bump CMake minimum version to use CMP0048 (#58 <https://github.com/ros/bond_core/issues/58>)
* Contributors: Michael Carroll
```

## bond_core

```
* Bump CMake minimum version to use CMP0048 (#58 <https://github.com/ros/bond_core/issues/58>)
* Contributors: Michael Carroll
```

## bondcpp

```
* Bump CMake minimum version to use CMP0048 (#58 <https://github.com/ros/bond_core/issues/58>)
* Contributors: Michael Carroll
```

## bondpy

```
* Use setuptools instead of distutils (#61 <https://github.com/ros/bond_core/issues/61>)
* Bump CMake minimum version to use CMP0048 (#58 <https://github.com/ros/bond_core/issues/58>)
* Contributors: Alejandro Hernández Cordero, Michael Carroll
```

## smclib

```
* Use setuptools instead of distutils (#61 <https://github.com/ros/bond_core/issues/61>)
* Bump CMake minimum version to use CMP0048 (#58 <https://github.com/ros/bond_core/issues/58>)
* Contributors: Alejandro Hernández Cordero, Michael Carroll
```
