### PR TITLE
catkin: 0.7.26-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1037,7 +1037,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.23-1
+      version: 0.7.26-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.26-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.23-1`

## catkin

```
* stop catkin from trying to find C++ libraries if not needed (#1083 <https://github.com/ros/catkin/issues/1083>)
* [Windows] make more relocatable wrapper (#1086 <https://github.com/ros/catkin/issues/1086>)
* suppress FPHSA name mismatch for empy (#1093 <https://github.com/ros/catkin/issues/1093>)
```
