### PR TITLE
ros_comm: 1.15.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1644,7 +1644,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.5-1
+      version: 1.15.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.6-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.15.5-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

```
* fix a bug that using a destroyed connection object (#1950 <https://github.com/ros/ros_comm/issues/1950>)
```

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

- No changes

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

- No changes
