### PR TITLE
common_msgs: 1.13.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -202,7 +202,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.12.7-1
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.13.0-1`:

- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.12.7-1`

## actionlib_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```

## common_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```

## diagnostic_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```

## geometry_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```

## nav_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```

## sensor_msgs

```
* Update BatteryState.msg (#140 <https://github.com/ros/common_msgs/issues/140>)
* Use setuptools instead of distutils (#159 <https://github.com/ros/common_msgs/issues/159>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Fix TabError: inconsistent use of tabs and spaces in indentation (#155 <https://github.com/ros/common_msgs/issues/155>)
  * Fix TabError: inconsistent use of tabs and spaces in indentation
  Python 3 is much more strict for spacing.
* Contributors: Ramon Wijnands, Rein Appeldoorn, Shane Loretz
```

## shape_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```

## stereo_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```

## trajectory_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Fix EOF line break so cat output is more usable.
* Contributors: Halie Murray-Davis, Shane Loretz
```

## visualization_msgs

```
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Shane Loretz
```
