### PR TITLE
pluginlib: 1.13.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1360,7 +1360,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.12.2-1
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.13.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.12.2-1`

## pluginlib

```
* Declare specific boost dependencies (#171 <https://github.com/ros/pluginlib/issues/171>)
* Contributors: Mikael Arguedas
```
