### PR TITLE
osrf_testing_tools_cpp: 1.3.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -702,7 +702,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `1.3.2-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.3.1-1`

## osrf_testing_tools_cpp

```
* Suppressed a FPHSA CMake warning in Backward (#48 <https://github.com/osrf/osrf_testing_tools_cpp/issues/48>)
* Contributors: Dirk Thomas
```

## test_osrf_testing_tools_cpp

- No changes
