### PR TITLE
rviz: 8.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1709,7 +1709,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.0.1-1
+      version: 8.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.0.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `8.0.1-1`

## rviz2

```
* Removed automoc completely. (#545 <https://github.com/ros2/rviz/issues/545>)
* Contributors: Chris Lalancette
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Changed to use modern cmake style with pluginlib (#542 <https://github.com/ros2/rviz/issues/542>)
* Removed automoc completely. (#545 <https://github.com/ros2/rviz/issues/545>)
* Contributors: Chris Lalancette, Karsten Knese
```

## rviz_default_plugins

```
* Removed rviz_default_plugins dependency on TinyXML (#531 <https://github.com/ros2/rviz/issues/531>)
  This clears the way for urdf to switch to TinyXML2
  Note that internally, urdf was converting the passed XML to a string and reparsing it in the implementation of ``urdf::model::initXml``
* Contributors: Dan Rose
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed automoc completely. (#545 <https://github.com/ros2/rviz/issues/545>)
* Added workaround for Eigen build bug (#546 <https://github.com/ros2/rviz/issues/546>)
* Contributors: Chris Lalancette
```

## rviz_rendering_tests

```
* Removed automoc completely. (#545 <https://github.com/ros2/rviz/issues/545>)
* Contributors: Chris Lalancette
```

## rviz_visual_testing_framework

```
* Removed automoc completely. (#545 <https://github.com/ros2/rviz/issues/545>)
* Contributors: Chris Lalancette
```
