### PR TITLE
mavros: 1.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7164,7 +7164,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.2.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## libmavconn

- No changes

## mavros

```
* has_capability only works for enums
* Uncrustify
* Reworked Waypoint plugin to use capabilities_cb
  Additionally added helper functions has_capability and has_capabilities
  so that people can use either ints or enums to check if the UAS has a
  capability. This might make accepting capabilities as a parameter moot
  though.
* Added alias for capabilities enum to UAS
* Added alias for capabilities enum to UAS
* Added a capabilities change cb queue
  Plugins can now write functions that they add to the
  capabilities_cb_vec. These functions will be called only when there is a
  change to the capabilities themselves not whenever the known status of
  the fcu_capabilities change.
  These functions should have a parameter of type
  mavlink::common::MAV_PROTOCOL_CAPABILITY which is essentially just a
  uint64_t however being more opinionated is helpful when looking for what
  the canonical enum names are in the mavlink project header files.
* Uncrustify
* Fixed Removed Uncrustify Option
  I'm not sure why this didn't break when I ran uncrustify previously but
  it seems that the align_number_left option was removed a while ago with
  this merge request but I may be mistaken
  https://github.com/uncrustify/uncrustify/pull/1393
  I replaced it which align_number_right=true since it seems to be the
  inverse of align_number_left=true.
* Removed deprecated MAV_FRAME values
* Removed use of variant in favor of templates
  Since ROS messages are now the storage type in the node, providing to
  and from conversion functions is sufficient and can be better expressed
  with function templates.
* Encode factor returns double
* Changed encoding factor cog code
* Uncrustify changes
* Added new parameter to config.yamls
* Updated waypoint plugin to support MISSION_ITEM_INT
  These changes add a new parameter use_mission_item_int, which allows
  users to prefer the old behavior. These changes also verify that the
  flight controller supports _INT messages since APM only sends
  REQUEST_ITEM messages even though it accepts _INT items back.
  This commit is functional and tested with the APM stack only.
  PX4 sitl jmavsim threw:
  WP: upload failed: Command is not supported.
  FCU: IGN MISSION_ITEM: Busy
* Removed x_lat, y_long, z_alt from WP
  These values seemed to be used due to the fact that double had
  a greater resolution than float and doubles are used in the
  ros msg. However they were only ever used for printing. Since
  the int version of these messages has a greater resolution I
  figure it is more useful to print the true value in the mavlink
  message rather than the ros message value
* Replaced MISSION_ITEM
* add yaw to CMD_DO_SET_HOME
* fix local angular velocity
* Contributors: Braedon, David Jablonski, Martina Rivizzigno
```

## mavros_extras

```
* Revert "extras: odom: Hardcode BODY_FRD enum_value to fix compilation"
  This reverts commit 1a898dea2202ee1af56d698bd40d40994346c5cb.
* extras: odom: Hardcode BODY_FRD enum_value to fix compilation
  That PR broke build: https://github.com/mavlink/mavlink/pull/1112
  TODO: find out what frame should be used
* Contributors: Vladimir Ermakov
```

## mavros_msgs

```
* add yaw to CMD_DO_SET_HOME
* Contributors: David Jablonski
```

## test_mavros

- No changes
