### PR TITLE
rosidl: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1305,7 +1305,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.9.2-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.2-1`

## rosidl_adapter

- No changes

## rosidl_cmake

```
* Fix variable suffix in rosidl_export_typesupport_targets (#483 <https://github.com/ros2/rosidl/issues/483>)
* Contributors: Ivan Santiago Paunovic
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_parser

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

```
* Clean up BoundedVector (#487 <https://github.com/ros2/rosidl/issues/487>)
* Contributors: Jonathan Wakely
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Fix variable suffix in rosidl_export_typesupport_targets (#483 <https://github.com/ros2/rosidl/issues/483>)
* Contributors: Ivan Santiago Paunovic
```

## rosidl_typesupport_introspection_cpp

```
* Fix variable suffix in rosidl_export_typesupport_targets (#483 <https://github.com/ros2/rosidl/issues/483>)
* Contributors: Ivan Santiago Paunovic
```
