### PR TITLE
rcutils: 0.9.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -951,7 +951,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## rcutils

```
* Move likely/unlikely macros from logging.h to macros.h (#253 <https://github.com/ros2/rcutils/issues/253>)
* Add rcutils_set_env function (#250 <https://github.com/ros2/rcutils/issues/250>)
* Reset error state after testing expected errors (#251 <https://github.com/ros2/rcutils/issues/251>)
* Fix a link to REP-2004 (#245 <https://github.com/ros2/rcutils/issues/245>)
* Contributors: Ivan Santiago Paunovic, Scott K Logan, Shota Aoki
```
