### PR TITLE
rcl: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -819,7 +819,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## rcl

```
* Expose rcl default logging output handler (#660 <https://github.com/ros2/rcl/issues/660>)
* Remove deprecated functions (#658 <https://github.com/ros2/rcl/issues/658>)
* Warn about unused return value for set_logger_level (#652 <https://github.com/ros2/rcl/issues/652>)
* Mark cyclonedds test_service test as flakey (#648 <https://github.com/ros2/rcl/issues/648>)
* Convert sleep_for into appropriate logic in tests(#631 <https://github.com/ros2/rcl/issues/631>)
* Reduce timeouts in tests(#613 <https://github.com/ros2/rcl/issues/613>)
* Add tests for time.c and timer.c (#599 <https://github.com/ros2/rcl/issues/599>)
* Update Quality Declaration for 1.0 (#647 <https://github.com/ros2/rcl/issues/647>)
* Contributors: Barry Xu, Dirk Thomas, Ivan Santiago Paunovic, Jorge Perez, Tully Foote, brawner
```

## rcl_action

```
* Update Quality Declaration for 1.0 (#647 <https://github.com/ros2/rcl/issues/647>)
* Contributors: brawner
```

## rcl_lifecycle

```
* Update Quality Declaration for 1.0 (#647 <https://github.com/ros2/rcl/issues/647>)
* Contributors: brawner
```

## rcl_yaml_param_parser

```
* Update Quality Declaration for 1.0 (#647 <https://github.com/ros2/rcl/issues/647>)
* Contributors: brawner
```
