### PR TITLE
Add dependencies for Gentoo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5282,6 +5282,7 @@ python3-asyncssh:
 python3-autobahn:
   debian: [python3-autobahn]
   fedora: [python3-autobahn]
+  gentoo: [dev-python/autobahn]
   rhel:
     '*': ['python%{python3_pkgversion}-autobahn']
     '7': null
@@ -5289,6 +5290,7 @@ python3-autobahn:
 python3-babeltrace:
   debian: [python3-babeltrace]
   fedora: [python3-babeltrace]
+  gentoo: [dev-util/babeltrace]
   ubuntu: [python3-babeltrace]
 python3-backoff-pip:
   arch:
@@ -5385,6 +5387,7 @@ python3-coverage:
 python3-cryptography:
   debian: [python3-cryptography]
   fedora: [python3-cryptography]
+  gentoo: [dev-python/cryptography]
   rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
 python3-datadog-pip:
@@ -5434,6 +5437,7 @@ python3-docker:
   arch: [python-docker]
   debian: [python3-docker]
   fedora: [python3-docker]
+  gentoo: [dev-python/docker-py]
   rhel:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
@@ -5441,6 +5445,7 @@ python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]
   fedora: [python3-docutils]
+  gentoo: [dev-python/docutils]
   ubuntu: [python3-docutils]
 python3-empy:
   debian:
@@ -5483,6 +5488,7 @@ python3-flake8:
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]
+  gentoo: [dev-python/future]
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
 python3-gi:
@@ -5500,6 +5506,7 @@ python3-gitlab:
     stretch:
       pip:
         packages: [python-gitlab]
+  gentoo: [dev-vcs/python-gitlab]
   ubuntu:
     '*': [python3-gitlab]
     artful:
@@ -5535,6 +5542,7 @@ python3-grpcio:
 python3-hypothesis:
   debian: [python3-hypothesis]
   fedora: [python3-hypothesis]
+  gentoo: [dev-python/hypothesis]
   ubuntu: [python3-hypothesis]
 python3-ifcfg:
   debian:
@@ -5651,6 +5659,7 @@ python3-opencv:
   debian:
     buster: [python3-opencv]
   fedora: [python3-opencv]
+  gentoo: ['media-libs/opencv[python]']
   openembedded: [opencv@meta-oe]
   ubuntu:
     bionic: [python3-opencv]


### PR DESCRIPTION
@tfoote this adds some missing python3 dependencies for Gentoo.

Fixes ros/ros-overlay#982