### PR TITLE
rqt_console: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1985,7 +1985,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_console-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros-gbp/rqt_console-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.10-1`

## rqt_console

```
* readd rqt_console global executable, regression from 0.4.10 (#24 <https://github.com/ros-visualization/rqt_console/issues/24>)
```
