### PR TITLE
rqt_logger_level: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2063,7 +2063,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_logger_level-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.10-1`

## rqt_logger_level

```
* readd rqt_logger_level global executable, regression from 0.4.10 (#9 <https://github.com/ros-visualization/rqt_logger_level/issues/9>)
```
