### PR TITLE
rqt_plot: 0.4.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2123,7 +2123,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_plot-release.git
-      version: 0.4.11-1
+      version: 0.4.12-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `0.4.12-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros-gbp/rqt_plot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.11-1`

## rqt_plot

```
* readd rqt_plot global executable, regression from 0.4.11 (#60 <https://github.com/ros-visualization/rqt_plot/issues/60>)
```
