### PR TITLE
fcl_catkin: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -399,6 +399,12 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: noetic-devel
     status: maintained
+  fcl_catkin:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wxmerkt/fcl_catkin-release.git
+      version: 0.6.1-1
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl_catkin` to `0.6.1-1`:

- upstream repository: https://github.com/wxmerkt/fcl_catkin.git
- release repository: https://github.com/wxmerkt/fcl_catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
