### PR TITLE
foonathan_memory_vendor: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -419,7 +419,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
-      version: 0.6.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foonathan_memory_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/eProsima/foonathan_memory_vendor.git
- release repository: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.6.0-1`
