### PR TITLE
ros_emacs_utils: 0.4.14-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1732,6 +1732,27 @@ repositories:
       url: https://github.com/ros-controls/ros_controllers.git
       version: noetic-devel
     status: maintained
+  ros_emacs_utils:
+    doc:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    release:
+      packages:
+      - ros_emacs_utils
+      - rosemacs
+      - roslisp_repl
+      - slime_ros
+      - slime_wrapper
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/code-iai-release/ros_emacs_utils-release.git
+      version: 0.4.14-3
+    source:
+      type: git
+      url: https://github.com/code-iai/ros_emacs_utils.git
+      version: master
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_emacs_utils` to `0.4.14-3`:

- upstream repository: https://github.com/code-iai/ros_emacs_utils.git
- release repository: https://github.com/code-iai-release/ros_emacs_utils-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
