### PR TITLE
exotica_val_description: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -399,6 +399,13 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: noetic-devel
     status: maintained
+  exotica_val_description:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wxmerkt/exotica_val_description-release.git
+      version: 1.0.0-1
+    status: maintained
   fcl_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica_val_description` to `1.0.0-1`:

- upstream repository: https://github.com/ipab-slmc/exotica_val_description.git
- release repository: https://github.com/wxmerkt/exotica_val_description-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
