### PR TITLE
pybind11_catkin: 2.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1373,6 +1373,13 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
     status: maintained
+  pybind11_catkin:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wxmerkt/pybind11_catkin-release.git
+      version: 2.5.0-1
+    status: maintained
   pyquaternion:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_catkin` to `2.5.0-1`:

- upstream repository: https://github.com/ipab-slmc/pybind11_catkin.git
- release repository: https://github.com/wxmerkt/pybind11_catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## pybind11_catkin

```
* Update to v2.5.0, add compatibility with ROS Noetic (20.04) (#12 <https://github.com/ipab-slmc/pybind11_catkin/issues/12>)
* Bump CMake version to avoid CMP0048. This breaks support with ROS Indigo (14.04).
* Contributors: Wolfgang Merkt
```
