### PR TITLE
plotjuggler: 2.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1357,6 +1357,21 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: melodic-devel
     status: maintained
+  plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 2.8.0-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: master
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.8.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## plotjuggler

```
* Update CMakeLists.txt
* Added graph context menu description (#288 <https://github.com/facontidavide/PlotJuggler/issues/288>)
* Update FUNDING.yml
* Merge branch 'master' of https://github.com/facontidavide/PlotJuggler
* finished with refactoring
* WIP: re publisher ROS2
* added stuff to dataload_ros2
* Update appimage_howto.md
* fix package name
* embrace pj_msgs (https://github.com/facontidavide/plotjuggler_msgs)
* new clang format and fix in header_stamp usage
* removed marl and rule editing
* more parsers added
* more or less working
* save computation like a champ with plot_data in each parser
* precompute strings only once
* fix compilation on ROS1
* Merge branch 'master' of https://github.com/facontidavide/PlotJuggler
* builtin parsers added
* Githug actions win (#284 <https://github.com/facontidavide/PlotJuggler/issues/284>)
  * try compiling on windows
  * Update windows.yaml
  * multiple workflows
  * Update README.md
  Co-authored-by: mailto:daf@blue-ocean-robotics.com <Davide Faconti>
* bug fix
* segfault fixed in TypeHasHeader
* removed rosdep of pj_msgs
* added pj_msgs to ROS2
* fix errors
* heavy refactoring of ROS2 plugins
* critical bug fix in ROS2 parsing
* try to fix problem with StringTreeLeaf::toStr
* reduce a bit allocations overhead
* reduce memory used by the job queue of marl, with periodic flushes
* Contributors: Davide Faconti, Ilya Petrov
```
