### PR TITLE
plotjuggler: 2.8.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9998,7 +9998,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.6.4-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.8.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.6.4-1`

## plotjuggler

```
* Update CMakeLists.txt
* Added graph context menu description (#288 <https://github.com/facontidavide/PlotJuggler/issues/288>)
* Update FUNDING.yml
* Merge branch 'master' of https://github.com/facontidavide/PlotJuggler
* finished with refactoring
* WIP: re publisher ROS2
* added stuff to dataload_ros2
* Update appimage_howto.md
* fix package name
* embrace pj_msgs (https://github.com/facontidavide/plotjuggler_msgs)
* new clang format and fix in header_stamp usage
* removed marl and rule editing
* more parsers added
* more or less working
* save computation like a champ with plot_data in each parser
* precompute strings only once
* fix compilation on ROS1
* Merge branch 'master' of https://github.com/facontidavide/PlotJuggler
* builtin parsers added
* Githug actions win (#284 <https://github.com/facontidavide/PlotJuggler/issues/284>)
  * try compiling on windows
  * Update windows.yaml
  * multiple workflows
  * Update README.md
  Co-authored-by: mailto:daf@blue-ocean-robotics.com <Davide Faconti>
* bug fix
* segfault fixed in TypeHasHeader
* removed rosdep of pj_msgs
* added pj_msgs to ROS2
* fix errors
* heavy refactoring of ROS2 plugins
* critical bug fix in ROS2 parsing
* try to fix problem with StringTreeLeaf::toStr
* reduce a bit allocations overhead
* reduce memory used by the job queue of marl, with periodic flushes
* Contributors: Davide Faconti, Ilya Petrov
```
