### PR TITLE
control_box_rst: 0.0.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -379,7 +379,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/rst-tu-dortmund/control_box_rst-release.git
-      version: 0.0.4-1
+      version: 0.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_box_rst` to `0.0.6-1`:

- upstream repository: https://github.com/rst-tu-dortmund/control_box_rst.git
- release repository: https://github.com/rst-tu-dortmund/control_box_rst-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.4-1`

## control_box_rst

```
* Hybrid cost functions added: Minimum time and control/state quadratic form
* Discretization grids: The time difference is now initialized to dt_ref for proper reference caching
* Contributors: Christoph Rösmann
```
