### PR TITLE
control_box_rst: 0.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -222,6 +222,22 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: master
     status: maintained
+  control_box_rst:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/control_box_rst-release.git
+      version: 0.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    status: developed
   control_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_box_rst` to `0.0.6-1`:

- upstream repository: https://github.com/rst-tu-dortmund/control_box_rst.git
- release repository: https://github.com/rst-tu-dortmund/control_box_rst-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## control_box_rst

```
* Hybrid cost functions added: Minimum time and control/state quadratic form
* Discretization grids: The time difference is now initialized to dt_ref for proper reference caching
* Contributors: Christoph Rösmann
```
