### PR TITLE
catch_ros: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -119,6 +119,22 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  catch_ros:
+    doc:
+      type: git
+      url: https://github.com/AIS-Bonn/catch_ros.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/AIS-Bonn/catch_ros-release.git
+      version: 0.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/AIS-Bonn/catch_ros.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros` to `0.3.0-1`:

- upstream repository: https://github.com/AIS-Bonn/catch_ros
- release repository: https://github.com/AIS-Bonn/catch_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## catch_ros

```
* cmake: catch_add_rostest() add new target as dependency of 'tests' target
  (issue: #8, PR: #9)
* README.md: add CATCH_CONFIG_MAIN hint (issue: #7)
* README: update link to the catch repo
* updated catch to 2.4.2 (PR: #6)
* ros_junit_reporter: fix warnings
* Contributors: Max Schwarz, Mez Gebre
```
