### PR TITLE
rosfmt: 6.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1876,6 +1876,22 @@ repositories:
       url: https://github.com/ros-infrastructure/rosdoc_lite.git
       version: master
     status: maintained
+  rosfmt:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosfmt.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/xqms/rosfmt-release.git
+      version: 6.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/xqms/rosfmt.git
+      version: master
+    status: maintained
   roslint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosfmt` to `6.2.0-1`:

- upstream repository: https://github.com/xqms/rosfmt.git
- release repository: https://github.com/xqms/rosfmt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rosfmt

```
* ensure vformat is only instantiated once -> faster compile times
* update to fmt 6.0.0
* Contributors: Max Schwarz
```
