### PR TITLE
geometric_shapes: 0.6.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3099,7 +3099,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.6.3-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.6.2-1`

## geometric_shapes

```
* [maint]   Provide checkIsometry() helper function (#144 <https://github.com/ros-planning/geometric_shapes/issues/144>)
* [maint]   Remove dynamic casts (#143 <https://github.com/ros-planning/geometric_shapes/issues/143>)
* [feature] Added createEmptyBodyFromShapeType() (#137 <https://github.com/ros-planning/geometric_shapes/issues/137>)
  This allows more efficient body construction when scale, padding or pose should also be set during the construction.
* Contributors: Martin Pecka, Michael Görner
```
