### PR TITLE
geometric_shapes: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -588,6 +588,21 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info-release.git
       version: 0.5.5-1
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometric_shapes-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: noetic-devel
+    status: maintained
   geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.7.0-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## geometric_shapes

```
* [feature] Added constructShapeFromBody() and constructMarkerFromBody() (#138 <https://github.com/ros-planning/geometric_shapes/issues/138>)
* [maint]   API cleanup
  * Improve inlining
  * ConvexMesh::MeshData as pimpl
  * Reverted ABI compatibility fixups for Melodic: ed4cf1339cf3765ae9ffa6e6fd111a4e342c5fa2, d582479084a10cac53a7f17e29818b3d8be6161e
* Contributors: Martin Pecka, Robert Haschke
```
