### PR TITLE
ddynamic_reconfigure: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -306,6 +306,13 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: maintained
+  ddynamic_reconfigure:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure.git
+      version: 0.3.0-1
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure` to `0.3.0-1`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ddynamic_reconfigure

```
* Merge pull request #12 from eurogroep/feat/groups
  feat(groups): Option to specify a group for a variable
* feat(groups): Option to specify a group for a variable
  The group "Default" will be set as default so no behavior will change.
  However, this commit will break ABI / API compatibility.
* Contributors: Rein Appeldoorn, Victor Lopez
```
