### PR TITLE
move_base_flex: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7592,7 +7592,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.3.2-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.1-1`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* Avoid duplicated warn logging output when we cannot cancel a plugin
* Remove unused methods and attributes from AbstractNavigationServer, which are already present at other places
* Reuse execution slots; cleanup only at destruction
* Enable different goal tolerance values for each action
```

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* Remove dependency on base_local_planner and move FootprintHelper class to mbf_costmap_nav and make it static
```

## mbf_msgs

```
* add impassable outcome code for recovery behaviors
* enable different goal tolerance values for each action
```

## mbf_simple_nav

- No changes

## mbf_utility

```
* Remove dependency on base_local_planner and move FootprintHelper class to mbf_costmap_nav and make it static
```

## move_base_flex

- No changes
