### PR TITLE
imu_tools: 1.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3827,7 +3827,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.2-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.1-1`

## imu_complementary_filter

```
* fix install path & boost linkage issues
* Contributors: Martin Günther, Sean Yen
```

## imu_filter_madgwick

```
* Drop the signals component of Boost (#103 <https://github.com/ccny-ros-pkg/imu_tools/issues/103>)
* Add the option to remove the gravity vector (#101 <https://github.com/ccny-ros-pkg/imu_tools/issues/101>)
* fix install path & boost linkage issues
* Contributors: Alexis Paques, Martin Günther, Mike Purvis, Sean Yen
```

## imu_tools

- No changes

## rviz_imu_plugin

```
* Export symbols so plugin can load
* properly show/hide visualization when enabled/disabled
* Contributors: CCNY Robotics Lab, Lou Amadio, Martin Günther, v4hn
```
