### PR TITLE
imu_tools: 1.1.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5326,7 +5326,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.1.7-1
+      version: 1.1.8-1
     source:
       type: git
       url: https://github.com/ccny-ros-pkg/imu_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.1.8-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.7-1`

## imu_complementary_filter

```
* fix install path & boost linkage issues
* Contributors: Sean Yen
```

## imu_filter_madgwick

```
* Drop the signals component of Boost (#103 <https://github.com/ccny-ros-pkg/imu_tools/issues/103>)
  Unused and is removed in Boost 1.71 (Ubuntu Focal). Signals2 is header-only.
* Add the option to remove the gravity vector (#101 <https://github.com/ccny-ros-pkg/imu_tools/issues/101>)
* Rewrite rosbags: Use MagneticField for magnetometer
* fix install path & boost linkage issues
* Contributors: Alexis Paques, Martin Günther, Mike Purvis, Sean Yen
```

## imu_tools

- No changes

## rviz_imu_plugin

```
* Export symbols so plugin can load
* properly show/hide visualization when enabled/disabled
* Contributors: Lou Amadio, v4hn
```
