### PR TITLE
gps_umd: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -672,6 +672,26 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: master
+    release:
+      packages:
+      - gps_common
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/gps_umd-release.git
+      version: 0.3.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: master
+    status: maintained
   hokuyo3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `0.3.2-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## gps_common

- No changes

## gps_umd

- No changes

## gpsd_client

```
* Fix build with gpsd 3.20 (#28 <https://github.com/swri-robotics/gps_umd/issues/28>)
* Contributors: P. J. Reed
```
