### PR TITLE
swri_console: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2507,6 +2507,22 @@ repositories:
       url: https://github.com/ros/std_msgs.git
       version: kinetic-devel
     status: maintained
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_console-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: master
+    status: developed
   unique_identifier:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `1.1.0-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/swri-robotics-gbp/swri_console-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## swri_console

```
* Added simple rosout_agg_recorder (#15 <https://github.com/pjreed/swri_console/issues/15>)
* Change logger levels from within swri_console (#20 <https://github.com/pjreed/swri_console/issues/20>)
* Load ROS logs and directories of ROS logs
* Fix compiler warnings found with Clang
* Add search bar
* Contributors: Edward Venator, P. J. Reed, Phil Westhart, Victor Murray, elliotjo, jgassaway
```
