### PR TITLE
sick_tim: 0.0.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10409,7 +10409,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/sick_tim-release.git
-      version: 0.0.16-1
+      version: 0.0.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.17-1`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.16-1`

## sick_tim

```
* Switch to non-deprecated node in launch files
  The state_publisher node is deprecated in Kinetic and was removed in
  Noetic.
* Avoid compilation warning in libusb on noetic
* Contributors: Martin Günther
```
