### PR TITLE
rospy_message_converter: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1922,6 +1922,22 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: noetic-devel
     status: maintained
+  rospy_message_converter:
+    doc:
+      type: git
+      url: https://github.com/uos/rospy_message_converter.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/uos-gbp/rospy_message_converter-release.git
+      version: 0.5.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uos/rospy_message_converter.git
+      version: master
+    status: maintained
   rosserial:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.1-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rospy_message_converter

```
* Initial release into Noetic
* Decode base64-encoded byte arrays as unicode
* Make tests compatible with python3
* add check for python3 str serializing #33 <https://github.com/uos/rospy_message_converter/issues/33> (#34 <https://github.com/uos/rospy_message_converter/issues/34>)
* efficient conversion of primitive array to ros type (#31 <https://github.com/uos/rospy_message_converter/issues/31>)
* efficient conversion of primitive array
* removed unused _convert_from_ros_primitive
* optionally ignore extra fields when deserializing (#29 <https://github.com/uos/rospy_message_converter/issues/29>)
* Remove EOL distros indigo + lunar from CI
* travis CI: Use matrix to split ROS distros
* Update README (convert to md, add build status)
* Contributors: Martin Günther, George Hartt, Jannik Abbenseth, Omri Rozenzaft
```
