### PR TITLE
imu_tools: 1.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -755,6 +755,27 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: noetic-devel
     status: unmaintained
+  imu_tools:
+    doc:
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: noetic
+    release:
+      packages:
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/uos-gbp/imu_tools-release.git
+      version: 1.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ccny-ros-pkg/imu_tools.git
+      version: noetic
+    status: developed
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.2-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## imu_complementary_filter

```
* fix install path & boost linkage issues
* Contributors: Martin Günther, Sean Yen
```

## imu_filter_madgwick

```
* Drop the signals component of Boost (#103 <https://github.com/ccny-ros-pkg/imu_tools/issues/103>)
* Add the option to remove the gravity vector (#101 <https://github.com/ccny-ros-pkg/imu_tools/issues/101>)
* fix install path & boost linkage issues
* Contributors: Alexis Paques, Martin Günther, Mike Purvis, Sean Yen
```

## imu_tools

- No changes

## rviz_imu_plugin

```
* Export symbols so plugin can load
* properly show/hide visualization when enabled/disabled
* Contributors: CCNY Robotics Lab, Lou Amadio, Martin Günther, v4hn
```
