### PR TITLE
sick_tim: 0.0.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2428,6 +2428,22 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: noetic-devel
     status: maintained
+  sick_tim:
+    doc:
+      type: git
+      url: https://github.com/uos/sick_tim.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/uos-gbp/sick_tim-release.git
+      version: 0.0.17-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/uos/sick_tim.git
+      version: noetic
+    status: developed
   slam_karto:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_tim` to `0.0.17-1`:

- upstream repository: https://github.com/uos/sick_tim
- release repository: https://github.com/uos-gbp/sick_tim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## sick_tim

```
* Switch to non-deprecated node in launch files
  The state_publisher node is deprecated in Kinetic and was removed in
  Noetic.
* Avoid compilation warning in libusb on noetic
* Contributors: Martin Günther
```
