### PR TITLE
libcpprest-dev: use package name without version specific key-value

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1971,12 +1971,7 @@ libcpprest-dev:
     buster: [libcpprest-dev]
     stretch: [libcpprest-dev]
   fedora: [cpprest-devel]
-  ubuntu:
-    artful: [libcpprest-dev]
-    bionic: [libcpprest-dev]
-    xenial: [libcpprest-dev]
-    yakkety: [libcpprest-dev]
-    zesty: [libcpprest-dev]
+  ubuntu: [libcpprest-dev]
 libcunit-dev:
   arch: [cunit]
   debian: [libcunit1-dev]


### PR DESCRIPTION
To support wider versions of ubuntu