### PR TITLE
ecl_tools: 0.61.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -347,6 +347,25 @@ repositories:
       url: https://github.com/ros/dynamic_reconfigure.git
       version: noetic-devel
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/0.61-noetic
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 0.61.8-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/0.61-noetic
+    status: maintained
   eigen_stl_containers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `0.61.8-1`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## ecl_build

```
* cross platform enabling of cx11
```
