### PR TITLE
cob_extern: 0.6.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -167,6 +167,28 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cob_extern:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_extern.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_extern
+      - libdlib
+      - libntcan
+      - libpcan
+      - libphidgets
+      - opengm
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_extern-release.git
+      version: 0.6.17-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_extern.git
+      version: indigo_dev
+    status: maintained
   code_coverage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_extern` to `0.6.17-1`:

- upstream repository: https://github.com/ipa320/cob_extern.git
- release repository: https://github.com/ipa320/cob_extern-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## cob_extern

- No changes

## libdlib

- No changes

## libntcan

- No changes

## libpcan

- No changes

## libphidgets

- No changes

## opengm

- No changes
