### PR TITLE
launch: 0.10.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -567,7 +567,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.1-1
+      version: 0.10.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.2-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.10.1-1`

## launch

```
* Fix new flake8 errors. (#420 <https://github.com/ros2/launch/issues/420>)
* Contributors: Michel Hidalgo
```

## launch_testing

```
* Set junit_family to xunit2 in pytest.ini
* Stop using implicit variables in example testing.
* Switch to from_parent to remove deprecation warning.
* Fix new flake8 errors. (#420 <https://github.com/ros2/launch/issues/420>)
* Remove uses of deprecated ready_fn. (#419 <https://github.com/ros2/launch/issues/419>)
* Contributors: Chris Lalancette, Michel Hidalgo
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
