### PR TITLE
spdlog_vendor: 1.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1737,7 +1737,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.1.2-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.1-1`

## spdlog_vendor

```
* Add an external package QD for the spdlog library (#8 <https://github.com/ros2/spdlog_vendor/issues/8>)
* Remove included extra ament_copyright (#12 <https://github.com/ros2/spdlog_vendor/issues/12>)
* Enable Copyright linter tests + Add Contributing.md file (#11 <https://github.com/ros2/spdlog_vendor/issues/11>)
* Add quality declaration spdlog_vendor (#6 <https://github.com/ros2/spdlog_vendor/issues/6>)
* Contributors: Jorge Perez, Scott K Logan
```
