### PR TITLE
rcl_logging: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -880,7 +880,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 0.4.0-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.0-1`

## rcl_logging_log4cxx

```
* warn about unused return value for set_logger_level (#38 <https://github.com/ros2/rcl_logging/issues/38>)
* Added public API documentation for log4cxx and spdlog (#32 <https://github.com/ros2/rcl_logging/issues/32>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas
```

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* Add some preliminary functional tests (#36 <https://github.com/ros2/rcl_logging/issues/36>)
* warn about unused return value for set_logger_level (#38 <https://github.com/ros2/rcl_logging/issues/38>)
* Added features to rcl_logging_spdlog (#35 <https://github.com/ros2/rcl_logging/issues/35>)
* Added public API documentation for log4cxx and spdlog (#32 <https://github.com/ros2/rcl_logging/issues/32>)
* Current state Quality Declaration, Contributing and Readme files (#29 <https://github.com/ros2/rcl_logging/issues/29>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Jorge Perez, Scott K Logan
```
