### PR TITLE
rmw_dds_common: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1077,7 +1077,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 0.1.0-3
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-3`

## rmw_dds_common

```
* Added Doxyfile (#19 <https://github.com/ros2/rmw_dds_common/issues/19>)
* Improve test coverage. (#20 <https://github.com/ros2/rmw_dds_common/issues/20>)
* Add README and QUALITY_DECLARATION for current QL level (#17 <https://github.com/ros2/rmw_dds_common/issues/17>)
* Contributors: Alejandro Hernández Cordero, Michel Hidalgo, brawner
```
