### PR TITLE
class_loader: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -170,7 +170,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.0.1-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-1`

## class_loader

```
* Added QD to doxygen related pages (#155 <https://github.com/ros/class_loader/issues/155>)
* Updated class_loader QD (#152 <https://github.com/ros/class_loader/issues/152>)
* fix copy and paste error (#154 <https://github.com/ros/class_loader/issues/154>)
* Fixed warning (#151 <https://github.com/ros/class_loader/issues/151>)
* Increased code coverage (#141 <https://github.com/ros/class_loader/issues/141>)
* Added Doxyfile (#148 <https://github.com/ros/class_loader/issues/148>)
* Added quality declaration draft (#142 <https://github.com/ros/class_loader/issues/142>)
* Contributors: Alejandro Hernández Cordero, Tully Foote
```
