### PR TITLE
unique_identifier_msgs: 2.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1901,7 +1901,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.1.1-2
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.1.2-1`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.1.1-2`

## unique_identifier_msgs

```
* Change Contributing.md to match linter template (#10 <https://github.com/ros2/unique_identifier_msgs/issues/10>)
* Add README and QUALITY_DECLARATION (#8 <https://github.com/ros2/unique_identifier_msgs/issues/8>)
* Contributors: Jorge Perez, brawner
```
