### PR TITLE
rosidl_defaults: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1358,7 +1358,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 0.9.0-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-1`

## rosidl_default_generators

- No changes

## rosidl_default_runtime

```
* Some simple feature documentation in the README (#8 <https://github.com/ros2/rosidl_defaults/issues/8>)
* Add Readme and QD for rosidl_default_runtime (#7 <https://github.com/ros2/rosidl_defaults/issues/7>)
* Contributors: brawner
```
