### PR TITLE
rcl: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -835,7 +835,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## rcl

- No changes

## rcl_action

- No changes

## rcl_lifecycle

```
* Increase rcl_lifecycle test coverage and add more safety checks (#649 <https://github.com/ros2/rcl/issues/649>)
* Contributors: Stephen Brawner
```

## rcl_yaml_param_parser

```
* Increase rcl_yaml_param_parser test coverage (#656 <https://github.com/ros2/rcl/issues/656>)
* Contributors: Stephen Brawner
```
