### PR TITLE
yaml_cpp_vendor: 7.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1960,7 +1960,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 7.0.1-1
+      version: 7.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `7.0.2-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `7.0.1-1`

## yaml_cpp_vendor

```
* Append to CMAKE_C_FLAGS instead of overwriting (#11 <https://github.com/ros2/yaml_cpp_vendor/issues/11>)
* Export yaml-cpp via modern cmake (#9 <https://github.com/ros2/yaml_cpp_vendor/issues/9>)
* Contributors: Karsten Knese, dodsonmg
```
