### PR TITLE
rosidl_typesupport: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1411,7 +1411,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 0.9.2-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.2-1`

## rosidl_typesupport_c

```
* Addresses test failures in release mode (#75 <https://github.com/ros2/rosidl_typesupport/issues/75>)
* Add tests for type_support functions (#63 <https://github.com/ros2/rosidl_typesupport/issues/63>)
* Contributors: Stephen Brawner
```

## rosidl_typesupport_cpp

```
* Addresses test failures in release mode (#75 <https://github.com/ros2/rosidl_typesupport/issues/75>)
* Add tests for type_support functions (#63 <https://github.com/ros2/rosidl_typesupport/issues/63>)
* Contributors: Stephen Brawner
```
