### PR TITLE
pluginlib: 2.5.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -760,7 +760,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 2.5.1-1
+      version: 2.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `2.5.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.5.1-1`

## pluginlib

```
* Link against tinyxml2 correctly (#190 <https://github.com/ros/pluginlib/issues/190>)
* Export tinyxml2 directly from pluginlib-extras.cmake (#192 <https://github.com/ros/pluginlib/issues/192>)
* Contributors: Karsten Knese, Sean Yen
```
