### PR TITLE
rosbag2: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1294,7 +1294,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.2.7-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.7-1`

## ros2bag

```
* Don't allow user to specify unimplemented compression mode 'message' (#415 <https://github.com/ros2/rosbag2/issues/415>)
* Use consistent quotes in help messages (#416 <https://github.com/ros2/rosbag2/issues/416>)
* Contributors: Dirk Thomas, Emerson Knapp
```

## rosbag2

- No changes

## rosbag2_compression

```
* Fix playback of compressed bagfiles (#417 <https://github.com/ros2/rosbag2/issues/417>)
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Emerson Knapp, Karsten Knese
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

```
* Fix playback of compressed bagfiles (#417 <https://github.com/ros2/rosbag2/issues/417>)
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Emerson Knapp, Karsten Knese
```

## rosbag2_storage

```
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Karsten Knese
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

```
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Karsten Knese
```

## rosbag2_tests

```
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Karsten Knese
```

## rosbag2_transport

- No changes

## shared_queues_vendor

```
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Karsten Knese
```

## sqlite3_vendor

```
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Karsten Knese
```

## zstd_vendor

```
* Export targets (#403 <https://github.com/ros2/rosbag2/issues/403>)
* Contributors: Karsten Knese
```
