### PR TITLE
python_qt_binding: 1.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -791,7 +791,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.5-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.4-1`

## python_qt_binding

```
* allow a list of INCLUDE_PATH (#92 <https://github.com/ros-visualization/python_qt_binding/issues/92>)
* Use magic $(MAKE) variable to suppress build warning (#91 <https://github.com/ros-visualization/python_qt_binding/issues/91>)
* Fix linking with non framework builds of qt (e.g. from conda-forge) (#84 <https://github.com/ros-visualization/python_qt_binding/issues/84>)
* Contributors: Anton Matosov, Dirk Thomas, Robert Haschke
```
