### PR TITLE
find_object_2d: 0.6.3-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -470,6 +470,21 @@ repositories:
       url: https://github.com/ros/filters.git
       version: noetic-devel
     status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/introlab/find_object_2d-release.git
+      version: 0.6.3-4
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: noetic-devel
+    status: maintained
   fkie_message_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `find_object_2d` to `0.6.3-3`:

- upstream repository: https://github.com/introlab/find-object.git
- release repository: https://github.com/introlab/find_object_2d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`