### PR TITLE
ros1_bridge: 0.9.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1145,7 +1145,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.9.0-4
+      version: 0.9.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.9.1-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-4`

## ros1_bridge

```
* Deprecate package key for service parameters, use full type instead (#263 <https://github.com/ros2/ros1_bridge/issues/263>)
* Fix removing obsolete ROS 2 service bridges (#267 <https://github.com/ros2/ros1_bridge/issues/267>)
* Gracefully handle invalid ROS 1 publishers (#266 <https://github.com/ros2/ros1_bridge/issues/266>)
* Use reliable publisher in simple bridge (#264 <https://github.com/ros2/ros1_bridge/issues/264>)
* Remove outdated information on Fast RTPS bug (#260 <https://github.com/ros2/ros1_bridge/issues/260>)
* Contributors: Dirk Thomas, Thom747
```
