### PR TITLE
Add tango-icon-theme rule for RHEL 7

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5700,6 +5700,8 @@ tango-icon-theme:
   macports: [tango-icon-theme]
   mandrake: [tango-icon-theme]
   opensuse: [tango-icon-theme]
+  rhel:
+    '7': [tango-icon-theme]
   slackware: [tango-icon-theme]
   ubuntu: [tango-icon-theme]
 tap-plugins:


### PR DESCRIPTION
The `tango-icon-theme` package was recently pushed to EPEL 7. The package is not yet available in EPEL 8.

https://apps.fedoraproject.org/packages/tango-icon-theme
https://src.fedoraproject.org/rpms/tango-icon-theme#bodhi_updates