### PR TITLE
joint_state_publisher: 2.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1147,7 +1147,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.0.1-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-1`

## joint_state_publisher

```
* Remove the tests for the Dashing branch. (#51 <https://github.com/ros/joint_state_publisher/issues/51>)
* Fix joint_state_publisher to work on Dashing. (#50 <https://github.com/ros/joint_state_publisher/issues/50>)
* Contributors: Chris Lalancette
```

## joint_state_publisher_gui

- No changes
