### PR TITLE
libstatistics_collector: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -620,7 +620,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-tooling/libstatistics_collector-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.0.1-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros-tooling/libstatistics_collector-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-2`

## libstatistics_collector

```
* Added quality declaration (#21 <https://github.com/ros-tooling/libstatistics_collector/issues/21>)
  * Added quality declaration
  * Added feedback
  * Fixed rep link
  * Fixed QD
  * added feedback
  * Added feedback
* Added Doxyfile (#23 <https://github.com/ros-tooling/libstatistics_collector/issues/23>)
* Run CI on Focal (#20 <https://github.com/ros-tooling/libstatistics_collector/issues/20>)
* Run lint worflow on Docker (#19 <https://github.com/ros-tooling/libstatistics_collector/issues/19>)
* Fix annotation syntax for thread safety attributes (#18 <https://github.com/ros-tooling/libstatistics_collector/issues/18>)
* Remove unused strategy matrix for ASAN CI job (#17 <https://github.com/ros-tooling/libstatistics_collector/issues/17>)
* Refactor workflow to extract CW reporting (#15 <https://github.com/ros-tooling/libstatistics_collector/issues/15>)
* Contributors: Alejandro Hernández Cordero, Emerson Knapp, Thomas Moulard
```
