### PR TITLE
image_common: 2.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -484,6 +484,27 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_common
+      - image_transport
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/image_common-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `2.3.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## camera_calibration_parsers

```
* Fix formatting and include paths for linters (#157 <https://github.com/ros-perception/image_common/issues/157>)
* Contributors: Martin Idel
```

## camera_info_manager

```
* Fix formatting and include paths for linters (#157 <https://github.com/ros-perception/image_common/issues/157>)
* Enable Windows build. (#159 <https://github.com/ros-perception/image_common/issues/159>)
* Contributors: Martin Idel, Sean Yen
```

## image_common

- No changes

## image_transport

```
* Fix formatting and include paths for linters (#157 <https://github.com/ros-perception/image_common/issues/157>)
* Fix QoS initialization from RMW QoS profile (#158 <https://github.com/ros-perception/image_common/issues/158>)
* Contributors: Jacob Perron, Martin Idel
```
