### PR TITLE
robot_navigation: 0.2.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1793,6 +1793,42 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
     status: maintained
+  robot_navigation:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/robot_navigation.git
+      version: noetic
+    release:
+      packages:
+      - costmap_queue
+      - dlux_global_planner
+      - dlux_plugins
+      - dwb_critics
+      - dwb_local_planner
+      - dwb_msgs
+      - dwb_plugins
+      - global_planner_tests
+      - locomotor
+      - locomotor_msgs
+      - locomove_base
+      - nav_2d_msgs
+      - nav_2d_utils
+      - nav_core2
+      - nav_core_adapter
+      - nav_grid
+      - nav_grid_iterators
+      - nav_grid_pub_sub
+      - robot_navigation
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DLu/robot_navigation-release.git
+      version: 0.2.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/robot_navigation.git
+      version: noetic
+    status: developed
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.2.6-1`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/DLu/robot_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
