### PR TITLE
behaviortree_cpp: 3.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -81,6 +81,23 @@ repositories:
       url: https://github.com/ros-drivers/audio_common.git
       version: master
     status: maintained
+  behaviortree_cpp:
+    doc:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    release:
+      packages:
+      - behaviortree_cpp_v3
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
+      version: 3.5.0-1
+    source:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `3.5.0-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## behaviortree_cpp_v3

```
* added IfThenElse and  WhileDoElse
* issue #190 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/190>
* unit test added
* reverting to a better solution
* RemappedSubTree added
* Fix issue #188 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/188>
* added function const std::string& key (issue #183 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/183>)
* Contributors: Davide Faconti, mailto:daf@blue-ocean-robotics.com
* added IfThenElse and  WhileDoElse
* issue #190 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/190>
* unit test added
* reverting to a better solution
* RemappedSubTree added
* Fix issue #188 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/188>
* added function const std::string& key (issue #183 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/183>)
* Contributors: Davide Faconti, mailto:daf@blue-ocean-robotics.com
```
