### PR TITLE
vision_opencv: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1976,6 +1976,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `2.2.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## cv_bridge

```
* Disable portable image tests (#337 <https://github.com/ros-perception/vision_opencv/issues/337>)
* use more specific boost rosdep keys (#319 <https://github.com/ros-perception/vision_opencv/issues/319>)
* add opencv4 into the dependency list for ROS2 (#324 <https://github.com/ros-perception/vision_opencv/issues/324>)
* Corrected the typo of Boost_INCLUDE_DIRS (#315 <https://github.com/ros-perception/vision_opencv/issues/315>)
* use target include directories (#313 <https://github.com/ros-perception/vision_opencv/issues/313>)
* Contributors: Karsten Knese, Lewis Liu, Michael Carroll, Mikael Arguedas, Sean Yen
```

## image_geometry

```
* Updated fromCameraInfo function to match ROS2 CameraInfo message (#295 <https://github.com/ros-perception/vision_opencv/issues/295>)
* Contributors: Luca Della Vedova
```

## vision_opencv

- No changes
