### PR TITLE
Updated find_object_2d version to 0.6.3-5 on Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -496,7 +496,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/find_object_2d-release.git
-      version: 0.6.3-4
+      version: 0.6.3-5
     source:
       type: git
       url: https://github.com/introlab/find-object.git


### PR DESCRIPTION
This should fix this build error: http://build.ros.org/view/Nbin_db_dB64/job/Nbin_db_dB64__find_object_2d__debian_buster_amd64__binary/1/consoleFull