### PR TITLE
rqt_common_plugins: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1548,6 +1548,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_action.git
       version: crystal-devel
     status: maintained
+  rqt_common_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: dashing-devel
+    status: maintained
   rqt_console:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros2-gbp/rqt_common_plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_common_plugins

```
* ROS 2 port, commenting out unavailable plugins (#457 <https://github.com/ros-visualization/rqt_common_plugins/issues/457>)
* convert to package format 2 (#455 <https://github.com/ros-visualization/rqt_common_plugins/issues/455>)
```
