### PR TITLE
mcl_3dl: 0.2.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5131,7 +5131,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.2.5-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.4-1`

## mcl_3dl

```
* Add validation for orientation of initial pose (#317 <https://github.com/at-wat/mcl_3dl/issues/317>)
* Update CI scripts (#318 <https://github.com/at-wat/mcl_3dl/issues/318>)
* Contributors: Atsushi Watanabe, Yuta Koga
```
