### PR TITLE
catch_ros: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -145,7 +145,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/AIS-Bonn/catch_ros-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros` to `0.4.0-1`:

- upstream repository: https://github.com/AIS-Bonn/catch_ros
- release repository: https://github.com/AIS-Bonn/catch_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.0-1`

## catch_ros

```
* cmake: increase minimum version to 3.4 to silence CMP0048 warning
* rostest_main: handle weird rostest behavior on retries
* [reporter] makes tests and failure from test-cases instead of assertions
* Contributors: Max Schwarz, Naveed Usmani
```
