### PR TITLE
rosmon: 2.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2216,6 +2216,27 @@ repositories:
       url: https://github.com/ros/roslisp.git
       version: master
     status: maintained
+  rosmon:
+    doc:
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    release:
+      packages:
+      - rosmon
+      - rosmon_core
+      - rosmon_msgs
+      - rqt_rosmon
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/xqms/rosmon-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/xqms/rosmon.git
+      version: master
+    status: developed
   rospack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.3.0-1`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rosmon

```
* Fix Issue "Can not handle arguments with spaces" (PR #110)
* Contributors: Kazuhiro Hiratsuka, Max Schwarz
```

## rosmon_core

```
* Optionally filter stdout (INFO/DEBUG, PR #119)
* Capture stderr separately and correctly do output=log (PR #119)
* Prevent infinite coredump aggregation & support systemd-coredump (PR #125)
* Support certain rosmon-* attributes on all scopes (fixes #116)
* ui: UI DrawStatus optimized to only refresh on events (PR #121)
* Adding fix for rosparam parsing to equivilate with undocumented behavior of roslaunch (PR #118)
* depend on python2/3 conditioned on ROS_PYTHON_VERSION (PR #123)
* Add YAML merge key parsing functionality (PR #117)
* test: unit tests for the warnings we trigger
* LaunchConfig warnings to stderr & make them captureable
* rosmon_core: Handle empty yaml file (PR #114)
* Improved support for nodes with terminal UI (PR #112)
* Fix Issue "Can not handle arguments with spaces" (PR #111)
* Option to obey output=XY tags (PR #109)
* fix a lot of whitespace issues introduced in #76
* Handle nesting with $(anon) subst correctly (PR #101)
* Contributors: Carl Colena, Kazuhiro Hiratsuka, Max Schwarz, marco-tranzatto
```

## rosmon_msgs

- No changes

## rqt_rosmon

- No changes
