### PR TITLE
rcl: 1.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -898,7 +898,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.2-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.1-1`

## rcl

```
* Improve docblocks (#659 <https://github.com/ros2/rcl/issues/659>)
* Contributors: Alejandro Hernández Cordero
```

## rcl_action

- No changes

## rcl_lifecycle

```
* Allow transition start and goal states to be null (#662 <https://github.com/ros2/rcl/issues/662>)
* Contributors: Karsten Knese
```

## rcl_yaml_param_parser

- No changes
