### PR TITLE
image_transport_plugins: 2.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -547,6 +547,27 @@ repositories:
       url: https://github.com/ros-perception/image_pipeline.git
       version: ros2
     status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/image_transport_plugins-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.3.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## compressed_depth_image_transport

```
* Use non-deprecated image_transport headers (#59 <https://github.com/ros-perception/image_transport_plugins/issues/59>)
* Contributors: Michael Carroll
```

## compressed_image_transport

```
* Use non-deprecated image_transport headers (#59 <https://github.com/ros-perception/image_transport_plugins/issues/59>)
* Add parameter declarations (#52 <https://github.com/ros-perception/image_transport_plugins/issues/52>)
* Contributors: Michael Carroll, Łukasz Mitka
```

## image_transport_plugins

- No changes

## theora_image_transport

- No changes
