### PR TITLE
hebi_cpp_api_ros: 3.2.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3425,7 +3425,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
-      version: 3.2.0-1
+      version: 3.2.0-2
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hebi_cpp_api_ros` to `3.2.0-2`:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.2.0-1`

## hebi_cpp_api

```
* added experimental high-level "Arm API" to enable easier control of robotic arm systems
```
