### PR TITLE
ublox: 1.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11338,7 +11338,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KumarRobotics/ublox-release.git
-      version: 1.3.1-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/KumarRobotics/ublox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `1.4.0-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/KumarRobotics/ublox-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.3.1-1`

## ublox

```
* Bump CMake minimum version to 3.0.2
* Contributors: Gonçalo Pereira
```

## ublox_gps

```
* Bump CMake minimum version to 3.0.2
* Move variables from .h to .cpp to solve linking issues
* added support for protocol version >= 18
* Contributors: Firat Kasmis, Gonçalo Pereira
```

## ublox_msgs

```
* Bump CMake minimum version to 3.0.2
* Contributors: Gonçalo Pereira
```

## ublox_serialization

```
* Bump CMake minimum version to 3.0.2
* Contributors: Gonçalo Pereira
```
