### PR TITLE
audio_common: 0.3.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -75,7 +75,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.5-1
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.6-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.5-1`

## audio_capture

```
* Merge pull request #141 <https://github.com/ros-drivers/audio_common/issues/141> from knorth55/add-maintainer
  add maintainer
* add maintainer
* Contributors: Shingo Kitagawa
```

## audio_common

```
* Merge pull request #141 <https://github.com/ros-drivers/audio_common/issues/141> from knorth55/add-maintainer
  add maintainer
* add maintainer
* Contributors: Shingo Kitagawa
```

## audio_common_msgs

```
* Merge pull request #141 <https://github.com/ros-drivers/audio_common/issues/141> from knorth55/add-maintainer
  add maintainer
* add maintainer
* Contributors: Shingo Kitagawa
```

## audio_play

```
* Merge pull request #141 <https://github.com/ros-drivers/audio_common/issues/141> from knorth55/add-maintainer
  add maintainer
* add maintainer
* Contributors: Shingo Kitagawa
```

## sound_play

```
* Merge pull request #140 <https://github.com/ros-drivers/audio_common/issues/140> from knorth55/support-python3
  fix syntax for python3
* Merge pull request #141 <https://github.com/ros-drivers/audio_common/issues/141> from knorth55/add-maintainer
  add maintainer
* add maintainer
* fix syntax for python3
* Contributors: Shingo Kitagawa
```
