### PR TITLE
ublox: 1.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2939,6 +2939,22 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: noetic-devel
     status: maintained
+  ublox:
+    release:
+      packages:
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/KumarRobotics/ublox-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: master
+    status: maintained
   unique_identifier:
     release:
       packages:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2940,6 +2940,10 @@ repositories:
       version: noetic-devel
     status: maintained
   ublox:
+    doc:
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: master
     release:
       packages:
       - ublox


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `1.4.0-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/KumarRobotics/ublox-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ublox

```
* Bump CMake minimum version to 3.0.2
* Contributors: Gonçalo Pereira
```

## ublox_gps

```
* Bump CMake minimum version to 3.0.2
* Move variables from .h to .cpp to solve linking issues
* added support for protocol version >= 18
* Contributors: Firat Kasmis, Gonçalo Pereira
```

## ublox_msgs

```
* Bump CMake minimum version to 3.0.2
* Contributors: Gonçalo Pereira
```

## ublox_serialization

```
* Bump CMake minimum version to 3.0.2
* Contributors: Gonçalo Pereira
```
