### PR TITLE
hebi_cpp_api_ros: 3.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -810,6 +810,23 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: master
     status: maintained
+  hebi_cpp_api_ros:
+    doc:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: master
+    release:
+      packages:
+      - hebi_cpp_api
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
+      version: 3.2.0-1
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: master
+    status: developed
   hokuyo3d:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hebi_cpp_api_ros` to `3.2.0-1`:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/HebiRobotics/hebi_cpp_api_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## hebi_cpp_api

```
* added experimental high-level "Arm API" to enable easier control of robotic arm systems
```
