### PR TITLE
Collapse or drop rules for EOL Fedora versions

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2757,15 +2757,7 @@ libmpich2-dev:
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]
-  fedora:
-    '21': [mariadb-devel]
-    '22': [mariadb-devel]
-    '23': [mariadb-devel]
-    '24': [mariadb-devel]
-    beefy: [mysql-devel]
-    heisenbug: [mariadb-devel]
-    schrödinger’s: [mariadb-devel]
-    spherical: [mysql-devel]
+  fedora: [mariadb-devel]
   gentoo: [virtual/libmysqlclient]
   macports: [mysql5]
   opensuse: [libmysqlclient-devel]
@@ -3990,9 +3982,7 @@ libusb:
 libusb-1.0:
   arch: [libusbx]
   debian: [libusb-1.0-0]
-  fedora:
-    '*': [libusbx]
-    beefy: [libusb1]
+  fedora: [libusbx]
   gentoo: ['virtual/libusb:1']
   opensuse: [libusb-1_0-0]
   rhel: [libusbx]
@@ -4000,9 +3990,7 @@ libusb-1.0:
 libusb-1.0-dev:
   arch: [libusbx]
   debian: [libusb-1.0-0-dev]
-  fedora:
-    '*': [libusbx-devel]
-    beefy: [libusb1-devel]
+  fedora: [libusbx-devel]
   gentoo: ['virtual/libusb:1']
   macports: [libusb]
   openembedded: [libusb1@openembedded-core]
@@ -4445,15 +4433,7 @@ lttng-tools:
 lua-dev:
   arch: [lua]
   debian: [liblua5.1-0-dev]
-  fedora:
-    '21': [compat-lua-devel]
-    '22': [compat-lua-devel]
-    '23': [compat-lua-devel]
-    '24': [compat-lua-devel]
-    beefy: [lua-devel]
-    heisenbug: [compat-lua-devel]
-    schrödinger’s: [lua-devel]
-    spherical: [lua-devel]
+  fedora: [compat-lua-devel]
   gentoo: [dev-lang/lua]
   macports: [lua51]
   ubuntu: [liblua5.1-0-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2775,9 +2775,6 @@ python-open3d-pip:
 python-opencv:
   arch: [opencv, python2-numpy]
   debian: [python-opencv]
-  fedora:
-    '*': null
-    '29': [opencv-python]
   freebsd: [py27-opencv]
   gentoo: ['media-libs/opencv[python]']
   openembedded: [opencv@meta-oe]
@@ -4006,11 +4003,6 @@ python-rpi.gpio:
     stretch:
       pip:
         packages: [RPi.GPIO]
-  fedora:
-    '25':
-      pip:
-        packages: [RPi.GPIO]
-    '26': [python-rpi-gpio]
   ubuntu:
     artful: [python-rpi.gpio]
     bionic: [python-rpi.gpio]
@@ -4581,9 +4573,6 @@ python-tabulate:
   debian:
     buster: [python-tabulate]
     stretch: [python-tabulate]
-  fedora:
-    '23': [python-tabulate]
-    '24': [python-tabulate]
   gentoo: [dev-python/tabulate]
   ubuntu:
     artful: [python-tabulate]
@@ -5572,9 +5561,7 @@ python3-lark-parser:
   debian:
     buster: [python3-lark-parser]
     stretch: [python3-lark-parser]
-  fedora:
-    '*': [python3-lark-parser]
-    '28': null
+  fedora: [python3-lark-parser]
   gentoo: [dev-python/lark]
   openembedded: [python3-lark-parser@meta-ros]
   rhel: ['python%{python3_pkgversion}-lark-parser']


### PR DESCRIPTION
Fedora 31 and 32 are the currently supported releases.