### PR TITLE
variants: 0.9.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2086,6 +2086,26 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: master
     status: maintained
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    release:
+      packages:
+      - desktop
+      - ros_base
+      - ros_core
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.9.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.9.1-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## desktop

- No changes

## ros_base

- No changes

## ros_core

```
* Add launch and launch_ros repos to ros_core variant (#28 <https://github.com/ros2/variants/issues/28>)
  This ensures that all of them are included in an installation of ros_core.
* Remove ros2msg and ros2srv from ros_core (#27 <https://github.com/ros2/variants/issues/27>)
  These packages no longer exist.
* Contributors: Jacob Perron
```
