### PR TITLE
fadecandy_ros: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2495,6 +2495,20 @@ repositories:
       url: https://github.com/eyeware/eyeware-ros.git
       version: master
     status: maintained
+  fadecandy_ros:
+    release:
+      packages:
+      - fadecandy_driver
+      - fadecandy_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/iron-ox/fadecandy_ros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/iron-ox/fadecandy_ros.git
+      version: master
+    status: developed
   fake_joint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `0.1.0-1`:

- upstream repository: https://github.com/iron-ox/fadecandy_ros.git
- release repository: https://github.com/iron-ox/fadecandy_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## fadecandy_driver

```
* Initial release.
```

## fadecandy_msgs

```
* Initial release
```
