### PR TITLE
Clean up invalid or incorrect RHEL rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2794,7 +2794,7 @@ libncurses-dev:
   fedora: [ncurses-devel]
   gentoo: [sys-libs/ncurses]
   macports: [ncurses]
-  rhel: [nucrses-devel]
+  rhel: [ncurses-devel]
   ubuntu: [libncurses5-dev]
 libneon27-gnutls-dev:
   debian: [libneon27-gnutls-dev]
@@ -3398,7 +3398,8 @@ libqt4:
   gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
   opensuse: [libqt4]
-  rhel: [qt]
+  rhel:
+    '7': [qt]
   ubuntu: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
 libqt4-dev:
   arch: [qt4]
@@ -3408,14 +3409,16 @@ libqt4-dev:
   gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
   opensuse: [libqt4-devel]
-  rhel: [qt-devel]
+  rhel:
+    '7': [qt-devel]
   ubuntu: [libqt4-dev]
 libqt4-opengl:
   arch: [qt4]
   debian: [libqt4-opengl]
   fedora: [qt]
   gentoo: ['dev-qt/qtopengl:4']
-  rhel: [qt]
+  rhel:
+    '7': [qt]
   ubuntu: [libqt4-opengl]
 libqt4-opengl-dev:
   arch: [qt4]
@@ -3424,7 +3427,8 @@ libqt4-opengl-dev:
   gentoo: ['dev-qt/qtopengl:4']
   macports: [qt4-mac]
   opensuse: [libqt4-devel]
-  rhel: [qt-devel]
+  rhel:
+    '7': [qt-devel]
   ubuntu: [libqt4-opengl-dev]
 libqt4-sql-psql:
   arch: [qt4]
@@ -3915,7 +3919,7 @@ libunittest++:
   fedora: [unittest]
   gentoo: [dev-libs/unittest++]
   macports: [unittest-cpp]
-  rhel: [unittest]
+  rhel: [unittest-cpp-devel]
   ubuntu: [libunittest++-dev]
 libunwind:
   debian:
@@ -5212,7 +5216,8 @@ qt4-qmake:
   gentoo: ['dev-qt/qtcore:4']
   macports: [qt4-mac]
   opensuse: [libqt4-devel]
-  rhel: [qt-devel]
+  rhel:
+    '7': [qt-devel]
   ubuntu: [qt4-qmake]
 qt5-image-formats-plugins:
   arch: [qt5-imageformats]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -668,7 +668,6 @@ python-bluez:
   debian: [python-bluez]
   fedora: [pybluez]
   gentoo: [dev-python/pybluez]
-  rhel: [python-bluez]
   ubuntu: [python-bluez]
 python-bokeh-pip:
   debian:
@@ -1203,7 +1202,8 @@ python-crypto:
 python-cryptography:
   debian: [python-cryptography]
   gentoo: [dev-python/cryptography]
-  rhel: [python2-cryptography]
+  rhel:
+    '7': [python2-cryptography]
   ubuntu: [python-cryptography]
 python-cvxopt:
   arch: [python-cvxopt]
@@ -1216,7 +1216,6 @@ python-cwiid:
   debian: [python-cwiid]
   fedora: [cwiid]
   gentoo: ['app-misc/cwiid[python]']
-  rhel: [cwiid]
   ubuntu: [python-cwiid]
 python-cython-pip:
   arch:
@@ -1624,7 +1623,7 @@ python-ftdi1:
 python-funcsigs:
   debian: [python-funcsigs]
   fedora: [python-funcsigs]
-  rhel: [python-funcsigs]
+  rhel: [python2-funcsigs]
   ubuntu: [python-funcsigs]
 python-future:
   debian: [python-future]
@@ -2263,7 +2262,8 @@ python-kml:
 python-kombu:
   debian: [python-kombu]
   fedora: [python-kombu]
-  rhel: [python-kombu]
+  rhel:
+    '7': [python-kombu]
   ubuntu: [python-kombu]
 python-kombu-pip:
   ubuntu:
@@ -2349,7 +2349,9 @@ python-lxml:
   osx:
     pip:
       packages: [lxml]
-  rhel: [python-lxml]
+  rhel:
+    '*': [python2-lxml]
+    '7': [python-lxml]
   ubuntu: [python-lxml]
 python-lzf-pip:
   debian:
@@ -2684,7 +2686,7 @@ python-numpy:
   osx:
     pip:
       packages: [numpy]
-  rhel: [numpy]
+  rhel: [python2-numpy]
   slackware: [numpy]
   ubuntu:
     artful: [python-numpy]
@@ -2958,7 +2960,7 @@ python-pathtools:
 python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
-  rhel: [python-pbr]
+  rhel: [python2-pbr]
   ubuntu: [python-pbr]
 python-pcapy:
   arch: [python2-pcapy]
@@ -3227,7 +3229,7 @@ python-pycodestyle:
   debian: [pycodestyle]
   fedora: [python-pycodestyle]
   gentoo: [dev-python/pycodestyle]
-  rhel: [python-pycodestyle]
+  rhel: [python2-pycodestyle]
   ubuntu: [pycodestyle]
 python-pycryptodome:
   arch: [python2-pycryptodome]
@@ -3674,7 +3676,8 @@ python-qt-bindings:
   gentoo: [dev-python/pyside, dev-python/PyQt4]
   macports: [p27-pyqt4]
   opensuse: [python-qt4-devel]
-  rhel: [PyQt4, PyQt4-devel, sip-devel]
+  rhel:
+    '7': [PyQt4, PyQt4-devel, sip-devel]
   ubuntu:
     '*': [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
     lucid: [python-qt4, python-qt4-dev, python-sip-dev]
@@ -4290,7 +4293,8 @@ python-sip:
   macports: [py27-sip]
   openembedded: [sip@meta-oe]
   opensuse: [python-sip-devel]
-  rhel: [sip-devel]
+  rhel:
+    '7': [sip-devel]
   slackware:
     slackpkg:
       packages: [sip]
@@ -5770,7 +5774,6 @@ python3-pyaudio:
   osx:
     pip:
       packages: [pyaudio]
-  rhel: ['python%{python3_pkgversion}-pyaudio']
   ubuntu: [python3-pyaudio]
 python3-pycodestyle:
   arch: [python-pycodestyle]
@@ -6313,7 +6316,8 @@ wxpython:
   macports: [py27-wxpython, py27-gobject, py27-gtk, py27-cairo]
   openembedded: [wxpython@meta-ros]
   opensuse: [python-wxGTK]
-  rhel: [wxPython-devel]
+  rhel:
+    '7': [wxPython-devel]
   ubuntu:
     artful: [python-wxgtk3.0]
     bionic: [python-wxgtk3.0]


### PR DESCRIPTION
These errors were discovered programmatically and were verified manually.

A few classes of changes here:
- wrong or misspelled packages
- packages which have been retired
- python 2 packages which are no longer maintained
- renamed virtual packages for compatibility between multiple releases in a single rule

Since EPEL 8 is still ramping up, I decided to leave rules which reference packages which could someday be released (for now).

Note that RHEL 8 doesn't have Qt 4 at all, and has a select number of Python 2 packages, which probably won't expand to any new ones.