### PR TITLE
Drop superfluous "'*': null" entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5705,7 +5705,6 @@ python3-pep8:
     jessie: [python3-pep8]
     stretch: [python3-pep8]
   fedora:
-    '*': null
     '30': [python3-pep8]
     '31': [python3-pep8]
   gentoo: [dev-python/pep8]


### PR DESCRIPTION
This behavior is implied, so the explicit entry can be dropped.