### PR TITLE
Add rosdep key 'python3-interpreter'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2143,15 +2143,6 @@ python-inputs-pip:
   ubuntu:
     pip:
       packages: [inputs]
-python3-interpreter:
-  arch: [python]
-  debian: [python3-minimal]
-  fedora: [python3]
-  gentoo: [dev-lang/python]
-  opensuse: [python3]
-  rhel: [python3]
-  slackware: [python3]
-  ubuntu: [python3-minimal]
 python-ipdb:
   debian: [python-ipdb]
   gentoo: [dev-python/ipdb]
@@ -5565,6 +5556,15 @@ python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]
   ubuntu: [python3-imageio]
+python3-interpreter:
+  arch: [python]
+  debian: [python3-minimal]
+  fedora: [python3]
+  gentoo: [dev-lang/python]
+  opensuse: [python3]
+  rhel: [python3]
+  slackware: [python3]
+  ubuntu: [python3-minimal]
 python3-kitchen:
   arch: [python-kitchen]
   debian: [python3-kitchen]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2147,6 +2147,15 @@ python-ipdb:
   debian: [python-ipdb]
   gentoo: [dev-python/ipdb]
   ubuntu: [python-ipdb]
+python3-interpreter:
+  arch: [python]
+  debian: [python3-minimal]
+  fedora: [python3]
+  gentoo: [dev-lang/python]
+  opensuse: [python3]
+  rhel: [python3]
+  slackware: [python3]
+  ubuntu: [python3-minimal]
 python-itsdangerous:
   debian:
     buster: [python-itsdangerous]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2143,10 +2143,6 @@ python-inputs-pip:
   ubuntu:
     pip:
       packages: [inputs]
-python-ipdb:
-  debian: [python-ipdb]
-  gentoo: [dev-python/ipdb]
-  ubuntu: [python-ipdb]
 python3-interpreter:
   arch: [python]
   debian: [python3-minimal]
@@ -2156,6 +2152,10 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
+python-ipdb:
+  debian: [python-ipdb]
+  gentoo: [dev-python/ipdb]
+  ubuntu: [python-ipdb]
 python-itsdangerous:
   debian:
     buster: [python-itsdangerous]


### PR DESCRIPTION
This rule is intended to provide the `python3` executable.

- arch: https://www.archlinux.org/packages/extra/x86_64/python/
- debian: https://packages.debian.org/search?searchon=names&keywords=python3-minimal
- fedora: https://apps.fedoraproject.org/packages/python3
- gentoo: https://packages.gentoo.org/packages/dev-lang/python
- opensuse: https://software.opensuse.org/package/python3
- rhel: http://mirror.centos.org/centos-7/7/os/x86_64/Packages/python3-3.6.8-13.el7.x86_64.rpm
- slackware: https://packages.slackware.com/?r=slackware64-current&p=python3-3.8.3-x86_64-1.txz
- ubuntu: https://packages.ubuntu.com/search?searchon=names&keywords=python3-minimal