### PR TITLE
fadecandy_ros: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -487,6 +487,20 @@ repositories:
       url: https://github.com/wxmerkt/exotica_val_description-release.git
       version: 1.0.0-1
     status: maintained
+  fadecandy_ros:
+    release:
+      packages:
+      - fadecandy_driver
+      - fadecandy_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/iron-ox/fadecandy_ros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/iron-ox/fadecandy_ros.git
+      version: master
+    status: developed
   fcl_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `0.1.0-1`:

- upstream repository: https://github.com/iron-ox/fadecandy_ros.git
- release repository: https://github.com/iron-ox/fadecandy_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## fadecandy_driver

```
* Initial release.
```

## fadecandy_msgs

```
* Initial release
```
