### PR TITLE
Add python3-usb rosdep entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6177,6 +6177,7 @@ python3-twisted:
   ubuntu: [python3-twisted]
 python3-usb:
   debian: [python3-usb]
+  gentoo: [dev-python/pyusb]
   ubuntu: [python3-usb]
 python3-vcstool:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6175,6 +6175,9 @@ python3-twisted:
     '*': ['python%{python3_pkgversion}-twisted']
     '7': null
   ubuntu: [python3-twisted]
+python3-usb:
+  debian: [python3-usb]
+  ubuntu: [python3-usb]
 python3-vcstool:
   debian:
     pip:


### PR DESCRIPTION
Needed to release fadecandy_ros onto neotic: https://github.com/ros/rosdistro/pull/25171