### PR TITLE
dual_quaternions: 0.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2718,6 +2718,21 @@ repositories:
       url: https://github.com/naoki-mizuno/ds4_driver.git
       version: master
     status: maintained
+  dual_quaternions:
+    doc:
+      type: git
+      url: https://github.com/Achllle/dual_quaternions.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Achllle/dual_quaternions-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/Achllle/dual_quaternions.git
+      version: master
+    status: maintained
   dwm1001_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions` to `0.3.1-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions.git
- release repository: https://github.com/Achllle/dual_quaternions-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dual_quaternions

```
* Fix rst reference
* Initial commit: copy dual_quaternions over from dual_quaternions_ros
* Contributors: Achille
```