### PR TITLE
dual_quaternions: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2050,6 +2050,13 @@ repositories:
       url: https://github.com/naoki-mizuno/ds4_driver.git
       version: master
     status: maintained
+  dual_quaternions:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Achllle/dual_quaternions-release.git
+      version: 0.3.1-1
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions` to `0.3.1-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions.git
- release repository: https://github.com/Achllle/dual_quaternions-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dual_quaternions

```
* Fix rst reference
* Initial commit: copy dual_quaternions over from dual_quaternions_ros
* Contributors: Achille
```
