### PR TITLE
novatel_gps_driver: 4.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1360,6 +1360,25 @@ repositories:
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
       version: eloquent-devel
     status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
+      version: 4.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    status: developed
   ntpd_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.0.3-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## novatel_gps_driver

```
* Handle GPGSV log with 0 satellites correctly (#77 <https://github.com/pjreed/novatel_gps_driver/issues/77>)
* Fill out error measurements in GPSFix messages (#71 <https://github.com/pjreed/novatel_gps_driver/issues/71>)
* Fix covariance in GPSFix messages (#69 <https://github.com/pjreed/novatel_gps_driver/issues/69>)
* Contributors: P. J. Reed
```

## novatel_gps_msgs

- No changes
