### PR TITLE
roscpp_core: 0.7.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2202,7 +2202,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.7.2-1`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.1-1`

## cpp_common

- No changes

## roscpp_serialization

- No changes

## roscpp_traits

- No changes

## rostime

```
* [Windows] Using C++11 std::chrono for ros_walltime & ros_steadytime (#121 <https://github.com/ros/roscpp_core/issues/121>)
```
