### PR TITLE
python_qt_binding: 0.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7703,7 +7703,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.4.0-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `0.4.2-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros-gbp/python_qt_binding-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.0-1`

## python_qt_binding

```
* pass ROS_BUILD_SHARED_LIBS to use visibility control properly (#89 <https://github.com/ros-visualization/python_qt_binding/issues/89>)
* allow a list of INCLUDE_PATH (#92 <https://github.com/ros-visualization/python_qt_binding/issues/92>)
* use magic $(MAKE) variable to suppress build warning (#91 <https://github.com/ros-visualization/python_qt_binding/issues/91>)
```
