### PR TITLE
qt_gui_core: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7835,7 +7835,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.4.1-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.0-1`

## qt_dotgraph

```
* use setuptools instead of distutils (#209 <https://github.com/ros-visualization/qt_gui_core/issues/209>)
* Please flake8 (#207 <https://github.com/ros-visualization/qt_gui_core/issues/207>)
```

## qt_gui

```
* use setuptools instead of distutils (#209 <https://github.com/ros-visualization/qt_gui_core/issues/209>)
* fix export perspective with Python 3 (#217 <https://github.com/ros-visualization/qt_gui_core/issues/217>)
* fix runtime error on shutdown (#213 <https://github.com/ros-visualization/qt_gui_core/issues/213>)
```

## qt_gui_app

```
* use setuptools instead of distutils (#209 <https://github.com/ros-visualization/qt_gui_core/issues/209>)
```

## qt_gui_cpp

```
* use setuptools instead of distutils (#209 <https://github.com/ros-visualization/qt_gui_core/issues/209>)
```

## qt_gui_py_common

```
* use setuptools instead of distutils (#209 <https://github.com/ros-visualization/qt_gui_core/issues/209>)
* ExclusiveOptionGroup: Fix return value of get_settings() (#220 <https://github.com/ros-visualization/qt_gui_core/issues/220>)
```
