### PR TITLE
system_modes: 0.2.0-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1895,6 +1895,10 @@ repositories:
       version: master
     status: developed
   system_modes:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
     release:
       packages:
       - system_modes
@@ -1902,7 +1906,12 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.2.0-3
+      version: 0.2.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
     status: developed
   teleop_twist_joy:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.2.0-4`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.0-3`
