### PR TITLE
[dep] gitk

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1081,6 +1081,10 @@ gitg:
   fedora: [gitg]
   gentoo: [dev-vcs/gitg]
   ubuntu: [gitg]
+gitk:
+  debian: [gitk]
+  fedora: [gitk]
+  ubuntu: [gitk]
 gksu:
   debian: [gksu]
   gentoo: [x11-libs/gksu]


### PR DESCRIPTION
- debian (sid) https://packages.debian.org/sid/vcs/gitk
- fedora (30) https://fedora.pkgs.org/30/fedora-i386/gitk-2.21.0-1.fc30.noarch.rpm.html
- gentoo: not found https://packages.gentoo.org/packages/dev-vcs/gitk
- ubuntu (xenial onward) https://packages.ubuntu.com/xenial/gitk