### PR TITLE
[noetic] Update eigenpy to 2.4.0-1

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -453,7 +453,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 2.3.2-2
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Adds a patch to install to `lib` rather than with the architecture-dependent prefix. This mirrors the patch on Kinetic.