### PR TITLE
urg_c: 1.0.405-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3066,6 +3066,21 @@ repositories:
       url: https://github.com/ros/urdf_parser_py.git
       version: melodic-devel
     status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urg_c-release.git
+      version: 1.0.405-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: master
+    status: maintained
   urg_stamped:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.405-1`:

- upstream repository: git://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros-gbp/urg_c-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## urg_c

```
* pass *pointer to* system timestamp, sync issue on quit
* Adding new maintainer.
* Contributors: Tony Baltovski, knickels
```
