### PR TITLE
teb_local_planner: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2970,7 +2970,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teb_local_planner` to `0.9.1-1`:

- upstream repository: https://github.com/rst-tu-dortmund/teb_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/teb_local_planner-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-1`

## teb_local_planner

```
* Fixed RobotFootprintModel visualization bug (thanks to Anson Wang)
* Reserve the size of the relevant obstacles vector to avoid excessive memory allocations (thanks to João Monteiro)
* CMake: Removed system include to avoid compiling issues on some platforms
* Contributors: Anson Wang, Christoph Rösmann, João Carlos Espiúca Monteiro
```
