### PR TITLE
ament_nodl: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -129,6 +129,17 @@ repositories:
       url: https://github.com/ament/ament_lint.git
       version: master
     status: developed
+  ament_nodl:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/canonical/ament_nodl-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/ament_nodl.git
+      version: master
+    status: developed
   ament_package:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_nodl` to `0.1.0-1`:

- upstream repository: https://github.com/ubuntu-robotics/ament_nodl.git
- release repository: https://github.com/canonical/ament_nodl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ament_nodl

```
* initial release
* Contributors: Ted Kern
```
