### PR TITLE
Add rosdep rule for python3-argcomplete

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,6 +5268,15 @@ python3:
   gentoo: [dev-lang/python]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
+python3-argcomplete:
+  alpine: [py3-argcomplete]
+  arch: [python-argcomplete]
+  centos: [python3-argcomplete]
+  debian: [python3-argcomplete]
+  fedora: [python3-argcomplete]
+  freebsd: [py37-argcomplete]
+  gentoo: [dev-python/argcomplete]
+  ubuntu: [python3-argcomplete]
 python3-asyncssh:
   debian: [python3-asyncssh]
   fedora: [python3-asyncssh]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5271,11 +5271,11 @@ python3:
 python3-argcomplete:
   alpine: [py3-argcomplete]
   arch: [python-argcomplete]
-  centos: [python3-argcomplete]
   debian: [python3-argcomplete]
   fedora: [python3-argcomplete]
   freebsd: [py37-argcomplete]
   gentoo: [dev-python/argcomplete]
+  rhel: ['python%{python3_pkgversion}-argcomplete']
   ubuntu: [python3-argcomplete]
 python3-asyncssh:
   debian: [python3-asyncssh]


### PR DESCRIPTION
- alpine: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-argcomplete
- arch: https://www.archlinux.org/packages/community/any/python-argcomplete/
- debian: https://packages.debian.org/search?searchon=names&keywords=python3-argcomplete
- fedora: https://fedora.pkgs.org/30/fedora-x86_64/python3-argcomplete-1.9.5-1.fc30.noarch.rpm.html
- freebsd: https://www.freshports.org/devel/py-argcomplete/
- gentoo: https://packages.gentoo.org/packages/dev-python/argcomplete
- rhel: https://centos.pkgs.org/8/centos-appstream-x86_64/python3-argcomplete-1.9.3-6.el8.noarch.rpm.html
- ubuntu: https://packages.ubuntu.com/search?keywords=python3-argcomplete&searchon=names