### PR TITLE
rosmon: 2.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2312,7 +2312,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosmon-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosmon` to `2.3.2-1`:

- upstream repository: https://github.com/xqms/rosmon.git
- release repository: https://github.com/xqms/rosmon-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.1-1`

## rosmon

- No changes

## rosmon_core

```
* rosmon_core: cmake: increase minimum version to address policy warnings
* rosmon_core: *really* fix search for boost_python for python 3
* Contributors: Max Schwarz
```

## rosmon_msgs

- No changes

## rqt_rosmon

- No changes
