### PR TITLE
Use 'rhel' instead of 'centos' in rosdep rules

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -429,10 +429,11 @@ python-amqp:
   gentoo: [dev-python/py-amqp]
   ubuntu: [python-amqp]
 python-aniso8601:
-  centos: [python-aniso8601]
   debian: [python-aniso8601]
   fedora: [python2-aniso8601]
   gentoo: [dev-python/aniso8601]
+  rhel:
+    '7': [python-aniso8601]
   ubuntu:
     artful: [python-aniso8601]
     bionic: [python-aniso8601]
@@ -999,9 +1000,10 @@ python-cherrypy:
   gentoo: [dev-python/cherrypy]
   ubuntu: [python-cherrypy3]
 python-clearsilver:
-  centos: [python-clearsilver]
   debian: [python-clearsilver]
   fedora: [python-clearsilver]
+  rhel:
+    '7': [python-clearsilver]
   ubuntu: [python-clearsilver]
 python-click:
   debian:
@@ -5210,7 +5212,6 @@ python-xmltodict:
 python-yaml:
   alpine: [py-yaml]
   arch: [python2-yaml]
-  centos: [PyYAML]
   debian: [python-yaml]
   fedora: [PyYAML]
   freebsd: [py27-yaml]
@@ -6299,7 +6300,6 @@ virtualenv:
   ubuntu: [virtualenv]
 wxpython:
   arch: [wxpython]
-  centos: [wxPython-devel]
   debian:
     buster: [python-wxgtk3.0]
     jessie: [python-wxgtk3.0]


### PR DESCRIPTION
There is logic in rosdep to use 'rhel' rules on CentOS Linux, so we shouldn't have any explicit 'centos' rules.