### PR TITLE
cartographer_ros: 1.0.9001-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -194,6 +194,25 @@ repositories:
       url: https://github.com/ros2/cartographer.git
       version: ros2
     status: maintained
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: dashing
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer_ros-release.git
+      version: 1.0.9001-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: dashing
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.9001-1`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## cartographer_ros

```
* Init rclcpp first (#41 <https://github.com/ros2/cartographer_ros/issues/41>)
* Strip ROS args before passing to GFlags (#40 <https://github.com/ros2/cartographer_ros/issues/40>)
* Fix argument intiialization to allow node to take in params (#39 <https://github.com/ros2/cartographer_ros/issues/39>)
* Contributors: Emerson Knapp, Shane Loretz
```

## cartographer_ros_msgs

- No changes
