### PR TITLE
cv_camera: 0.5.0-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -361,6 +361,22 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: maintained
+  cv_camera:
+    doc:
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/OTL/cv_camera-release.git
+      version: 0.5.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/OTL/cv_camera.git
+      version: master
+    status: maintained
   ddynamic_reconfigure:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `cv_camera` to `0.5.0-3`:

- upstream repository: https://github.com/OTL/cv_camera
- release repository: https://github.com/OTL/cv_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## cv_camera

```
* Use OpenCV 3.x+ enums instead of 2.x defines (#28)
* Allow specifying camera name for camera_info_manager (#26)
  I think this is reasonable. Thanks.
* Contributors: Alexey Rogachevskiy
```
