### PR TITLE
csm: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1782,6 +1782,21 @@ repositories:
       url: https://github.com/crigroup/criutils.git
       version: master
     status: maintained
+  csm:
+    doc:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/csm-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    status: unmaintained
   cv_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.2-1`:

- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/ros-gbp/csm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
