### PR TITLE
csm: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -361,6 +361,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: maintained
+  csm:
+    doc:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/csm-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/AndreaCensi/csm.git
+      version: master
+    status: unmaintained
   ddynamic_reconfigure:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.2-1`:

- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/ros-gbp/csm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
