### PR TITLE
marvelmind_nav: 1.0.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1151,6 +1151,16 @@ repositories:
       url: https://github.com/swri-robotics/marti_messages.git
       version: master
     status: developed
+  marvelmind_nav:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
+      version: 1.0.11-1
+    source:
+      type: git
+      url: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package.git
+      version: master
   mavlink:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav` to `1.0.11-1`:

- upstream repository: https://bitbucket.org/marvelmind_robotics/ros_marvelmind_package
- release repository: https://github.com/MarvelmindRobotics/marvelmind_nav-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## marvelmind_nav

```
* waypoint msg added
* telemetry msg added
* quality msg added
* License header added
* License header added
* License header added
* License header added
* Contributors: smoker77
```
