### PR TITLE
kobuki_firmware: 1.2.0-3 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1016,7 +1016,11 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/kobuki_firmware-release.git
-      version: 1.2.0-2
+      version: 1.2.0-3
+    source:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_firmware.git
+      version: release/1.2.x
     status: maintained
   kobuki_ftdi:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_firmware` to `1.2.0-3`:

- upstream repository: https://github.com/kobuki-base/kobuki_firmware.git
- release repository: https://github.com/stonier/kobuki_firmware-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.0-2`

## kobuki_firmware

```
* Custom PID gain setting of wheel velocity controlled added
```
