### PR TITLE
control_toolbox: 1.18.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -325,11 +325,12 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 1.18.0-1
+      version: 1.18.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
       version: melodic-devel
+    status: maintained
   convex_decomposition:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `1.18.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.18.0-1`

## control_toolbox

```
* Python 3 compat
* Migrate to new industrial_ci
* Contributors: Matt Reynolds, Tobias Fischer
```
