### PR TITLE
twist_mux_msgs: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2984,6 +2984,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: noetic-devel
     status: maintained
+  twist_mux_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux_msgs-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: melodic-devel
+    status: maintained
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux_msgs.git
- release repository: https://github.com/ros-gbp/twist_mux_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## twist_mux_msgs

- No changes
