### PR TITLE
robot_localization: 2.6.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8442,7 +8442,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.6.6-1
+      version: 2.6.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.6.7-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.6.6-1`

## robot_localization

```
* Parameterizing transform failure warnings
* [melodic] Fix Windows build break. (#557 <https://github.com/cra-ros-pkg/robot_localization/issues/557>)
* Contributors: Sean Yen, Tom Moore, florianspy
```
