### PR TITLE
phidgets_drivers: 2.0.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1773,7 +1773,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.0.2-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.1-1`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_api

```
* Use '=default' for default destructors. (#66 <https://github.com/ros-drivers/phidgets_drivers/issues/66>)
* Contributors: Chris Lalancette
```

## phidgets_digital_inputs

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_digital_outputs

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_motors

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_temperature

- No changes
