### PR TITLE
phidgets_drivers: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -917,6 +917,38 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: foxy-devel
     status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: dashing
+    release:
+      packages:
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/phidgets_drivers-release.git
+      version: 2.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: dashing
+    status: maintained
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.0.2-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_api

```
* Use '=default' for default destructors. (#66 <https://github.com/ros-drivers/phidgets_drivers/issues/66>)
* Contributors: Chris Lalancette
```

## phidgets_digital_inputs

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_digital_outputs

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_motors

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Release build fixes (#67 <https://github.com/ros-drivers/phidgets_drivers/issues/67>)
* Contributors: Chris Lalancette
```

## phidgets_temperature

- No changes
