### PR TITLE
eigen_stl_containers: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -394,6 +394,22 @@ repositories:
       url: https://github.com/ros2/eigen3_cmake_module.git
       version: master
     status: maintained
+  eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    status: maintained
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `1.0.0-1`:

- upstream repository: https://github.com/ros/eigen_stl_containers.git
- release repository: https://github.com/ros2-gbp/eigen_stl_containers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## eigen_stl_containers

```
* Port package to ROS 2 (#16 <https://github.com/ros/eigen_stl_containers/issues/16>)
* Switch to package.xml format 2.
* Make sure to include <functional>
* Contributors: Chris Lalancette, Víctor Mayoral Vilches
```
