### PR TITLE
noetic/distribution.yaml: upgrading package version of rtabmap to 0.2…

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2877,7 +2877,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.0-1
+      version: 0.20.0-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
…0.0-2

This should fix this build error: https://github.com/introlab/rtabmap/issues/557