### PR TITLE
rmw_dds_common: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1291,7 +1291,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## rmw_dds_common

```
* Add Security Vulnerability Policy pointing to REP-2006 (#21 <https://github.com/ros2/rmw_dds_common/issues/21>)
* Fix graph cache tests (#22 <https://github.com/ros2/rmw_dds_common/issues/22>)
* Contributors: Chris Lalancette, Michel Hidalgo
```
