### PR TITLE
rclpy: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1150,7 +1150,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-1`

## rclpy

```
* Protect access to global logging calls with a mutex (#562 <https://github.com/ros2/rclpy/issues/562>)
* Ensure executors' spinning API handles shutdown properly (#563 <https://github.com/ros2/rclpy/issues/563>)
* Contributors: Michel Hidalgo, William Woodall
```
