### PR TITLE
lgsvl_msgs: 0.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6508,7 +6508,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lgsvl/lgsvl_msgs-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.3-1`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.2-1`

## lgsvl_msgs

```
* Update readme and license
* Changing some Vector3's to Points where they make more sense.
* Renaming CanBus to CanBusData.
* Adding VehicleStateData.
* Adding VehicleControlData.
* Adding CanBus and DetectedRadarObject/Array.
* Making package hybrid ROS1/ROS2 package.
* Contributors: Hadi Tabatabaee, Joshua Whitley
```
