### PR TITLE
rosbag2: 0.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1527,7 +1527,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.0-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Find rosbag2_cpp (tinyxml2) before rcl (#423 <https://github.com/ros2/rosbag2/issues/423>)
* Shared publisher handle (#420 <https://github.com/ros2/rosbag2/issues/420>)
* Contributors: Chris Lalancette, Karsten Knese
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

```
* Shared publisher handle (#420 <https://github.com/ros2/rosbag2/issues/420>)
* Contributors: Chris Lalancette
```
