### PR TITLE
nodl: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -855,6 +855,24 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros2
     status: maintained
+  nodl:
+    doc:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    release:
+      packages:
+      - nodl_python
+      - ros2nodl
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/canonical/nodl-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    status: developed
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodl` to `0.1.0-1`:

- upstream repository: https://github.com/ubuntu-robotics/nodl.git
- release repository: https://github.com/canonical/nodl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## nodl_python

```
* Initial release
* Add API for finding NoDL interface by package/executable
* Add API for parsing NoDL files
* Contributors: Kyle Fazzari, Ted Kern
```

## ros2nodl

```
* Initial release
* Add show and validate verbs
* Contributors: Ted Kern
```
