### PR TITLE
geographic_info: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -549,7 +549,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-geographic-info/geographic_info-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `1.0.4-1`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros-geographic-info/geographic_info-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.3-1`
