### PR TITLE
lgsvl_msgs: 0.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1149,6 +1149,10 @@ repositories:
         release: release/eloquent/{package}/{version}
       url: https://github.com/lgsvl/lgsvl_msgs-release.git
       version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: eloquent-devel
   libg2o:
     release:
       tags:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1143,6 +1143,12 @@ repositories:
       url: https://github.com/ros2/launch_ros.git
       version: eloquent
     status: developed
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/lgsvl/lgsvl_msgs-release.git
+      version: 0.0.3-1
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.3-1`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## lgsvl_msgs

```
* Update readme and license
* Changing some Vector3's to Points where they make more sense.
* Renaming CanBus to CanBusData.
* Adding VehicleStateData.
* Adding VehicleControlData.
* Adding CanBus and DetectedRadarObject/Array.
* Making package hybrid ROS1/ROS2 package.
* Contributors: Hadi Tabatabaee, Joshua Whitley
```
