### PR TITLE
lgsvl_msgs: 0.0.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1337,6 +1337,16 @@ repositories:
       url: https://github.com/aws-robotics/lex-ros2.git
       version: master
     status: developed
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/lgsvl/lgsvl_msgs-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: dashing-devel
   librealsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.3-1`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## lgsvl_msgs

```
* Update readme and license
* Changing some Vector3's to Points where they make more sense.
* Renaming CanBus to CanBusData.
* Adding VehicleStateData.
* Adding VehicleControlData.
* Adding CanBus and DetectedRadarObject/Array.
* Making package hybrid ROS1/ROS2 package.
* Contributors: Hadi Tabatabaee, Joshua Whitley
```
