### PR TITLE
noetic/distribution.yaml: updated rtabmap package version

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2914,7 +2914,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.0-2
+      version: 0.20.0-3
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
This would fix all those build errors (http://build.ros.org/job/Nbin_uF64__rtabmap__ubuntu_focal_amd64__binary/3/console):

```
...
22:11:43 dpkg-shlibdeps: error: cannot find library librtabmap_core.so.0.20 needed by debian/ros-noetic-rtabmap/opt/ros/noetic/bin/rtabmap-export (ELF format: 'elf64-x86-64' abi: '0201003e00000000'; RPATH: '')
...
```

Ref: https://github.com/introlab/rtabmap-release/commit/1379768e765e0ae372b14870c9ca31328c2e24d0
Full details about this problem: https://github.com/introlab/rtabmap/issues/63