### PR TITLE
rqt_moveit: 0.5.9-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2598,7 +2598,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_moveit-release.git
-      version: 0.5.8-1
+      version: 0.5.9-3
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_moveit` to `0.5.9-3`:

- upstream repository: https://github.com/ros-visualization/rqt_moveit.git
- release repository: https://github.com/ros-gbp/rqt_moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.8-1`

## rqt_moveit

```
* use catkin_install_python instead of install
```
