### PR TITLE
rclcpp: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1162,7 +1162,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 1.1.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## rclcpp

```
* Added missing virtual destructors. (#1149 <https://github.com/ros2/rclcpp/issues/1149>)
* Fixed a test which was using different types on the same topic. (#1150 <https://github.com/ros2/rclcpp/issues/1150>)
* Made ``test_rate`` more reliable on Windows and improve error output when it fails (#1146 <https://github.com/ros2/rclcpp/issues/1146>)
* Added Security Vulnerability Policy pointing to REP-2006. (#1130 <https://github.com/ros2/rclcpp/issues/1130>)
* Added missing header in ``logging_mutex.cpp``. (#1145 <https://github.com/ros2/rclcpp/issues/1145>)
* Changed the WaitSet API to pass a shared pointer by value instead than by const reference when possible. (#1141 <https://github.com/ros2/rclcpp/issues/1141>)
* Changed ``SubscriptionBase::get_subscription_handle() const`` to return a shared pointer to const value. (#1140 <https://github.com/ros2/rclcpp/issues/1140>)
* Extended the lifetime of ``rcl_publisher_t`` by holding onto the shared pointer in order to avoid a use after free situation. (#1119 <https://github.com/ros2/rclcpp/issues/1119>)
* Improved some docblocks (#1127 <https://github.com/ros2/rclcpp/issues/1127>)
* Fixed a lock-order-inversion (potential deadlock) (#1135 <https://github.com/ros2/rclcpp/issues/1135>)
* Fixed a potential Construction/Destruction order problem between global contexts vector and Context of static lifetime (#1132 <https://github.com/ros2/rclcpp/issues/1132>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Ivan Santiago Paunovic, Michel Hidalgo, tomoya
```

## rclcpp_action

```
* Added missing virtual destructors. (#1149 <https://github.com/ros2/rclcpp/issues/1149>)
* Add Security Vulnerability Policy pointing to REP-2006. (#1130 <https://github.com/ros2/rclcpp/issues/1130>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## rclcpp_components

```
* Added missing virtual destructors. (#1149 <https://github.com/ros2/rclcpp/issues/1149>)
* Add Security Vulnerability Policy pointing to REP-2006. (#1130 <https://github.com/ros2/rclcpp/issues/1130>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## rclcpp_lifecycle

```
* Added missing virtual destructors. (#1149 <https://github.com/ros2/rclcpp/issues/1149>)
* Add Security Vulnerability Policy pointing to REP-2006. (#1130 <https://github.com/ros2/rclcpp/issues/1130>)
* Fixed ``test_lifecycle_node.cpp:check_parameters`` (#1136 <https://github.com/ros2/rclcpp/issues/1136>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```
