### PR TITLE
add rosdep key for python-pyassimp3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5786,6 +5786,10 @@ python3-psutil:
   rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
+python3-pyassimp:
+  debian: [python3-pyassimp]
+  fedora: [assimp-python3]
+  ubuntu: [python3-pyassimp]
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5787,9 +5787,13 @@ python3-psutil:
   slackware: [psutil]
   ubuntu: [python3-psutil]
 python3-pyassimp:
-  debian: [python3-pyassimp]
-  fedora: [assimp-python3]
-  ubuntu: [python3-pyassimp]
+  debian:
+    '*': [python3-pyassimp]
+    stretch: null
+  fedora: [python3-assimp]
+  ubuntu:
+    '*': [python3-pyassimp]
+    xenial: null
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]


### PR DESCRIPTION
 * Used by moveit and a number of other packages - exists in python2 as "python-pyassimp"
 * Ubuntu: https://packages.ubuntu.com/focal/python3-pyassimp
 * Debian: https://packages.debian.org/unstable/python3-pyassimp
 * Fedora: https://fedora.pkgs.org/31/fedora-aarch64/python3-assimp-3.3.1-20.fc31.noarch.rpm.html

I don't understand Gentoo packaging enough to figure out what the correct key is for python3 - somebody else can hopefully add that down the road if they actually use Gentoo