### PR TITLE
twist_mux: 3.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3078,6 +3078,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: noetic-devel
     status: maintained
+  twist_mux:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/twist_mux-release.git
+      version: 3.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: melodic-devel
+    status: maintained
   twist_mux_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `3.1.1-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros-gbp/twist_mux-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## twist_mux

```
* Bump CMake version to avoid CMP0048
* Contributors: Bence Magyar
```
