### PR TITLE
ifm3d_core: 0.18.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5076,7 +5076,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-15
+      version: 0.18.0-2
     status: developed
   ifm_o3mxxx:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.18.0-2`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.17.0-15`
