### PR TITLE
ifm3d_core: 0.18.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3695,7 +3695,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-9
+      version: 0.18.0-1
     status: developed
   ifopt:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.18.0-1`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.17.0-9`
