### PR TITLE
ifm3d_core: 0.18.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -878,7 +878,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-15
+      version: 0.18.0-1
     status: developed
   image_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.18.0-1`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.17.0-15`
