### PR TITLE
ifm3d_core: 0.18.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1092,7 +1092,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ifm/ifm3d-release.git
-      version: 0.17.0-12
+      version: 0.18.0-1
     status: developed
   image_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.18.0-1`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.17.0-12`
