### PR TITLE
ifm3d_core: 0.18.0-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -881,6 +881,13 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: master
     status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.18.0-5
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.18.0-5`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
