### PR TITLE
rosparam_shortcuts: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2399,6 +2399,21 @@ repositories:
       url: https://github.com/ros/rospack.git
       version: noetic-devel
     status: maintained
+  rosparam_shortcuts:
+    doc:
+      type: git
+      url: https://github.com/davetcoleman/rosparam_shortcuts.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
+      version: 0.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/PickNikRobotics/rosparam_shortcuts.git
+      version: noetic-devel
   rospy_message_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosparam_shortcuts` to `0.4.0-1`:

- upstream repository: https://github.com/PickNikRobotics/rosparam_shortcuts.git
- release repository: https://github.com/PickNikRobotics/rosparam_shortcuts-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rosparam_shortcuts

```
* bump cmake version (#13 <https://github.com/PickNikRobotics/rosparam_shortcuts/issues/13>)
  get rid of CMP0048 warning.
  https://github.com/ros-planning/geometric_shapes/pull/129
* Contributors: Michael Görner
```
