### PR TITLE
cartesian_msgs: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -136,6 +136,20 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  cartesian_msgs:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/cartesian_msgs.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PickNikRobotics/cartesian_msgs-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/cartesian_msgs.git
+      version: jade-devel
   catch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartesian_msgs` to `0.0.3-1`:

- upstream repository: https://github.com/PickNikRobotics/cartesian_msgs.git
- release repository: https://github.com/PickNikRobotics/cartesian_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## cartesian_msgs

```
* catkin lint cleanup
* Contributors: Dave Coleman
```
