### PR TITLE
ifm3d_core: 0.18.0-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -599,6 +599,13 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  ifm3d_core:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.18.0-4
+    status: developed
   image_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d_core` to `0.18.0-4`:

- upstream repository: https://github.com/ifm/ifm3d
- release repository: https://github.com/ifm/ifm3d-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
