### PR TITLE
rviz: 8.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2017,7 +2017,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.0.2-1
+      version: 8.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.0.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `8.0.2-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fixed deprecated Qt usage. (#555 <https://github.com/ros2/rviz/issues/555>)
* Contributors: Jacob Perron
```

## rviz_default_plugins

```
* Fixed deprecated Qt usage. (#555 <https://github.com/ros2/rviz/issues/555>)
* Contributors: Jacob Perron
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
