### PR TITLE
tracetools_analysis: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2173,6 +2173,24 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: master
     status: maintained
+  tracetools_analysis:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: foxy
+    release:
+      packages:
+      - ros2trace_analysis
+      - tracetools_analysis
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: foxy
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `1.0.1-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
