### PR TITLE
rgbd_launch: 2.3.0-1 in 'noetic/distribution.yaml' [semi-bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1956,6 +1956,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
     status: maintained
+  rgbd_launch:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rgbd_launch-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/rgbd_launch.git
+      version: noetic-devel
+    status: maintained
   robot_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_launch` to `2.3.0`:

- upstream repository: https://github.com/ros-drivers/rgbd_launch.git
- release repository: https://github.com/ros-gbp/rgbd_launch-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`, but PR is made manually due to https://github.com/ros-drivers/rgbd_launch/issues/48#issuecomment-637884114
- previous version for package: None