### PR TITLE
rqt_moveit: 1.0.1-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2663,6 +2663,17 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: crystal-devel
     status: maintained
+  rqt_moveit:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_moveit-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: eloquent-devel
+    status: maintained
   rqt_msg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_moveit` to `1.0.1-2`:

- upstream repository: https://github.com/ros-visualization/rqt_moveit.git
- release repository: https://github.com/ros2-gbp/rqt_moveit-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_moveit

```
* removed non-resolvable build_tool dependency (fix for releasing)
```
