### PR TITLE
phidgets_drivers: 0.7.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9834,10 +9834,11 @@ repositories:
       - phidgets_high_speed_encoder
       - phidgets_ik
       - phidgets_imu
+      - phidgets_msgs
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.9-1
+      version: 0.7.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.10-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.9-1`

## libphidget21

```
* Update maintainers in package.xml
* Move libusb dependency into the libphidget21 package.xml.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_api

```
* Update maintainers in package.xml
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Remove unused indexHandler from Encoder class.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Small cleanups throughout the code.
* Push libphidgets API calls down to phidgets_api.
* Quiet down the to-be-overridden callbacks.
* Consistently use nullptr instead of 0.
* Make the phidget_api destructors virtual.
* Move libusb dependency into the libphidget21 package.xml.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_drivers

```
* Update maintainers in package.xml
* Split custom messages into their own package.
* Add in phidgets_ik to the phidgets_drivers metapackage.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_high_speed_encoder

```
* Update maintainers in package.xml
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Split custom messages into their own package.
* Rewrite the high speed encoder node.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Small cleanups throughout the code.
* Style cleanup.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_ik

```
* Update maintainers in package.xml
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Split custom messages into their own package.
* Add in a nodelet version of the interfaceKit.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Small cleanups throughout the code.
* Push libphidgets API calls down to phidgets_api.
* Completely remove boost from the project.
* Remove unused dependencies from phidgets_ik.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_imu

```
* Update maintainers in package.xml
* Fix wrong defaults for standard deviations (#46 <https://github.com/ros-drivers/phidgets_drivers/issues/46>)
  The old parameter defaults were wrong:
  | parameter                 | old default                       | new default                        |
  |                           |                                   |                                    |
  | angular_velocity_stdev    | 0.000349056 rad/s (= 0.02 deg/s)  | 0.001658 rad/s    (= 0.095deg/s)   |
  | linear_acceleration_stdev | 0.002943 m/s^2 (= 0.0003 g)       | 0.002745862 m/s^2 (= 0.00028 g)    |
  | magnetic_field_stdev      | 0.001658 rad/s (= 0.095deg/s)     | 1.1e-7 T         (= 1.1 mG)        |
  Notes: T = Tesla, mG = milligauss
  Specifications come from the PhidgetSpatial Precision 3/3/3 1044_0 data sheet: https://www.phidgets.com/?&prodid=32
* Improve the IMU calibration service (#41 <https://github.com/ros-drivers/phidgets_drivers/issues/41>)
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Small cleanups throughout the code.
* Push libphidgets API calls down to phidgets_api.
* IMU: small fixes found by turning on compiler warnings.
* Completely remove boost from the project.
* Remove unused tf dependency from phidgets_imu.
* Switch to package format 2.
* Cleanup spacing in all of the CMakeLists.txt
* Contributors: Chris Lalancette, Martin Günther, Michael Grupp
```

## phidgets_msgs

```
* Split custom messages into their own package.
* Contributors: Chris Lalancette, Martin Günther
```
