### PR TITLE
usb_cam: 0.3.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3299,6 +3299,21 @@ repositories:
       url: https://github.com/seqsense/urg_stamped.git
       version: master
     status: developed
+  usb_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: develop
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/usb_cam-release.git
+      version: 0.3.6-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: develop
+    status: unmaintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.3.6-1`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros-gbp/usb_cam-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## usb_cam

```
* .travis.yml: udpate to trusty
* add AV_ prefix to PIX_FMT_* for X,Y (#71 <https://github.com/ros-drivers/usb_cam/issues/71>)
* Contributors: Kei Okada
```
