### PR TITLE
csm: 1.0.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -385,7 +385,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/csm-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/AndreaCensi/csm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `csm` to `1.0.2-2`:

- upstream repository: https://github.com/AndreaCensi/csm.git
- release repository: https://github.com/ros-gbp/csm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-1`
