### PR TITLE
ifm3d: 0.6.2-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -895,6 +895,13 @@ repositories:
       url: https://github.com/at-wat/hokuyo3d.git
       version: master
     status: developed
+  ifm3d:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-ros-release.git
+      version: 0.6.2-3
+    status: developed
   ifm3d_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ifm3d` to `0.6.2-3`:

- upstream repository: https://github.com/ifm/ifm3d-ros
- release repository: https://github.com/ifm/ifm3d-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
