### PR TITLE
phidgets_drivers: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1695,6 +1695,38 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: melodic-devel
     status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: noetic
+    release:
+      packages:
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: noetic
+    status: developed
   pinocchio:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.0-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## libphidget22

```
* Update to libphidget22 from 2020.
* Update maintainers in package.xml
* Patch warnings in libphidget22.
* Fix up libphidget22 package.xml dependencies.
* Add in libphidget22 package.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_accelerometer

```
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
  The old parameter defaults were wrong:
  | parameter                 | old default                       | new default                        |
  |                           |                                   |                                    |
  | angular_velocity_stdev    | 0.000349056 rad/s (= 0.02 deg/s)  | 0.001658 rad/s    (= 0.095deg/s)   |
  | linear_acceleration_stdev | 0.002943 m/s^2 (= 0.0003 g)       | 0.002745862 m/s^2 (= 0.00028 g)    |
  | magnetic_field_stdev      | 0.001658 rad/s (= 0.095deg/s)     | 1.1e-7 T          (= 1.1 mG)       |
  Notes: T = Tesla, mG = milligauss
  This is a forward-port of #46 <https://github.com/ros-drivers/phidgets_drivers/issues/46> to noetic.
  Specifications come from the PhidgetSpatial Precision 3/3/3 1044_0 data sheet: https://www.phidgets.com/?&prodid=32
* Update maintainers in package.xml
* Switch to libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add support for Phidgets Accelerometer sensors.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_analog_inputs

```
* Update maintainers in package.xml
* Switch to libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Implement data interval setting for analog inputs.
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Analog inputs.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_api

```
* Update maintainers in package.xml
* Switch to libphidget22
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Implement data interval setting for analog inputs.
* Add in the license files and add to the headers.
* Completely remove libphidget21.
  Nothing else depends on it.
* Rewrite Motor Phidget to use libphidget22.
  Also implement a new motor node.
* Rewrite High Speed Encoder to use libphidget22.
* Rewrite IR to use libphidget22.
* Rewrite IMU using libphidget22.
* Add support for Phidgets Magnetometer sensors.
* Add support for Phidgets Gyroscope sensors.
* Add support for Phidgets Accelerometer sensors.
* Add in support for Phidgets Temperature sensors.
* Rewrite phidgets_ik on top of libphidget22 classes.
  This should be equivalent functionality, but allows the use
  of VINT devices now.
* Add in support for Phidgets Analog inputs.
* Add in support for Phidgets Digital Inputs.
* Add in support for Phidgets Digital Outputs.
* Add in libphidget22 helper functions.
* Rename Phidget class to Phidget21 class.
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Remove unused indexHandler from Encoder class.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Push libphidgets API calls down to phidgets_api.
* Quiet down the to-be-overridden callbacks.
* Consistently use nullptr instead of 0.
* Make the phidget_api destructors virtual.
* Style cleanup.
* Move libusb dependency into the libphidget21 package.xml.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_digital_inputs

```
* Update maintainers in package.xml
* Switch to libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Digital Inputs.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_digital_outputs

```
* Update maintainers in package.xml
* Switch to libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Digital Outputs.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_drivers

```
* Update maintainers in package.xml
* Switch to libphidget22
* Completely remove libphidget21.
* Rewrite Motor Phidget to use libphidget22.
* Rewrite IMU using libphidget22.
* Add support for Phidgets Magnetometer sensors.
* Add support for Phidgets Gyroscope sensors.
* Add support for Phidgets Accelerometer sensors.
* Add in support for Phidgets Temperature sensors.
* Add in support for Phidgets Analog inputs.
* Add in support for Phidgets Digital Inputs.
* Add in support for Phidgets Digital Outputs.
* Add in libphidget22 package.
* Split custom messages into their own package.
* Add in phidgets_ik to the phidgets_drivers metapackage.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_gyroscope

```
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
  The old parameter defaults were wrong:
  | parameter                 | old default                       | new default                        |
  |                           |                                   |                                    |
  | angular_velocity_stdev    | 0.000349056 rad/s (= 0.02 deg/s)  | 0.001658 rad/s    (= 0.095deg/s)   |
  | linear_acceleration_stdev | 0.002943 m/s^2 (= 0.0003 g)       | 0.002745862 m/s^2 (= 0.00028 g)    |
  | magnetic_field_stdev      | 0.001658 rad/s (= 0.095deg/s)     | 1.1e-7 T          (= 1.1 mG)       |
  Notes: T = Tesla, mG = milligauss
  This is a forward-port of #46 <https://github.com/ros-drivers/phidgets_drivers/issues/46> to noetic.
  Specifications come from the PhidgetSpatial Precision 3/3/3 1044_0 data sheet: https://www.phidgets.com/?&prodid=32
* Improve the IMU calibration service (#47 <https://github.com/ros-drivers/phidgets_drivers/issues/47>)
  * Change misleading IMU calibration log message.
  * Block 2 seconds in IMU calibration handler.
  * Make is_calibrated topic latched
  Forward-port of #41 <https://github.com/ros-drivers/phidgets_drivers/issues/41>. Fixes #42 <https://github.com/ros-drivers/phidgets_drivers/issues/42>.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
  Switch to libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add support for Phidgets Gyroscope sensors.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_high_speed_encoder

```
* Update maintainers in package.xml
* Switch to libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Fix a small typo.
* Rewrite High Speed Encoder to use libphidget22.
* Rename Phidget class to Phidget21 class.
* Remove unused std_msgs dependency from Phidgets High Speed Encoder.
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Split custom messages into their own package.
* Rewrite the high speed encoder node.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
* Style cleanup.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_ik

```
* Update maintainers in package.xml
* Switch to libphidget22
* Fix phidgets_ik dependencies.
* Rewrite IK as just a launch file.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Rewrite phidgets_ik on top of libphidget22 classes.
* Rename Phidget class to Phidget21 class.
  Also rename the files, etc.
* Run clang-format on the whole codebase.
* Switch to C++14 everywhere.
* Split custom messages into their own package.
* Add in a nodelet version of the interfaceKit.
* Change API from separate open/waitForAttachment to openAndWaitForAttachment.
  None of the current users need it to be split, and this will make
  it easier to port to libphidgets22.
* Small cleanups throughout the code.
* Push libphidgets API calls down to phidgets_api.
* Completely remove boost from the project.
* Style cleanup.
* Remove unused dependencies from phidgets_ik.
* Switch to package format 2.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_magnetometer

```
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
  The old parameter defaults were wrong:
  | parameter                 | old default                       | new default                        |
  |                           |                                   |                                    |
  | angular_velocity_stdev    | 0.000349056 rad/s (= 0.02 deg/s)  | 0.001658 rad/s    (= 0.095deg/s)   |
  | linear_acceleration_stdev | 0.002943 m/s^2 (= 0.0003 g)       | 0.002745862 m/s^2 (= 0.00028 g)    |
  | magnetic_field_stdev      | 0.001658 rad/s (= 0.095deg/s)     | 1.1e-7 T          (= 1.1 mG)       |
  Notes: T = Tesla, mG = milligauss
  This is a forward-port of #46 <https://github.com/ros-drivers/phidgets_drivers/issues/46> to noetic.
  Specifications come from the PhidgetSpatial Precision 3/3/3 1044_0 data sheet: https://www.phidgets.com/?&prodid=32
* Update maintainers in package.xml
* Switch to libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Fix small typos in README and LICENSE files.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add support for Phidgets Magnetometer sensors.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_motors

```
* Update maintainers in package.xml
* Switch to libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Rewrite Motor Phidget to use libphidget22.
  Also implement a new motor node.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_msgs

```
* Split custom messages into their own package.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_spatial

```
* Fix wrong defaults for standard deviations (#48 <https://github.com/ros-drivers/phidgets_drivers/issues/48>)
  The old parameter defaults were wrong:
  | parameter                 | old default                       | new default                        |
  |                           |                                   |                                    |
  | angular_velocity_stdev    | 0.000349056 rad/s (= 0.02 deg/s)  | 0.001658 rad/s    (= 0.095deg/s)   |
  | linear_acceleration_stdev | 0.002943 m/s^2 (= 0.0003 g)       | 0.002745862 m/s^2 (= 0.00028 g)    |
  | magnetic_field_stdev      | 0.001658 rad/s (= 0.095deg/s)     | 1.1e-7 T          (= 1.1 mG)       |
  Notes: T = Tesla, mG = milligauss
  This is a forward-port of #46 <https://github.com/ros-drivers/phidgets_drivers/issues/46> to noetic.
  Specifications come from the PhidgetSpatial Precision 3/3/3 1044_0 data sheet: https://www.phidgets.com/?&prodid=32
* Improve the IMU calibration service (#47 <https://github.com/ros-drivers/phidgets_drivers/issues/47>)
  * Change misleading IMU calibration log message.
  * Block 2 seconds in IMU calibration handler.
  * Make is_calibrated topic latched
  Forward-port of #41 <https://github.com/ros-drivers/phidgets_drivers/issues/41>. Fixes #42 <https://github.com/ros-drivers/phidgets_drivers/issues/42>.
* Update maintainers in package.xml
* Merge pull request #39 <https://github.com/ros-drivers/phidgets_drivers/issues/39> from clalancette/add-libphidget22
  Switch to libphidget22
* Resynchronize the times at periodic intervals.
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Fixes from review.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Finish removing launch file from phidgets_spatial.
* Rewrite IMU using libphidget22.
* Contributors: Chris Lalancette, Martin Günther
```

## phidgets_temperature

```
* Update maintainers in package.xml
* Switch to libphidget22
* Add launch files for all drivers.
* Add in try/catch blocks for connecting.
  If an error occurs, we catch it, print it, then re-throw it.
  This allows us to show a better error when using nodelets.
* Documentation updates to README.md
* Set the publish_rate to 0 by default.
  This means we will only publish on changes.
* Add in the license files and add to the headers.
* Remove nodes in favor of nodelets.
* Add in support for Phidgets Temperature sensors.
* Contributors: Chris Lalancette, Martin Günther
```
