### PR TITLE
mrt_cmake_modules: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5747,7 +5747,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.3-1`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.2-1`

## mrt_cmake_modules

```
* Replace deprecated platform.distro call with distro module
* Raise required CMake version to 3.0.2 to suppress warning with Noetic
* Remove boost signals component that is no longer part of boost
* Fixed c++14 test path include.
* Fix installation of python api files
* Update README.md
* Reformat with new version of cmake-format
* Add lcov as dependency again
* Fix FindBoostPython.cmake for cmake below 3.11 and python3
* Fix multiple include of MrtPCL
* Contributors: Christian-Eike Framing, Fabian Poggenhans, Johannes Beck, Johannes Janosovits, Moritz Cremer
```
