### PR TITLE
robot_localization: 2.6.8-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2010,6 +2010,21 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: kinetic-devel
     status: maintained
+  robot_localization:
+    doc:
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/cra-ros-pkg/robot_localization-release.git
+      version: 2.6.8-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: melodic-devel
   robot_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.6.8-2`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## robot_localization

```
* Adding conditional build dependencies (#572 <https://github.com/cra-ros-pkg/robot_localization/issues/572>)
* Contributors: Tom Moore
```
