### PR TITLE
fadecandy_ros: 0.1.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -547,6 +547,20 @@ repositories:
       url: https://github.com/wxmerkt/exotica_val_description-release.git
       version: 1.0.0-1
     status: maintained
+  fadecandy_ros:
+    release:
+      packages:
+      - fadecandy_driver
+      - fadecandy_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/iron-ox/fadecandy_ros-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/iron-ox/fadecandy_ros.git
+      version: master
+    status: developed
   fcl_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `0.1.1-2`:

- upstream repository: https://github.com/iron-ox/fadecandy_ros.git
- release repository: https://github.com/iron-ox/fadecandy_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## fadecandy_driver

```
* Merge pull request #7 <https://github.com/iron-ox/fadecandy_ros/issues/7> from jonbinney/python3-fixes
  Fixes for python3/noetic compatibility
* Contributors: Jon Binney
```

## fadecandy_msgs

- No changes
