### PR TITLE
laser_filters: 1.8.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4625,7 +4625,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.8.10-1
+      version: 1.8.11-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.8.11-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.8.10-1`

## laser_filters

```
* Merge pull request #97 <https://github.com/ros-perception/laser_filters/issues/97> from eurogroep/feat/speckle-filter-for-noise-removal
* Merge pull request #96 <https://github.com/ros-perception/laser_filters/issues/96> from eurogroep/feat/intensity-filter-dynamic-reconfigure-and-optionally-override-intensity-values
  feat(IntensityFilter): Dynamic reconfigure and optionally override intensity
* Merge pull request #3 <https://github.com/ros-perception/laser_filters/issues/3> from nlimpert/nlimpert/speckle-filter-radius-outlier-merge
  Merge distance based speckle filter with RadiusOutlier removal
* Contributors: Jonathan Binney, Nicolas Limpert, Rein Appeldoorn
```
