### PR TITLE
rosbag2: 0.3.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1562,7 +1562,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.2-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.3.1-1`

## ros2bag

```
* Improve help message for CLI verbs (#427 <https://github.com/ros2/rosbag2/issues/427>)
* Contributors: Jacob Perron
```

## rosbag2

- No changes

## rosbag2_compression

```
* Add user provided split size to error message (#430 <https://github.com/ros2/rosbag2/issues/430>)
* Contributors: Anas Abou Allaban
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

```
* Add user provided split size to error (#430 <https://github.com/ros2/rosbag2/issues/430>)
  * Add user provided split size to error
  Signed-off-by: Anas Abou Allaban <mailto:aabouallaban@pm.me>
* Make split size error clearer (#428 <https://github.com/ros2/rosbag2/issues/428>)
  Signed-off-by: Anas Abou Allaban <mailto:aabouallaban@pm.me>
* Contributors: Anas Abou Allaban
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
