### PR TITLE
openni2_camera: 1.4.2-1 in 'noetic distribution.yaml' [semi-bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1691,6 +1691,24 @@ repositories:
       url: https://github.com/ros-perception/open_karto.git
       version: melodic-devel
     status: maintained
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: noetic-devel
+    release:
+      packages:
+      - openni2_camera
+      - openni2_launch
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/openni2_camera-release.git
+      version: 1.4.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: noetic-devel
+    status: maintained
   openslam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository openni2_camera 1.4.2

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`, but PR is made manually due to a similar/the same issue as similar to https://github.com/ros-drivers/rgbd_launch/issues/48#issuecomment-637884114
- previous version for package: None