### PR TITLE
diagnostics: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -379,6 +379,26 @@ repositories:
       url: https://github.com/ros-perception/depthimage_to_laserscan.git
       version: foxy-devel
     status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: foxy
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_updater
+      - self_test
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/diagnostics-release.git
+      version: 2.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: foxy
+    status: maintained
   eigen3_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.0.2-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## diagnostic_aggregator

```
* 2.0.2
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* generate changelog
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* Ros2 migrate diagnostic aggregator (#118 <https://github.com/ros/diagnostics/issues/118>)
  * Removed AMENT_IGNORE and uncrustified
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Started migration of c++ API
  * To be done: logging, assertions, parameter handling
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Started migration of python tests
  * Started migration of analyzer group
  * Migrated from XMLRPC to ROS2 parameters parsing
  * Doesn't create working analzers, yet
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Migrated analyzers plugin
  * Split anaylzers into seperate plugin lib
  * Build shared lib to be used by plugin class loader
  * Fixed plugin registration of analyzers
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Analyzer group correctly setting up analyzers
  * Improved parameter handling of generic_analyzer
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * API migration to ROS2 c++ + logging
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * uncrustified
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Reworked analyzer paths and names
  * Separate handling of the analyzer's (and analyzer group's):
  ** "nice" name
  ** path (path of their results in the robot monitor)
  ** breadcrumb (prefix of their yaml configuration)
  * Logging
  * Uncrustify
  * Examples
  * Less strict cpplint
  * removed using namespace
  * Fixes complation of analyzer group test
  * Removed dependency to boost
  * Using std::mutex instead of boost::mutex. Using std::lock_guard
  instead of boost::scoped_lock since std::scoped_lock was not introduced before C++17
  * Using std::regex instead of boost::regex
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Alphabetical order of includes and dependencies
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Adopted suggestions from review by @Karsten1987
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Minor improvements
  * Using unique_ptrs instead of plain c pointers
  * Simplifying loops
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * use class logger variable
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * make linter tests pass
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * bring back variable names and (void) them
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * linters
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * Aggregator demo launch
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Adds launch-based test
  * Adds launch-based test, starting aggregator with a yaml configuration
  * Test is not yet working, something wrong with process orchestration
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * One passing test
  * One passing test, just looking for output of the bond statemachine
  * One failing test, looking for the actual analyzer output we want to
  test for
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Short documentation of the demo
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * minor fixes
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Working tests for analyzer creation from yaml
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Cleanup, we don't need lifecycle (yes)
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * linters
  * Fixed tests
  * launch testing now working withou previous stdcout hack
  * deleted deprecated (not working) tests
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * - QOS config in python demo publisher
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * fix install location, necessary for eloquent
  * fix undefined behaviour when parameters are kept as default
  * CMakeLists.txt touchup for OSX
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Moved 'Demo' to 'Example'
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Cleanup
  * Removed non-ported python parts (blocked by bondpy port)
  * Uncrustify, cpplint
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * enhance github actions for diagnostic_aggregator package
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Upgrade to foxy
  - Fixed example
  - Explicit QoS profiles for rclypy publishers
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * use new create_timer API
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * add launch testing dependency
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * do not use boost in pluginlib
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Removed all features depending on bond(core)
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * use latest github actions
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Reoved dependency to uuid
  Was introduced as upstream dependency for bond(core), which was removed
  as dependency as well.
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Adds missing dependency to launch_testing_ros
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * deprecation warning only on non-windows
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * export symbols on windows
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * fix cpplint
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Proper handling of file separators in cmake
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Proper handling of file separators in cmake
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Tests working on windows and linux
  More path fixes inside tests. Tests were expecting to find the node
  executable in the CMAKE_BINARY_DIR before, which is true on linux
  but not on windows.
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * fix windows installation path
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * correctly enable visibility macros
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * correct sign conversion
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  Co-authored-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  Co-authored-by: Robin Vanhove <1r0b1n0@gmail.com>
* Contributors: Karsten Knese
```

## diagnostic_updater

```
* 2.0.2
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* generate changelog
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* Re-add leading character to node name (#109 <https://github.com/ros/diagnostics/issues/109>)
  The ROS 2 API is giving us the node name without a leading slash.
* Ros2 migrate diagnostic aggregator (#118 <https://github.com/ros/diagnostics/issues/118>)
  * Removed AMENT_IGNORE and uncrustified
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Started migration of c++ API
  * To be done: logging, assertions, parameter handling
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Started migration of python tests
  * Started migration of analyzer group
  * Migrated from XMLRPC to ROS2 parameters parsing
  * Doesn't create working analzers, yet
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Migrated analyzers plugin
  * Split anaylzers into seperate plugin lib
  * Build shared lib to be used by plugin class loader
  * Fixed plugin registration of analyzers
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Analyzer group correctly setting up analyzers
  * Improved parameter handling of generic_analyzer
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * API migration to ROS2 c++ + logging
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * uncrustified
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
  * Reworked analyzer paths and names
  * Separate handling of the analyzer's (and analyzer group's):
  ** "nice" name
  ** path (path of their results in the robot monitor)
  ** breadcrumb (prefix of their yaml configuration)
  * Logging
  * Uncrustify
  * Examples
  * Less strict cpplint
  * removed using namespace
  * Fixes complation of analyzer group test
  * Removed dependency to boost
  * Using std::mutex instead of boost::mutex. Using std::lock_guard
  instead of boost::scoped_lock since std::scoped_lock was not introduced before C++17
  * Using std::regex instead of boost::regex
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Alphabetical order of includes and dependencies
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Adopted suggestions from review by @Karsten1987
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Minor improvements
  * Using unique_ptrs instead of plain c pointers
  * Simplifying loops
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * use class logger variable
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * make linter tests pass
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * bring back variable names and (void) them
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * linters
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * Aggregator demo launch
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Adds launch-based test
  * Adds launch-based test, starting aggregator with a yaml configuration
  * Test is not yet working, something wrong with process orchestration
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * One passing test
  * One passing test, just looking for output of the bond statemachine
  * One failing test, looking for the actual analyzer output we want to
  test for
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Short documentation of the demo
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * minor fixes
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Working tests for analyzer creation from yaml
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Cleanup, we don't need lifecycle (yes)
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * linters
  * Fixed tests
  * launch testing now working withou previous stdcout hack
  * deleted deprecated (not working) tests
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * - QOS config in python demo publisher
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * fix install location, necessary for eloquent
  * fix undefined behaviour when parameters are kept as default
  * CMakeLists.txt touchup for OSX
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Moved 'Demo' to 'Example'
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Cleanup
  * Removed non-ported python parts (blocked by bondpy port)
  * Uncrustify, cpplint
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * enhance github actions for diagnostic_aggregator package
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Upgrade to foxy
  - Fixed example
  - Explicit QoS profiles for rclypy publishers
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * use new create_timer API
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * add launch testing dependency
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * do not use boost in pluginlib
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Removed all features depending on bond(core)
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * use latest github actions
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Reoved dependency to uuid
  Was introduced as upstream dependency for bond(core), which was removed
  as dependency as well.
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Adds missing dependency to launch_testing_ros
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * deprecation warning only on non-windows
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * export symbols on windows
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * fix cpplint
  Signed-off-by: Karsten Knese <karsten.knese@us.bosch.com>
  * Proper handling of file separators in cmake
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Proper handling of file separators in cmake
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * Tests working on windows and linux
  More path fixes inside tests. Tests were expecting to find the node
  executable in the CMAKE_BINARY_DIR before, which is true on linux
  but not on windows.
  Signed-off-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  * fix windows installation path
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * correctly enable visibility macros
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  * correct sign conversion
  Signed-off-by: Karsten Knese <karsten@openrobotics.org>
  Co-authored-by: Arne Nordmann <arne.nordmann@de.bosch.com>
  Co-authored-by: Robin Vanhove <1r0b1n0@gmail.com>
* Fix DiagnosedPublisher (#135 <https://github.com/ros/diagnostics/issues/135>)
  * The DiagnosedPublisher should be a wrapper around a publisher for any type of message, but it could only be used with publishers for DiagnosticArray messages. This was fixed.
  * cpplint: include utility
  * Check message type for header
* fix linters (#134 <https://github.com/ros/diagnostics/issues/134>)
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* Contributors: DensoADAS, Karsten Knese, Scott K Logan
```

## self_test

```
* 2.0.2
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* generate changelog
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* fix linters (#134 <https://github.com/ros/diagnostics/issues/134>)
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* Contributors: Karsten Knese
```
