### PR TITLE
rcpputils: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1221,7 +1221,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## rcpputils

```
* Include stdexcept in get_env.hpp (#69 <https://github.com/ros2/rcpputils/issues/69>)
* Update quality declaration for version stability (#66 <https://github.com/ros2/rcpputils/issues/66>)
* Handle empty paths in is_absolute (#67 <https://github.com/ros2/rcpputils/issues/67>)
* Add Security Vulnerability Policy pointing to REP-2006 (#65 <https://github.com/ros2/rcpputils/issues/65>)
* Contributors: Chris Lalancette, Scott K Logan, Steven! Ragnarök
```
