### PR TITLE
geometry2: 0.13.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -598,7 +598,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.3-1
+      version: 0.13.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.4-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.13.3-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Add missing virtual destructors (#272 <https://github.com/ros2/geometry2/issues/272>)
* Contributors: Ivan Santiago Paunovic
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* export targets in addition to include directories / libraries (#271 <https://github.com/ros2/geometry2/issues/271>)
* Contributors: Dirk Thomas
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* export targets in addition to include directories / libraries (#271 <https://github.com/ros2/geometry2/issues/271>)
* Add missing virtual destructors (#272 <https://github.com/ros2/geometry2/issues/272>)
* Contributors: Dirk Thomas, Ivan Santiago Paunovic
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
