### PR TITLE
rviz: 8.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2063,7 +2063,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.0.3-1
+      version: 8.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.1.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `8.0.3-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* avoid absolute OGRE path in exported targets (#558 <https://github.com/ros2/rviz/issues/558>)
* Contributors: Dirk Thomas
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* avoid absolute OGRE path in exported targets (#558 <https://github.com/ros2/rviz/issues/558>)
* Contributors: Dirk Thomas
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
