### PR TITLE
imu_pipeline: 0.3.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -998,6 +998,25 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: noetic-devel
     status: unmaintained
+  imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: noetic-devel
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/imu_pipeline-release.git
+      version: 0.3.0-2
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: noetic-devel
+    status: maintained
   imu_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.3.0-2`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros-gbp/imu_pipeline-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## imu_pipeline

```
* Bump CMake version to avoid CMP0048 warning.
* Updated to package.xml format 2.
* Contributors: Tony Baltovski
```

## imu_processors

```
* Bump CMake version to avoid CMP0048 warning.
* Updated to package.xml format 2.
* Contributors: Tony Baltovski
```

## imu_transformer

```
* Bump CMake version to avoid CMP0048 warning.
* Updated to package.xml format 2.
* Contributors: Tony Baltovski
```
