### PR TITLE
phidgets_drivers: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1763,7 +1763,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.1-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## libphidget22

```
* Re-run bloom to fix the line endings in the patch file
  (#77 <https://github.com/ros-drivers/phidgets_drivers/issues/77>)
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_accelerometer

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_analog_inputs

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_api

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_digital_inputs

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_digital_outputs

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_drivers

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_gyroscope

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_high_speed_encoder

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_ik

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_magnetometer

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_motors

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_msgs

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_spatial

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## phidgets_temperature

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```
