### PR TITLE
joint_state_publisher: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -709,6 +709,25 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: ros2
     status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: foxy
+    release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/joint_state_publisher-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: foxy
+    status: maintained
   joystick_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.2.0-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## joint_state_publisher

```
* Minor fixes from review.
* Add in pytest.ini files for jsp and jsp_gui.
* Stop using deprecated launch parameters in Foxy.
* Contributors: Chris Lalancette
```

## joint_state_publisher_gui

```
* Minor fixes from review.
* Add in pytest.ini files for jsp and jsp_gui.
* Contributors: Chris Lalancette
```
