### PR TITLE
urg_node: 0.1.14-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16559,7 +16559,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/urg_node.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -16568,7 +16568,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   urg_stamped:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11599,7 +11599,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/urg_node.git
-      version: indigo-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -11608,7 +11608,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   urg_stamped:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3389,6 +3389,21 @@ repositories:
       url: https://github.com/ros-drivers/urg_c.git
       version: master
     status: maintained
+  urg_node:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urg_node-release.git
+      version: 0.1.14-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: kinetic-devel
+    status: maintained
   urg_stamped:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.14-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros-gbp/urg_node-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## urg_node

```
* Bumped CMake version.
* Removed trailing whitespace.
* Contributors: Tony Baltovski
```
