### PR TITLE
teleop_tools: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3234,6 +3234,27 @@ repositories:
       url: https://github.com/rst-tu-dortmund/teb_local_planner.git
       version: noetic-devel
     status: maintained
+  teleop_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: kinetic-devel
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_tools-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: kinetic-devel
+    status: maintained
   twist_mux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `0.4.0-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros-gbp/teleop_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## joy_teleop

```
* Fix iteritems and dependency in python3
* Bump CMake version to avoid CMP0048
* Fix install of python scripts for Noetic
* Python3 compatibility for noetic (#52 <https://github.com/ros-teleop/teleop_tools/issues/52>)
* Contributors: Bence Magyar, Tim Clephas
```

## key_teleop

```
* Value should be int
* Bump CMake version to avoid CMP0048
* Fix install of python scripts for Noetic
* Python3 compatibility for noetic (#52 <https://github.com/ros-teleop/teleop_tools/issues/52>)
* Contributors: Bence Magyar, Tim Clephas
```

## mouse_teleop

```
* Fix tk dependency
* Bump CMake version to avoid CMP0048
* Fix install of python scripts for Noetic
* Python3 compatibility for noetic (#52 <https://github.com/ros-teleop/teleop_tools/issues/52>)
* Contributors: Bence Magyar, Tim Clephas
```

## teleop_tools

```
* Bump CMake version to avoid CMP0048
* Python3 compatibility for noetic (#52 <https://github.com/ros-teleop/teleop_tools/issues/52>)
* Add mouse_teleop to metapackage
* Contributors: Bence Magyar, Tim Clephas, Yasuhiro Ishiguro
```

## teleop_tools_msgs

```
* Bump CMake version to avoid CMP0048
* Python3 compatibility for noetic (#52 <https://github.com/ros-teleop/teleop_tools/issues/52>)
* Contributors: Bence Magyar, Tim Clephas
```
