### PR TITLE
Fix branch name of 'source' entries

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5651,7 +5651,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git
-      version: master
+      version: develop
     status: maintained
   mrpt_bridge:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1439,7 +1439,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git
-      version: master
+      version: develop
     status: developed
   mrt_cmake_modules:
     doc:


### PR DESCRIPTION
Fix the branch Jenkins should look at for build jobs in "source" (non-released) builds.