### PR TITLE
Add source entry for system_tests in foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2123,7 +2123,7 @@ repositories:
   system_tests:
     source:
       type: git
-      url: https://github.com/ros2/system_tests
+      url: https://github.com/ros2/system_tests.git
       version: master
     status: developed
   teleop_twist_joy:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2120,6 +2120,12 @@ repositories:
       url: https://github.com/micro-ROS/system_modes.git
       version: master
     status: developed
+  system_tests:
+    source:
+      type: git
+      url: https://github.com/ros2/system_tests
+      version: master
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
[Suggested](https://github.com/ros2/ros2_documentation/pull/737#issuecomment-638961374) by @dirk-thomas in order to be able to run `rosintsall_generator`