### PR TITLE
control_box_rst: 0.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -308,7 +308,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rst-tu-dortmund/control_box_rst-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_box_rst` to `0.0.7-1`:

- upstream repository: https://github.com/rst-tu-dortmund/control_box_rst.git
- release repository: https://github.com/rst-tu-dortmund/control_box_rst-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.6-1`

## control_box_rst

```
* Fixed issue: Wrong sparse Jacobian pattern in solver LM
* Stage functions: added dedicated method for state and time dependency
* Lsq form added to hybrid cost functions
* Added missing header for eigenvalue computation
* Contributors: Christoph Rösmann
```
