### PR TITLE
libg2o: 2020.05.29-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -813,6 +813,13 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libg2o:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/libg2o-release.git
+      version: 2020.05.29-3
+    status: maintained
   librealsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libg2o` to `2020.05.29-3`:

- upstream repository: https://github.com/RainerKuemmerle/g2o.git
- release repository: https://github.com/ros2-gbp/libg2o-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
