### PR TITLE
pointcloud_to_laserscan: 1.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1830,6 +1830,22 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: melodic-devel
     status: maintained
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
+      version: 1.4.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: lunar-devel
+    status: maintained
   pybind11_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `1.4.1-1`:

- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros-gbp/pointcloud_to_laserscan-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## pointcloud_to_laserscan

```
* LaserScan to PointCloud node + nodelet (#28 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/28>)
* fix roslint (#29 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/29>)
* Merge pull request #20 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/20> from ros-perception/range_max_check
  Add check for range_max
* Add check for range_max
* Contributors: Paul Bovbel, Rein Appeldoorn
```
