### PR TITLE
ros_workspace: 1.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2335,7 +2335,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 0.8.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `1.0.1-1`:

- upstream repository: https://github.com/nuclearsandwich/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.0-1`

## ros_workspace

```
* set flag to skip parent_prefix_path (#19 <https://github.com/ros2/ros_workspace/issues/19>)
* Contributors: Dirk Thomas
```
