### PR TITLE
ament_package: 0.8.9-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -136,7 +136,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.8.8-1
+      version: 0.8.9-1
     source:
       type: git
       url: https://github.com/ament/ament_package.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.8.9-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.8-1`

## ament_package

```
* add configure-time flag to skip parent_prefix_path (#115 <https://github.com/ament/ament_package/issues/115>)
* [windows] fix _ament_python_executable fallback code path (#113 <https://github.com/ament/ament_package/issues/113>)
```
