### PR TITLE
oxford_gps_eth: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1706,6 +1706,21 @@ repositories:
       url: https://github.com/ros-perception/openslam_gmapping.git
       version: melodic-devel
     status: unmaintained
+  oxford_gps_eth:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
+      version: master
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `1.1.1-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## oxford_gps_eth

```
* Install Python script
* Add missing rospy dependency
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```
