### PR TITLE
turtlesim: 1.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2252,7 +2252,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlesim` to `1.2.3-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.2-1`

## turtlesim

```
* update Foxy turtle (#90 <https://github.com/ros/ros_tutorials/issues/90>)
* Contributors: Dirk Thomas
```
