### PR TITLE
dataspeed_ulc_ros: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -407,6 +407,16 @@ repositories:
       url: https://github.com/OTL/cv_camera.git
       version: master
     status: maintained
+  dataspeed_ulc_ros:
+    release:
+      packages:
+      - dataspeed_ulc
+      - dataspeed_ulc_can
+      - dataspeed_ulc_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release.git
+      version: 0.0.5-1
   ddynamic_reconfigure:
     release:
       tags:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -408,6 +408,10 @@ repositories:
       version: master
     status: maintained
   dataspeed_ulc_ros:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git
+      version: master
     release:
       packages:
       - dataspeed_ulc
@@ -417,6 +421,11 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release.git
       version: 0.0.5-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git
+      version: master
+    status: developed      
   ddynamic_reconfigure:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_ulc_ros` to `0.0.5-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dataspeed_ulc

- No changes

## dataspeed_ulc_can

```
* Updates scale factor on linear accel and decel limit CAN signals
* Adds README to document the ROS node interface
* Contributors: Micho Radovnikovich
```

## dataspeed_ulc_msgs

- No changes
