### PR TITLE
sros2: 0.9.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2101,7 +2101,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2106,7 +2106,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/sros2.git
-      version: master
+      version: foxy
     status: developed
   system_modes:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## sros2

```
* Fix list keys verb (#219 <https://github.com/ros2/sros2/issues/219>)
* Contributors: Mikael Arguedas
```

## sros2_cmake

- No changes
