### PR TITLE
rosbag2_bag_v2: 0.0.10-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1608,7 +1608,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
-      version: 0.0.9-2
+      version: 0.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_bag_v2` to `0.0.10-1`:

- upstream repository: https://github.com/ros2/rosbag2_bag_v2.git
- release repository: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.9-2`

## ros1_rosbag_storage_vendor

- No changes

## rosbag2_bag_v2_plugins

```
* workaroud add shared_queues_vendor as test dependency (#30 <https://github.com/ros2/rosbag2_bag_v2/issues/30>)
* Contributors: Karsten Knese
```
