### PR TITLE
sophus: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3138,6 +3138,21 @@ repositories:
       url: https://github.com/ros-perception/slam_karto.git
       version: melodic-devel
     status: maintained
+  sophus:
+    doc:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.1.x
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/sophus-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/stonier/sophus.git
+      version: release/1.1.x
+    status: maintained
   sparse_bundle_adjustment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.1.0-1`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
