### PR TITLE
py_trees_ros: 0.5.21-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7658,7 +7658,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 0.5.18-0
+      version: 0.5.21-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.5.21-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.5.18-0`

## py_trees_ros

```
* [trees] option for bagging, , #159 <https://github.com/splintered-reality/py_trees_ros/pull/159>
```
