### PR TITLE
jderobot_color_tuner: 0.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4127,7 +4127,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/ColorTuner-release.git
-      version: 0.0.3-6
+      version: 0.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_color_tuner` to `0.0.4-1`:

- upstream repository: https://github.com/JdeRobot/ColorTuner.git
- release repository: https://github.com/JdeRobot/ColorTuner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.0.3-6`

## jderobot_color_tuner

```
* Merge pull request #17 <https://github.com/JdeRobot/ColorTuner/issues/17> from JdeRobot/test
  Merge the testing branch into master
* Merge pull request #16 <https://github.com/JdeRobot/ColorTuner/issues/16> from pankhurivanjani/test
  Final commits with correction before release
* Merge pull request #14 <https://github.com/JdeRobot/ColorTuner/issues/14> from pankhurivanjani/master
  Updated CMakeLists.txt
* Final commits with correction before release
* Merge pull request #15 <https://github.com/JdeRobot/ColorTuner/issues/15> from pankhurivanjani/test
  modifying files for test before release
* modifying files for test before release
* Merge pull request #13 <https://github.com/JdeRobot/ColorTuner/issues/13> from pankhurivanjani/test
  Updating CMakeLists.txt
* Updating CMakeLists.txt
* Updated CMakeLists.tx
* Merge pull request #12 <https://github.com/JdeRobot/ColorTuner/issues/12> from pankhurivanjani/master
  Solves ros package release issues
* Adding dependencies in package.xml
* Removing pre-compiled python artifacts
* Merge pull request #9 <https://github.com/JdeRobot/ColorTuner/issues/9> from pankhurivanjani/master
  Updating docs for ColorTuner
* Adding docs to colortuner tool
* Merge pull request #1 <https://github.com/JdeRobot/ColorTuner/issues/1> from JdeRobot/master
  syncing with original repository
* Contributors: Pankhuri Vanjani, pankhurivanjani
```
