### PR TITLE
add rosdep key for python3-werkzeug

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6235,6 +6235,12 @@ python3-websocket:
   gentoo: [dev-python/websocket-client]
   rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
+python3-werkzeug:
+  arch: [python-werkzeug]
+  debian: [python3-werkzeug]
+  fedora: [python3-werkzeug]
+  gentoo: [dev-python/werkzeug]
+  ubuntu: [python3-werkzeug]
 python3-west-pip:
   debian:
     pip:


### PR DESCRIPTION
Used for web server applications that display robot information.

* Arch: https://www.archlinux.org/packages/community/any/python-werkzeug/
* Debian: https://packages.debian.org/search?suite=all&searchon=names&keywords=werkzeug
* Fedora: https://apps.fedoraproject.org/packages/s/werkzeug
* Gentoo: https://packages.gentoo.org/packages/search?q=werkzeug
* Ubuntu: https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=werkzeug

Local testing with forked repository showed rosdep key resolves to expected package.