### PR TITLE
add rosdep key for python3-shapely

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6110,6 +6110,7 @@ python3-sexpdata:
 python3-shapely:
   arch: [python-shapely]
   debian: [python3-shapely]
+  fedora: [python3-shapely]
   gentoo: [sci-libs/Shapely]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6107,6 +6107,14 @@ python3-sexpdata:
     xenial:
       pip:
         packages: [sexpdata]
+python3-shapely:
+  arch: [python-shapely]
+  debian: [python3-shapely]
+  gentoo: [sci-libs/Shapely]
+  osx:
+    pip:
+      packages: [shapely]
+  ubuntu: [python3-shapely]
 python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip]


### PR DESCRIPTION
Used for geometry operations. For example, finding the coordinates of the closest point on a polygon:
https://stackoverflow.com/questions/33311616/find-coordinate-of-the-closest-point-on-polygon-in-shapely

* Arch: https://www.archlinux.org/packages/?sort=&q=shapely&maintainer=&flagged=
* Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=shapely
* Fedora: not found so no rule added (https://apps.fedoraproject.org/packages/s/shapely)
* Gentoo: https://packages.gentoo.org/packages/search?q=shapely
* PyPI: https://pypi.org/search/?q=shapely
* Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=shapely&searchon=names

Local testing with forked repository showed rosdep key resolves to expected package.