### PR TITLE
add rosdep key for python3-tilestache

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6163,7 +6163,7 @@ python3-termcolor:
   fedora: [python3-termcolor]
   gentoo: [dev-python/termcolor]
   ubuntu: [python3-termcolor]
-python3-tilestache:
+python3-tilestache-pip:
   debian:
     pip:
       packages: [tilestache]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6163,6 +6163,19 @@ python3-termcolor:
   fedora: [python3-termcolor]
   gentoo: [dev-python/termcolor]
   ubuntu: [python3-termcolor]
+python3-tilestache:
+  debian:
+    pip:
+      packages: [tilestache]
+  fedora:
+    pip:
+      packages: [tilestache]
+  gentoo:
+    pip:
+      packages: [tilestache]
+  ubuntu:
+    pip:
+      packages: [tilestache]
 python3-tk:
   debian: [python3-tk]
   fedora: [python3-tkinter]


### PR DESCRIPTION
Useful for serving image tiles, such as overhead imagery from USGS. An example use case is to use the overhead image tiles in a web browser to show where a robot is in the world.

Tilestache does not appear to be released into the latest versions of supported operating systems. Instead, it appears that the only repository source on newer operating systems is PyPI. The links below to OS distributions show that there are no results for tilestache.

* PyPI: https://pypi.org/search/?q=tilestache&o=
* Arch: https://www.archlinux.org/packages/?sort=&q=tilestache&maintainer=&flagged=
* Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=tilestache
* Fedora: https://apps.fedoraproject.org/packages/s/tilestache
* Gentoo: https://packages.gentoo.org/packages/search?q=tilestache
* Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=tilestache&searchon=names

Local testing with forked repository showed rosdep key resolves to expected package.