### PR TITLE
add rosdep focal key for python-websocket

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5108,6 +5108,7 @@ python-websocket:
     artful_python3: [python3-websocket]
     bionic: [python-websocket]
     bionic_python3: [python3-websocket]
+    focal: [python3-websocket]
     precise:
       pip:
         packages: [websocket-client]


### PR DESCRIPTION
Adding rule for new Ubuntu distribution.

* Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python3-websocket&searchon=names

Local testing with forked repository showed rosdep key resolves to expected package. Uses Python2 version for Ubuntu Bionic and Debian Sid, and uses Python3 version for Ubuntu Focal.