### PR TITLE
urg_node: 0.1.14-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16564,7 +16564,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/urg_node-release.git
-      version: 0.1.14-1
+      version: 0.1.14-2
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `0.1.14-2`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros-gbp/urg_node-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.14-1`

## urg_node

```
* Bumped CMake version.
* Removed trailing whitespace.
* Contributors: Tony Baltovski
```
