### PR TITLE
rr_openrover_stack: 1.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10072,6 +10072,30 @@ repositories:
       url: https://github.com/ros-visualization/rqt_web.git
       version: master
     status: maintained
+  rr_openrover_stack:
+    doc:
+      type: git
+      url: https://github.com/RoverRobotics/rr_openrover_stack.git
+      version: melodic-devel
+    release:
+      packages:
+      - rr_control_input_manager
+      - rr_openrover_description
+      - rr_openrover_driver
+      - rr_openrover_driver_msgs
+      - rr_openrover_simulation
+      - rr_openrover_stack
+      - rr_rover_zero_driver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
+      version: 1.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RoverRobotics/rr_openrover_stack.git
+      version: melodic-devel
+    status: developed
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_stack` to `1.1.0-2`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_stack.git
- release repository: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rr_control_input_manager

```
* release to melodic
```

## rr_openrover_description

```
* release to melodic
```

## rr_openrover_driver

```
* release to melodic
```

## rr_openrover_driver_msgs

```
* release to melodic
```

## rr_openrover_simulation

```
* release to melodic
```

## rr_openrover_stack

```
* release to melodic
```

## rr_rover_zero_driver

```
* release to melodic
```
