### PR TITLE
rr_openrover_stack: 1.0.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13971,12 +13971,13 @@ repositories:
       - rr_openrover_description
       - rr_openrover_driver
       - rr_openrover_driver_msgs
+      - rr_openrover_simulation
       - rr_openrover_stack
       - rr_rover_zero_driver
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
-      version: 0.8.0-1
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/RoverRobotics/rr_openrover_stack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_stack` to `1.0.0-3`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_stack.git
- release repository: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.0-1`

## rr_control_input_manager

```
* adding support for freedom robotics and add watchdog timer to rover zero driver
* Contributors: padiln
```

## rr_openrover_description

```
* Merge branch 'develop' into feature/padiln/rviz_gazebo_sim
* adding rviz and gazebo simulation to rr_openrover stack
* added support for gazebo and rviz simulation for 2wd and 4wd rovers
* Contributors: padiln
```

## rr_openrover_driver

```
* Update teleop.launch
* Contributors: Nick Fragale, padiln
```

## rr_openrover_driver_msgs

```
* Contributors: padiln
```

## rr_openrover_simulation

```
* update simulation package version
* Merge pull request #69 <https://github.com/RoverRobotics/rr_openrover_stack/issues/69> from RoverRobotics/feature/rook/gazebo-xcontroller
  Xbox controller input for Gazebo simulation
* clean up launch files
* fix file reference
* ungroup launch files
* Xbox controller input for Gazebo simulation
* add world_name args to gazebo launch files
* cleanup simulation launch files
* adding rviz and gazebo simulation to rr_openrover stack
* added support for gazebo and rviz simulation for 2wd and 4wd rovers
* Contributors: William Rook, padiln
```

## rr_openrover_stack

```
* Merge pull request #76 <https://github.com/RoverRobotics/rr_openrover_stack/issues/76> from RoverRobotics/feature/padiln/expose_odometry
  Feature/padiln/expose odometry
* Merge branch 'develop' into feature/padiln/rviz_gazebo_sim
* Merge pull request #51 <https://github.com/RoverRobotics/rr_openrover_stack/issues/51> from RoverRobotics/master
  Sync with master
* Merge pull request #43 <https://github.com/RoverRobotics/rr_openrover_stack/issues/43> from RoverRobotics/kinetic-devel
  Merging change log update from bloom release
* Merge pull request #40 <https://github.com/RoverRobotics/rr_openrover_stack/issues/40> from RoverRobotics/kinetic-devel
  Kinetic devel
* Contributors: padiln
```

## rr_rover_zero_driver

```
* add all ros parameters to launch files
* updated rr_rover_zero_driver to support pid and encoders
* merge with develop branch
* Merge pull request #75 <https://github.com/RoverRobotics/rr_openrover_stack/issues/75> from RoverRobotics/feature/rook/rover_zero_driver_estop
  Feature/rook/rover zero driver estop
* Fixed estop merge issue
* changed lock name to be more descriptive
* Merge pull request #72 <https://github.com/RoverRobotics/rr_openrover_stack/issues/72> from RoverRobotics/feature/rookrobotic/rover_zer_pid_get_set
  fix syntax issues
* Merge branch 'develop' into feature/rookrobotic/rover_zer_pid_get_set
* fix syntax issues
* Update rover_zero.py
  make _v_pid_overwrite a boolean.
* added odometry data to rover_zero.py
* Estop Handler in Roboclaw
* fix variable names
* getter and setter for Velocity Pid
* start odometry callback
* Default Twist message subscriber to /cmd_vel
* Contributors: William Rook, padiln
```
