### PR TITLE
add rosdep key for python3-simplejson

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6107,6 +6107,12 @@ python3-sexpdata:
     xenial:
       pip:
         packages: [sexpdata]
+python3-simplejson:
+  arch: [python-simplejson]
+  debian: [python3-simplejson]
+  fedora: [python3-simplejson]
+  gentoo: [dev-python/simplejson]
+  ubuntu: [python3-simplejson]
 python3-sip:
   debian: [python3-sip-dev]
   fedora: [python3-sip]


### PR DESCRIPTION
Used for reading in configuration files and storing as JSON data in Python scripts.

* Arch: https://www.archlinux.org/packages/?sort=&q=python-simplejson&maintainer=&flagged=
* Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-simplejson
* Fedora: https://apps.fedoraproject.org/packages/s/python3-simplejson
* Gentoo: https://packages.gentoo.org/packages/search?q=python3-simplejson
* Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python3-simplejson&searchon=names

Local testing with forked repository showed rosdep key resolves to expected package.