### PR TITLE
avt_vimba_camera: 0.0.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -684,7 +684,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/avt_vimba_camera-release.git
-      version: 0.0.11-1
+      version: 0.0.12-1
     source:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.12-1`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.11-1`

## avt_vimba_camera

```
* Fix MonoCamera nodelet (#16 <https://github.com/astuff/avt_vimba_camera/issues/16>)
* Launch File Updates (#13 <https://github.com/astuff/avt_vimba_camera/issues/13>)
  
    * Standardize launch file formatting, remove commented code
    * Provide args for all parameters
    * Launch file for Mako G-319
  
* Remove duplicated launch file installs (#15 <https://github.com/astuff/avt_vimba_camera/issues/15>)
* Brief README (#10 <https://github.com/astuff/avt_vimba_camera/issues/10>)
* Add more pixelformats, thanks to @jmoreau-hds (#3 <https://github.com/astuff/avt_vimba_camera/issues/3>)
* Contributors: icolwell-as
```
