### PR TITLE
avt_vimba_camera: 0.0.12-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -81,6 +81,22 @@ repositories:
       url: https://github.com/ros-drivers/audio_common.git
       version: master
     status: maintained
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/astuff/avt_vimba_camera-release.git
+      version: 0.0.12-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: master
+    status: maintained
   behaviortree_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `avt_vimba_camera` to `0.0.12-2`:

- upstream repository: https://github.com/astuff/avt_vimba_camera.git
- release repository: https://github.com/astuff/avt_vimba_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## avt_vimba_camera

```
* Fix MonoCamera nodelet (#16 <https://github.com/astuff/avt_vimba_camera/issues/16>)
* Launch File Updates (#13 <https://github.com/astuff/avt_vimba_camera/issues/13>)
  
    * Standardize launch file formatting, remove commented code
    * Provide args for all parameters
    * Launch file for Mako G-319
  
* Remove duplicated launch file installs (#15 <https://github.com/astuff/avt_vimba_camera/issues/15>)
* Brief README (#10 <https://github.com/astuff/avt_vimba_camera/issues/10>)
* Add more pixelformats, thanks to @jmoreau-hds (#3 <https://github.com/astuff/avt_vimba_camera/issues/3>)
* Contributors: icolwell-as
```
