### PR TITLE
Changing branch for generation of Velodyne packages.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16762,7 +16762,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: master
+      version: melodic-devel
     release:
       packages:
       - velodyne
@@ -16777,7 +16777,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: master
+      version: melodic-devel
     status: developed
   velodyne_simulator:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11772,7 +11772,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: master
+      version: melodic-devel
     release:
       packages:
       - velodyne
@@ -11787,7 +11787,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
-      version: master
+      version: melodic-devel
     status: developed
   velodyne_simulator:
     doc:


### PR DESCRIPTION
The `master` branch of the `velodyne` repo now targets Noetic. This updates the references for Kinetic and Melodic versions to the correct `melodic-devel` branch.