### PR TITLE
geometry: 1.13.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -819,7 +819,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry-release.git
-      version: 1.13.1-1
+      version: 1.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry` to `1.13.2-1`:

- upstream repository: https://github.com/ros/geometry.git
- release repository: https://github.com/ros-gbp/geometry-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.13.1-1`

## eigen_conversions

- No changes

## geometry

- No changes

## kdl_conversions

- No changes

## tf

```
* fix shebang line for python3 (#212 <https://github.com/ros/geometry/issues/212>)
* Contributors: Mikael Arguedas
```

## tf_conversions

- No changes
