### PR TITLE
xacro: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2392,6 +2392,21 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/xacro-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.2-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## xacro

```
* Merge improvements of melodic and noetic branches into dashing-devel: see 1.14.1, 1.13.5 for details
* Contributors: Robert Haschke
```
