### PR TITLE
Python3 pyassimp

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5809,6 +5809,15 @@ python3-psutil:
   rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
+python3-pyassimp:
+  debian:
+    '*': [python3-pyassimp]
+    jessie: null
+    stretch: null
+  fedora: [python3-assimp]
+  ubuntu:
+    '*': [python3-pyassimp]
+    xenial: null
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]


### PR DESCRIPTION
- Ubuntu: https://packages.ubuntu.com/bionic/python3-pyassimp
- Fedora: https://fedora.pkgs.org/31/fedora-armhfp/python3-assimp-3.3.1-20.fc31.noarch.rpm.html
- Debian: https://packages.debian.org/unstable/python3-pyassimp