### PR TITLE
mpc_local_planner: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1519,6 +1519,26 @@ repositories:
       url: https://github.com/magazino/move_base_flex.git
       version: noetic
     status: developed
+  mpc_local_planner:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
+      version: noetic-devel
+    release:
+      packages:
+      - mpc_local_planner
+      - mpc_local_planner_examples
+      - mpc_local_planner_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner-release.git
+      version: 0.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
+      version: noetic-devel
+    status: developed
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mpc_local_planner` to `0.0.3-1`:

- upstream repository: https://github.com/rst-tu-dortmund/mpc_local_planner.git
- release repository: https://github.com/rst-tu-dortmund/mpc_local_planner-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## mpc_local_planner

```
* Added feasibility check with costmap robot model
* Changed obstacle parameters cutoff_factor and force_inclusion_factor to cutoff_dist and force_inclusion_dist
* Added check for obstacle pointer validity in StageInequalitySE2
* Dynamic obstacles: the inequality constraints now use the actual time parameter rather than the time from the previous optimization
* Added hybrid cost (time and control effort)
* Added kinematic bicycle model with velocity input
* Grid: The time difference is now initialized to dt_ref for reference trajectory caching
* Fixed wrong start orientation in point-to-point grid initialization
* Fixed wrong angular computation in midpoint differences
* Added missing install files (thanks to marbosjo)
* Changed minimum CMake version to 3.1
* Contributors: Christoph Rösmann, marbosjo
```

## mpc_local_planner_examples

```
* Added feasibility check with costmap robot model
* Changed obstacle parameters cutoff_factor and force_inclusion_factor to cutoff_dist and force_inclusion_dist
* Dynamic obstacles: the inequality constraints now use the actual time parameter rather than the time from the previous optimization
* Changed minimum CMake version to 3.1
* Contributors: Christoph Rösmann
```

## mpc_local_planner_msgs

```
* Changed minimum CMake version to 3.1
* Contributors: Christoph Rösmann
```
