### PR TITLE
tf2_server: 1.0.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10943,7 +10943,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/peci1/tf2_server-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/peci1/tf2_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_server` to `1.0.6-1`:

- upstream repository: https://github.com/peci1/tf2_server.git
- release repository: https://github.com/peci1/tf2_server-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.5-1`

## tf2_server

```
* Minor: catkin_lint.
* Fix: prevent deadlocks on stopping timers.
* Fix: Ignore stale frames in subtree search.
* Fix: Fix nodelet namespace.
* Contributors: Martin Pecka
```
