### PR TITLE
slam_toolbox: 1.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3301,6 +3301,26 @@ repositories:
       url: https://github.com/ros-perception/slam_karto.git
       version: melodic-devel
     status: maintained
+  slam_toolbox:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: noetic-devel
+    release:
+      packages:
+      - slam_toolbox
+      - slam_toolbox_msgs
+      - slam_toolbox_rviz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/SteveMacenski/slam_toolbox-release.git
+      version: 1.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: noetic-devel
+    status: maintained
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `1.5.0-1`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
