### PR TITLE
Update Fast-RTPS URL

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -878,7 +878,7 @@ repositories:
       test_commits: false
       test_pull_requests: false
       type: git
-      url: https://github.com/eProsima/Fast-RTPS.git
+      url: https://github.com/eProsima/Fast-DDS.git
       version: 6a6f79c4256a00fc13834a2aaa3c60a0aaac5e76
     status: developed
   fmi_adapter_ros2:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -723,7 +723,7 @@ repositories:
       test_commits: false
       test_pull_requests: false
       type: git
-      url: https://github.com/eProsima/Fast-RTPS.git
+      url: https://github.com/eProsima/Fast-DDS.git
       version: ros2-eloquent
     status: developed
   filters:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -502,7 +502,7 @@ repositories:
       test_commits: false
       test_pull_requests: false
       type: git
-      url: https://github.com/eProsima/Fast-RTPS.git
+      url: https://github.com/eProsima/Fast-DDS.git
       version: 9c28edc805863117d500ebb7aef86d509471ebd8
     status: maintained
   filters:


### PR DESCRIPTION
The repository has been renamed to Fast-DDS.

See also https://github.com/ros2/ros2/pull/938