### PR TITLE
v4l2_camera: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2352,6 +2352,21 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: foxy
     status: maintained
+  v4l2_camera:
+    doc:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    status: developed
   variants:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.1.1-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## v4l2_camera

```
* Add missing rclcpp_components build dependency
* Contributors: Sander G. van Dijk
```
