### PR TITLE
Added yapf3 for ubuntu focal to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6399,6 +6399,7 @@ yapf:
     stretch: [yapf]
   ubuntu:
     '*': [yapf]
+    focal: [yapf3]
     saucy:
       pip:
         packages: [yapf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6398,8 +6398,7 @@ yapf:
     buster: [yapf]
     stretch: [yapf]
   ubuntu:
-    '*': [yapf]
-    focal: [yapf3]
+    '*': [yapf]]
     saucy:
       pip:
         packages: [yapf]
@@ -6421,3 +6420,6 @@ yapf:
     yakkety:
       pip:
         packages: [yapf]
+yapf3: 
+  ubuntu: 
+    focal: [yapf3]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6398,7 +6398,7 @@ yapf:
     buster: [yapf]
     stretch: [yapf]
   ubuntu:
-    '*': [yapf]]
+    '*': [yapf]
     saucy:
       pip:
         packages: [yapf]


### PR DESCRIPTION
`yapf` does not exist under Ubuntu focal but is available under `yapf3`.
I changed the python.yaml accordingly.