### PR TITLE
add rosdep key for pika-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -249,6 +249,22 @@ pika:
     pip:
       packages: [pika]
   ubuntu: [python-pika]
+pika-pip:
+  arch:
+    pip:
+      packages: [pika]
+  debian:
+    pip:
+      packages: [pika]
+  fedora:
+    pip:
+      packages: [pika]
+  gentoo:
+    pip:
+      packages: [pika]
+  ubuntu:
+    pip:
+      packages: [pika]
 pydocstyle:
   debian:
     buster: [pydocstyle]


### PR DESCRIPTION
Pika is a RabbitMQ client library for Python, useful for interacting with devices and systems that use the AMQP protocol. The version available from the existing `pika` key on Ubuntu Bionic is `0.11.0-1`. The version from PyPI is `1.1.0`. There are many systems using the newer version.

* PyPI: https://pypi.org/project/pika/
* Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=python-pika&searchon=names