### PR TITLE
urg_c: 1.0.4001-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2352,6 +2352,22 @@ repositories:
       url: https://github.com/ros/urdfdom_headers.git
       version: foxy
     status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_c-release.git
+      version: 1.0.4001-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    status: maintained
   v4l2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_c` to `1.0.4001-1`:

- upstream repository: https://github.com/ros-drivers/urg_c.git
- release repository: https://github.com/ros2-gbp/urg_c-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## urg_c

```
* add maintainer for ros2 (#13 <https://github.com/ros-drivers/urg_c/issues/13>)
* Contributors: Michael Ferguson
```
