### PR TITLE
marti_common: 2.13.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1333,6 +1333,40 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/lusb.git
       version: master
     status: developed
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: master
+    release:
+      packages:
+      - marti_data_structures
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_nodelet
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_rospy
+      - swri_route_util
+      - swri_serial_util
+      - swri_string_util
+      - swri_system_util
+      - swri_transform_util
+      - swri_yaml_util
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 2.13.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: master
+    status: developed
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.13.2-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_math_util

- No changes

## swri_nodelet

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_opencv_util

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_roscpp

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_rospy

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_system_util

- No changes

## swri_transform_util

```
* Support ROS Noetic (#581 <https://github.com/swri-robotics/marti_common/issues/581>)
* Contributors: P. J. Reed
```

## swri_yaml_util

- No changes
