### PR TITLE
marti_messages: 1.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1233,6 +1233,7 @@ repositories:
       packages:
       - marti_can_msgs
       - marti_common_msgs
+      - marti_dbw_msgs
       - marti_nav_msgs
       - marti_perception_msgs
       - marti_sensor_msgs
@@ -1241,7 +1242,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.1.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_dbw_msgs

```
* Add marti dbw msgs (ROS2) (#107 <https://github.com/swri-robotics/marti_messages/issues/107>)
* Contributors: P. J. Reed, Matthew Bries
```

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

```
* Merge pull request #102 <https://github.com/swri-robotics/marti_messages/issues/102> from matt-attack/dashing-diff
* Merge pull request #103 <https://github.com/swri-robotics/marti_messages/issues/103> from matt-attack/dashing-dir
* Fix out of bounds enum
* Add unknown direction enum
* Add differentialmeasurement message for DGPS/RTK
* Contributors: Matthew Bries, P. J. Reed
```

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
