### PR TITLE
jderobot_assets: 1.0.2-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4115,7 +4115,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 1.0.2-1
+      version: 1.0.2-4
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `1.0.2-4`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-1`

## jderobot_assets

```
* Added models needed for drone-gymkhana exercise
* Contributors: Pedro Arias
```
