### PR TITLE
marti_messages: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -883,6 +883,31 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: foxy
     status: maintained
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_dbw_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    status: developed
   message_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.1.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_dbw_msgs

```
* Add marti dbw msgs (ROS2) (#107 <https://github.com/swri-robotics/marti_messages/issues/107>)
* Contributors: P. J. Reed, Matthew Bries
```

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

```
* Merge pull request #102 <https://github.com/swri-robotics/marti_messages/issues/102> from matt-attack/dashing-diff
* Merge pull request #103 <https://github.com/swri-robotics/marti_messages/issues/103> from matt-attack/dashing-dir
* Fix out of bounds enum
* Add unknown direction enum
* Add differentialmeasurement message for DGPS/RTK
* Contributors: Matthew Bries, P. J. Reed
```

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
