### PR TITLE
graph_msgs: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4267,7 +4267,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/davetcoleman/graph_msgs-release.git
+      url: https://github.com/PickNikRobotics/graph_msgs-release.git
       version: 0.1.0-1
     source:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4260,11 +4260,19 @@ repositories:
       version: master
     status: maintained
   graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: jade-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/davetcoleman/graph_msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: jade-devel
     status: maintained
   grasping_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/graph_msgs
- release repository: https://github.com/davetcoleman/graph_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-0`

## graph_msgs

```
* Added header / timestamp
* Contributors: Dave Coleman
```
