### PR TITLE
urg_node_msgs: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2368,6 +2368,21 @@ repositories:
       url: https://github.com/ros-drivers/urg_c.git
       version: ros2-devel
     status: maintained
+  urg_node_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node_msgs-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    status: maintained
   v4l2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/ros-drivers/urg_node_msgs.git
- release repository: https://github.com/ros2-gbp/urg_node_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## urg_node_msgs

```
* add myself as maintainer (#4 <https://github.com/ros-drivers/urg_node_msgs/issues/4>)
* Contributors: Michael Ferguson
```
