### PR TITLE
gps_umd: 1.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -619,6 +619,27 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: foxy
     status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    release:
+      packages:
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/gps_umd-release.git
+      version: 1.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    status: developed
   ifm3d_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.3-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## gps_msgs

- No changes

## gps_tools

```
* Foxy support (#29 <https://github.com/swri-robotics/gps_umd/issues/29>)
* Contributors: P. J. Reed
```

## gps_umd

- No changes

## gpsd_client

```
* Foxy support (#29 <https://github.com/swri-robotics/gps_umd/issues/29>)
* Contributors: P. J. Reed
```
