### PR TITLE
urg_node: 1.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3589,7 +3589,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `1.0.1-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros2-gbp/urg_node-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## urg_node

```
* node name is now urg_node_driver (#70 <https://github.com/ros-drivers/urg_node/issues/70>)
  The node was renamed as part of the composable refactor
  At runtime, it still defaults to urg_node as the graph
  name
* call run in a thread, fixes #66 <https://github.com/ros-drivers/urg_node/issues/66> (#71 <https://github.com/ros-drivers/urg_node/issues/71>)
* add myself as maintainer for ros2 (#73 <https://github.com/ros-drivers/urg_node/issues/73>)
* Contributors: Michael Ferguson
```
