### PR TITLE
marti_common: 3.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -904,6 +904,35 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: foxy
     status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    release:
+      packages:
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 3.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    status: developed
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.2.1-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## swri_console_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_image_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_math_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_opencv_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_roscpp

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_route_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_serial_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_system_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```

## swri_transform_util

```
* ROS Foxy support (#582 <https://github.com/swri-robotics/marti_common/issues/582>)
* Contributors: P. J. Reed
```
