### PR TITLE
raspimouse2: 1.0.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1956,6 +1956,25 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: crystal-devel
     status: maintained
+  raspimouse2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: dashing-devel
+    release:
+      packages:
+      - raspimouse
+      - raspimouse_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/rt-net/raspimouse2-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: dashing-devel
+    status: developed
   rc_dynamics_api:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse2` to `1.0.1-1`:

- upstream repository: https://github.com/rt-net/raspimouse2.git
- release repository: https://github.com/rt-net/raspimouse2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## raspimouse

```
* Fix documents of release 1.0.0 (#23 <https://github.com/rt-net/raspimouse2/issues/23>)
* Contributors: Shota Aoki
```

## raspimouse_msgs

```
* Fix documents of release 1.0.0 (#23 <https://github.com/rt-net/raspimouse2/issues/23>)
* Contributors: Shota Aoki
```
