### PR TITLE
Add rosdep key for python3-catkin-lint

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5372,6 +5372,9 @@ python3-can:
   ubuntu:
     '*': [python3-can]
     xenial: null
+python3-catkin-lint:
+  debian: [python3-catkin-lint]
+  ubuntu: [python3-catkin-lint]
 python3-catkin-pkg:
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]


### PR DESCRIPTION
This package already exists for Python2 under the name `python-catkin-lint`

For focal this package can be installed under two names, but I'll try to keep with the standard `python3`.

```
# apt search '.*catkin-lint'
catkin-lint/focal 1.6.6-1 all
  Check Robot OS catkin packages for common errors

python3-catkin-lint/focal 1.6.6-1 all
  Check Robot OS catkin packages for common errors (transitional package)
```

https://packages.ubuntu.com/focal/catkin-lint
https://packages.ubuntu.com/focal/python3-catkin-lint
https://packages.debian.org/unstable/catkin-lint
https://packages.debian.org/unstable/python3-catkin-lint