### PR TITLE
Add rosdep key for python3-pika

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5764,6 +5764,9 @@ python3-pep8:
 python3-pexpect:
   debian: [python3-pexpect]
   ubuntu: [python3-pexpect]
+python3-pika:
+  debian: [python3-pika]
+  ubuntu: [python3-pika]
 python3-pil:
   alpine: [py3-pillow]
   arch: [python-pillow]


### PR DESCRIPTION
This package already exists for Python2 under the name `pika`.

https://packages.ubuntu.com/focal/python3-pika
https://packages.debian.org/unstable/python3-pika

