### PR TITLE
Add wildcard libjsoncpp rosdep for Ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2625,17 +2625,13 @@ libjsoncpp:
   gentoo: [dev-libs/jsoncpp]
   rhel: [jsoncpp]
   ubuntu:
-    artful: [libjsoncpp1]
-    bionic: [libjsoncpp1]
+    '*': [libjsoncpp1]
     precise: [libjsoncpp0]
     saucy: [libjsoncpp0]
     trusty: [libjsoncpp0]
     utopic: [libjsoncpp0]
     vivid: [libjsoncpp0]
     wily: [libjsoncpp0v5]
-    xenial: [libjsoncpp1]
-    yakkety: [libjsoncpp1]
-    zesty: [libjsoncpp1]
 libjsoncpp-dev:
   arch: [jsoncpp]
   debian: [libjsoncpp-dev]


### PR DESCRIPTION
The libjsoncpp rosdep key was missing an entry for `focal`.  Every version of Ubuntu after Wily uses `libjsoncpp1` (see https://packages.ubuntu.com/focal/libjsoncpp1 for focal), so this replaces it with a wildcard for future compatibility.