### PR TITLE
laser_proc: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -801,6 +801,22 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: foxy
     status: maintained
+  laser_proc:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_proc-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    status: maintained
   launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `1.0.1-1`:

- upstream repository: https://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros2-gbp/laser_proc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## laser_proc

```
* Make sure to add necessary build dependencies. (#9 <https://github.com/ros-perception/laser_proc/issues/9>)
* Contributors: Chris Lalancette
```
