### PR TITLE
carViz: 0.1.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -946,6 +946,19 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  carViz:
+    release:
+      packages:
+      - jderobot_carviz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/carViz-release.git
+      version: 0.1.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/carViz.git
+      version: master
   carla_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carViz` to `0.1.5-1`:

- upstream repository: https://github.com/JdeRobot/carViz.git
- release repository: https://github.com/JdeRobot/carViz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`
