### PR TITLE
jderobot_assets: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1143,7 +1143,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 1.0.3-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `1.1.0-1`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.3-1`

## jderobot_assets

```
* Set noetic version
* Minor changes on README
* Contributors: Shreyas Gokhale, pariaspe
```
