### PR TITLE
dual_quaternions: switch to kinetic-devel branch 

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2722,7 +2722,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Achllle/dual_quaternions.git
-      version: master
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -2731,7 +2731,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Achllle/dual_quaternions.git
-      version: master
+      version: kinetic-devel
     status: maintained
   dwm1001_ros:
     doc:


### PR DESCRIPTION
I must've missed this while running the prerelease test. Got an error that setuptools isn't supported in kinetic (doesn't happen in Noetic) so switched back to `distutils.core` on branch `kinetic-devel`.

I'm not sure if this is the way to do it or if I have to use the bloom-release tool.

Previous PR: #25174 