### PR TITLE
marti_common: 2.13.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1347,6 +1347,40 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/lusb.git
       version: master
     status: developed
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: master
+    release:
+      packages:
+      - marti_data_structures
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_nodelet
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_rospy
+      - swri_route_util
+      - swri_serial_util
+      - swri_string_util
+      - swri_system_util
+      - swri_transform_util
+      - swri_yaml_util
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+      version: 2.13.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: master
+    status: developed
   marti_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.13.3-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## marti_data_structures

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_console_util

```
* Bump minimum cmake version
* Contributors: P. J. Reed
```

## swri_dbw_interface

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_geometry_util

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_image_util

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_math_util

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_nodelet

```
* Bump minimum cmake version
* Contributors: P. J. Reed
```

## swri_opencv_util

```
* Bump minimum cmake version
* Contributors: P. J. Reed
```

## swri_prefix_tools

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_roscpp

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_rospy

```
* Use setuptools instead of distutils (#583 <https://github.com/swri-robotics/marti_common/issues/583>)
* Bump minimum cmake version
* Contributors: Shane Loretz, P. J. Reed
```

## swri_route_util

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_serial_util

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_string_util

```
* Bump minimum cmake version
* Contributors: P. J. Reed
```

## swri_system_util

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```

## swri_transform_util

```
* Use setuptools instead of distutils (#583 <https://github.com/swri-robotics/marti_common/issues/583>)
* Bump minimum cmake version
* Contributors: Shane Loretz, P. J. Reed
```

## swri_yaml_util

```
* Use setuptools instead of distutils
* Contributors: P. J. Reed
```
