### PR TITLE
qt_gui_core: 1.0.9-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1766,7 +1766,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.0.7-1
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.0.9-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.7-1`

## qt_dotgraph

- No changes

## qt_gui

```
* fix export perspective on Python 3 (#217 <https://github.com/ros-visualization/qt_gui_core/issues/217>)
* fix runtime error on shutdown (#213 <https://github.com/ros-visualization/qt_gui_core/issues/213>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
