### PR TITLE
Add ROS 2 Rolling Ridley to the rosdistro index.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,5 @@ kinetic/* @tfoote
 lunar/* @clalancette
 melodic/* @clalancette
 noetic/* @sloretz
+rolling/* @cottsay @nuclearsandwich
 rosdep/* @ros/rosdeputies

--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -87,5 +87,11 @@ distributions:
     distribution_status: active
     distribution_type: ros1
     python_version: 3
+  rolling:
+    distribution: [rolling/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/rolling-cache.yaml.gz
+    distribution_status: rolling
+    distribution_type: ros2
+    python_version: 3
 type: index
 version: 4

--- a/index.yaml
+++ b/index.yaml
@@ -45,5 +45,8 @@ distributions:
   noetic:
     distribution: [noetic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/noetic-cache.yaml.gz
+  rolling:
+    distribution: [rolling/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/rolling-cache.yaml.gz
 type: index
 version: 3

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms:
+  ubuntu:
+  - focal
+repositories: {}
+type: distribution
+version: 2

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5,6 +5,6 @@
 release_platforms:
   ubuntu:
   - focal
-repositories: {}
+repositories:
 type: distribution
 version: 2


### PR DESCRIPTION
As a first step to deploying Rolling Ridley with the rosdistro migration tools we need an empty target distro.

This adds that empty target rosdistro with the distribution status of `rolling`, itself being [proposed for inclusion in REP 153](https://github.com/ros-infrastructure/rep/pull/274).

I added myself and @cottsay as codeowners since @cottsay will be the ROS boss for 2021's Galactic Geochelone distribution based on the Rolling distribution. I could also see us creating and using a `@ros/ros-bosses` and distributing the load even more broadly as we do for rosdep keys with `@ros/rosdeputies`.