### PR TITLE
rqt_reconfigure: 0.5.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3037,7 +3037,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.5.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.2-1`

## rqt_reconfigure

```
* Support PEP 338 invocation of rqt_reconfigure (#86 <https://github.com/cottsay/rqt_reconfigure/issues/86>)
* Save instance state in rqt settings (#79 <https://github.com/cottsay/rqt_reconfigure/issues/79>)
* Only enable apply group button when effective (#76 <https://github.com/cottsay/rqt_reconfigure/issues/76>)
* Handle invalid enum values (#80 <https://github.com/cottsay/rqt_reconfigure/issues/80>)
* Fix shebang line for Python 3 (#84 <https://github.com/cottsay/rqt_reconfigure/issues/84>)
* Contributors: Mikael Arguedas, Scott K Logan
```
