### PR TITLE
dual_quaternions: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2727,7 +2727,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Achllle/dual_quaternions-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/Achllle/dual_quaternions.git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2722,7 +2722,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Achllle/dual_quaternions.git
-      version: kinetic-devel
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -2731,7 +2731,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Achllle/dual_quaternions.git
-      version: kinetic-devel
+      version: master
     status: maintained
   dwm1001_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions` to `0.3.2-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions.git
- release repository: https://github.com/Achllle/dual_quaternions-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.1-1`

## dual_quaternions

```
* Use distutils iso setuptools for running on buildfarm
* Contributors: Achille
```
