### PR TITLE
dual_quaternions: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2070,7 +2070,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/Achllle/dual_quaternions-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     status: maintained
   dynamic_reconfigure:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions` to `0.3.2-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions.git
- release repository: https://github.com/Achllle/dual_quaternions-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.1-1`

Note: fixes broken build due to use of setuptools iso distutils.core. Thank you for your patience with this!

## dual_quaternions

```
* Use distutils iso setuptools for running on buildfarm
* Contributors: Achille
```
