### PR TITLE
dual_quaternions: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -479,7 +479,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/Achllle/dual_quaternions-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     status: maintained
   dual_quaternions_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions` to `0.3.2-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions.git
- release repository: https://github.com/Achllle/dual_quaternions-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.1-1`

Note: fixes broken build due to package version mismatch in setup.py and package.xml. Thank you for your patience with this!

## dual_quaternions

```
* Use distutils iso setuptools for running on buildfarm
* Contributors: Achille
```
