### PR TITLE
dual_quaternions_ros: 0.1.3-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2733,6 +2733,13 @@ repositories:
       url: https://github.com/Achllle/dual_quaternions.git
       version: kinetic-devel
     status: maintained
+  dual_quaternions_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Achllle/dual_quaternions_ros-release.git
+      version: 0.1.3-3
+    status: maintained
   dwm1001_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions_ros` to `0.1.3-3`:

- upstream repository: https://github.com/Achllle/dual_quaternions_ros.git
- release repository: https://github.com/Achllle/dual_quaternions_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dual_quaternions_ros

```
* Merge pull request #53 from Achllle/ros_only
  Split up into dual_quaternions and dual_quaternions_ros
* Omitted: this repository used to host the dual_quaternions python package before it was
  split up and moved to a separate repo (dual_quaternions)
* Contributors: Achille, Achille Verheye
```
