### PR TITLE
dual_quaternions_ros: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2072,6 +2072,13 @@ repositories:
       url: https://github.com/Achllle/dual_quaternions-release.git
       version: 0.3.1-1
     status: maintained
+  dual_quaternions_ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/Achllle/dual_quaternions_ros-release.git
+      version: 0.1.3-1
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions_ros` to `0.1.3-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions_ros.git
- release repository: https://github.com/Achllle/dual_quaternions_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dual_quaternions_ros

```
* Merge pull request #53 from Achllle/ros_only
  Split up into dual_quaternions and dual_quaternions_ros
* Omitted: this repository used to host the dual_quaternions python package before it was
  split up and moved to a separate repo (dual_quaternions)
* Contributors: Achille, Achille Verheye
```
