### PR TITLE
rqt: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9547,7 +9547,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.5.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.1-1`

## rqt_gui

```
* add missing dependencies: rospkg-modules, python_qt_binding, rospy (#227 <https://github.com/ros-visualization/rqt/issues/227>)
```

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
