### PR TITLE
datmo: 0.1.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1872,6 +1872,22 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git
       version: master
     status: developed
+  datmo:
+    doc:
+      type: git
+      url: https://github.com/kostaskonkk/datmo.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/kostaskonkk/datmo-release.git
+      version: 0.1.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kostaskonkk/datmo.git
+      version: devel
+    status: maintained
   dbw_fca_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `datmo` to `0.1.2-2`:

- upstream repository: https://github.com/kostaskonkk/datmo.git
- release repository: https://github.com/kostaskonkk/datmo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
