### PR TITLE
apriltag: 3.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -172,6 +172,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apriltag:
+    doc:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/AprilRobotics/apriltag-release.git
+      version: 3.1.2-1
+    source:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    status: maintained
   behaviortree_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.1.2-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/AprilRobotics/apriltag-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
