### PR TITLE
flexbe: 1.2.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3630,7 +3630,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.2.5-1`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.4-1`

## flexbe_behavior_engine

```
* Merge branch 'develop' into feature/state_logger_rework
* Contributors: Philipp Schillinger
```

## flexbe_core

```
* [flexbe_core] Consider a running mirror as being controlled
  (see #123 <https://github.com/team-vigir/flexbe_behavior_engine/issues/123>)
* Merge pull request #113 <https://github.com/team-vigir/flexbe_behavior_engine/issues/113> from team-vigir/feature/state_logger_rework
  State Logger Rework
* Merge branch 'develop' into feature/state_logger_rework
* [flexbe_core] Allow to specify a subset of logged userdata keys
* [flexbe_core] Extend configuration options
* [flexbe_core] Rework state logger implementation
* Contributors: Philipp Schillinger
```

## flexbe_input

```
* Merge branch 'develop' into feature/state_logger_rework
* Contributors: Philipp Schillinger
```

## flexbe_mirror

```
* Merge branch 'develop' into feature/state_logger_rework
* Contributors: Philipp Schillinger
```

## flexbe_msgs

```
* Merge branch 'develop' into feature/state_logger_rework
* [flexbe_msgs] Remove deprecated constants from input action
* Contributors: Philipp Schillinger
```

## flexbe_onboard

```
* [flexbe_onboard] Un-import behavior-specific imports after execution
* [flexbe_onboard] Add test cases for onboard engine
* Merge pull request #113 <https://github.com/team-vigir/flexbe_behavior_engine/issues/113> from team-vigir/feature/state_logger_rework
  State Logger Rework
* Merge branch 'develop' into feature/state_logger_rework
* [flexbe_onboard] Cleanup onboard and add thread locks
  (see #117 <https://github.com/team-vigir/flexbe_behavior_engine/issues/117>)
* [flexbe_onboard] Expose new state logger args in onboard launch file
* Contributors: Philipp Schillinger
```

## flexbe_states

```
* [flexbe_states] Fix ambiguous import of subscriber state
* Merge branch 'develop' into feature/state_logger_rework
* [flexbe_states] Clean up input state
* Contributors: Philipp Schillinger
```

## flexbe_testing

```
* Merge branch 'develop' into feature/state_logger_rework
* Contributors: Philipp Schillinger
```

## flexbe_widget

```
* Merge pull request #120 <https://github.com/team-vigir/flexbe_behavior_engine/issues/120> from cheffe112/startup_race_condition
  wait for READY status from Behavior Engine before launching behavior to avoid race conditions on startup
* avoid callback trigger before ready event has been created
* Merge pull request #113 <https://github.com/team-vigir/flexbe_behavior_engine/issues/113> from team-vigir/feature/state_logger_rework
  State Logger Rework
* Merge branch 'develop' into feature/state_logger_rework
* wait for READY status from Behavior Engine before launching behavior
  Whenever behavior_onboard and be_launcher are launched together, there used to be a race condition of publishing the behavior in behavior_launcher, but the subscriber in behavior_onboard not being ready yet. Hence, behavior_launcher now waits for the READY status to appear on the flexbe/status topic before it actually attempts to launch the behavior.
* [flexbe_widget] Update evaluate_logs script to new format
* Merge pull request #118 <https://github.com/team-vigir/flexbe_behavior_engine/issues/118> from StefanFabian/action_server_callback_based
  Using event based action server instead of control loop.
* Improved preempt logic.
* Only accept goal if ActionServer is not active.
* Handle errors before behavior start.
* Using event based action server instead of control loop.
  Waiting for terminal state of flexbe before setting goal to a terminal state and accepting a new one.
* Contributors: Philipp Schillinger, Stefan Fabian, Tobias Doernbach
```
