### PR TITLE
leo_description: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6466,6 +6466,11 @@ repositories:
       type: git
       url: https://github.com/LeoRover/leo_description.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_description-release.git
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_description` to `0.3.0-1`:

- upstream repository: https://github.com/LeoRover/leo_description.git
- release repository: https://github.com/fictionlab-gbp/leo_description-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## leo_description

```
* Move the launch files and rviz config to leo_viz package, remove dependencies
* update dependencies
* update deprecated joint state publisher gui functionality
```
