### PR TITLE
python3-pika rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5764,6 +5764,12 @@ python3-pep8:
 python3-pexpect:
   debian: [python3-pexpect]
   ubuntu: [python3-pexpect]
+python3-pika:
+  debian:
+    '*': [python3-pika]
+    jessie: null
+  fedora: [python3-pika]
+  ubuntu: [python3-pika]
 python3-pil:
   alpine: [py3-pillow]
   arch: [python-pillow]


### PR DESCRIPTION
- Debian: https://packages.debian.org/stretch/python3-pika
- Ubuntu: https://packages.ubuntu.com/bionic/python3-pika
- Fedora: https://fedora.pkgs.org/30/fedora-updates-x86_64/python3-pika-1.0.1-1.fc30.noarch.rpm.html