### PR TITLE
leo_viz: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6496,6 +6496,11 @@ repositories:
       type: git
       url: https://github.com/LeoRover/leo_viz.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_viz-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_viz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_viz` to `0.1.1-1`:

- upstream repository: https://github.com/LeoRover/leo_viz.git
- release repository: https://github.com/fictionlab-gbp/leo_viz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## leo_viz

```
* Don't run joint_state_publisher together with joint_state_publisher_gui
* initial commit
```
