### PR TITLE
leo_viz: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4772,6 +4772,11 @@ repositories:
       type: git
       url: https://github.com/LeoRover/leo_viz.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_viz-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_viz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_viz` to `0.1.1-1`:

- upstream repository: https://github.com/LeoRover/leo_viz.git
- release repository: https://github.com/fictionlab-gbp/leo_viz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## leo_viz

```
* Don't run joint_state_publisher together with joint_state_publisher_gui
* initial commit
```
