### PR TITLE
sick_safetyscanners: 1.0.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14659,7 +14659,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners` to `1.0.5-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners.git
- release repository: https://github.com/SICKAG/sick_safetyscanners-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.4-1`

## sick_safetyscanners

```
* fixing correct offset in field geometries
* Fixed error in reading chars for device name and project name
* feat(diagnostics): Sensor state diagnostics
  Exposes sensor hardware information and sensor state.
* Filter out max range values to INF according to REP 117
* Correct first initialization of m_time_offset
* boost::asio API changes in 1.70+
* Catch exceptions by const ref.
* Fix error_code comparison to int.
* Contributors: Chad Rockey, Jad Haj Mustafa, Lennart Puck, Mike Purvis, Rein Appeldoorn
```
