### PR TITLE
apriltag: 3.1.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -69,7 +69,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag-release.git
-      version: 3.1.2-1
+      version: 3.1.2-2
     source:
       type: git
       url: https://github.com/aprilrobotics/apriltag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.1.2-2`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/AprilRobotics/apriltag-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.1.2-1`
