### PR TITLE
add rosdep key for geomag

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -149,7 +149,7 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
-geomag:
+geomag-pip:
   debian:
     pip:
       packages: [geomag]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -149,19 +149,6 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
-geomag-pip:
-  debian:
-    pip:
-      packages: [geomag]
-  fedora:
-    pip:
-      packages: [geomag]
-  osx:
-    pip:
-      packages: [geomag]
-  ubuntu:
-    pip:
-      packages: [geomag]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]
@@ -5530,6 +5517,19 @@ python3-future:
   gentoo: [dev-python/future]
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
+python3-geomag-pip:
+  debian:
+    pip:
+      packages: [geomag]
+  fedora:
+    pip:
+      packages: [geomag]
+  osx:
+    pip:
+      packages: [geomag]
+  ubuntu:
+    pip:
+      packages: [geomag]
 python3-gi:
   arch: [python-gobject]
   debian: [python3-gi]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -149,6 +149,19 @@ exhale-pip:
   ubuntu:
     pip:
       packages: [exhale]
+geomag:
+  debian:
+    pip:
+      packages: [geomag]
+  fedora:
+    pip:
+      packages: [geomag]
+  osx:
+    pip:
+      packages: [geomag]
+  ubuntu:
+    pip:
+      packages: [geomag]
 gunicorn:
   debian: [gunicorn]
   fedora: [python-gunicorn]


### PR DESCRIPTION
Used to find magnetic declination for any given latitude/longitude/altitude. Allows easier calculation of global heading from IMU or compass data in robots distributed around the world. This package is only available via PyPI, not OS package managers.

* PyPI: https://pypi.org/project/geomag/
* Arch: https://www.archlinux.org/packages/?sort=&q=geomag&maintainer=&flagged=
* Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=geomag
* Fedora: https://apps.fedoraproject.org/packages/s/geomag
* Gentoo: https://packages.gentoo.org/packages/search?q=geomag
* Ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=geomag&searchon=names