### PR TITLE
[migration-tools] Handle repositories with no release entry.

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -80,13 +80,15 @@ new_repositories = []
 repositories_to_retry = []
 for repo_name, repo_data in sorted(source_distribution.repositories.items()):
     if repo_name not in dest_distribution.repositories:
-        new_repositories.append(repo_name)
         dest_repo_data = copy.deepcopy(repo_data)
-        release_tag = dest_repo_data.release_repository.tags['release']
-        release_tag = release_tag.replace(args.source,args.dest)
-        dest_repo_data.release_repository.tags['release'] = release_tag
+        if dest_repo_data.release_repository:
+            new_repositories.append(repo_name)
+            release_tag = dest_repo_data.release_repository.tags['release']
+            release_tag = release_tag.replace(args.source,args.dest)
+            dest_repo_data.release_repository.tags['release'] = release_tag
         dest_distribution.repositories[repo_name] = dest_repo_data
-    elif dest_distribution.repositories[repo_name].release_repository.version is None:
+    elif dest_distribution.repositories[repo_name].release_repository is not None and \
+            dest_distribution.repositories[repo_name].release_repository.version is None:
         dest_distribution.repositories[repo_name].release_repository.version = repo_data.release_repository.version
         repositories_to_retry.append(repo_name)
     else:


### PR DESCRIPTION
Earlier versions of foxy which this script was tested with did not have any repositories without release entries. This covers that case by:
* Copying all repositories entries, even those that lack release entries.
* Only attempting to bloom repositories which have release entries.