### PR TITLE
rr_openrover_stack: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10160,7 +10160,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rr_openrover_stack` to `1.1.1-1`:

- upstream repository: https://github.com/RoverRobotics/rr_openrover_stack.git
- release repository: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-2`

## rr_control_input_manager

- No changes

## rr_openrover_description

```
* Flip orrientation of Lidar, and rename launch file names
* add pyserial to package.xml
* Contributors: 1102, padiln
```

## rr_openrover_driver

```
* Flip orrientation of Lidar, and rename launch file names
* Contributors: 1102
```

## rr_openrover_driver_msgs

- No changes

## rr_openrover_simulation

```
* add pyserial to package.xml
* Contributors: padiln
```

## rr_openrover_stack

```
* add pyserial to package.xml
* Contributors: padiln
```

## rr_rover_zero_driver

```
* correct find_packge for rover zero cmakelists
* fixing pyKDL RPY to Quat conversion
* fix rospy dependency issue
* proper depend tag
* add pyserial to package.xml
* Contributors: 1102, padiln
```
