### PR TITLE
ros_control_boilerplate: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2489,6 +2489,21 @@ repositories:
       url: https://github.com/ros-controls/ros_control.git
       version: noetic-devel
     status: maintained
+  ros_control_boilerplate:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/ros_control_boilerplate.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
+      version: 0.6.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros_control_boilerplate.git
+      version: noetic-devel
+    status: maintained
   ros_controllers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.6.0-1`:

- upstream repository: https://github.com/PickNikRobotics/ros_control_boilerplate.git
- release repository: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ros_control_boilerplate

```
* Generalize GenericHWControlLoop to all types of RobotHW (#38 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/38>)
* Update README.md
* Fix build badges in README (#37 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/37>)
* Update .travis.yml to use moveit_ci (#36 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/36>)
* Contributors: Jafar Abdi, RobertWilbrandt
```
