### PR TITLE
[dep] Update python*-rosinstall-generator.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3966,8 +3966,7 @@ python-rosinstall-generator:
   macports: [py27-rosinstall-generator]
   rhel:
     '7': [python2-rosinstall_generator]
-  ubuntu:
-    '*': [python-rosinstall-generator]
+  ubuntu: [python-rosinstall-generator]
 python-rospkg:
   alpine:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6070,7 +6070,7 @@ python3-rosdistro-modules:
   rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
 python3-rosinstall-generator:
-  ubuntu: [python3-rospkg]
+  ubuntu: [python3-rosinstall-generator]
 python3-rospkg:
   alpine:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3967,16 +3967,7 @@ python-rosinstall-generator:
   rhel:
     '7': [python2-rosinstall_generator]
   ubuntu:
-    lucid: [python-rosinstall-generator]
-    maverick: [python-rosinstall-generator]
-    natty: [python-rosinstall-generator]
-    oneiric: [python-rosinstall-generator]
-    precise: [python-rosinstall-generator]
-    quantal: [python-rosinstall-generator]
-    raring: [python-rosinstall-generator]
-    saucy: [python-rosinstall-generator]
-    trusty: [python-rosinstall-generator]
-    trusty_python3: [python3-rosinstall-generator]
+    '*': [python-rosinstall-generator]
 python-rospkg:
   alpine:
     pip:
@@ -6079,6 +6070,8 @@ python3-rosdistro-modules:
   openembedded: [python3-rosdistro@meta-ros]
   rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
+python3-rosinstall-generator:
+  ubuntu: [python3-rospkg]
 python3-rospkg:
   alpine:
     pip:


### PR DESCRIPTION
# Changes
- Asterisk `python-rosinstall-generator` for all Ubuntu.
- Add python3 for specific LTS Ubuntu distros.

# Background of the changes
On Ubuntu 16.04 I got the following upon `rosdep install`:
```
pkg_NOODLE: No definition of [python-rosinstall-generator] for OS version [xenial]
```
Noticed rosdep keys for the pkg in question isn't defined after Ubuntu 14.04. The pkg is available in `apt` world.

```
$ docker run -it ros:kinetic-ros-base bash

:
The following NEW packages will be installed:
  python-rosinstall-generator
:
  Unpacking python-rosinstall-generator (0.1.19-1) ...
  Setting up python-rosinstall-generator (0.1.19-1) ...
  root@6960e681f1c6:/#
```
Disclaimer: I haven't confirmed asterisking all Ubuntu works.