### PR TITLE
neonavigation: 0.8.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8524,7 +8524,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.8.7-1
+      version: 0.8.8-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.8.8-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.7-1`

## costmap_cspace

- No changes

## joystick_interrupt

```
* joystick_interrupt: fix joystick_mux event handling and add tests (#504 <https://github.com/at-wat/neonavigation/issues/504>)
* joystick_interrupt: validate joystick button array size in joystick_mux (#503 <https://github.com/at-wat/neonavigation/issues/503>)
* Contributors: Atsushi Watanabe
```

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: avoid showing too many warning messages (#501 <https://github.com/at-wat/neonavigation/issues/501>)
* Contributors: Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
