### PR TITLE
Migrate Foxy to Rolling using migrate-rosdistro.py

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10,7 +10,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: foxy
+      version: master
     release:
       packages:
       - ament_cmake
@@ -41,13 +41,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: foxy
+      version: master
     status: developed
   ament_cmake_ros:
     doc:
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: foxy
+      version: master
     release:
       packages:
       - ament_cmake_ros
@@ -60,13 +60,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: foxy
+      version: master
     status: maintained
   ament_index:
     doc:
       type: git
       url: https://github.com/ament/ament_index.git
-      version: foxy
+      version: master
     release:
       packages:
       - ament_index_cpp
@@ -79,13 +79,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_index.git
-      version: foxy
+      version: master
     status: maintained
   ament_lint:
     doc:
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: foxy
+      version: master
     release:
       packages:
       - ament_clang_format
@@ -127,7 +127,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: foxy
+      version: master
     status: developed
   ament_nodl:
     release:
@@ -144,7 +144,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_package.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -154,7 +154,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_package.git
-      version: foxy
+      version: master
     status: developed
   angles:
     doc:
@@ -243,7 +243,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/class_loader.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -253,13 +253,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
-      version: foxy
+      version: ros2
     status: maintained
   common_interfaces:
     doc:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: foxy
+      version: master
     release:
       packages:
       - actionlib_msgs
@@ -282,13 +282,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: foxy
+      version: master
     status: maintained
   console_bridge_vendor:
     doc:
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -298,7 +298,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: foxy
+      version: master
     status: maintained
   control_box_rst:
     doc:
@@ -346,7 +346,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/demos.git
-      version: foxy
+      version: master
     release:
       packages:
       - action_tutorials_cpp
@@ -376,7 +376,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/demos.git
-      version: foxy
+      version: master
     status: developed
   depthimage_to_laserscan:
     doc:
@@ -418,7 +418,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -427,7 +427,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: foxy
+      version: master
     status: maintained
   eigen_stl_containers:
     doc:
@@ -449,7 +449,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -459,13 +459,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: foxy
+      version: master
     status: maintained
   examples:
     doc:
       type: git
       url: https://github.com/ros2/examples.git
-      version: foxy
+      version: master
     release:
       packages:
       - examples_rclcpp_minimal_action_client
@@ -492,7 +492,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/examples.git
-      version: foxy
+      version: master
     status: maintained
   fastcdr:
     release:
@@ -594,7 +594,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: foxy
+      version: ros2
     release:
       packages:
       - examples_tf2_py
@@ -617,7 +617,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: foxy
+      version: ros2
     status: maintained
   googletest:
     release:
@@ -631,7 +631,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/googletest.git
-      version: foxy
+      version: ros2
     status: maintained
   gps_umd:
     doc:
@@ -732,7 +732,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -742,7 +742,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: foxy
+      version: ros2
     status: maintained
   joint_state_publisher:
     doc:
@@ -787,7 +787,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/kdl_parser.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -797,13 +797,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/kdl_parser.git
-      version: foxy
+      version: ros2
     status: maintained
   laser_geometry:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -813,7 +813,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: foxy
+      version: ros2
     status: maintained
   laser_proc:
     doc:
@@ -835,7 +835,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch.git
-      version: foxy
+      version: master
     release:
       packages:
       - launch
@@ -851,13 +851,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch.git
-      version: foxy
+      version: master
     status: developed
   launch_ros:
     doc:
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: foxy
+      version: master
     release:
       packages:
       - launch_ros
@@ -871,7 +871,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: foxy
+      version: master
     status: maintained
   lgsvl_msgs:
     release:
@@ -911,7 +911,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: foxy-devel
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -920,7 +920,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: foxy-devel
+      version: master
     status: developed
   libyaml_vendor:
     release:
@@ -932,7 +932,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
-      version: foxy
+      version: master
     status: maintained
   marti_common:
     doc:
@@ -991,7 +991,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1001,13 +1001,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: foxy
+      version: master
     status: maintained
   navigation_msgs:
     doc:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
-      version: foxy
+      version: ros2
     release:
       packages:
       - map_msgs
@@ -1020,7 +1020,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
-      version: foxy
+      version: ros2
     status: maintained
   nodl:
     doc:
@@ -1044,7 +1044,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: foxy
+      version: ros2
     release:
       packages:
       - orocos_kdl
@@ -1056,13 +1056,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
-      version: foxy
+      version: ros2
     status: maintained
   osrf_pycommon:
     doc:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1071,13 +1071,13 @@ repositories:
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
-      version: foxy
+      version: master
     status: maintained
   osrf_testing_tools_cpp:
     doc:
       type: git
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
-      version: foxy
+      version: master
     release:
       packages:
       - osrf_testing_tools_cpp
@@ -1090,7 +1090,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
-      version: foxy
+      version: master
     status: maintained
   pcl_msgs:
     release:
@@ -1154,7 +1154,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1164,13 +1164,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: foxy
+      version: ros2
     status: maintained
   python_cmake_module:
     doc:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1179,7 +1179,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
-      version: foxy
+      version: master
     status: developed
   python_qt_binding:
     doc:
@@ -1224,7 +1224,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: foxy
+      version: master
     release:
       packages:
       - rcl
@@ -1239,13 +1239,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
-      version: foxy
+      version: master
     status: maintained
   rcl_interfaces:
     doc:
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: foxy
+      version: master
     release:
       packages:
       - action_msgs
@@ -1264,13 +1264,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: foxy
+      version: master
     status: maintained
   rcl_logging:
     doc:
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: foxy
+      version: master
     release:
       packages:
       - rcl_logging_log4cxx
@@ -1284,7 +1284,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: foxy
+      version: master
     status: maintained
   rclc:
     doc:
@@ -1309,7 +1309,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: foxy
+      version: master
     release:
       packages:
       - rclcpp
@@ -1324,13 +1324,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: foxy
+      version: master
     status: maintained
   rclpy:
     doc:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1340,13 +1340,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: foxy
+      version: master
     status: maintained
   rcpputils:
     doc:
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1355,13 +1355,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: foxy
+      version: master
     status: developed
   rcutils:
     doc:
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1371,13 +1371,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: foxy
+      version: master
     status: maintained
   realtime_support:
     doc:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: foxy
+      version: master
     release:
       packages:
       - rttest
@@ -1390,13 +1390,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: foxy
+      version: master
     status: maintained
   resource_retriever:
     doc:
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: foxy
+      version: ros2
     release:
       packages:
       - libcurl_vendor
@@ -1409,13 +1409,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: foxy
+      version: ros2
     status: maintained
   rmw:
     doc:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: foxy
+      version: master
     release:
       packages:
       - rmw
@@ -1428,13 +1428,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw.git
-      version: foxy
+      version: master
     status: maintained
   rmw_connext:
     doc:
       type: git
       url: https://github.com/ros2/rmw_connext.git
-      version: foxy
+      version: master
     release:
       packages:
       - rmw_connext_cpp
@@ -1447,13 +1447,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_connext.git
-      version: foxy
+      version: master
     status: maintained
   rmw_cyclonedds:
     doc:
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: foxy
+      version: master
     release:
       packages:
       - rmw_cyclonedds_cpp
@@ -1465,13 +1465,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: foxy
+      version: master
     status: developed
   rmw_dds_common:
     doc:
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1481,13 +1481,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: foxy
+      version: master
     status: maintained
   rmw_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: foxy
+      version: master
     release:
       packages:
       - rmw_fastrtps_cpp
@@ -1501,13 +1501,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: foxy
+      version: master
     status: developed
   rmw_implementation:
     doc:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1517,13 +1517,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: foxy
+      version: master
     status: developed
   robot_state_publisher:
     doc:
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1533,13 +1533,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: foxy
+      version: ros2
     status: maintained
   ros1_bridge:
     doc:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1549,7 +1549,7 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/ros2/ros1_bridge.git
-      version: foxy
+      version: master
     status: maintained
   ros2_intel_realsense:
     doc:
@@ -1616,7 +1616,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: foxy
+      version: master
     release:
       packages:
       - ros2action
@@ -1641,7 +1641,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: foxy
+      version: master
     status: maintained
   ros_environment:
     doc:
@@ -1663,7 +1663,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: foxy
+      version: master
     release:
       packages:
       - ros2test
@@ -1676,7 +1676,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: foxy
+      version: master
     status: maintained
   ros_workspace:
     release:
@@ -1693,7 +1693,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: foxy
+      version: master
     release:
       packages:
       - ros2bag
@@ -1717,7 +1717,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: foxy
+      version: master
     status: developed
   rosbag2_bag_v2:
     doc:
@@ -1742,7 +1742,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: foxy
+      version: master
     release:
       packages:
       - rosidl_adapter
@@ -1763,13 +1763,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: foxy
+      version: master
     status: maintained
   rosidl_dds:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: foxy
+      version: master
     release:
       packages:
       - rosidl_generator_dds_idl
@@ -1781,13 +1781,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: foxy
+      version: master
     status: maintained
   rosidl_defaults:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: foxy
+      version: master
     release:
       packages:
       - rosidl_default_generators
@@ -1800,13 +1800,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: foxy
+      version: master
     status: maintained
   rosidl_python:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: foxy
+      version: master
     release:
       packages:
       - rosidl_generator_py
@@ -1818,13 +1818,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: foxy
+      version: master
     status: maintained
   rosidl_runtime_py:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1834,13 +1834,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: foxy
+      version: master
     status: maintained
   rosidl_typesupport:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: foxy
+      version: master
     release:
       packages:
       - rosidl_typesupport_c
@@ -1853,13 +1853,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: foxy
+      version: master
     status: maintained
   rosidl_typesupport_connext:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
-      version: foxy
+      version: master
     release:
       packages:
       - connext_cmake_module
@@ -1872,13 +1872,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git
-      version: foxy
+      version: master
     status: maintained
   rosidl_typesupport_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: foxy
+      version: master
     release:
       packages:
       - fastrtps_cmake_module
@@ -1892,13 +1892,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: foxy
+      version: master
     status: developed
   rpyutils:
     doc:
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1908,7 +1908,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: foxy
+      version: master
     status: developed
   rqt:
     doc:
@@ -2194,7 +2194,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rviz.git
-      version: foxy
+      version: ros2
     release:
       packages:
       - rviz2
@@ -2213,7 +2213,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rviz.git
-      version: foxy
+      version: ros2
     status: maintained
   spdlog_vendor:
     release:
@@ -2225,13 +2225,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/spdlog_vendor.git
-      version: foxy
+      version: master
     status: maintained
   sros2:
     doc:
       type: git
       url: https://github.com/ros2/sros2.git
-      version: foxy
+      version: master
     release:
       packages:
       - sros2
@@ -2244,7 +2244,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/sros2.git
-      version: foxy
+      version: master
     status: developed
   system_modes:
     doc:
@@ -2269,7 +2269,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/system_tests.git
-      version: foxy
+      version: master
     status: developed
   teleop_twist_joy:
     doc:
@@ -2307,7 +2307,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2317,13 +2317,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: foxy
+      version: master
     status: maintained
   tinyxml2_vendor:
     doc:
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2333,7 +2333,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml2_vendor.git
-      version: foxy
+      version: master
     status: maintained
   tinyxml_vendor:
     release:
@@ -2345,13 +2345,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tinyxml_vendor.git
-      version: foxy
+      version: master
     status: maintained
   tlsf:
     doc:
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2361,7 +2361,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: foxy
+      version: master
     status: maintained
   tracetools_analysis:
     doc:
@@ -2406,13 +2406,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
-      version: foxy
+      version: master
     status: maintained
   unique_identifier_msgs:
     doc:
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2422,13 +2422,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: foxy
+      version: master
     status: maintained
   urdf:
     doc:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2438,7 +2438,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/urdf.git
-      version: foxy
+      version: ros2
     status: maintained
   urdf_parser_py:
     doc:
@@ -2462,7 +2462,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/urdfdom.git
-      version: foxy
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2472,13 +2472,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/urdfdom.git
-      version: foxy
+      version: ros2
     status: maintained
   urdfdom_headers:
     doc:
       type: git
       url: https://github.com/ros/urdfdom_headers.git
-      version: foxy
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2487,7 +2487,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git
-      version: foxy
+      version: master
     status: maintained
   urg_c:
     doc:
@@ -2616,7 +2616,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/yaml_cpp_vendor.git
-      version: foxy
+      version: master
     status: maintained
 type: distribution
 version: 2

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -336,7 +336,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.5.1-2
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6,5 +6,2617 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  ament_cmake:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: foxy
+    release:
+      packages:
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_export_targets
+      - ament_cmake_gmock
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_nose
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_version
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake-release.git
+      version: 0.9.5-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: foxy
+    status: developed
+  ament_cmake_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: foxy
+    release:
+      packages:
+      - ament_cmake_ros
+      - domain_coordinator
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
+      version: 0.9.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: foxy
+    status: maintained
+  ament_index:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: foxy
+    release:
+      packages:
+      - ament_index_cpp
+      - ament_index_python
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_index-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: foxy
+    status: maintained
+  ament_lint:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: foxy
+    release:
+      packages:
+      - ament_clang_format
+      - ament_clang_tidy
+      - ament_cmake_clang_format
+      - ament_cmake_clang_tidy
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_mypy
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pycodestyle
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_mypy
+      - ament_pclint
+      - ament_pep257
+      - ament_pycodestyle
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_lint-release.git
+      version: 0.9.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: foxy
+    status: developed
+  ament_nodl:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_nodl-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/ament_nodl.git
+      version: master
+    status: developed
+  ament_package:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_package-release.git
+      version: 0.9.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: foxy
+    status: developed
+  angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/angles-release.git
+      version: 1.12.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    status: maintained
+  apriltag:
+    doc:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag-release.git
+      version: 3.1.2-3
+    source:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    status: maintained
+  behaviortree_cpp:
+    doc:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    release:
+      packages:
+      - behaviortree_cpp_v3
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
+      version: 3.5.0-2
+    source:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    status: developed
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer-release.git
+      version: 1.0.9001-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    status: maintained
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: dashing
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer_ros-release.git
+      version: 1.0.9001-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: dashing
+    status: maintained
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/class_loader-release.git
+      version: 2.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: foxy
+    status: maintained
+  common_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: foxy
+    release:
+      packages:
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/common_interfaces-release.git
+      version: 2.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: foxy
+    status: maintained
+  console_bridge_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
+      version: 1.2.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: foxy
+    status: maintained
+  control_box_rst:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/control_box_rst-release.git
+      version: 0.0.7-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    status: developed
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/control_msgs-release.git
+      version: 2.3.0-4
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: foxy-devel
+    status: maintained
+  cyclonedds:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cyclonedds-release.git
+      version: 0.5.1-2
+    source:
+      type: git
+      url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+      version: master
+    status: maintained
+  demos:
+    doc:
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: foxy
+    release:
+      packages:
+      - action_tutorials_cpp
+      - action_tutorials_interfaces
+      - action_tutorials_py
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
+      - topic_monitor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/demos-release.git
+      version: 0.9.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: foxy
+    status: developed
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
+      version: 2.3.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: foxy-devel
+    status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: foxy
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_updater
+      - self_test
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/diagnostics-release.git
+      version: 2.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: foxy
+    status: maintained
+  eigen3_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: foxy
+    status: maintained
+  eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    status: maintained
+  example_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/example_interfaces-release.git
+      version: 0.9.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: foxy
+    status: maintained
+  examples:
+    doc:
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: foxy
+    release:
+      packages:
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclcpp_multithreaded_executor
+      - examples_rclpy_executors
+      - examples_rclpy_minimal_action_client
+      - examples_rclpy_minimal_action_server
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/examples-release.git
+      version: 0.9.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: foxy
+    status: maintained
+  fastcdr:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fastcdr-release.git
+      version: 1.0.13-2
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/eProsima/Fast-CDR.git
+      version: v1.0.13
+    status: maintained
+  fastrtps:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fastrtps-release.git
+      version: 2.0.0-4
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/eProsima/Fast-DDS.git
+      version: 9c28edc805863117d500ebb7aef86d509471ebd8
+    status: maintained
+  filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/filters-release.git
+      version: 2.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    status: maintained
+  fmi_adapter_ros2:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: master
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      version: master
+    status: developed
+  fmilibrary_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
+      version: 0.2.0-2
+  foonathan_memory_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/eProsima/foonathan_memory_vendor.git
+      version: master
+    status: maintained
+  geographic_info:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: ros2
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/geographic_info-release.git
+      version: 1.0.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: ros2
+    status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: foxy
+    release:
+      packages:
+      - examples_tf2_py
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry2-release.git
+      version: 0.13.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: foxy
+    status: maintained
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.8.9000-2
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: foxy
+    status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    release:
+      packages:
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gps_umd-release.git
+      version: 1.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ifm3d-release.git
+      version: 0.18.0-5
+    status: developed
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - image_common
+      - image_transport
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/image_common-release.git
+      version: 2.3.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: ros2
+    status: maintained
+  image_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: ros2
+    release:
+      packages:
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/image_pipeline-release.git
+      version: 2.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: ros2
+    status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/image_transport_plugins-release.git
+      version: 2.3.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/interactive_markers-release.git
+      version: 2.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: foxy
+    status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: foxy
+    release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/joint_state_publisher-release.git
+      version: 2.2.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: foxy
+    status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    release:
+      packages:
+      - joy
+      - joy_linux
+      - sdl2_vendor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/joystick_drivers-release.git
+      version: 2.4.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    status: maintained
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kdl_parser-release.git
+      version: 2.4.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/kdl_parser.git
+      version: foxy
+    status: maintained
+  laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_geometry-release.git
+      version: 2.2.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: foxy
+    status: maintained
+  laser_proc:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_proc-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    status: maintained
+  launch:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: foxy
+    release:
+      packages:
+      - launch
+      - launch_testing
+      - launch_testing_ament_cmake
+      - launch_xml
+      - launch_yaml
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/launch-release.git
+      version: 0.10.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: foxy
+    status: developed
+  launch_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: foxy
+    release:
+      packages:
+      - launch_ros
+      - launch_testing_ros
+      - ros2launch
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_ros-release.git
+      version: 0.10.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: foxy
+    status: maintained
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/lgsvl_msgs-release.git
+      version: 0.0.3-2
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: foxy-devel
+  libg2o:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libg2o-release.git
+      version: 2020.5.29-2
+    status: maintained
+  librealsense:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    release:
+      packages:
+      - librealsense2
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/librealsense-release.git
+      version: 2.34.0-2
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    status: maintained
+  libstatistics_collector:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/libstatistics_collector.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libstatistics_collector-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-tooling/libstatistics_collector.git
+      version: foxy-devel
+    status: developed
+  libyaml_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libyaml_vendor-release.git
+      version: 1.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/libyaml_vendor.git
+      version: foxy
+    status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    release:
+      packages:
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_prefix_tools
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_common-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: dashing-devel
+    status: developed
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_dbw_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/marti_messages-release.git
+      version: 1.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    status: developed
+  message_filters:
+    doc:
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_message_filters-release.git
+      version: 3.2.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: foxy
+    status: maintained
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: foxy
+    release:
+      packages:
+      - map_msgs
+      - move_base_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/navigation_msgs-release.git
+      version: 2.0.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: foxy
+    status: maintained
+  nodl:
+    doc:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    release:
+      packages:
+      - nodl_python
+      - ros2nodl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nodl-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    status: developed
+  orocos_kinematics_dynamics:
+    doc:
+      type: git
+      url: https://github.com/ros2/orocos_kinematics_dynamics.git
+      version: foxy
+    release:
+      packages:
+      - orocos_kdl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/orocos_kinematics_dynamics-release.git
+      version: 3.3.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/orocos_kinematics_dynamics.git
+      version: foxy
+    status: maintained
+  osrf_pycommon:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_pycommon-release.git
+      version: 0.1.10-2
+    source:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: foxy
+    status: maintained
+  osrf_testing_tools_cpp:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: foxy
+    release:
+      packages:
+      - osrf_testing_tools_cpp
+      - test_osrf_testing_tools_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_testings_tools_cpp-release.git
+      version: 1.3.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: foxy
+    status: maintained
+  pcl_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pcl_msgs-release.git
+      version: 1.0.0-3
+    status: maintained
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: foxy-devel
+    release:
+      packages:
+      - pcl_conversions
+      - perception_pcl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/perception_pcl-release.git
+      version: 2.2.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: foxy-devel
+    status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: dashing
+    release:
+      packages:
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/phidgets_drivers-release.git
+      version: 2.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: dashing
+    status: maintained
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pluginlib-release.git
+      version: 2.5.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: foxy
+    status: maintained
+  python_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/python_cmake_module-release.git
+      version: 0.8.0-2
+    source:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: foxy
+    status: developed
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/python_qt_binding-release.git
+      version: 1.0.5-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: crystal-devel
+    status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: foxy-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/qt_gui_core-release.git
+      version: 1.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: foxy-devel
+    status: maintained
+  rcl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: foxy
+    release:
+      packages:
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl-release.git
+      version: 1.1.5-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: foxy
+    status: maintained
+  rcl_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: foxy
+    release:
+      packages:
+      - action_msgs
+      - builtin_interfaces
+      - composition_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - rosgraph_msgs
+      - statistics_msgs
+      - test_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_interfaces-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: foxy
+    status: maintained
+  rcl_logging:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: foxy
+    release:
+      packages:
+      - rcl_logging_log4cxx
+      - rcl_logging_noop
+      - rcl_logging_spdlog
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: foxy
+    status: maintained
+  rclc:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: master
+    release:
+      packages:
+      - rclc
+      - rclc_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rclc-release.git
+      version: 0.1.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: master
+    status: developed
+  rclcpp:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: foxy
+    release:
+      packages:
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rclcpp-release.git
+      version: 2.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: foxy
+    status: maintained
+  rclpy:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rclpy-release.git
+      version: 1.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: foxy
+    status: maintained
+  rcpputils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcpputils-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: foxy
+    status: developed
+  rcutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcutils-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: foxy
+    status: maintained
+  realtime_support:
+    doc:
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: foxy
+    release:
+      packages:
+      - rttest
+      - tlsf_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_support-release.git
+      version: 0.9.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: foxy
+    status: maintained
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: foxy
+    release:
+      packages:
+      - libcurl_vendor
+      - resource_retriever
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/resource_retriever-release.git
+      version: 2.3.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: foxy
+    status: maintained
+  rmw:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: foxy
+    release:
+      packages:
+      - rmw
+      - rmw_implementation_cmake
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: foxy
+    status: maintained
+  rmw_connext:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_connext.git
+      version: foxy
+    release:
+      packages:
+      - rmw_connext_cpp
+      - rmw_connext_shared_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_connext-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_connext.git
+      version: foxy
+    status: maintained
+  rmw_cyclonedds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: foxy
+    release:
+      packages:
+      - rmw_cyclonedds_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
+      version: 0.7.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: foxy
+    status: developed
+  rmw_dds_common:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_dds_common.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_dds_common-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_dds_common.git
+      version: foxy
+    status: maintained
+  rmw_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: foxy
+    release:
+      packages:
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: foxy
+    status: developed
+  rmw_implementation:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_implementation-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: foxy
+    status: developed
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_state_publisher-release.git
+      version: 2.4.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: foxy
+    status: maintained
+  ros1_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros1_bridge-release.git
+      version: 0.9.2-2
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: foxy
+    status: maintained
+  ros2_intel_realsense:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: refactor
+    release:
+      packages:
+      - realsense_examples
+      - realsense_msgs
+      - realsense_node
+      - realsense_ros
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
+      version: 2.0.8-3
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: refactor
+    status: maintained
+  ros2_ouster_drivers:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: foxy-devel
+    release:
+      packages:
+      - ouster_msgs
+      - ros2_ouster
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
+      version: 0.2.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
+      version: foxy-devel
+    status: maintained
+  ros2_tracing:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: foxy
+    release:
+      packages:
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_tracing-release.git
+      version: 1.0.1-3
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
+      version: foxy
+    status: developed
+  ros2cli:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: foxy
+    release:
+      packages:
+      - ros2action
+      - ros2cli
+      - ros2component
+      - ros2doctor
+      - ros2interface
+      - ros2lifecycle
+      - ros2lifecycle_test_fixtures
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2topic
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli-release.git
+      version: 0.9.5-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: foxy
+    status: maintained
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_environment-release.git
+      version: 2.5.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: foxy
+    status: maintained
+  ros_testing:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: foxy
+    release:
+      packages:
+      - ros2test
+      - ros_testing
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_testing-release.git
+      version: 0.2.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: foxy
+    status: maintained
+  ros_workspace:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: maintained
+  rosbag2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: foxy
+    release:
+      packages:
+      - ros2bag
+      - rosbag2
+      - rosbag2_compression
+      - rosbag2_converter_default_plugins
+      - rosbag2_cpp
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_test_common
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      - zstd_vendor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.3.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: foxy
+    status: developed
+  rosbag2_bag_v2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    release:
+      packages:
+      - ros1_rosbag_storage_vendor
+      - rosbag2_bag_v2_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
+      version: 0.0.10-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: foxy
+    status: maintained
+  rosidl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: foxy
+    release:
+      packages:
+      - rosidl_adapter
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_parser
+      - rosidl_runtime_c
+      - rosidl_runtime_cpp
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: foxy
+    status: maintained
+  rosidl_dds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: foxy
+    release:
+      packages:
+      - rosidl_generator_dds_idl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dds-release.git
+      version: 0.7.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: foxy
+    status: maintained
+  rosidl_defaults:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: foxy
+    release:
+      packages:
+      - rosidl_default_generators
+      - rosidl_default_runtime
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_defaults-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: foxy
+    status: maintained
+  rosidl_python:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: foxy
+    release:
+      packages:
+      - rosidl_generator_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_python-release.git
+      version: 0.9.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: foxy
+    status: maintained
+  rosidl_runtime_py:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
+      version: 0.9.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: foxy
+    status: maintained
+  rosidl_typesupport:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: foxy
+    release:
+      packages:
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: foxy
+    status: maintained
+  rosidl_typesupport_connext:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_connext.git
+      version: foxy
+    release:
+      packages:
+      - connext_cmake_module
+      - rosidl_typesupport_connext_c
+      - rosidl_typesupport_connext_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_connext.git
+      version: foxy
+    status: maintained
+  rosidl_typesupport_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: foxy
+    release:
+      packages:
+      - fastrtps_cmake_module
+      - rosidl_typesupport_fastrtps_c
+      - rosidl_typesupport_fastrtps_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: foxy
+    status: developed
+  rpyutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rpyutils.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rpyutils-release.git
+      version: 0.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rpyutils.git
+      version: foxy
+    status: developed
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt-release.git
+      version: 1.0.6-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: crystal-devel
+    status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_action-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: crystal-devel
+    status: maintained
+  rqt_common_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: dashing-devel
+    status: maintained
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_console-release.git
+      version: 1.1.1-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: dashing-devel
+    status: maintained
+  rqt_graph:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_graph-release.git
+      version: 1.0.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: crystal-devel
+    status: maintained
+  rqt_image_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_view-release.git
+      version: 1.0.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: foxy-devel
+    status: maintained
+  rqt_msg:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_msg-release.git
+      version: 1.0.2-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: crystal-devel
+    status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_plot-release.git
+      version: 1.0.8-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: crystal-devel
+    status: maintained
+  rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_publisher-release.git
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: crystal-devel
+    status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_py_console-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: crystal-devel
+    status: maintained
+  rqt_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: dashing
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
+      version: 1.0.5-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: dashing
+    status: maintained
+  rqt_robot_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_monitor.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_monitor.git
+      version: dashing-devel
+    status: maintained
+  rqt_robot_steering:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    status: maintained
+  rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_service_caller-release.git
+      version: 1.0.3-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: crystal-devel
+    status: maintained
+  rqt_shell:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_shell-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: crystal-devel
+    status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_srv-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: crystal-devel
+    status: maintained
+  rqt_top:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: crystal-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_top-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_top.git
+      version: crystal-devel
+    status: maintained
+  rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_topic-release.git
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: dashing-devel
+    status: maintained
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: foxy
+    release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz-release.git
+      version: 8.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: foxy
+    status: maintained
+  spdlog_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/spdlog_vendor-release.git
+      version: 1.1.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/spdlog_vendor.git
+      version: foxy
+    status: maintained
+  sros2:
+    doc:
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: foxy
+    release:
+      packages:
+      - sros2
+      - sros2_cmake
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sros2-release.git
+      version: 0.9.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: foxy
+    status: developed
+  system_modes:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
+    release:
+      packages:
+      - system_modes
+      - system_modes_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/system_modes-release.git
+      version: 0.2.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
+    status: developed
+  system_tests:
+    source:
+      type: git
+      url: https://github.com/ros2/system_tests.git
+      version: foxy
+    status: developed
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: dashing
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
+      version: 2.2.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: dashing
+    status: maintained
+  teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
+      version: 2.3.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    status: maintained
+  test_interface_files:
+    doc:
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/test_interface_files-release.git
+      version: 0.8.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: foxy
+    status: maintained
+  tinyxml2_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
+      version: 0.7.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: foxy
+    status: maintained
+  tinyxml_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
+      version: 0.8.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
+      version: foxy
+    status: maintained
+  tlsf:
+    doc:
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tlsf-release.git
+      version: 0.5.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: foxy
+    status: maintained
+  tracetools_analysis:
+    doc:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: foxy
+    release:
+      packages:
+      - ros2trace_analysis
+      - tracetools_analysis
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tracetools_analysis-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
+      version: foxy
+    status: developed
+  turtlesim:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_tutorials-release.git
+      version: 1.2.4-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: foxy-devel
+    status: maintained
+  uncrustify_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
+      version: 1.4.0-2
+    source:
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: foxy
+    status: maintained
+  unique_identifier_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
+      version: 2.1.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: foxy
+    status: maintained
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf-release.git
+      version: 2.4.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: foxy
+    status: maintained
+  urdf_parser_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    release:
+      packages:
+      - urdfdom_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_py-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    status: maintained
+  urdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdfdom.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom-release.git
+      version: 2.3.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/urdfdom.git
+      version: foxy
+    status: maintained
+  urdfdom_headers:
+    doc:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: foxy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_headers-release.git
+      version: 1.0.5-2
+    source:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: foxy
+    status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_c-release.git
+      version: 1.0.4001-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    status: maintained
+  urg_node:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node-release.git
+      version: 1.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    status: maintained
+  urg_node_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node_msgs-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    status: maintained
+  v4l2_camera:
+    doc:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: master
+    status: developed
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    release:
+      packages:
+      - desktop
+      - ros_base
+      - ros_core
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.9.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: master
+    status: maintained
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 2.2.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: ros2
+    status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/xacro-release.git
+      version: 2.0.2-2
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: dashing-devel
+    status: maintained
+  yaml_cpp_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+      version: 7.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/yaml_cpp_vendor.git
+      version: foxy
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Rolling Ridley releases were bloomed using the script invocation:

```
python3 migration-tools/migrate-rosdistro.py --source foxy --source-ref 5dc357a5d2351032b62938d4ab2e10027e61570f --dest rolling --release-org ros2-gbp
```

During this initial run, two repositories failed to bloom and one was left in an incomplete state and so so have no current version in Rolling.

* marti_common due to an Internal Server Error when pushing changes to the ros2-gbp repository on GitHub, this has happened on several retries and requires further investigation. It may just be too large of a push to handle with https.
* fmi_adapter_ros2 due to release_tag being set to :{ask} with no last_release set for Foxy.
* cyclonedds I made a bloom release of cyclonedds 0.6.0 for Foxy which hadn't yet merged and the disparity between the foxy/distribution.yaml and the bloom tracks caused the wrong release to be made. This is easily resolved by a bloom release of cyclonedds directly into rolling with the corrected version and I'll also be adding a check to the script to catch this situation for future migrations.

An additional commit is on this branch updating the source branches for core packages.
