### PR TITLE
marti_common: 2.13.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1389,7 +1389,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.13.3-1
+      version: 2.13.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.13.4-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.13.3-1`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Clean up Boost usage (#584 <https://github.com/swri-robotics/marti_common/issues/584>)
* Contributors: P. J. Reed
```

## swri_image_util

```
* Clean up Boost usage (#584 <https://github.com/swri-robotics/marti_common/issues/584>)
* Contributors: P. J. Reed
```

## swri_math_util

```
* Clean up Boost usage (#584 <https://github.com/swri-robotics/marti_common/issues/584>)
* Contributors: P. J. Reed
```

## swri_nodelet

- No changes

## swri_opencv_util

```
* Clean up Boost usage (#584 <https://github.com/swri-robotics/marti_common/issues/584>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

```
* Clean up Boost usage (#584 <https://github.com/swri-robotics/marti_common/issues/584>)
* Contributors: P. J. Reed
```

## swri_transform_util

```
* Clean up Boost usage (#584 <https://github.com/swri-robotics/marti_common/issues/584>)
* Contributors: P. J. Reed
```

## swri_yaml_util

```
* Clean up Boost usage (#584 <https://github.com/swri-robotics/marti_common/issues/584>)
* Contributors: P. J. Reed
```
