### PR TITLE
sros2: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2991,7 +2991,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.1-1`

## sros2

```
* bump setup.py package version
* Merge pull request #222 <https://github.com/ros2/sros2/issues/222> from mikaelarguedas/eloquent_backports
  Eloquent backports
* Fix list_keys verb
  backport and adaptation of https://github.com/ros2/sros2/pull/219 to eloquent
* Update maintainer to point to ros-security mailing list + fix package.xml (#179 <https://github.com/ros2/sros2/issues/179>)
* Update tutorials for Eloquent-style ros arguments. (#170 <https://github.com/ros2/sros2/issues/170>)
* Contributors: Mikael Arguedas
```

## sros2_cmake

```
* Merge pull request #222 <https://github.com/ros2/sros2/issues/222> from mikaelarguedas/eloquent_backports
  Eloquent backports
* Update maintainer to point to ros-security mailing list + fix package.xml (#179 <https://github.com/ros2/sros2/issues/179>)
  * update maintainer and fix invalid package.xml
  * use format 3 for consistency and futureproofness
* Contributors: Mikael Arguedas
```
