### PR TITLE
sbpl: 1.3.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3379,6 +3379,12 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: noetic-devel
     status: maintained
+  sbpl:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/sbpl-release.git
+      version: 1.3.1-3
   sick_safetyscanners:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbpl` to `1.3.1-3`:

- upstream repository: https://github.com/sbpl/sbpl
- release repository: https://github.com/ros-gbp/sbpl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
