### PR TITLE
rmw_implementation: 1.0.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1512,7 +1512,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `1.0.0-3`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-2`

## rmw_implementation

```
* Remove MANUAL_BY_NODE liveliness API (#101 <https://github.com/ros2/rmw_implementation/issues/101>)
* Contributors: Ivan Santiago Paunovic
```
