### PR TITLE
jderobot_assets: 1.0.4-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4149,7 +4149,7 @@ repositories:
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git
-      version: kinetic-devel
+      version: melodic-devel
     status: developed
   jderobot_camviz:
     release:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4145,7 +4145,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/assets-release.git
-      version: 1.0.2-1
+      version: 1.0.4-3
     source:
       type: git
       url: https://github.com/JdeRobot/assets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_assets` to `1.0.4-3`:

- upstream repository: https://github.com/JdeRobot/assets.git
- release repository: https://github.com/JdeRobot/assets-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-1`

## jderobot_assets

```
* Launching turtlebot line follower fix
* Fixed turtlebot3 line following
* Added perspectives.
* Update car_1_junction.world
* Create f1_1_circuit.launch
* Update kobuki_1_reconstruccion3d.world
* Contributors: JoseMaria Cañas, Sakshay Mahna, Shreyas Gokhale, pariaspe
```
