### PR TITLE
Added rosdep rule to for python package pycpd under Ubuntu.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3247,6 +3247,10 @@ python-pycodestyle:
   gentoo: [dev-python/pycodestyle]
   rhel: [python2-pycodestyle]
   ubuntu: [pycodestyle]
+python-pycpd:
+  ubuntu:
+    pip:
+      packages: [pycpd]
 python-pycryptodome:
   arch: [python2-pycryptodome]
   debian: [python-pycryptodome]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3247,7 +3247,13 @@ python-pycodestyle:
   gentoo: [dev-python/pycodestyle]
   rhel: [python2-pycodestyle]
   ubuntu: [pycodestyle]
-python-pycpd:
+python-pycpd-pip:
+  debian:
+    pip:
+      packages: [pycpd]
+  fedora:
+    pip:
+      packages: [pycpd]
   ubuntu:
     pip:
       packages: [pycpd]


### PR DESCRIPTION
This adds a rosdep rule for the Python package [pycpd](https://pypi.org/project/pycpd/).