### PR TITLE
disable dev jobs for rosbag2_bag_v2

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2657,7 +2657,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.6-2
     source:
-      test_pull_requests: true
+      test_commits: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2383,7 +2383,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.7-4
     source:
-      test_pull_requests: false
+      test_commits: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1735,7 +1735,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.10-1
     source:
-      test_pull_requests: false
+      test_commits: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: foxy

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1725,7 +1725,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
-      version: master
+      version: foxy
     release:
       packages:
       - ros1_rosbag_storage_vendor
@@ -1735,7 +1735,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.10-1
     source:
-      test_pull_requests: true
+      test_pull_requests: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: foxy

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1733,10 +1733,10 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.10-2
     source:
-      test_pull_requests: true
+      test_pull_requests: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
-      version: foxy
+      version: master
     status: maintained
   rosidl:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1733,7 +1733,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.10-2
     source:
-      test_pull_requests: false
+      test_commits: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master


### PR DESCRIPTION
given that dev jobs can't source a ROS1 distro beforehand, it makes sense to disable the dev jobs for the `rosbag2_bag_v2` packages as they rely on `roscpp` to be found.