### PR TITLE
Require python3- prefix with PyPI keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,6 @@ Additionally, if you rely on a dependency that uses `_python3`-suffixed codename
 #### pip
 
 Python packages, which are only available on [PyPI](https://pypi.org/) should use the `-pip` extension to avoid colliding with future keys from package managers.
-Some existing rules are duplicated with `python-` or `python3-` prefixes, but this is no longer recommended.
 
 For example:
 
@@ -159,6 +158,8 @@ foobar-pip:
     pip:
       packages: [foobar]
 ```
+
+Some existing rules are duplicated with `python-` or `python3-` prefixes, but this is no longer recommended.
 
 How to submit pull requests
 ---------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ python3-foobar-pip:
 
 Some existing rules do not have `python-` or `python3-` prefixes, but this is no longer recommended.
 If the package ever becomes available in Debian or Ubuntu, the `python3-` prefix ensures that the `pip` key is next to it alphabetically.
-The `-pip` key should be removed When the package becomes available on all platforms, and all existing users of the `-pip` key should migrate to the new key.
+The `-pip` key should be removed when the package becomes available on all platforms, and all existing users of the `-pip` key should migrate to the new key.
 
 How to submit pull requests
 ---------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,18 +148,20 @@ Additionally, if you rely on a dependency that uses `_python3`-suffixed codename
 
 #### pip
 
-Python packages, which are only available on [PyPI](https://pypi.org/) should use the `-pip` extension to avoid colliding with future keys from package managers.
+Python packages, which are only available on [PyPI](https://pypi.org/), should use the prefix `python3-` and suffix `-pip` to avoid colliding with future keys from package managers.
 
 For example:
 
 ```yaml
-foobar-pip:
+python3-foobar-pip:
   ubuntu:
     pip:
       packages: [foobar]
 ```
 
-Some existing rules are duplicated with `python-` or `python3-` prefixes, but this is no longer recommended.
+Some existing rules do not have `python-` or `python3-` prefixes, but this is no longer recommended.
+If the package ever becomes available in Debian or Ubuntu, the `python3-` prefix makes sure the `pip` key is next to it alphabetically.
+The `-pip` key should be removed When the package becomes available on all platforms, and all existing users of the `-pip` key should migrate to the new key.
 
 How to submit pull requests
 ---------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ python3-foobar-pip:
 ```
 
 Some existing rules do not have `python-` or `python3-` prefixes, but this is no longer recommended.
-If the package ever becomes available in Debian or Ubuntu, the `python3-` prefix makes sure the `pip` key is next to it alphabetically.
+If the package ever becomes available in Debian or Ubuntu, the `python3-` prefix ensures that the `pip` key is next to it alphabetically.
 The `-pip` key should be removed When the package becomes available on all platforms, and all existing users of the `-pip` key should migrate to the new key.
 
 How to submit pull requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,16 +148,13 @@ Additionally, if you rely on a dependency that uses `_python3`-suffixed codename
 
 #### pip
 
-Python packages, which are only available on pip, should use the `-pip` extension. Also the `python-`/`python3-` prefix needs to be used.
+Python packages, which are only available on [PyPI](https://pypi.org/) should use the `-pip` extension to avoid colliding with future keys from package managers.
+Some existing rules are duplicated with `python-` or `python3-` prefixes, but this is no longer recommended.
+
 For example:
 
 ```yaml
-python-foobar-pip:
-  ubuntu:
-    pip:
-      packages: [foobar]
-...
-python3-foobar-pip:
+foobar-pip:
   ubuntu:
     pip:
       packages: [foobar]


### PR DESCRIPTION
Discussion

https://github.com/ros/rosdistro/pull/25474#discussion_r441702655
https://github.com/ros/rosdistro/pull/23836#discussion_r382837461

I think it would make sense to avoid `python-` or `python3-` prefixes on `PyPI` only keys because it could give a mistaken impression that it determines the Python version used.
The prefix doesn't make a difference because the actual python version depends on `ROS_PYTHON_VERSION` which itself is set by the ROS distro.

https://www.ros.org/reps/rep-0151.html#rosdep-and-pip-packages.

I think it would be confusing if a package in ROS Melodic workspace depended on `python3-foobar-pip` because `rosdep` would install it for Python 2.