### PR TITLE
use 2.0.x branch of Fast-DDS in Foxy and Rolling

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -518,7 +518,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 9c28edc805863117d500ebb7aef86d509471ebd8
+      version: 2.0.x
     status: maintained
   filters:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -518,7 +518,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 9c28edc805863117d500ebb7aef86d509471ebd8
+      version: 2.0.x
     status: maintained
   filters:
     doc:


### PR DESCRIPTION
To match the branch we are tracking in the `ros2.repos` files.