### PR TITLE
astuff_sensor_msgs: 3.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -97,7 +97,6 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
       version: 3.1.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: master

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -75,6 +75,33 @@ repositories:
       url: https://github.com/aprilrobotics/apriltag.git
       version: master
     status: maintained
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    release:
+      packages:
+      - astuff_sensor_msgs
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
+      - pacmod_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/astuff/astuff_sensor_msgs-release.git
+      version: 3.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    status: maintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `3.1.0-1`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## astuff_sensor_msgs

```
* Remove radar_msgs (#57 <https://github.com/astuff/astuff_sensor_msgs/issues/57>)
* Contributors: icolwell-as
```

## delphi_esr_msgs

- No changes

## delphi_mrr_msgs

- No changes

## delphi_srr_msgs

- No changes

## derived_object_msgs

```
* Remove CipvTrack message and radar_msgs dependency (#62 <https://github.com/astuff/astuff_sensor_msgs/issues/62>)
* Contributors: icolwell-as
```

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

- No changes
