### PR TITLE
marti_common: 2.13.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1409,7 +1409,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.13.5-1
+      version: 2.13.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.13.6-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.13.5-1`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_math_util

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_nodelet

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_opencv_util

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_serial_util

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_string_util

- No changes

## swri_system_util

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_transform_util

```
* Update catkin dependencies (#588 <https://github.com/swri-robotics/marti_common/issues/588>)
* Contributors: P. J. Reed
```

## swri_yaml_util

- No changes
