### PR TITLE
Set doc+source branches for ros2_tracing in Eloquent

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2226,7 +2226,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-      version: 0.2.10
+      version: eloquent
     release:
       packages:
       - ros2trace
@@ -2244,7 +2244,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-      version: 0.2.10
+      version: eloquent
     status: developed
   ros2cli:
     doc:


### PR DESCRIPTION
Makes it a bit cleaner/more uniform.