### PR TITLE
rosbag_fancy: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9114,7 +9114,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/xqms/rosbag_fancy-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_fancy` to `0.2.0-1`:

- upstream repository: https://github.com/xqms/rosbag_fancy
- release repository: https://github.com/xqms/rosbag_fancy-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.1-1`

## rosbag_fancy

```
* bag_writer: fix uninitialized read in run() during shutdown
  This happens in certain cases during shutdown, where msg is not set.
* bag_writer: make sure we don't overwrite bag files with same stamp
* ui: move paused/recording indicator to bottom
* bag_writer: special handling for tf2 static transforms on bag reopen
* add --paused flag to start in paused mode
* UI improvements for start/stop
* start/stop service calls
* add tf2_republisher tool (helpful for playback)
* topic_manager: compile fix for clang
* Contributors: Max Schwarz
```
