### PR TITLE
webots_ros2_desktop: 0.0.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3411,6 +3411,35 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: eloquent
     status: maintained
+  webots_ros2_desktop:
+    doc:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: eloquent
+    release:
+      packages:
+      - webots_ros2
+      - webots_ros2_abb
+      - webots_ros2_core
+      - webots_ros2_demos
+      - webots_ros2_desktop
+      - webots_ros2_epuck
+      - webots_ros2_examples
+      - webots_ros2_importer
+      - webots_ros2_msgs
+      - webots_ros2_tiago
+      - webots_ros2_universal_robot
+      - webots_ros2_ur_e_description
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/cyberbotics/webots_ros2-release.git
+      version: 0.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: eloquent
+    status: developed
   xacro:
     doc:
       type: git


### PR DESCRIPTION
## webots_ros2_desktop (eloquent) - 0.0.3-1

The packages in the `webots_ros2_desktop` repository were released into the `eloquent` distro by running `/usr/bin/bloom-release --rosdistro eloquent --track eloquent webots_ros2_desktop --edit` on `Thu, 18 Jun 2020 14:16:42 -0000`

These packages were released:
- `webots_ros2`
- `webots_ros2_abb`
- `webots_ros2_core`
- `webots_ros2_demos`
- `webots_ros2_desktop`
- `webots_ros2_epuck`
- `webots_ros2_examples`
- `webots_ros2_importer`
- `webots_ros2_msgs`
- `webots_ros2_tiago`
- `webots_ros2_universal_robot`
- `webots_ros2_ur_e_description`

Version of package(s) in repository `webots_ros2_desktop`:

- upstream repository: https://github.com/omichel/webots_ros2.git
- release repository: unknown
- rosdistro version: `null`
- old version: `null`
- new version: `0.0.3-1`

Versions of tools used:

- bloom version: `0.9.7`
- catkin_pkg version: `0.4.20`
- rosdep version: `0.19.0`
- rosdistro version: `0.8.2`
- vcstools version: `0.1.42`
