### PR TITLE
rmw: 1.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1423,7 +1423,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 1.0.1-2
+      version: 1.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `1.1.0-2`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-2`

## rmw

```
* Add message lost subscription event (#232 <https://github.com/ros2/rmw/issues/232>)
* Move statuses definitions to rmw/events_statuses/*.h (#232 <https://github.com/ros2/rmw/issues/232>)
* Increase rmw testing coverage above 95% (#238 <https://github.com/ros2/rmw/issues/238>)
* Handle zero-length names_and_types properly (#239 <https://github.com/ros2/rmw/issues/239>)
* Add missing RMW_PUBLIC to security_options_set_root_path (#236 <https://github.com/ros2/rmw/issues/236>)
* Update Quality Declaration for QL 2 (#233 <https://github.com/ros2/rmw/issues/233>)
* Add Security Vulnerability Policy pointing to REP-2006. (#230 <https://github.com/ros2/rmw/issues/230>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic, Karsten Knese, Scott K Logan, Stephen Brawner, brawner
```

## rmw_implementation_cmake

- No changes
