### PR TITLE
rmw_connext: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1442,7 +1442,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 1.0.0-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-2`

## rmw_connext_cpp

```
* Add support to RMW_EVENT_MESSAGE_LOST (#424 <https://github.com/ros2/rmw_connext/issues/424>)
* Allow RMW events to map to more than one DDS event (#424 <https://github.com/ros2/rmw_connext/issues/424>)
* Revert the idl_pp code to try up to 10 times. (#425 <https://github.com/ros2/rmw_connext/issues/425>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## rmw_connext_shared_cpp

```
* Add support to RMW_EVENT_MESSAGE_LOST (#424 <https://github.com/ros2/rmw_connext/issues/424>)
* Allow RMW events to map to more than one DDS event (#424 <https://github.com/ros2/rmw_connext/issues/424>)
* Contributors: Ivan Santiago Paunovic
```
