### PR TITLE
p2os: 2.2.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1952,6 +1952,24 @@ repositories:
       url: https://github.com/ros-perception/openslam_gmapping.git
       version: melodic-devel
     status: unmaintained
+  p2os:
+    release:
+      packages:
+      - p2os_doc
+      - p2os_driver
+      - p2os_launch
+      - p2os_msgs
+      - p2os_teleop
+      - p2os_urdf
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/allenh1/p2os-release.git
+      version: 2.2.1-2
+    source:
+      type: git
+      url: https://github.com/allenh1/p2os.git
+      version: master
+    status: maintained
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `p2os` to `2.2.1-2`:

- upstream repository: https://github.com/allenh1/p2os
- release repository: https://github.com/allenh1/p2os-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## p2os_doc

```
* Prepare release 2.2.0 (#59 <https://github.com/allenh1/p2os/issues/59>)
  * Update changelog
  * 2.2.0
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Hunter L. Allen
```

## p2os_driver

```
* Two fixes for Melodic. (#62 <https://github.com/allenh1/p2os/issues/62>)
  In p2os_driver, the p2os_msgs_gencpp doesn't exist (and, as
  far as I can tell, never existed).  It worked up until recently
  because older versions of CMake would complain but not fail,
  while more recent cmake versions actually fail.  Just remove
  the dependency.
  The second fix is a cosmetic issue, where CMake would spew a
  bunch of warnings on the command line.  Increase the version
  to 3.9.5 to match other CMakeLists.txt and to get rid of the
  warnings.
* Prepare release 2.2.0 (#59 <https://github.com/allenh1/p2os/issues/59>)
  * Update changelog
  * 2.2.0
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Fix driver license (#56 <https://github.com/allenh1/p2os/issues/56>)
  * Upon further inspection, this p2os_driver is GPL 2
  * Fix kinecalc license line
  * Update p2os_ptz license
  * Fix robot_params license
* Add CI (#54 <https://github.com/allenh1/p2os/issues/54>)
  * Add .travis.yml
  * Add .gitignore
  * Add test script
  * Rename *.h to *.hpp
  * Rename *.cc to *.cpp
  * Apply change to CMakeLists.txt
  * Fix copyright line(s), as well as fix header guard style
  * Default standard to C++14, and bump CMake minimum to 3.9.5
  * Remove unused boost include
  * Make headers pass CI
  * Add build status to the README
* Contributors: Chris Lalancette, Hunter L. Allen
```

## p2os_launch

```
* Prepare release 2.2.0 (#59 <https://github.com/allenh1/p2os/issues/59>)
  * Update changelog
  * 2.2.0
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Hunter L. Allen
```

## p2os_msgs

```
* Prepare release 2.2.0 (#59 <https://github.com/allenh1/p2os/issues/59>)
  * Update changelog
  * 2.2.0
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Hunter L. Allen
```

## p2os_teleop

```
* Two fixes for Melodic. (#62 <https://github.com/allenh1/p2os/issues/62>)
  In p2os_driver, the p2os_msgs_gencpp doesn't exist (and, as
  far as I can tell, never existed).  It worked up until recently
  because older versions of CMake would complain but not fail,
  while more recent cmake versions actually fail.  Just remove
  the dependency.
  The second fix is a cosmetic issue, where CMake would spew a
  bunch of warnings on the command line.  Increase the version
  to 3.9.5 to match other CMakeLists.txt and to get rid of the
  warnings.
* Prepare release 2.2.0 (#59 <https://github.com/allenh1/p2os/issues/59>)
  * Update changelog
  * 2.2.0
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Contributors: Chris Lalancette, Hunter L. Allen
```

## p2os_urdf

```
* Prepare release 2.2.0 (#59 <https://github.com/allenh1/p2os/issues/59>)
  * Update changelog
  * 2.2.0
* Update email address (#58 <https://github.com/allenh1/p2os/issues/58>)
* Fixed color in gazebo with 3at. (#57 <https://github.com/allenh1/p2os/issues/57>)
* Contributors: Alberto, Hunter L. Allen
```
