### PR TITLE
rmw_cyclonedds: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1460,7 +1460,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.7.1-2
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.1-2`

## rmw_cyclonedds_cpp

```
* Add support to message lost event (#192 <https://github.com/ros2/rmw_cyclonedds/issues/192>)
* Mitigate lost service responses discovery issue (#187 <https://github.com/ros2/rmw_cyclonedds/issues/187>)
* Contributors: Ivan Santiago Paunovic, eboasson
```
