### PR TITLE
rcl_logging: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1273,13 +1273,14 @@ repositories:
       version: master
     release:
       packages:
+      - rcl_logging_interface
       - rcl_logging_log4cxx
       - rcl_logging_noop
       - rcl_logging_spdlog
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 1.0.0-2
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-2`

## rcl_logging_interface

```
* Add new package with rcl logging interface (#41 <https://github.com/ros2/rcl_logging/issues/41>)
* Contributors: Chris Lalancette
```

## rcl_logging_log4cxx

```
* Use new package with rcl logging interface (#41 <https://github.com/ros2/rcl_logging/issues/41>)
* Contributors: Chris Lalancette
```

## rcl_logging_noop

```
* Use new package with rcl logging interface (#41 <https://github.com/ros2/rcl_logging/issues/41>)
* Contributors: Chris Lalancette
```

## rcl_logging_spdlog

```
* Use new package with rcl logging interface (#41 <https://github.com/ros2/rcl_logging/issues/41>)
* Increased test coverage (#40 <https://github.com/ros2/rcl_logging/issues/40>)
* Add Security Vulnerability Policy pointing to REP-2006.
* Rename Quality_Declaration.md -> QUALITY_DECLARATION.md
* Contributors: Chris Lalancette, Scott K Logan
```
