### PR TITLE
rcl: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1234,7 +1234,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.5-2
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.5-2`

## rcl

```
* Improve rcl init test coverage. (#684 <https://github.com/ros2/rcl/issues/684>)
* Improve clock test coverage. (#685 <https://github.com/ros2/rcl/issues/685>)
* Add message lost event (#673 <https://github.com/ros2/rcl/issues/673>)
* Minor fixes to rcl clock implementation. (#688 <https://github.com/ros2/rcl/issues/688>)
* Improve enclave validation test coverage. (#682 <https://github.com/ros2/rcl/issues/682>)
* Use RCL_RET_* codes only. (#686 <https://github.com/ros2/rcl/issues/686>)
* Fixed doxygen warnings (#677 <https://github.com/ros2/rcl/issues/677>)
* Add tests for rcl package (#668 <https://github.com/ros2/rcl/issues/668>)
* Remove logging_external_interface.h, provided by rcl_logging_interface package now (#676 <https://github.com/ros2/rcl/issues/676>)
* Print RCL_LOCALHOST_ENV_VAR if error happens via rcutils_get_env. (#672 <https://github.com/ros2/rcl/issues/672>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Ivan Santiago Paunovic, Jorge Perez, Michel Hidalgo, tomoya
```

## rcl_action

```
* Fixed doxygen warnings (#677 <https://github.com/ros2/rcl/issues/677>)
* Contributors: Alejandro Hernández Cordero
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
