### PR TITLE
rclpy: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1336,7 +1336,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.2-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-2`

## rclpy

```
* Add message lost subscription event (#572 <https://github.com/ros2/rclpy/issues/572>)
* Fix executor behavior on shutdown (#574 <https://github.com/ros2/rclpy/issues/574>)
* Add missing rcutils/macros.h header (#573 <https://github.com/ros2/rclpy/issues/573>)
* Add topic_name property to Subscription (#571 <https://github.com/ros2/rclpy/issues/571>)
* Add topic_name property to publisher (#568 <https://github.com/ros2/rclpy/issues/568>)
* Fix and document rclpy_handle_get_pointer_from_capsule() (#569 <https://github.com/ros2/rclpy/issues/569>)
* Fix docstrings (#566 <https://github.com/ros2/rclpy/issues/566>)
* Contributors: Audrow, Audrow Nash, Claire Wang, Ivan Santiago Paunovic, Jacob Perron, Shane Loretz, Zhen Ju
```
