### PR TITLE
Add RHEL rule for benchmark

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -234,6 +234,9 @@ benchmark:
     '*': [libbenchmark-dev]
     stretch: null
   fedora: [google-benchmark]
+  rhel:
+    '*': [google-benchmark]
+    '7': null
   ubuntu:
     '*': [libbenchmark-dev]
     xenial: null


### PR DESCRIPTION
Available for EPEL 8, but not for EPEL 7.

https://src.fedoraproject.org/rpms/google-benchmark#bodhi_updates