### PR TITLE
Add python3-collada

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5410,9 +5410,15 @@ python3-click:
   rhel: ['python%{python3_pkgversion}-click']
   ubuntu: [python3-click]
 python3-collada:
-  debian: [python3-collada]
+  debian:
+    '*': [python3-collada]
+    buster: null
+    stretch: null
   fedora: [python3-collada]
-  ubuntu: [python3-collada]
+  ubuntu:
+    '*': [python3-collada]
+    bionic: null
+    xenial: null
 python3-collada-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5409,6 +5409,10 @@ python3-click:
   gentoo: [dev-python/click]
   rhel: ['python%{python3_pkgversion}-click']
   ubuntu: [python3-click]
+python3-collada:
+  debian: [python3-collada]
+  fedora: [python3-collada]
+  ubuntu: [python3-collada]
 python3-collada-pip:
   debian:
     pip:


### PR DESCRIPTION
My package (webots_ros2_importe: https://github.com/cyberbotics/webots_ros2/blob/master/webots_ros2_importer/package.xml#L16) currently depends on `python3-collada-pip` but I would prefer to avoid adding pip dependencies.

debian: https://packages.debian.org/sid/main/python3-collada
fedora: https://fedora.pkgs.org/31/fedora-aarch64/python3-collada-0.6-3.fc31.noarch.rpm.html
ubuntu: https://packages.ubuntu.com/focal/python3-collada