### PR TITLE
navigation_experimental: 0.3.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1696,6 +1696,31 @@ repositories:
       url: https://github.com/ros-planning/navigation.git
       version: noetic-devel
     status: maintained
+  navigation_experimental:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_experimental.git
+      version: noetic-devel
+    release:
+      packages:
+      - assisted_teleop
+      - goal_passer
+      - navigation_experimental
+      - pose_base_controller
+      - pose_follower
+      - sbpl_lattice_planner
+      - sbpl_recovery
+      - twist_recovery
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_experimental-release.git
+      version: 0.3.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation_experimental.git
+      version: noetic-devel
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_experimental` to `0.3.4-1`:

- upstream repository: https://github.com/ros-planning/navigation_experimental.git
- release repository: https://github.com/ros-gbp/navigation_experimental-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## assisted_teleop

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## goal_passer

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## navigation_experimental

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## pose_base_controller

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## pose_follower

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## sbpl_lattice_planner

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## sbpl_recovery

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## twist_recovery

```
* Initial release into noetic
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```
