### PR TITLE
leo_viz: 0.2.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6500,7 +6500,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_viz-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_viz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_viz` to `0.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_viz.git
- release repository: https://github.com/fictionlab-gbp/leo_viz-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.1-1`

## leo_viz

```
* Add Rviz configurations for odometry, slam and navigation
* Add Image panel to default config, change default config name from model to robot
```
