### PR TITLE
soem: 1.4.1000-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14915,17 +14915,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/mgruhler/soem.git
-      version: master
+      version: kinetic
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mgruhler/soem-gbp.git
-      version: 1.4.0-1
+      version: 1.4.1000-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/mgruhler/soem.git
-      version: master
+      version: kinetic
     status: maintained
   sophus:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.4.1000-1`:

- upstream repository: https://github.com/mgruhler/soem.git
- release repository: https://github.com/mgruhler/soem-gbp.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.4.0-1`

## soem

```
* fix formatting of README
* remove stale bot
* change version number policy and bump to 1.4.1000
* bump cmake_minimum to 3.0.2
* Merge pull request #33 <https://github.com/mgruhler/soem/issues/33> from seanyen/windows
  [master] Enable Windows build.
* undef WIN32_LEAN_AND_MEAN instead of touching SOEM code.
* Enable Windows build.
* Contributors: Matthias Gruhler, seanyen
```
