### PR TITLE
soem: 1.4.1000-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10668,7 +10668,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mgruhler/soem-gbp.git
-      version: 1.4.0-1
+      version: 1.4.1000-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.4.1000-1`:

- upstream repository: https://github.com/mgruhler/soem.git
- release repository: https://github.com/mgruhler/soem-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.4.0-1`

## soem

```
* fix formatting of README
* remove stale bot
* change version number policy and bump to 1.4.1000
* bump cmake_minimum to 3.0.2
* Merge pull request #33 <https://github.com/mgruhler/soem/issues/33> from seanyen/windows
  [master] Enable Windows build.
* undef WIN32_LEAN_AND_MEAN instead of touching SOEM code.
* Enable Windows build.
* Contributors: Matthias Gruhler, seanyen
```
