### PR TITLE
soem: 1.4.1001-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3496,6 +3496,21 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: noetic-devel
     status: maintained
+  soem:
+    doc:
+      type: git
+      url: https://github.com/mgruhler/soem.git
+      version: melodic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mgruhler/soem-gbp.git
+      version: 1.4.1001-1
+    source:
+      type: git
+      url: https://github.com/mgruhler/soem.git
+      version: melodic
+    status: maintained
   sophus:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.4.1001-1`:

- upstream repository: https://github.com/mgruhler/soem.git
- release repository: https://github.com/mgruhler/soem-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## soem

```
* remove package upgrade message
* Contributors: D2/EIN-gr Gruhler, Matthias
```
