### PR TITLE
Add python3 key for importlib-metadata.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5598,6 +5598,24 @@ python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]
   ubuntu: [python3-imageio]
+python3-importlib-metadata:
+  debian:
+    '*': [python3-importlib-metadata]
+    buster:
+      pip:
+        packages: [importlib-metadata]
+    stretch:
+      pip:
+        packages: [importlib-metadata]
+  fedora: [python3-importlib-metadata]
+  ubuntu:
+    '*': [python3-importlib-metadata]
+    bionic:
+      pip:
+        packages: [importlib-metadata]
+    xenial:
+      pip:
+        packages: [importlib-metadata]
 python3-interpreter:
   arch: [python]
   debian: [python3-minimal]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5608,6 +5608,7 @@ python3-importlib-metadata:
       pip:
         packages: [importlib-metadata]
   fedora: [python3-importlib-metadata]
+  gentoo: [dev-python/importlib_metadata]
   ubuntu:
     '*': [python3-importlib-metadata]
     bionic:


### PR DESCRIPTION
This will be used by some upcoming ROS 2 code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Here's a link to the distributions that support this package: https://pkgs.org/search/?q=importlib