### PR TITLE
jderobot_color_tuner: 0.0.5-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4167,7 +4167,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/ColorTuner-release.git
-      version: 0.0.4-2
+      version: 0.0.5-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_color_tuner` to `0.0.5-2`:

- upstream repository: https://github.com/JdeRobot/ColorTuner.git
- release repository: https://github.com/JdeRobot/ColorTuner-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `0.0.4-2`

## jderobot_color_tuner

```
* Update package.xml
* Update package.xml
* Update package.xml
* Contributors: Pankhuri Vanjani
* Update package.xml
* Update package.xml
* Update package.xml
* Contributors: Pankhuri Vanjani
```
