### PR TITLE
melodic: migrate abb_driver to new repository

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12,7 +12,6 @@ repositories:
     release:
       packages:
       - abb
-      - abb_driver
       - abb_irb2400_moveit_config
       - abb_irb2400_moveit_plugins
       - abb_irb2400_support
@@ -32,6 +31,11 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb_driver.git
       version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb_driver-release.git
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/abb_driver.git


### PR DESCRIPTION
As per subject.

This PR combines a Bloom release of `ros-industrial/abb_driver` and the removal of the same packages from the `ros-industrial/abb` repository in a single commit.

The `release` entry was created manually, as Bloom doesn't let me release a package which is already part of a releases repository (and rightfully so).

