### PR TITLE
rosbag_snapshot: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9143,6 +9143,25 @@ repositories:
       url: https://github.com/eurogroep/rosbag_pandas.git
       version: master
     status: maintained
+  rosbag_snapshot:
+    doc:
+      type: git
+      url: https://github.com/ros/rosbag_snapshot.git
+      version: main
+    release:
+      packages:
+      - rosbag_snapshot
+      - rosbag_snapshot_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/rosbag_snapshot-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/rosbag_snapshot.git
+      version: main
+    status: maintained
   rosbash_params:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_snapshot` to `1.0.1-1`:

- upstream repository: https://github.com/ros/rosbag_snapshot.git
- release repository: https://github.com/ros-gbp/rosbag_snapshot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
