### PR TITLE
mqtt_bridge: 0.1.7-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7881,7 +7881,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/groove-x/mqtt_bridge-release.git
-      version: 0.1.6-0
+      version: 0.1.7-2
     source:
       type: git
       url: https://github.com/groove-x/mqtt_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge` to `0.1.7-2`:

- upstream repository: https://github.com/groove-x/mqtt_bridge.git
- release repository: https://github.com/groove-x/mqtt_bridge-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.6-0`

## mqtt_bridge

```
* Fix mqtt subscribing to private path (#27 <https://github.com/groove-x/mqtt_bridge/issues/27>)
* Fix frequency limit (#26 <https://github.com/groove-x/mqtt_bridge/issues/26>)
* Add bson module in requirements.txt (#10 <https://github.com/groove-x/mqtt_bridge/issues/10>)
* Fix Bridge not to fall when ros msg cannot be created (#4 <https://github.com/groove-x/mqtt_bridge/issues/4>)
* Contributors: 5tan, Junya Hayashi, Tomas Cernik, Yuma Mihira, kapilPython
```
