### PR TITLE
mrpt2: 2.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5718,7 +5718,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.0.4-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.3-1`
