### PR TITLE
jderobot_carviz: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4162,6 +4162,17 @@ repositories:
       type: git
       url: https://github.com/JdeRobot/CamViz.git
       version: master
+  jderobot_carviz:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/carViz-release.git
+      version: 0.1.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/carViz.git
+      version: master
   jderobot_color_tuner:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_carviz` to `0.1.6-1`:

- upstream repository: https://github.com/JdeRobot/carViz.git
- release repository: https://github.com/JdeRobot/carViz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## jderobot_carviz

- No changes
