### PR TITLE
mrpt2: 2.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1016,7 +1016,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MRPT/mrpt.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/foxy/{package}/{version}

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1012,6 +1012,21 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: foxy
     status: maintained
+  mrpt2:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
+      version: 2.0.4-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    status: developed
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.0.4-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
