### PR TITLE
Add rosdep key for OpenMP

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3049,6 +3049,11 @@ libois-dev:
   fedora: [ois-devel]
   gentoo: [dev-games/ois]
   ubuntu: [libois-dev]
+libomp-dev:
+  arch: [openmp]
+  debian: [libomp-dev]
+  fedora: [libomp-devel]
+  ubuntu: [libomp-dev]
 libopal-dev:
   debian: [libopal-dev]
   fedora: [opal-devel]


### PR DESCRIPTION
Add a rosdep key for the OpenMP package (In this case for [`yak`](https://github.com/ros-industrial/yak)), so users can install all dependencies from rosdep. 

Debian: https://packages.debian.org/search?keywords=libomp-dev
Ubuntu: https://packages.ubuntu.com/search?keywords=libomp-dev&searchon=names&suite=all&section=all
Fedora: https://pkgs.org/search/?q=libomp-devel 
Arch: https://www.archlinux.org/packages/extra/x86_64/openmp/