### PR TITLE
ur_msgs: 1.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11638,6 +11638,21 @@ repositories:
       url: https://github.com/uos/uos_tools.git
       version: master
     status: maintained
+  ur_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-industrial-release/ur_msgs-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: melodic-devel
+    status: developed
   ur_robot_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros-industrial-release/ur_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ur_msgs

```
* First release of this package from its new repository.
* Contributors: gavanderhoorn
```
