### PR TITLE
pilz_robots: 0.5.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7211,7 +7211,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.16-1
+      version: 0.5.17-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.17-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.16-1`

## pilz_control

```
* Add cartesian speed monitoring to pilz joint trajectory controller
* Deactivate command interface in PilzJointTrajectoryController
* Add joint acceleration limits to pilz joint trajectory controller
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_status_indicator_rqt

- No changes

## pilz_testutils

```
* Add JointStatePublisherMock
* Add LoggerMock
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

```
* Remove extended ROS sleep function
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Infinite modbus connection retries
* Improved modbus error messages
* New modbus api
* Refactor components to use Cartesian speed monitor functionality in controller
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

- No changes

## prbt_support

```
* Redirect start of fake_speed_override_node to separate launch file
* Contributors: Pilz GmbH and Co. KG
```
