### PR TITLE
ompl: 1.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1079,6 +1079,12 @@ repositories:
       url: https://github.com/ubuntu-robotics/nodl.git
       version: master
     status: developed
+  ompl:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/ompl-release.git
+      version: 1.5.0-1
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.5.0-1`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
