### PR TITLE
rcpputils: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1352,7 +1352,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 1.0.1-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-2`

## rcpputils

```
* Fix parent_path() for empty paths and paths of length one (#73 <https://github.com/ros2/rcpputils/issues/73>)
* Add get_executable_name() function (#70 <https://github.com/ros2/rcpputils/issues/70>)
* Address memory leak in remove pointer test (#72 <https://github.com/ros2/rcpputils/issues/72>)
* Add current_path to filesystem_helpers (#63 <https://github.com/ros2/rcpputils/issues/63>)
* Align path combine behavior with C++17 (#68 <https://github.com/ros2/rcpputils/issues/68>)
* Update quality declaration to QL 2 (#71 <https://github.com/ros2/rcpputils/issues/71>)
* Contributors: Jacob Perron, Scott K Logan, Stephen Brawner
```
