### PR TITLE
turtlebot3_msgs: 2.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2430,6 +2430,21 @@ repositories:
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
       version: foxy
     status: developed
+  turtlebot3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
+      version: 2.2.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: foxy-devel
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_msgs` to `2.2.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## turtlebot3_msgs

```
* ROS 2 Eloquent Elusor supported
* ROS 2 Foxy Fitzroy supported
* Contributors: Will Son
```
