### PR TITLE
turtlebot3_msgs: 2.2.1-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3167,6 +3167,21 @@ repositories:
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
       version: eloquent
     status: developed
+  turtlebot3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
+      version: 2.2.1-2
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: eloquent-devel
+    status: developed
   turtlesim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_msgs` to `2.2.1-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## turtlebot3_msgs

```
* ROS 2 Eloquent Elusor supported
* ROS 2 Foxy Fitzroy supported
* Contributors: Will Son
```
