### PR TITLE
Added collectd and collect-utils rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -502,6 +502,15 @@ collada-dom:
     utopic: [collada-dom-dev]
     vivid: [collada-dom-dev]
     wily: [collada-dom-dev]
+collectd:
+  debian: [collectd]
+  fedora: [collectd]
+  gentoo: [app-metrics/collectd]
+  ubuntu: [collectd]
+collectd-utils:
+  debian: [collectd-utils]
+  fedora: [collectd-utils]
+  ubuntu: [collectd-utils]
 comedi:
   debian: [libcomedi-dev]
   fedora: [comedilib-devel]


### PR DESCRIPTION
collectd is a small daemon which collects system information periodically and provides mechanisms to monitor and store the values in a variety of ways.

#### collectd:
ubuntu: https://packages.ubuntu.com/focal/collectd
debian: https://packages.debian.org/sid/utils/collectd
gentoo: https://packages.gentoo.org/packages/app-metrics/collectd
fedora: https://fedora.pkgs.org/31/fedora-aarch64/collectd-5.9.0-2.fc31.aarch64.rpm.html

#### collectd-utils:
ubuntu: https://packages.ubuntu.com/focal/collectd-utils
debian: https://packages.debian.org/sid/utils/collectd-utils
fedora: https://fedora.pkgs.org/31/fedora-aarch64/collectd-utils-5.9.0-2.fc31.aarch64.rpm.html

