### PR TITLE
Fix v4l2_camera source branch

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2604,7 +2604,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: master
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -2613,7 +2613,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
-      version: master
+      version: foxy
     status: developed
   variants:
     doc:


### PR DESCRIPTION
Addresses comments in https://github.com/ros/rosdistro/pull/25393#issuecomment-647768637 to stop failing build jobs