### PR TITLE
ros_environment: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1653,7 +1653,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_environment-release.git
-      version: 2.5.0-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `3.0.0-1`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros2-gbp/ros_environment-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.5.0-2`
