### PR TITLE
Fix 'benchmark' rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -233,9 +233,9 @@ benchmark:
   debian:
     '*': [libbenchmark-dev]
     stretch: null
-  fedora: [google-benchmark]
+  fedora: [google-benchmark-devel]
   rhel:
-    '*': [google-benchmark]
+    '*': [google-benchmark-devel]
     '7': null
   ubuntu:
     '*': [libbenchmark-dev]


### PR DESCRIPTION
Use the `-devel` subpackage to match the `-dev` subpackage on Debian/Ubuntu.

https://src.fedoraproject.org/rpms/google-benchmark#bodhi_updates