### PR TITLE
ros2cli: 0.9.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1685,7 +1685,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.9.5-1
+      version: 0.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.9.6-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.5-1`
