### PR TITLE
rviz: 8.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2257,7 +2257,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.1.1-1
+      version: 8.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `8.1.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Updated a hack to avoid CMake warning with assimp 5.0.1 and older, applying it cross platforms (#565 <https://github.com/ros2/rviz/issues/565>)
* Contributors: Dirk Thomas
```

## rviz_common

```
* Changed to not install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Fixed alphabetical include order (#563 <https://github.com/ros2/rviz/issues/563>)
* Changed to avoid trying to moc generate ``env_config.hpp`` file. (#550 <https://github.com/ros2/rviz/issues/550>)
* Contributors: Chris Lalancette, Karsten Knese
```

## rviz_default_plugins

```
* Changed to not install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Changed to use a dedicated TransformListener thread. (#551 <https://github.com/ros2/rviz/issues/551>)
* Suppressed warnings when building with older Qt versions. (#562 <https://github.com/ros2/rviz/issues/562>)
* Restored compatibility with older Qt versions (#561 <https://github.com/ros2/rviz/issues/561>)
* Contributors: Chris Lalancette, Dirk Thomas, ymd-stella
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Changed to not install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Contributors: Chris Lalancette
```

## rviz_rendering_tests

```
* Changed to not install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Contributors: Chris Lalancette
```

## rviz_visual_testing_framework

- No changes
