### PR TITLE
soem: 1.4.1002-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3574,7 +3574,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mgruhler/soem-gbp.git
-      version: 1.4.1001-1
+      version: 1.4.1002-1
     source:
       type: git
       url: https://github.com/mgruhler/soem.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.4.1002-1`:

- upstream repository: https://github.com/mgruhler/soem.git
- release repository: https://github.com/mgruhler/soem-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.4.1001-1`

## soem

```
* Merge pull request #39 <https://github.com/mgruhler/soem/issues/39> from mgruhler/fix/warnings_as_errors_focal
  remove -Werror flag for linux
* remove -Werror flag for linux
* Contributors: Matthias Gruhler
```
