### PR TITLE
soem: 1.4.1002-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10701,17 +10701,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/mgruhler/soem.git
-      version: master
+      version: melodic
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mgruhler/soem-gbp.git
-      version: 1.4.0-1
+      version: 1.4.1002-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/mgruhler/soem.git
-      version: master
+      version: melodic
     status: maintained
   sophus:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.4.1002-1`:

- upstream repository: https://github.com/mgruhler/soem.git
- release repository: https://github.com/mgruhler/soem-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.4.0-1`

## soem

```
* Merge pull request #39 <https://github.com/mgruhler/soem/issues/39> from mgruhler/fix/warnings_as_errors_focal
  remove -Werror flag for linux
* remove -Werror flag for linux
* Contributors: Matthias Gruhler
```
