### PR TITLE
rviz: 1.13.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10356,7 +10356,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.12-1
+      version: 1.13.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.13-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.13.12-1`

## rviz

```
* [feature] Make the goal pose tool magenta (#1520 <https://github.com/ros-visualization/rviz/issues/1520>)
* [bugfix]  Fix memory access in case of 3-byte pixel formats (#1519 <https://github.com/ros-visualization/rviz/issues/1519>)
* [bugfix]  PropertyTree: set custom SelectionModel only with valid model (#1504 <https://github.com/ros-visualization/rviz/issues/1504>)
* Contributors: Ivor Wanders, Michael Görner, Robert Haschke
```
