### PR TITLE
rviz: 1.14.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3446,7 +3446,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.0-2
+      version: 1.14.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.1-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.14.0-2`

## rviz

```
* Merged melodic-devel improvements
  * [feature] Make the goal pose tool magenta (#1520 <https://github.com/ros-visualization/rviz/issues/1520>)
  * [bugfix]  Fix memory access in case of 3-byte pixel formats (#1519 <https://github.com/ros-visualization/rviz/issues/1519>)
  * [bugfix]  PropertyTree: set custom SelectionModel only with valid model (#1504 <https://github.com/ros-visualization/rviz/issues/1504>)
* [bugfix] Fix initial pose and goal pose tools (#1510 <https://github.com/ros-visualization/rviz/issues/1510>)
* [bugfix] Fix cutoff in LaserScanDisplay (#1512 <https://github.com/ros-visualization/rviz/issues/1512>)
* [maint]  Added test/send_point_cloud_2.py (#1514 <https://github.com/ros-visualization/rviz/issues/1514>)
* [maint]  Fix (or silence) warnings of newer gcc / clang
* [maint]  clang-format-10
* PropertyTree: set custom SelectionModel only with valid model (#1504 <https://github.com/ros-visualization/rviz/issues/1504>)
* Contributors: Evan Flynn, G.Doisy, Ivor Wanders, Michael Görner, Robert Haschke
```
