### PR TITLE
urg_stamped: 0.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3906,7 +3906,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.6-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.5-1`

## urg_stamped

```
* Add check for device timestamp jump to node (#66 <https://github.com/seqsense/urg_stamped/issues/66>)
* Add timestamp jump detector to Walltime (#65 <https://github.com/seqsense/urg_stamped/issues/65>)
* Contributors: Yuta Koga
```
