### PR TITLE
ur_msgs: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11655,7 +11655,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ur_msgs-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `1.3.1-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros-industrial-release/ur_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.3.0-1`

## ur_msgs

```
* Change ``payload`` field name to ``mass`` (#5 <https://github.com/ros-industrial/ur_msgs/issues/5>)
* Added ``center_of_gravity`` field to ``SetPayload`` service (#2 <https://github.com/ros-industrial/ur_msgs/issues/2>)
* Mark package as architecture independent (#1 <https://github.com/ros-industrial/ur_msgs/issues/1>)
* Contributors: Felix Exner, gavanderhoorn
```
