### PR TITLE
rtmros_nextage: 0.8.6-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10300,7 +10300,6 @@ repositories:
       version: indigo-devel
     release:
       packages:
-      - nextage_calibration
       - nextage_description
       - nextage_gazebo
       - nextage_ik_plugin
@@ -10310,7 +10309,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/rtmros_nextage-release.git
-      version: 0.8.6-1
+      version: 0.8.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtmros_nextage` to `0.8.6-2`:

- upstream repository: https://github.com/tork-a/rtmros_nextage.git
- release repository: https://github.com/tork-a/rtmros_nextage-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.6-1`

## nextage_description

- No changes

## nextage_gazebo

```
* Merge pull request #371 <https://github.com/tork-a/rtmros_nextage/issues/371> from pazeshun/add-bright-world
  Add gazebo world for non-NVIDIA GPU
* Add gazebo world for non-NVIDIA GPU
  Without activating NVIDIA GPU, world is very dark on gazebo 9 (ROS melodic), so disable shadow to make world bright
  See https://github.com/tork-a/rtmros_nextage/issues/370
  See https://bitbucket.org/osrf/gazebo/issues/2623/no-shadows-and-sun-light-with-non-nvidia
* use default instaed of value of <arg name='model'> tag
* [nextage_gazebo/package.xml] add gazebo_model_path setting.
* Contributors: Kei Okada, Masaki Murooka, Shun Hasegawa
```

## nextage_ik_plugin

```
* Merge pull request #374 <https://github.com/tork-a/rtmros_nextage/issues/374> from k-okada/fix_365
  Fix to compile on melodic
* Fix to compile on melodic
  fixed version of #365 <https://github.com/tork-a/rtmros_nextage/issues/365>
* Contributors: Kei Okada
```

## nextage_moveit_config

```
* Merge pull request #372 <https://github.com/tork-a/rtmros_nextage/issues/372> from pazeshun/fix-travis
  Fix travis by fixing rosdep and moveit test
* Change target pose in moveit test to pass kinetic test
* Contributors: Kei Okada, Shun Hasegawa
```

## nextage_ros_bridge

- No changes

## rtmros_nextage

- No changes
