### PR TITLE
gazebo_ros_pkgs: 3.5.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -586,7 +586,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.5.0-1
+      version: 3.5.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.5.0-2`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.5.0-1`

## gazebo_dev

```
* Merge pull request #1129 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1129> from ros-simulation/e_to_f_june_2020
  Eloquent ➡️ Foxy
* Dashing -> Eloquent
* Gazebo 11 for Foxy (#1093 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1093>)
  * Gazebo 11 for Foxy
* 3.3.5
* Contributors: Jose Luis Rivero, Louise Poubel
```

## gazebo_msgs

```
* Merge pull request #1129 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1129> from ros-simulation/e_to_f_june_2020
  Eloquent ➡️ Foxy
* Dashing -> Eloquent
* 3.3.5
* Contributors: Jose Luis Rivero, Louise Poubel
```

## gazebo_plugins

```
* Merge pull request #1130 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1130> from ros-simulation/foxy_tests
  Fix all Foxy tests
* Merge pull request #1129 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1129> from ros-simulation/e_to_f_june_2020
  Eloquent ➡️ Foxy
* Apply acceleration until both left and right reach targetspeed (#1009 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1009>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* use target include directories (#1040 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1040>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Dashing -> Eloquent
* [forward port] Image publishers use SensorDataQoSProfile (#1031 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1031>) (#1052 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1052>)
  All other sensor publishers were updated previously to use the same profile (#926 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/926>).
  I'm not sure if the image publishers were overlooked or the image_transport API didn't
  support setting the QoS profile at the time.
* Fix cppcheck errors (#1123 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1123>)
  cppcheck 1.90 complains about syntax errors even though it is valid C++ code.
  This refactoring fixes the reported errors.
* Replace deprecated parameters callback API (#1121 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1121>)
  rclcpp::Node now supports multiple parameter callbacks, so we do not need to worry about overwriting an existing callback.
  This change fixes compile time deprecation warnings since ROS Foxy.
* Replace deprecated image_common headers (#1122 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1122>)
  This fixes compile-time deprecation warnings.
* Measure IMU orientation with respect to world (ros2) (#1064 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1064>)
  * Measure IMU orientation with respect to world (#1058 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1058>)
  Report the IMU orientation from the sensor plugin with respect to the world frame.
  This complies with convention documented in REP 145: https://www.ros.org/reps/rep-0145.html
  In order to not break existing behavior, users should opt-in by adding a new SDF tag.
  Co-authored-by: Jacob Perron <mailto:jacob@openrobotics.org>
  * IMU sensor: comply with REP 145 by default
  Change default value of initial_orientation_as_reference to false
  and print deprecation warning if user explicitly sets it to true.
  Co-authored-by: Jacob Perron <mailto:jacob@openrobotics.org>
* Make QoS for publishers and subscriptions configurable  (#1092 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1092>)
  * Make QoS for publishers and subscriptions configurable
  Whenever a plugin creates a ROS publisher or subscription, use the QoS profile provided by the node for the given topic.
  This enables users to override the QoS settings in SDF.
  Depends on https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1091.
* [eloquent] Fix Windows build. (#1077 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1077>)
  * Adding Windows bringup.
* Gazebo 11 for Foxy (#1093 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1093>)
  * Gazebo 11 for Foxy
* 3.3.5
* Backport Gazebo11/Bionic fix for boost variant (#1102 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1102>)
* Measure IMU orientation with respect to world (dashing) (#1065 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1065>)
  Report the IMU orientation from the sensor plugin
  with respect to the world frame.
  This complies with convention documented in REP 145:
  https://www.ros.org/reps/rep-0145.html
  In order to not break existing behavior,
  users should opt-in by adding a new SDF tag.
  Co-authored-by: Jacob Perron <mailto:jacob@openrobotics.org>
* Uncrustify (#1060 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1060>)
  Style changes to conform to the new default setting introduced in https://github.com/ament/ament_lint/pull/210.
  Arguments that do not fit on one line must start on a new line.
* Contributors: Jacob Perron, Jose Luis Rivero, Karsten Knese, Louise Poubel, Sean Yen, Steve Peters, Steven Peters, scgroot
```

## gazebo_ros

```
* Merge pull request #1130 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1130> from ros-simulation/foxy_tests
  Fix all Foxy tests
* Merge pull request #1129 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1129> from ros-simulation/e_to_f_june_2020
  Eloquent ➡️ Foxy
* Dashing -> Eloquent
* [ROS 2] Use "" as default in spawn_entity.py instead of self.get_namespace(). (#1117 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1117>)
* Fix flake8 failures (#1110 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1110>)
* Add gazebo_ros::QoS class (#1091 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1091>)
  Contains logic for parsing <qos> SDF elements and creating rclcpp::QoS objects for ROS publishers and subscriptions.
  Co-authored-by: Ivan Santiago Paunovic <ivanpauno@ekumenlabs.com>
* [eloquent] Fix Windows build. (#1077 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1077>)
* 3.3.5
* [forward port to Foxy] Add node required parameter to launch (#1074 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1074>)  (#1086 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1086>)
* Use configurable timeout in other wait for service calls (#1073 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1073>)
  * Use configurable timeout in other wait for service calls
  Follow-up to #1072 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1072>
* Increase spawn entity wait for service timeout (#1072 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1072>)
  If we have a reaonsable complex launch file and lots of DDS discovery traffic, sometimes five seconds isn't enough.
  This change makes the timeout configurable and changes the default timeout to thirty seconds.
* Uncrustify (#1060 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1060>)
  Style changes to conform to the new default setting introduced in https://github.com/ament/ament_lint/pull/210.
  Arguments that do not fit on one line must start on a new line.
* [ros2] make transient local reliable (#1033 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1033>)
  Co-Authored-By: chapulina <mailto:louise@openrobotics.org>
* Contributors: Alejandro Hernández Cordero, Ivan Santiago Paunovic, Jacob Perron, Jose Luis Rivero, Karsten Knese, Louise Poubel, Mabel Zhang, Sean Yen
```

## gazebo_ros_pkgs

```
* Merge pull request #1129 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1129> from ros-simulation/e_to_f_june_2020
  Eloquent ➡️ Foxy
* Dashing -> Eloquent
* 3.3.5
* Contributors: Jose Luis Rivero, Louise Poubel
```
