### PR TITLE
ros2_planning_system: 0.0.8-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2216,7 +2216,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `0.0.8-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.7-1`

## plansys2_bringup

```
* Boost:optional
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```

## plansys2_domain_expert

```
* Boost:optional
* Support for BT actions
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```

## plansys2_executor

```
* Boost:optional
* Support for BT actions
* Add BT support
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```

## plansys2_lifecycle_manager

```
* Boost:optional
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```

## plansys2_msgs

- No changes

## plansys2_pddl_parser

- No changes

## plansys2_planner

```
* Boost:optional
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```

## plansys2_problem_expert

```
* Boost:optional
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```

## plansys2_terminal

```
* Boost:optional
* Add BT support
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```
