### PR TITLE
rcutils: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1367,7 +1367,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 1.0.1-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-2`

## rcutils

```
* Add token join macros (#262 <https://github.com/ros2/rcutils/issues/262>)
* Add rcutils_string_array_sort function (#248 <https://github.com/ros2/rcutils/issues/248>)
* Add rcutils_string_array_resize function (#247 <https://github.com/ros2/rcutils/issues/247>)
* Increase testing coverage of rcutils to 95% (#258 <https://github.com/ros2/rcutils/issues/258>)
* Update QUALITY_DECLARATION to reflect QL 2 status (#260 <https://github.com/ros2/rcutils/issues/260>)
* Update version stability section of quality declaration for 1.0 (#256 <https://github.com/ros2/rcutils/issues/256>)
* Contributors: Alejandro Hernández Cordero, Jorge Perez, Karsten Knese, Michel Hidalgo, Scott K Logan, Steven! Ragnarök, Stephen Brawner
```
