### PR TITLE
rcpputils: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1352,7 +1352,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## rcpputils

```
* Add scope_exit helper (#78 <https://github.com/ros2/rcpputils/issues/78>)
* Bump setup-ros to 0.0.23, action-ros-lint to 0.0.6, action-ros-ci to 0.0.17 (#77 <https://github.com/ros2/rcpputils/issues/77>)
* Contributors: Devin Bonnie, Michel Hidalgo
```
