### PR TITLE
marti_common: 2.13.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5136,7 +5136,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.13.1-1
+      version: 2.13.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.13.7-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.13.1-1`

## marti_data_structures

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

```
* Fix swri_math_util boost dependencies again (#590 <https://github.com/swri-robotics/marti_common/issues/590>)
* Contributors: P. J. Reed
```

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

- No changes

## swri_rospy

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

```
* Fix swri_math_util boost dependencies again (#590 <https://github.com/swri-robotics/marti_common/issues/590>)
* Contributors: P. J. Reed
```

## swri_transform_util

```
* Improve object transformer to take into account the pose of the object (#589 <https://github.com/swri-robotics/marti_common/issues/589>)
* Contributors: Matthew Bries
```

## swri_yaml_util

- No changes
