### PR TITLE
Add python3 rosdep for msgpack

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5683,6 +5683,10 @@ python3-mock:
 python3-msgpack:
   debian: [python3-msgpack]
   ubuntu: [python3-msgpack]
+python3-msgpack-pip:
+  ubuntu:
+    pip:
+      packages: [msgpack]
 python3-mypy:
   arch: [mypy]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5685,10 +5685,6 @@ python3-msgpack:
     '*': [python3-msgpack]
     stretch: null
   ubuntu: [python3-msgpack]
-python3-msgpack-pip:
-  ubuntu:
-    pip:
-      packages: [msgpack]
 python3-mypy:
   arch: [mypy]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5681,7 +5681,9 @@ python3-mock:
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-msgpack:
-  debian: [python3-msgpack]
+  debian:
+    '*': [python3-msgpack]
+    stretch: null
   ubuntu: [python3-msgpack]
 python3-msgpack-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5680,6 +5680,9 @@ python3-mock:
   openembedded: [python3-mock@meta-ros]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
+python3-msgpack:
+  debian: [python3-msgpack]
+  ubuntu: [python3-msgpack]
 python3-mypy:
   arch: [mypy]
   debian:


### PR DESCRIPTION
Adding `python3-msgpack` to rosdep for:
- `ubuntu`: https://packages.ubuntu.com/search?keywords=python3-msgpack&searchon=names
- `debian`: https://packages.debian.org/search?keywords=python3-msgpack&searchon=names&suite=buster&section=all
- ~`pip`: https://pypi.org/project/msgpack/~

~EDIT: added pip installations for latest version of `msgpack`~