### PR TITLE
usb_cam_hardware: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3927,6 +3927,25 @@ repositories:
       url: https://github.com/ros-drivers/usb_cam.git
       version: develop
     status: unmaintained
+  usb_cam_hardware:
+    doc:
+      type: git
+      url: https://github.com/yoshito-n-students/usb_cam_hardware.git
+      version: noetic-devel
+    release:
+      packages:
+      - usb_cam_controllers
+      - usb_cam_hardware
+      - usb_cam_hardware_interface
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/usb_cam_hardware.git
+      version: noetic-devel
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam_hardware` to `0.0.5-1`:

- upstream repository: https://github.com/yoshito-n-students/usb_cam_hardware.git
- release repository: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## usb_cam_controllers

```
* Port to noetic distro
```

## usb_cam_hardware

```
* Port to noetic distro
```

## usb_cam_hardware_interface

```
* Port to noetic distro
```
