### PR TITLE
codec_image_transport: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -319,6 +319,21 @@ repositories:
       url: https://github.com/mikeferguson/code_coverage.git
       version: master
     status: developed
+  codec_image_transport:
+    doc:
+      type: git
+      url: https://github.com/yoshito-n-students/codec_image_transport.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yoshito-n-students/codec_image_transport-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/codec_image_transport.git
+      version: noetic-devel
+    status: maintained
   common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `codec_image_transport` to `0.0.5-1`:

- upstream repository: https://github.com/yoshito-n-students/codec_image_transport.git
- release repository: https://github.com/yoshito-n-students/codec_image_transport-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## codec_image_transport

```
* Port to noetic distro
```
