### PR TITLE
Pip installed scipy for  rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6108,11 +6108,15 @@ python3-scipy:
   gentoo: [sci-libs/scipy]
   macports: [py37-scipy]
   opensuse: [python3-scipy]
+  ubuntu: [python3-scipy]
+python3-scipy-pip:
   osx:
     pip:
       depends: [gfortran]
       packages: [scipy]
-  ubuntu: [python3-scipy]
+  ubuntu:
+    pip:
+      packages: [scipy]
 python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6108,12 +6108,12 @@ python3-scipy:
   gentoo: [sci-libs/scipy]
   macports: [py37-scipy]
   opensuse: [python3-scipy]
-  ubuntu: [python3-scipy]
-python3-scipy-pip:
   osx:
     pip:
       depends: [gfortran]
       packages: [scipy]
+  ubuntu: [python3-scipy]
+python3-scipy-pip:
   ubuntu:
     pip:
       packages: [scipy]


### PR DESCRIPTION
PyPI version of package are far ahead of the ubuntu/debian apt repository version of `scipy`. Adding a pip installed version for people who need the latest version. Also fixed the existing `scipy` tags to follow the naming convention outlined in https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md

- `PyPI`: https://pypi.org/project/scipy/
- `ubuntu`: https://packages.ubuntu.com/search?keywords=python3-scipy&searchon=names