### PR TITLE
Add additional python3 keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5184,6 +5184,7 @@ postgresql-postgis:
   ubuntu:
     artful: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
     bionic: [postgresql-10-postgis-2.4, postgresql-contrib, postgresql-server-dev-all]
+    focal: [postgresql-12-postgis-3, postgresql-contrib, postgresql-server-dev-all]
     trusty: [postgresql-9.3-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
     xenial: [postgresql-9.5-postgis-2.2, postgresql-contrib, postgresql-server-dev-all]
 potrace:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5403,6 +5403,9 @@ python3-catkin-pkg-modules:
       packages: [catkin-pkg]
   rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg-modules]
+python3-cherrypy3:
+  debian: [python3-cherrypy3]
+  ubuntu: [python3-cherrypy3]
 python3-click:
   debian: [python3-click]
   fedora: [python3-click]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5398,6 +5398,12 @@ python3-collada-pip:
   ubuntu:
     pip:
       packages: [pycollada]
+python3-colorama:
+  debian: [python3-colorama]
+  fedora: [python3-colorama]
+  gentoo: [dev-python/colorama]
+  rhel: ['python%{python3_pkgversion}-colorama']
+  ubuntu: [python3-colorama]
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]
@@ -5517,6 +5523,12 @@ python3-gi:
   fedora: [python3-gobject]
   gentoo: [dev-python/pygobject]
   ubuntu: [python3-gi]
+python3-github:
+  debian: [python3-github]
+  fedora: [python3-github]
+  gentoo: [dev-python/github]
+  rhel: ['python%{python3_pkgversion}-github']
+  ubuntu: [python3-github]
 python3-gitlab:
   debian:
     '*': [python3-gitlab]
@@ -6219,6 +6231,12 @@ python3-termcolor:
   fedora: [python3-termcolor]
   gentoo: [dev-python/termcolor]
   ubuntu: [python3-termcolor]
+python3-texttable:
+  debian: [python3-texttable]
+  fedora: [python3-texttable]
+  gentoo: [dev-python/texttable]
+  rhel: ['python%{python3_pkgversion}-texttable']
+  ubuntu: [python3-texttable]
 python3-tilestache-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5422,6 +5422,9 @@ python3-collada-pip:
   ubuntu:
     pip:
       packages: [pycollada]
+python3-colorama:
+  debian: [python3-colorama]
+  ubuntu: [python3-colorama]
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5529,8 +5529,8 @@ python3-gi:
 python3-github:
   debian: [python3-github]
   fedora: [python3-github]
-  gentoo: [dev-python/github]
-  rhel: ['python%{python3_pkgversion}-github']
+  gentoo: [dev-python/PyGithub]
+  rhel: ['python%{python3_pkgversion}-pygithub']
   ubuntu: [python3-github]
 python3-gitlab:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5660,6 +5660,9 @@ python3-lxml:
       packages: [lxml]
   rhel: ['python%{python3_pkgversion}-lxml']
   ubuntu: [python3-lxml]
+python3-mapnik:
+  debian: [python3-mapnik]
+  ubuntu: [python3-mapnik]
 python3-markdown:
   debian: [python3-markdown]
   fedora: [python3-markdown]


### PR DESCRIPTION
add
- python3-texttable
  - `ubuntu` https://packages.ubuntu.com/focal/python3-texttable
  - `debian` https://packages.debian.org/buster/python3-texttable
  - `gentoo` https://packages.gentoo.org/packages/dev-python/texttable
  - `rhel` https://centos.pkgs.org/8/epel-x86_64/python3-texttable-1.6.2-5.el8.noarch.rpm.html
  - `fedora` https://fedora.pkgs.org/30/fedora-x86_64/python3-texttable-1.4.0-2.fc30.noarch.rpm.html
- python3-github :  Source: https://pypi.python.org/pypi/PyGithub / https://github.com/PyGithub/PyGithub
  - `ubuntu` https://packages.ubuntu.com/focal/python3-github
  - `debian` https://packages.debian.org/buster/python3-github
  - `gentoo` https://packages.gentoo.org/packages/dev-python/PyGithub
  - `rhel` https://centos.pkgs.org/7/epel-x86_64/python36-pygithub-1.39-5.el7.noarch.rpm.html
  - `fedora` https://fedora.pkgs.org/30/fedora-x86_64/python3-github3py-1.0.0-0.10a4.fc30.noarch.rpm.html
- python3-colorama
  - `ubuntu` https://packages.ubuntu.com/focal/python3-colorama
  - `debian` https://packages.debian.org/buster/python3-colorama
  - `gentoo` https://packages.gentoo.org/packages/dev-python/colorama
  - `rhel` https://centos.pkgs.org/8/epel-x86_64/python3-colorama-0.4.3-1.el8.noarch.rpm.html
  - `fedora` https://fedora.pkgs.org/30/fedora-x86_64/python3-colorama-0.4.1-1.fc30.noarch.rpm.html