### PR TITLE
mobile_robot_simulator: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5482,11 +5482,19 @@ repositories:
       version: master
     status: maintained
   mobile_robot_simulator:
+    doc:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nobleo/mobile_robot_simulator-release.git
       version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: master
     status: maintained
   mongodb_store:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5481,6 +5481,13 @@ repositories:
       url: https://github.com/astuff/ml_classifiers.git
       version: master
     status: maintained
+  mobile_robot_simulator:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/mobile_robot_simulator-release.git
+      version: 1.0.1-1
+    status: maintained
   mongodb_store:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mobile_robot_simulator` to `1.0.1-1`:

- upstream repository: https://github.com/nobleo/mobile_robot_simulator.git
- release repository: https://github.com/nobleo/mobile_robot_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
