### PR TITLE
nodl: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1073,7 +1073,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/canonical/nodl-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodl` to `0.2.0-1`:

- upstream repository: https://github.com/ubuntu-robotics/nodl.git
- release repository: https://github.com/canonical/nodl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-1`

## nodl_python

```
* strip qos from nodl_python (will re-add later)
* test all packages and use codecov
* fix schemas not being exported for lookup in other packages
* Contributors: Kyle Fazzari, Ted Kern
```

## ros2nodl

```
* strip qos from nodl_python (will re-add later)
* test all packages and use codecov
* Contributors: Kyle Fazzari, Ted Kern
```
