### PR TITLE
rmw_connext: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1443,7 +1443,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## rmw_connext_cpp

```
* Ensure compliant init/shutdown API implementation. (#432 <https://github.com/ros2/rmw_connext/issues/432>)
* Ensure compliant init options API implementations. (#431 <https://github.com/ros2/rmw_connext/issues/431>)
* Finalize context if and only if it's shutdown (#428 <https://github.com/ros2/rmw_connext/issues/428>)
* Contributors: Michel Hidalgo
```

## rmw_connext_shared_cpp

```
* Handle RMW_DEFAULT_DOMAIN_ID. (#427 <https://github.com/ros2/rmw_connext/issues/427>)
* Contributors: Michel Hidalgo
```
