### PR TITLE
rmw_fastrtps: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1497,7 +1497,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.0.1-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-2`

## rmw_fastrtps_cpp

```
* Ensure compliant init/shutdown API implementation. (#401 <https://github.com/ros2/rmw_fastrtps/issues/401>)
* Update Quality Declaration to QL3. (#403 <https://github.com/ros2/rmw_fastrtps/issues/403>)
* Finalize context iff shutdown. (#396 <https://github.com/ros2/rmw_fastrtps/issues/396>)
* Make service wait for response reader (#390 <https://github.com/ros2/rmw_fastrtps/issues/390>)
* Contributors: Michel Hidalgo, Miguel Company
```

## rmw_fastrtps_dynamic_cpp

```
* Ensure compliant init/shutdown API implementation. (#401 <https://github.com/ros2/rmw_fastrtps/issues/401>)
* Finalize context iff shutdown. (#396 <https://github.com/ros2/rmw_fastrtps/issues/396>)
* Make service wait for response reader (#390 <https://github.com/ros2/rmw_fastrtps/issues/390>)
* Contributors: Michel Hidalgo, Miguel Company
```

## rmw_fastrtps_shared_cpp

```
* Do not use string literals as implementation identifiers in tests. (#402 <https://github.com/ros2/rmw_fastrtps/issues/402>)
* Ensure compliant init options API implementations. (#399 <https://github.com/ros2/rmw_fastrtps/issues/399>)
* Finalize context iff shutdown. (#396 <https://github.com/ros2/rmw_fastrtps/issues/396>)
* Handle RMW_DEFAULT_DOMAIN_ID. (#394 <https://github.com/ros2/rmw_fastrtps/issues/394>)
* Make service wait for response reader (#390 <https://github.com/ros2/rmw_fastrtps/issues/390>)
* Contributors: Michel Hidalgo, Miguel Company
```
