### PR TITLE
navigation2: 0.3.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1318,7 +1318,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.3.5-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.4-1`
