### PR TITLE
nmc_nlp_lite-release: 0.0.7-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6235,6 +6235,22 @@ repositories:
       type: git
       url: https://github.com/NiryoRobotics/niryo_one_ros_simulation.git
       version: master
+  nmc_nlp_lite-release:
+    doc:
+      type: git
+      url: https://github.com/nmcbins/nmc_nlp_lite_ros.git
+      version: master
+    release:
+      packages:
+      - nmc_nlp_lite
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
+      version: 0.0.7-2
+    source:
+      type: git
+      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
+      version: master
   nmea_comms:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6235,7 +6235,7 @@ repositories:
       type: git
       url: https://github.com/NiryoRobotics/niryo_one_ros_simulation.git
       version: master
-  nmc_nlp_lite-release:
+  nmc_nlp_lite_ros:
     doc:
       type: git
       url: https://github.com/nmcbins/nmc_nlp_lite_ros.git
@@ -6249,7 +6249,7 @@ repositories:
       version: 0.0.7-2
     source:
       type: git
-      url: https://github.com/nmcbins/nmc_nlp_lite-release.git
+      url: https://github.com/nmcbins/nmc_nlp_lite_ros.git
       version: master
   nmea_comms:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `nmc_nlp_lite-release` to `0.0.7-2`:

- upstream repository: https://github.com/nmcbins/nmc_nlp_lite_ros.git
- release repository: https://github.com/nmcbins/nmc_nlp_lite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
