### PR TITLE
srdfdom: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10761,7 +10761,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
-      version: 0.5.1-0
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.5.2-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.1-0`

## srdfdom

```
* [maint]  Modernize Travis config (#57 <https://github.com/ros-planning/srdfdom/issues/57>)
* [maint]  Modernize package.xml
* [maint]  Modernize python (python2 / python3 compatibility)
* [maint]  Modernize cmake and setup.py
* [maint]  Fix unittest
* [maint]  Use [[deprecated]] for better portability (#47 <https://github.com/ros-planning/srdfdom/issues/47>)
* [maint]  Travis: enable ccache
* [maint]  Fix catkin_lint issues
* [maint]  Format code with clang-format (#42 <https://github.com/ros-planning/srdfdom/issues/42>, #43 <https://github.com/ros-planning/srdfdom/issues/43>)
* [bugfix] Parse group's robot states with C locale (#44 <https://github.com/ros-planning/srdfdom/issues/44>)
* [bugfix] Trigger error in case of SRDF syntax error (#41 <https://github.com/ros-planning/srdfdom/issues/41>)
* Contributors: Alejandro Hernández Cordero, Dave Coleman, Jonathan Binney, Michael Görner, Robert Haschke, Sean Yen, Simon Schmeisser, kkufieta
```
