### PR TITLE
mir_robot: 1.0.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7489,7 +7489,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.0.6-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.5-1`

## mir_actions

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## mir_description

```
* Update to non-deprecated robot_state_publisher node
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## mir_driver

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## mir_dwb_critics

```
* Add missing matplotlib dependency
* Fix some catkin_lint warnings
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## mir_gazebo

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## mir_msgs

```
* Fix some catkin_lint warnings
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## mir_navigation

```
* Add missing matplotlib dependency
* plot_mprim: Fix color display
* Fix bug in genmprim_unicycle_highcost_5cm
  In Python3, np.arange doesn't accept floats.
* Fix some catkin_lint warnings
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## mir_robot

```
* Set cmake_policy CMP0048 to fix warning
* Add sdc21x0 dependency to mir_robot meta package
* Contributors: Martin Günther
```

## sdc21x0

```
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```
