### PR TITLE
mir_robot: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1615,6 +1615,32 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: noetic-devel
     status: maintained
+  mir_robot:
+    doc:
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: noetic
+    release:
+      packages:
+      - mir_actions
+      - mir_description
+      - mir_driver
+      - mir_dwb_critics
+      - mir_gazebo
+      - mir_msgs
+      - mir_navigation
+      - mir_robot
+      - sdc21x0
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/uos-gbp/mir_robot-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dfki-ric/mir_robot.git
+      version: noetic
+    status: developed
   move_base_flex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.0-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## mir_actions

```
* Initial release into noetic
* Contributors: Martin Günther
```

## mir_description

```
* Initial release into noetic
* Contributors: Martin Günther
```

## mir_driver

```
* Initial release into noetic
* Adapt to changes in websocket-client >= 0.49
  Ubuntu 16.04 has python-websocket  0.18
  Ubuntu 20.04 has python3-websocket 0.53
* Update scripts to Python3 (Noetic)
* Contributors: Martin Günther
```

## mir_dwb_critics

```
* Initial release into noetic
* Update scripts to Python3 (Noetic)
* Contributors: Martin Günther
```

## mir_gazebo

```
* Initial release into noetic
* Contributors: Martin Günther
```

## mir_msgs

```
* Initial release into noetic
* Contributors: Martin Günther
```

## mir_navigation

```
* Initial release into noetic
* Remove hector_mapping dependency (not released in noetic)
* Update scripts to Python3 (Noetic)
* Contributors: Martin Günther
```

## mir_robot

```
* Initial release into noetic
* Contributors: Martin Günther
```

## sdc21x0

```
* Initial release into noetic
* Contributors: Martin Günther
```
