### PR TITLE
Move ros2/kdl_parser -> ros/kdl_parser

### DIFF
--- a/ardent/distribution.yaml
+++ b/ardent/distribution.yaml
@@ -344,7 +344,7 @@ repositories:
       version: 2.0.0-0
     source:
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: ardent
     status: maintained
   launch:

--- a/bouncy/distribution.yaml
+++ b/bouncy/distribution.yaml
@@ -542,7 +542,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: bouncy
     status: maintained
   laser_geometry:

--- a/crystal/distribution.yaml
+++ b/crystal/distribution.yaml
@@ -732,7 +732,7 @@ repositories:
   kdl_parser:
     doc:
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: crystal
     release:
       tags:
@@ -742,7 +742,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: crystal
     status: developed
   keystroke:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1175,7 +1175,7 @@ repositories:
   kdl_parser:
     doc:
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: dashing
     release:
       tags:
@@ -1185,7 +1185,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: dashing
     status: maintained
   kinesis_manager:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -978,7 +978,7 @@ repositories:
   kdl_parser:
     doc:
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: eloquent
     release:
       tags:
@@ -988,7 +988,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: eloquent
     status: maintained
   kobuki_core:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -809,7 +809,7 @@ repositories:
   kdl_parser:
     doc:
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: foxy
     release:
       tags:
@@ -819,7 +819,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: foxy
     status: maintained
   laser_geometry:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -786,7 +786,7 @@ repositories:
   kdl_parser:
     doc:
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: ros2
     release:
       tags:
@@ -796,7 +796,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/kdl_parser.git
+      url: https://github.com/ros/kdl_parser.git
       version: ros2
     status: maintained
   laser_geometry:


### PR DESCRIPTION
`ros2/kdl_parser` is being recombined with `ros/kdl_parser`.