### PR TITLE
octomap: 1.9.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1079,6 +1079,25 @@ repositories:
       url: https://github.com/ubuntu-robotics/nodl.git
       version: master
     status: developed
+  octomap:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: master
+    release:
+      packages:
+      - dynamic_edt_3d
+      - octomap
+      - octovis
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/octomap-release.git
+      version: 1.9.5-1
+    source:
+      type: git
+      url: https://github.com/octomap/octomap.git
+      version: devel
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap` to `1.9.5-1`:

- upstream repository: https://github.com/OctoMap/octomap.git
- release repository: https://github.com/ros-gbp/octomap-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
