### PR TITLE
Enable test_abi for Foxy: ament_index, rcl, rcl_interfaces, rcpputils, rmw, rosidl

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -76,6 +76,7 @@ repositories:
       url: https://github.com/ros2-gbp/ament_index-release.git
       version: 1.0.0-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_index.git
@@ -1285,6 +1286,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcl-release.git
       version: 1.1.5-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
@@ -1310,6 +1312,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
       version: 1.0.0-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
@@ -1402,6 +1405,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcpputils-release.git
       version: 1.1.0-1
     source:
+      test_abi: true
       type: git
       url: https://github.com/ros2/rcpputils.git
       version: foxy
@@ -1474,6 +1478,7 @@ repositories:
       url: https://github.com/ros2-gbp/rmw-release.git
       version: 1.0.1-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw.git
@@ -1809,6 +1814,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosidl-release.git
       version: 1.0.1-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl.git


### PR DESCRIPTION
First set of packages to enable ABI on Foxy under the works of quality levels.

//cc @chapulina 