### PR TITLE
rosbag_uploader: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9196,6 +9196,27 @@ repositories:
       url: https://github.com/ros/rosbag_snapshot.git
       version: main
     status: maintained
+  rosbag_uploader:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/rosbag-uploader-ros1.git
+      version: master
+    release:
+      packages:
+      - file_uploader_msgs
+      - recorder_msgs
+      - rosbag_cloud_recorders
+      - s3_common
+      - s3_file_uploader
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/aws-gbp/rosbag_uploader-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/aws-robotics/rosbag-uploader-ros1.git
+      version: master
+    status: maintained
   rosbash_params:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_uploader` to `1.0.0-1`:

- upstream repository: https://github.com/aws-robotics/rosbag-uploader-ros1.git
- release repository: https://github.com/aws-gbp/rosbag_uploader-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
