### PR TITLE
Add zmq for Ubuntu 20.04

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5272,6 +5272,7 @@ python-zmq:
   gentoo: [dev-python/pyzmq]
   ubuntu:
     '*': [python-zmq]
+    focal: [python3-zmq]
     trusty_python3: [python3-zmq]
 python3:
   debian: [python3-dev]


### PR DESCRIPTION
Add zmq entry for Ubuntu 20.04 (focal)