### PR TITLE
octomap_msgs: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1098,6 +1098,21 @@ repositories:
       url: https://github.com/octomap/octomap.git
       version: devel
     status: maintained
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros-gbp/octomap_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## octomap_msgs

```
* Change version to 2.0.0 for ROS2; update maintainer
* Porting to ROS2, based on ROS version 0.3.3 #13 <https://github.com/OctoMap/octomap_msgs/pull/13>
* Contributors: Yan Yu, Ibai Apellaniz, Henning Kayser, Wolfgang Merkt
```
