### PR TITLE
multisense_ros: 4.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1746,6 +1746,28 @@ repositories:
       url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
       version: master
     status: maintained
+  multisense_ros:
+    doc:
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
+    release:
+      packages:
+      - multisense
+      - multisense_bringup
+      - multisense_cal_check
+      - multisense_description
+      - multisense_lib
+      - multisense_ros
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
+      version: 4.0.4-1
+    source:
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `4.0.4-1`:

- upstream repository: https://github.com/carnegierobotics/multisense_ros.git
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## multisense

```
* update release to reference github instead of bitbucket
```

## multisense_bringup

```
* update release to reference github instead of bitbucket
```

## multisense_cal_check

```
* update release to reference github instead of bitbucket
```

## multisense_description

```
* update release to reference github instead of bitbucket
```

## multisense_lib

```
* update release to reference github instead of bitbucket
```

## multisense_ros

```
* update release to reference github instead of bitbucket
```
