### PR TITLE
rosbag_uploader: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9211,7 +9211,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/rosbag_uploader-release.git
-      version: 1.0.0-3
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/aws-robotics/rosbag-uploader-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_uploader` to `1.0.1-1`:

- upstream repository: https://github.com/aws-robotics/rosbag-uploader-ros1.git
- release repository: https://github.com/aws-gbp/rosbag_uploader-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-3`

## file_uploader_msgs

```
* Address build error on ROS buildfarm (#135 <https://github.com/aws-robotics/rosbag-uploader-ros1/issues/135>)
  try to fix buildfarm build error and iterate on bloom release
* Contributors: Miaofei Mei
```

## recorder_msgs

```
* Address build error on ROS buildfarm (#135 <https://github.com/aws-robotics/rosbag-uploader-ros1/issues/135>)
  try to fix buildfarm build error and iterate on bloom release
* Contributors: Miaofei Mei
```

## rosbag_cloud_recorders

```
* Address build error on ROS buildfarm (#135 <https://github.com/aws-robotics/rosbag-uploader-ros1/issues/135>)
  try to fix buildfarm build error and iterate on bloom release
* Contributors: Miaofei Mei
```

## s3_common

```
* Address build error on ROS buildfarm (#135 <https://github.com/aws-robotics/rosbag-uploader-ros1/issues/135>)
  try to fix buildfarm build error and iterate on bloom release
* Contributors: Miaofei Mei
```

## s3_file_uploader

```
* Address build error on ROS buildfarm (#135 <https://github.com/aws-robotics/rosbag-uploader-ros1/issues/135>)
  try to fix buildfarm build error and iterate on bloom release
* Contributors: Miaofei Mei
```
