### PR TITLE
  multisense_ros: 4.0.4-1 in 'kinetic/distribution.yaml' and 'melodic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8073,9 +8073,9 @@ repositories:
     status: developed
   multisense_ros:
     doc:
-      type: hg
-      url: https://bitbucket.org/crl/multisense_ros
-      version: default
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
     release:
       packages:
       - multisense
@@ -8087,11 +8087,11 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 4.0.0-0
+      version: 4.0.4-1
     source:
-      type: hg
-      url: https://bitbucket.org/crl/multisense_ros
-      version: default
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
     status: maintained
   multiwii:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5898,9 +5898,9 @@ repositories:
     status: maintained
   multisense_ros:
     doc:
-      type: hg
-      url: https://bitbucket.org/crl/multisense_ros
-      version: default
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
     release:
       packages:
       - multisense
@@ -5912,11 +5912,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 4.0.3-1
+      version: 4.0.4-1
     source:
-      type: hg
-      url: https://bitbucket.org/crl/multisense_ros
-      version: default
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
     status: maintained
   mvsim:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1746,6 +1746,28 @@ repositories:
       url: https://github.com/praveen-palanisamy/multiple-object-tracking-lidar.git
       version: master
     status: maintained
+  multisense_ros:
+    doc:
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
+    release:
+      packages:
+      - multisense
+      - multisense_bringup
+      - multisense_cal_check
+      - multisense_description
+      - multisense_lib
+      - multisense_ros
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
+      version: 4.0.4-1
+    source:
+      type: git
+      url: https://github.com/carnegierobotics/multisense_ros.git
+      version: master
+    status: maintained
   navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository multisense_ros to 4.0.4-1:

- upstream repository: https://github.com/carnegierobotics/multisense_ros.git
- release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git
- distro files `kinetic/distribution.yaml` `melodic/distribution.yaml`


## multisense                                                                                                                                                                                                                                                                                                                

```
* update release to reference github instead of bitbucket
```

## multisense_bringup

```
* update release to reference github instead of bitbucket
```

## multisense_cal_check

```
* update release to reference github instead of bitbucket
```

## multisense_description

```
* update release to reference github instead of bitbucket
```

## multisense_lib

```
* update release to reference github instead of bitbucket
```

## multisense_ros

```
* update release to reference github instead of bitbucket
```
