### PR TITLE
neonavigation: 0.9.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8528,7 +8528,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.8.8-1
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.9.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.8-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

- No changes

## safety_limiter

```
* safety_limiter: make safety_limiter dynamic-reconfigurable (#509 <https://github.com/at-wat/neonavigation/issues/509>)
* Contributors: Naotaka Hatao
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
