### PR TITLE
mobile_robot_simulator: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1656,6 +1656,21 @@ repositories:
       url: https://github.com/dfki-ric/mir_robot.git
       version: noetic
     status: developed
+  mobile_robot_simulator:
+    doc:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/mobile_robot_simulator-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: master
+    status: maintained
   move_base_flex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mobile_robot_simulator` to `1.0.1-1`:

- upstream repository: https://github.com/nobleo/mobile_robot_simulator.git
- release repository: https://github.com/nobleo/mobile_robot_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
