### PR TITLE
pilz_robots: 0.5.18-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7234,7 +7234,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.17-1
+      version: 0.5.18-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.18-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.17-1`

## pilz_control

```
* Make AsyncTest header-only
* Extends robot mock
* Fixes result of follow_joint_trajectory action
* Rename triggerCancellingOfActiveGoal() -> cancelActiveGoal()
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_status_indicator_rqt

- No changes

## pilz_testutils

```
* Make AsyncTest header-only
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Make AsyncTest header-only
* Move modbus connection checker function in separate file
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

- No changes

## prbt_support

```
* Make AsyncTest header-only
* Contributors: Pilz GmbH and Co. KG
```
