### PR TITLE
carla_msgs: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -959,7 +959,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/carla-simulator/ros-carla-msgs-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `carla_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/carla-simulator/ros-carla-msgs.git
- release repository: https://github.com/carla-simulator/ros-carla-msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-1`
