### PR TITLE
sick_scan: 1.7.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14722,7 +14722,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 1.6.0-1
+      version: 1.7.6-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `1.7.6-1`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.6.0-1`
