### PR TITLE
Add yamale to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5220,6 +5220,12 @@ python-xmltodict:
     yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
 python-yamale-pip:
+  debian:
+    pip:
+      packages: [yamale]
+  fedora:
+    pip:
+      packages: [yamale]
   ubuntu:
     pip:
       packages: [yamale]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5219,6 +5219,10 @@ python-xmltodict:
     xenial: [python-xmltodict]
     yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
+python-yamale-pip:
+  ubuntu:
+    pip:
+      packages: [yamale]
 python-yaml:
   alpine: [py-yaml]
   arch: [python2-yaml]


### PR DESCRIPTION
Hello, I'd like to add a key for a pip package called Yamale (https://pypi.org/project/yamale/).

Yamale is a schema and validator for yaml; it's handy for making sure that the yaml files that I `rosparam load` contain the configs that I expect and that they're the correct datatype and things like that.

I'm pretty sure this PR conforms to the guidelines in CONTRIBUTING.md, I've run the nosetests and tested locally so hopefully these changes are ok, please let me know if I've missed anything. Thanks!