### PR TITLE
psen_scan: 1.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7710,7 +7710,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan` to `1.0.5-1`:

- upstream repository: https://github.com/PilzDE/psen_scan.git
- release repository: https://github.com/PilzDE/psen_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.4-1`

## psen_scan

```
* Add coverage check to travis ci and switches to cmake version 2.8.12
* Rename all test-files and move into subfolders
* Update README
* Remove ros parameters 'publish_topic' and 'node_name'.
* Add integrationtest to test correct publishing of scan topic.
* Change Rviz config to some common values
* Add new acceptance test for psen_scan.
* Add travis job for clang-format
* Contributors: Pilz GmbH & Co KG
```
