### PR TITLE
control_msgs: 2.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/control_msgs-release.git
-      version: 2.3.0-3
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `2.4.0-1`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros-gbp/control_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.0-3`

## control_msgs

```
* Add std_msgs prefix path to header
* Add JointJog msg to ROS 2 - foxy
* Contributors: AdamPettinger, AndyZe
```
