### PR TITLE
realtime_tools: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1521,6 +1521,21 @@ repositories:
       url: https://github.com/ros2/realtime_support.git
       version: foxy
     status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: foxy-devel
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.1.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros-gbp/realtime_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## realtime_tools

```
* fix msbuild warning
* address linter failures
* enable linters
* avoid deprecations
* Realtime server goal thread handle safety + additional warning fixes (#2 <https://github.com/ros-controls/realtime_tools/issues/2>) (#57 <https://github.com/ros-controls/realtime_tools/issues/57>)
  * Made code thread safe, fixed warnings with repeated aborts/success/cancels
  Fixed -reorder warning
  Early return
  * removed atomic
  * removed unneeded header
* use template instead
* use std::atomic instead of volatile
* Contributors: Karsten Knese, Yutaka Kondo, ddengster
```
