### PR TITLE
xacro: 1.14.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4126,7 +4126,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.2-1
+      version: 1.14.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.3-2`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.14.2-1`

## xacro

```
* [feature] Improve warnings
  - Unify meaning of verbosity > 0 (to print file location)
  - Provide file location on warning in check_attrs()
  - Issue warning on child elements of <xacro:include> tag
* [feature] Allow dotted access to yaml-loaded dicts: d.key1.key2.key3 (#245 <https://github.com/ros/xacro/issues/245>)
* [maint]   Travis: Update distro to Bionic
* Contributors: Robert Haschke, G.A. vd. Hoorn
```
