### PR TITLE
power_msgs: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2240,6 +2240,20 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: lunar-devel
     status: maintained
+  power_msgs:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/power_msgs.git
+      version: ros1
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/power_msgs-release.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/power_msgs.git
+      version: ros1
   pybind11_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `power_msgs` to `0.4.1-1`:

- upstream repository: https://github.com/fetchrobotics/power_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/power_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## power_msgs

```
* updates maintainers
* Contributors: Alex Moriarty, Russell Toris
```
