### PR TITLE
vision_msgs: 0.0.1-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4044,6 +4044,22 @@ repositories:
       url: https://github.com/yoshito-n-students/usb_cam_hardware.git
       version: noetic-devel
     status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: noetic-devel
+    status: maintained
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
I'm not sure why I had to do this manually; bloom was unable to create an OAuth token to create this PR.

Increasing version of package(s) in repository vision_msgs to 0.0.1-1:

- upstream repository: `https://github.com/Kukanani/vision_msgs.git`
- release repository: `https://github.com/Kukanani/vision_msgs.git`
- distro file: `noetic/distribution.yaml`
- bloom version: 0.9.7
    previous version for package: `null`