### PR TITLE
ros: 1.15.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2588,7 +2588,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.4-1
+      version: 1.15.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.5-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.15.4-1`

## mk

- No changes

## rosbash

```
* fix for sourcing rosfish (#262 <https://github.com/ros/ros/issues/262>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

```
* fix size output of 'rosclean check' (#266 <https://github.com/ros/ros/issues/266>)
* fix subparsers of rosclean (#265 <https://github.com/ros/ros/issues/265>)
```

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

- No changes
