### PR TITLE
oxford_gps_eth: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2097,6 +2097,21 @@ repositories:
       url: https://github.com/ros-perception/openslam_gmapping.git
       version: melodic-devel
     status: unmaintained
+  oxford_gps_eth:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
+      version: master
+    status: maintained
   p2os:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `1.2.0-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## oxford_gps_eth

```
* Use setuptools instead of distutils for python
  http://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Add flexibility to change GGA topic and broadcast IP for NTRIP forwarding
* Fix local frame covariance calculation
* Use cached standard deviation values instead of raw packet values because those values are multiplexed into several packets
* Add quality check of standard deviation values
* Print debugging info with ROS_DEBUG()
* Change BUILD_ASSERT() to std_assert()
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```
