### PR TITLE
oxford_gps_eth: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6925,7 +6925,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `1.2.0-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.1-1`

## oxford_gps_eth

```
* Use setuptools instead of distutils for python
  http://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Add flexibility to change GGA topic and broadcast IP for NTRIP forwarding
* Fix local frame covariance calculation
* Use cached standard deviation values instead of raw packet values because those values are multiplexed into several packets
* Add quality check of standard deviation values
* Print debugging info with ROS_DEBUG()
* Change BUILD_ASSERT() to std_assert()
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```
