### PR TITLE
fadecandy_ros: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -681,7 +681,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/iron-ox/fadecandy_ros-release.git
-      version: 0.1.1-2
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/iron-ox/fadecandy_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `0.1.2-1`:

- upstream repository: https://github.com/iron-ox/fadecandy_ros.git
- release repository: https://github.com/iron-ox/fadecandy_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.1-2`

## fadecandy_driver

```
* Merge pull request #10 <https://github.com/iron-ox/fadecandy_ros/issues/10> from eurogroep/chore/log-io-error
  chore: log IO error
* Merge pull request #9 <https://github.com/iron-ox/fadecandy_ros/issues/9> from eurogroep/fix/rospy-shutdown
  fix(shutdown): Shutdown gracefully when no connection was set-up
* Contributors: Rein Appeldoorn
```

## fadecandy_msgs

- No changes
