### PR TITLE
auv_msgs: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -830,7 +830,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/oceansystemslab/auv_msgs-release.git
-      version: 0.1.0-0
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/oceansystemslab/auv_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `auv_msgs` to `0.1.1-1`:

- upstream repository: https://github.com/oceansystemslab/auv_msgs.git
- release repository: https://github.com/oceansystemslab/auv_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-0`

## auv_msgs

```
* Bump CMake version to prevent CMP0048
* Contributors: Bence Magyar
```
