### PR TITLE
joystick_drivers: 1.14.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1250,6 +1250,27 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: noetic-devel
     status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: master
+    release:
+      packages:
+      - joy
+      - joystick_drivers
+      - ps3joy
+      - spacenav_node
+      - wiimote
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/joystick_drivers-release.git
+      version: 1.14.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: master
+    status: maintained
   jsk_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.14.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## joy

```
* frame_id in the header of the joystick msg (#166 <https://github.com/ros-drivers/joystick_drivers/issues/166>)
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Merge pull request #158 <https://github.com/ros-drivers/joystick_drivers/issues/158> from clalancette/ros1-cleanups
  ROS1 joy cleanups
* Greatly simplify the sticky_buttons support.
* Small fixes to rumble support.
* Use C++ style casts.
* Use empty instead of length.
* joy_def_ff -> joy_dev_ff
* Cleanup header includes.
* Use size_t appropriately.
* NULL -> nullptr everywhere.
* Style cleanup in joy_node.cpp.
* Merge pull request #154 <https://github.com/ros-drivers/joystick_drivers/issues/154> from zchen24/master
  Minor: moved default to right indent level
* Contributors: Chris Lalancette, Joshua Whitley, Mamoun Gharbi, Zihan Chen
```

## joystick_drivers

```
* Update master to target Noetic (#173 <https://github.com/ros-drivers/joystick_drivers/issues/173>)
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Joshua Whitley
```

## ps3joy

```
* Fixing linter errors for Noetic. (#174 <https://github.com/ros-drivers/joystick_drivers/issues/174>)
* Make sure to import struct where it is used. (#162 <https://github.com/ros-drivers/joystick_drivers/issues/162>)
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Chris Lalancette, Joshua Whitley
```

## spacenav_node

```
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Joshua Whitley
```

## wiimote

```
* Fixing linter errors for Noetic. (#174 <https://github.com/ros-drivers/joystick_drivers/issues/174>)
* Update master to target Noetic (#173 <https://github.com/ros-drivers/joystick_drivers/issues/173>)
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Joshua Whitley
```
