### PR TITLE
joystick_drivers: 1.14.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4253,7 +4253,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.13.0-1
+      version: 1.14.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.14.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.13.0-1`

## joy

```
* frame_id in the header of the joystick msg (#166 <https://github.com/ros-drivers/joystick_drivers/issues/166>)
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Merge pull request #158 <https://github.com/ros-drivers/joystick_drivers/issues/158> from clalancette/ros1-cleanups
  ROS1 joy cleanups
* Greatly simplify the sticky_buttons support.
* Small fixes to rumble support.
* Use C++ style casts.
* Use empty instead of length.
* joy_def_ff -> joy_dev_ff
* Cleanup header includes.
* Use size_t appropriately.
* NULL -> nullptr everywhere.
* Style cleanup in joy_node.cpp.
* Merge pull request #154 <https://github.com/ros-drivers/joystick_drivers/issues/154> from zchen24/master
  Minor: moved default to right indent level
* Contributors: Chris Lalancette, Joshua Whitley, Mamoun Gharbi, Zihan Chen
```

## joystick_drivers

```
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Joshua Whitley
```

## ps3joy

```
* Make sure to import struct where it is used. (#162 <https://github.com/ros-drivers/joystick_drivers/issues/162>)
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Chris Lalancette, Joshua Whitley
```

## spacenav_node

```
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Joshua Whitley
```

## wiimote

```
* roslint and Generic Clean-Up (#161 <https://github.com/ros-drivers/joystick_drivers/issues/161>)
* Contributors: Joshua Whitley
```
