### PR TITLE
auv_msgs: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -122,6 +122,21 @@ repositories:
       url: https://github.com/ros-drivers/audio_common.git
       version: master
     status: maintained
+  auv_msgs:
+    doc:
+      type: git
+      url: https://github.com/oceansystemslab/auv_msgs.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/oceansystemslab/auv_msgs-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/oceansystemslab/auv_msgs.git
+      version: noetic-devel
+    status: maintained
   avt_vimba_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `auv_msgs` to `0.1.1-1`:

- upstream repository: https://github.com/oceansystemslab/auv_msgs.git
- release repository: https://github.com/oceansystemslab/auv_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## auv_msgs

```
* Bump CMake version to prevent CMP0048
* Contributors: Bence Magyar
```
