### PR TITLE
Add connexion to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5437,6 +5437,16 @@ python3-colorama:
   gentoo: [dev-python/colorama]
   rhel: ['python%{python3_pkgversion}-colorama']
   ubuntu: [python3-colorama]
+python3-connexion:
+  debian:
+    pip:
+      packages: [connexion]
+  fedora:
+    pip:
+      packages: [connexion]
+  ubuntu:
+    pip:
+      packages: [connexion]
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5437,7 +5437,7 @@ python3-colorama:
   gentoo: [dev-python/colorama]
   rhel: ['python%{python3_pkgversion}-colorama']
   ubuntu: [python3-colorama]
-python3-connexion:
+python3-connexion-pip:
   debian:
     pip:
       packages: [connexion]


### PR DESCRIPTION
I'd like to add a key for a pip package named connexion (https://connexion.readthedocs.io/en/latest/index.html).

Connexion is a framework on top of Flask that automagically handles HTTP requests defined using OpenAPI (formerly known as Swagger), supporting both v2.0 and v3.0 of the specification.

It's nice to write REST Interfaces for ROS applications.

``nostests`` runs successfully.