### PR TITLE
sbg_driver: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2365,6 +2365,20 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: foxy
     status: maintained
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: 1.0.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: master
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `1.0.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros2.git
- release repository: https://github.com/SBG-Systems/sbg_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## sbg_driver

```
* First version
```
