### PR TITLE
xv_11_laser_driver: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4244,6 +4244,17 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: noetic-devel
     status: maintained
+  xv_11_laser_driver:
+    doc:
+      type: git
+      url: https://github.com/rohbotics/xv_11_laser_driver.git
+      version: 0.3.0
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rohbotics/xv_11_laser_driver-release.git
+      version: 0.3.0-1
+    status: maintained
   yp-spur:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xv_11_laser_driver` to `0.3.0-1`:

- upstream repository: https://github.com/rohbotics/xv_11_laser_driver.git
- release repository: https://github.com/rohbotics/xv_11_laser_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## xv_11_laser_driver

```
* update default firmware_version to 2
* Contributors: Rohan Agrawal
```
