### PR TITLE
tango_icons_vendor: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2427,6 +2427,11 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
       version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/tango_icons_vendor.git
+      version: master
+    status: maintained
   teleop_twist_joy:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2421,6 +2421,12 @@ repositories:
       url: https://github.com/ros2/system_tests.git
       version: foxy
     status: developed
+  tango_icons_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
+      version: 0.0.1-1
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_icons_vendor` to `0.0.1-1`:

- upstream repository: https://github.com/ros-visualization/tango_icons_vendor.git
- release repository: https://github.com/ros2-gbp/tango_icons_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## tango_icons_vendor

```
* Added common linters (#7 <https://github.com/ros-visualization/tango_icons_vendor/issues/7>)
  * Added common linters
  * Fixed license in package.xml
* Remaned package qt_gui_icons -> tango_icons_vendor (#4 <https://github.com/ros-visualization/tango_icons_vendor/issues/4>)
  * Remaned package qt_gui_icons -> tango_icons_vendor
  * Updated CMake var to install tango icons: INSTALL_TANGO_ICONS
  * Added cmake option INSTALL_TANGO_ICONS
  * Fixed logic
  * set INSTALL_TANGO_ICONS_DEFAULT_VALUE to option
  * Make linters happy
* Updated link on the description (#6 <https://github.com/ros-visualization/tango_icons_vendor/issues/6>)
* Updated the maintainer (#5 <https://github.com/ros-visualization/tango_icons_vendor/issues/5>)
* Version 0.0.0 this package was never released (#3 <https://github.com/ros-visualization/tango_icons_vendor/issues/3>)
* Install icons by default on macOS too (#1 <https://github.com/ros-visualization/tango_icons_vendor/issues/1>)
* Updating package.xml
* fixup! Install tango icons
* Adding icons
* Install tango icons
* Contributors: Alejandro Hernández Cordero, Stephen, Stephen Brawner
```
