### PR TITLE
plotjuggler: 2.8.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7315,7 +7315,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.8.1-1
+      version: 2.8.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.8.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.8.1-1`

## plotjuggler

```
* might fix issue #301 <https://github.com/facontidavide/PlotJuggler/issues/301>
* fix warnings
* fix potential mutex problem related to #300 <https://github.com/facontidavide/PlotJuggler/issues/300>
* bug fix
* Update package.xml
* updated gif
* cherry picking changes from #290 <https://github.com/facontidavide/PlotJuggler/issues/290>
* fix #296 <https://github.com/facontidavide/PlotJuggler/issues/296>
* fix issues on windows Qt 5.15
* fix error
* move StatePublisher to tf2
* revert changes
* fix warnings
* Contributors: Davide Faconti
```
