### PR TITLE
plotjuggler: 2.8.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2269,11 +2269,12 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.8.0-1
+      version: 2.8.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
       version: master
+    status: maintained
   plotjuggler_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.8.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.8.0-1`

## plotjuggler

```
* might fix issue #301 <https://github.com/facontidavide/PlotJuggler/issues/301>
* fix warnings
* fix potential mutex problem related to #300 <https://github.com/facontidavide/PlotJuggler/issues/300>
* bug fix
* Update package.xml
* updated gif
* cherry picking changes from #290 <https://github.com/facontidavide/PlotJuggler/issues/290>
* fix #296 <https://github.com/facontidavide/PlotJuggler/issues/296>
* fix issues on windows Qt 5.15
* fix error
* move StatePublisher to tf2
* revert changes
* fix warnings
* Contributors: Davide Faconti
```
