### PR TITLE
dataspeed_can: 1.0.16-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2326,7 +2326,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.15-1
+      version: 1.0.16-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `1.0.16-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.15-1`

## dataspeed_can

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_msg_filters

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_tools

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Fix processing bags with DBC files for extended CAN IDs
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_usb

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Contributors: Kevin Hallenbeck
```
