### PR TITLE
WIP: random_numbers: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1350,6 +1350,21 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: foxy-devel
     status: maintained
+  random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: 1.0.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: ros2
+    status: maintained
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `1.0.0-1`:

- upstream repository: https://github.com/ros-planning/random_numbers.git
- release repository: https://github.com/ros-gbp/random_numbers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## random_numbers

```
* Fix ROS2 port (#18 <https://github.com/ros-planning/random_numbers/issues/18>)
* Update Travis for ROS2 (#14 <https://github.com/ros-planning/random_numbers/issues/14>, #16 <https://github.com/ros-planning/random_numbers/issues/16>)
* Fix shared library install path (#13 <https://github.com/ros-planning/random_numbers/issues/13>)
* Contributors: Henning Kayser, Mike Lautman, Robert Haschke, Sean Yen
```
