### PR TITLE
rcl: 1.1.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1364,7 +1364,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.5-1
+      version: 1.1.6-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.6-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.5-1`

## rcl

```
* Keep domain id if ROS_DOMAIN_ID is invalid (#689 <https://github.com/ros2/rcl/issues/689>) (#694 <https://github.com/ros2/rcl/issues/694>)
* Use RCL_RET_* codes only (#686 <https://github.com/ros2/rcl/issues/686>) (#693 <https://github.com/ros2/rcl/issues/693>)
* Add check for invalid output in rcl_node_options_copy (#671 <https://github.com/ros2/rcl/issues/671>)
* Add tests for rcl package (#668 <https://github.com/ros2/rcl/issues/668>)
* Fixed doxygen warnings (#677 <https://github.com/ros2/rcl/issues/677>) (#696 <https://github.com/ros2/rcl/issues/696>)
* Print RCL_LOCALHOST_ENV_VAR if error happens via rcutils_get_env (#672 <https://github.com/ros2/rcl/issues/672>)
* Contributors: Alejandro Hernández Cordero, Jorge Perez, Michel Hidalgo, tomoya
```

## rcl_action

```
* Fixed doxygen warnings (#677 <https://github.com/ros2/rcl/issues/677>) (#696 <https://github.com/ros2/rcl/issues/696>)
* Contributors: Alejandro Hernández Cordero
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
