### PR TITLE
rmw_fastrtps: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1645,7 +1645,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Handle RMW_DEFAULT_DOMAIN_ID (#394 <https://github.com/ros2/rmw_fastrtps/issues/394>) (#398 <https://github.com/ros2/rmw_fastrtps/issues/398>)
* Contributors: Michel Hidalgo
```
