### PR TITLE
rclcpp: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1451,7 +1451,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.0.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.1-1`

## rclcpp

```
* Link against thread library where necessary (#1210 <https://github.com/ros2/rclcpp/issues/1210>) (#1214 <https://github.com/ros2/rclcpp/issues/1214>)
* Fix exception message on rcl_clock_init (#1182 <https://github.com/ros2/rclcpp/issues/1182>) (#1193 <https://github.com/ros2/rclcpp/issues/1193>)
* Contributors: Dirk Thomas, tomoya
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
