### PR TITLE
rclpy: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1467,7 +1467,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.4-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.3-1`

## rclpy

```
* Wrap lines to shorten line length (#586 <https://github.com/ros2/rclpy/issues/586>)
* Improve error message if rclpy C extensions are not found (#580 <https://github.com/ros2/rclpy/issues/580>)
* Fix moved troubleshooting URL (#579 <https://github.com/ros2/rclpy/issues/579>)
* Add resolved_name() method to publisher (#568 <https://github.com/ros2/rclpy/issues/568>) (#576 <https://github.com/ros2/rclpy/issues/576>)
* Contributors: Dirk Thomas, Shane Loretz
```
