### PR TITLE
variants: 0.9.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2729,7 +2729,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.9.2-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## desktop

```
* Add turtlesim to desktop (#29 <https://github.com/ros2/variants/issues/29>)
* Contributors: Dirk Thomas
```

## ros_base

- No changes

## ros_core

- No changes
