### PR TITLE
dual_quaternions_ros: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2112,7 +2112,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/Achllle/dual_quaternions_ros-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     status: maintained
   dynamic_reconfigure:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions_ros` to `0.1.4-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions_ros.git
- release repository: https://github.com/Achllle/dual_quaternions_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.3-1`

## dual_quaternions_ros

```
* Remove find_package (build) dependencies in dq_ros: not needed during build, just at runtime
* Contributors: Achille
```
