### PR TITLE
dual_quaternions_ros: 0.1.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2742,7 +2742,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Achllle/dual_quaternions_ros-release.git
-      version: 0.1.3-3
+      version: 0.1.4-1
     status: maintained
   dwm1001_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_quaternions_ros` to `0.1.4-1`:

- upstream repository: https://github.com/Achllle/dual_quaternions_ros.git
- release repository: https://github.com/Achllle/dual_quaternions_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.3-3`

## dual_quaternions_ros

```
* Remove find_package (build) dependencies in dq_ros: not needed during build, just at runtime
* Contributors: Achille
```
