### PR TITLE
knowledge_representation: 0.9.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4575,6 +4575,7 @@ repositories:
       url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
       version: 0.9.0-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/utexas-bwi/knowledge_representation.git
       version: master

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4568,6 +4568,17 @@ repositories:
       url: https://github.com/aws-robotics/kinesisvideo-ros1.git
       version: master
     status: maintained
+  knowledge_representation:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
+      version: 0.9.0-1
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/knowledge_representation.git
+      version: master
+    status: developed
   kobuki:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `knowledge_representation` to `0.9.0-1`:

- upstream repository: https://github.com/utexas-bwi/knowledge_representation.git
- release repository: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
