### PR TITLE
rmw: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1424,7 +1424,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 1.1.0-2
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-2`

## rmw

```
* Remove domain_id and localhost_only from node API (#248 <https://github.com/ros2/rmw/issues/248>)
* Require enclave upon rmw_init() call. (#247 <https://github.com/ros2/rmw/issues/247>)
* Update init/shutdown API documentation. (#243 <https://github.com/ros2/rmw/issues/243>)
* Update init options API documentation. (#244 <https://github.com/ros2/rmw/issues/244>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_implementation_cmake

- No changes
