### PR TITLE
rmw_fastrtps: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1497,7 +1497,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.1.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## rmw_fastrtps_cpp

```
* Remove domain_id and localhost_only from node API (#407 <https://github.com/ros2/rmw_fastrtps/issues/407>)
* Amend rmw_init() implementation: require enclave. (#406 <https://github.com/ros2/rmw_fastrtps/issues/406>)
* Update Quality Declarations to QL3. (#404 <https://github.com/ros2/rmw_fastrtps/issues/404>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_fastrtps_dynamic_cpp

```
* Remove domain_id and localhost_only from node API (#407 <https://github.com/ros2/rmw_fastrtps/issues/407>)
* Amend rmw_init() implementation: require enclave. (#406 <https://github.com/ros2/rmw_fastrtps/issues/406>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_fastrtps_shared_cpp

```
* Update Quality Declarations to QL3. (#404 <https://github.com/ros2/rmw_fastrtps/issues/404>)
* Contributors: Michel Hidalgo
```
