### PR TITLE
rmw_connext: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1443,7 +1443,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 1.2.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.0-1`

## rmw_connext_cpp

```
* Remove domain_id and localhost_only from node API (#438 <https://github.com/ros2/rmw_connext/issues/438>)
* Amend rmw_init() implementation: require enclave. (#437 <https://github.com/ros2/rmw_connext/issues/437>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_connext_shared_cpp

```
* Remove domain_id and localhost_only from node API (#438 <https://github.com/ros2/rmw_connext/issues/438>)
* Contributors: Ivan Santiago Paunovic
```
