### PR TITLE
slam_toolbox: 2.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2365,6 +2365,22 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: foxy
     status: maintained
+  slam_toolbox:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/SteveMacenski/slam_toolbox-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: foxy-devel
+    status: maintained
   spdlog_vendor:
     release:
       tags:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2394,21 +2394,6 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: foxy
     status: maintained
-  slam_toolbox:
-    doc:
-      type: git
-      url: https://github.com/SteveMacenski/slam_toolbox.git
-      version: foxy-devel
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/SteveMacenski/slam_toolbox-release.git
-      version: 2.3.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/SteveMacenski/slam_toolbox.git
-      version: foxy-devel
   sbg_driver:
     doc:
       type: git
@@ -2424,6 +2409,21 @@ repositories:
       url: https://github.com/SBG-Systems/sbg_ros2.git
       version: master
     status: maintained
+  slam_toolbox:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/SteveMacenski/slam_toolbox-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: foxy-devel
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `2.3.0-1`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
