### PR TITLE
nonpersistent_voxel_layer: 2.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1126,6 +1126,22 @@ repositories:
       url: https://github.com/ubuntu-robotics/nodl.git
       version: master
     status: developed
+  nonpersistent_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
+      version: 2.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: foxy-devel
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nonpersistent_voxel_layer` to `2.2.1-1`:

- upstream repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
- release repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
