### PR TITLE
sainsmart_relay_usb: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3698,6 +3698,21 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: noetic-devel
     status: maintained
+  sainsmart_relay_usb:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb.git
+      version: master
+    status: maintained
   sbpl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sainsmart_relay_usb` to `0.0.3-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb.git
- release repository: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## sainsmart_relay_usb

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Remove check for ROS distributions less than Kinetic
* Use the simple filename 'udev' when installing rules, instead of the debian package name
* Contributors: Kevin Hallenbeck
```
