### PR TITLE
dataspeed_pds: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1866,7 +1866,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
-      version: 1.0.2-0
+      version: 1.0.3-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dataspeed_pds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.3-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-0`

## dataspeed_pds

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_aut
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_can

```
* Fix cmake dependency error with catkin_EXPORTED_TARGETS
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_aut
* Use fewer function calls to setup message sync (ROS)
* Use fewer function calls to setup message sync (CAN)
* Add argument to enable/disable CAN message filtering on DBW message range
* Enabled code coverage testing when built as debug
* Fixed bad asserts
* Contributors: Eric Myllyoja, Kevin Hallenbeck
```

## dataspeed_pds_msgs

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_aut
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_rqt

```
* Use setuptools instead of distutils for python
  http://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_aut
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_scripts

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_aut
* Contributors: Kevin Hallenbeck
```
