### PR TITLE
rospy_message_converter: 0.5.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13320,7 +13320,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/rospy_message_converter-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.2-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.1-1`

## rospy_message_converter

```
* Check for wrong field types when converting from dict to ros msg
* Check for missing fields when converting from dict to ros msg
* Contributors: Martin Günther, alecarnevale
```
