### PR TITLE
Add lcm to rosdep rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2806,6 +2806,18 @@ liblapack-dev:
 liblapacke-dev:
   debian: [liblapacke-dev]
   ubuntu: [liblapacke-dev]
+liblcm:
+  debian: [liblcm1]
+  fedora: [liblcm]
+  ubuntu:
+    '*': [liblcm1]
+    'xenial': null
+liblcm-dev:
+  debian: [liblcm-dev]
+  fedora: [liblcm-devel]
+  ubuntu:
+    '*': [liblcm-dev]
+    'xenial': null
 libleptonica-dev:
   arch: [leptonica]
   debian: [libleptonica-dev]


### PR DESCRIPTION
Available in Ubuntu Bionic and newer
- https://packages.debian.org/buster/liblcm-dev
- https://packages.debian.org/buster/liblcm1
- https://fedora.pkgs.org/31/fedora-x86_64/lcm-devel-1.3.1-13.fc31.i686.rpm.html
- https://fedora.pkgs.org/31/fedora-x86_64/lcm-1.3.1-13.fc31.x86_64.rpm.html
- https://packages.ubuntu.com/bionic/libs/liblcm-dev
- https://packages.ubuntu.com/bionic/libs/liblcm1
- https://packages.ubuntu.com/focal/libs/liblcm-dev
- https://packages.ubuntu.com/focal/libs/liblcm1
