### PR TITLE
velodyne: 1.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4176,6 +4176,28 @@ repositories:
       url: https://github.com/yoshito-n-students/usb_cam_hardware.git
       version: noetic-devel
     status: maintained
+  velodyne:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: master
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pcl
+      - velodyne_pointcloud
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/velodyne-release.git
+      version: 1.6.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: master
+    status: developed
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.6.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## velodyne

```
* Updating maintainer email address.
* Merge branch 'feature/opc_nopcl' of github.com:spuetz/velodyne into feature/opc_nopcl
* Contributors: Joshua Whitley, Sebastian Pütz
```

## velodyne_driver

```
* Unify tf frame parameters between transform and cloud nodes (#344 <https://github.com/ros-drivers/velodyne/issues/344>)
  * Unify tf frame parameters between transform and cloud nodes
  * Use more common ROS terminology instead of 'htm'
  * Just use tf listener when necessary
  * Migrate package to tf2
  * Explicitly store sensor frame in a dedicated variable to make code easier to read
  * Avoid unnecessary transforms when sensor_frame == target_frame
  Co-authored-by: anre <mailto:andreas.reich@unibw.de>
* Updating maintainer email address.
* when device poll timeouts, do not stop node
* use correct node handles and node names for diagnostic_updater::Updater
* Added config option to timestamp a full scan based on first velo packet instead of last packet
* Merge pull request #214 <https://github.com/ros-drivers/velodyne/issues/214> from spuetz/feature/opc_nopcl
  Container cleanup and organized pointclouds
* Merge pull request #243 <https://github.com/ros-drivers/velodyne/issues/243> from dandedrick/reconfig-enable
  driver: add enabled reconfigure param
* Merge pull request #234 <https://github.com/ros-drivers/velodyne/issues/234> from kmhallen/c++11
  Set minimum C++ standard to C++11
* Merge pull request #222 <https://github.com/ros-drivers/velodyne/issues/222> from mpitropov/feat_Use_GPS_time
  Add flag to enable using GPS time from within the Velodyne packet instead of ROS time for scan.
* Merge pull request #220 <https://github.com/ros-drivers/velodyne/issues/220> from nbussas/static
  Transform static variable into member
* Merge pull request #216 <https://github.com/ros-drivers/velodyne/issues/216> from ros-drivers/maint/poll_timeout_handling
  Testing reporting error instead of stopping node on disconnect.
* fixed in range min max, and cleaned up the initialization
* Contributors: AndreasR30, Dan Dedrick, Daniel Seifert, Joshua Whitley, Kevin Hallenbeck, Matthew Pitropov, Nils Hauke Bussas, Sebastian, Sebastian Pütz, Shawn Hanna
```

## velodyne_laserscan

```
* Updating maintainer email address.
* Add laserscan support for new PointXYZIR structure (#316 <https://github.com/ros-drivers/velodyne/issues/316>)
  * Add laserscan support for new PointXYZIR structure
  * Support PointCloud2 offsets that are multiples of 4
* Merge pull request #234 <https://github.com/ros-drivers/velodyne/issues/234> from kmhallen/c++11
  Set minimum C++ standard to C++11
* Contributors: Joshua Whitley, Kevin Hallenbeck, Matthew Pitropov, Sebastian, Sebastian Pütz
```

## velodyne_msgs

```
* Updating maintainer email address.
* Contributors: Joshua Whitley, Sebastian Pütz
```

## velodyne_pcl

```
* Velodyne pcl (#335 <https://github.com/ros-drivers/velodyne/issues/335>)
  * fix time assignment in organized cloud container
  * add velodyne_pcl package with point_types.h
  * rename containers to cover the added time property
  * Adding roslint to velodyne_pcl. (#1 <https://github.com/ros-drivers/velodyne/issues/1>)
  * Update CMake version to 3.5
  * Update package.xml to Format2 and package version to 1.5.2
  Co-authored-by: Joshua Whitley <mailto:josh.whitley@autoware.org>
* Contributors: Sebastian Pütz
```

## velodyne_pointcloud

```
* Unify tf frame parameters between transform and cloud nodes (#344 <https://github.com/ros-drivers/velodyne/issues/344>)
  * Unify tf frame parameters between transform and cloud nodes
  * Use more common ROS terminology instead of 'htm'
  * Just use tf listener when necessary
  * Migrate package to tf2
  * Explicitly store sensor frame in a dedicated variable to make code easier to read
  * Avoid unnecessary transforms when sensor_frame == target_frame
  Co-authored-by: anre <mailto:andreas.reich@unibw.de>
* Velodyne pcl (#335 <https://github.com/ros-drivers/velodyne/issues/335>)
  * fix time assignment in organized cloud container
  * add velodyne_pcl package with point_types.h
  * add README.md with infos for conversion
  * rename containers to cover the added time property
  * Update package.xml to Format2 and package version to 1.5.2
  Co-authored-by: Joshua Whitley <mailto:josh.whitley@autoware.org>
* Passing fixed_frame and target_frame to Convert object. (#330 <https://github.com/ros-drivers/velodyne/issues/330>)
* Updating maintainer email address.
* Increase the max_range of the 32C launch file (#323 <https://github.com/ros-drivers/velodyne/issues/323>)
* Getting model param for timings from private node handle. (#318 <https://github.com/ros-drivers/velodyne/issues/318>)
* updated model to have a default of "" so that tests run successfully
* Move timing offsets functionality into class private. Also fix linter errors
* Added model param to each of the cloud nodelet starters
* Initial commit to timestamp each point using the timing spec in the manuals
* use correct node handles and node names for diagnostic_updater::Updater
* Added config option to timestamp a full scan based on first velo packet instead of last packet
* Remove a dead store from rawdata.cc.
* fix for #267 <https://github.com/ros-drivers/velodyne/issues/267>, transform each packet
* Merge pull request #250 <https://github.com/ros-drivers/velodyne/issues/250> from zhixy/master
  bug fix for row step
* Merge pull request #253 <https://github.com/ros-drivers/velodyne/issues/253> from ros-drivers/fix/fixed_frame_target_frame
  Add configurable fixed_frame/target_frame for velodyne_pointcloud
* Merge pull request #214 <https://github.com/ros-drivers/velodyne/issues/214> from spuetz/feature/opc_nopcl
  Container cleanup and organized pointclouds
* Merge pull request #236 <https://github.com/ros-drivers/velodyne/issues/236> from mpitropov/fix_transform_node_frame_bug
  set correct output frame
* Merge pull request #234 <https://github.com/ros-drivers/velodyne/issues/234> from kmhallen/c++11
  Set minimum C++ standard to C++11
* Merge pull request #223 <https://github.com/ros-drivers/velodyne/issues/223> from mpitropov/feat_Add_fixed_frame
  Add fixed frame and use ros message time within transform node
* Made static tf publisher test adhere to REP 105
* change more odom to map
* Merge pull request #224 <https://github.com/ros-drivers/velodyne/issues/224> from mpitropov/feat_add_diagnostics
  Added diagnostic publishing
* Merge pull request #222 <https://github.com/ros-drivers/velodyne/issues/222> from mpitropov/feat_Use_GPS_time
  Add flag to enable using GPS time from within the Velodyne packet instead of ROS time for scan.
* Created gps_time param to enable this feature
* Contributors: AndreasR30, Chris Lalancette, Daniel Seifert, Ian Colwell, Joshua Whitley, Kevin Hallenbeck, Matthew Pitropov, Sebastian, Sebastian Pütz, Shawn Hanna, zhixiangyang
```
