### PR TITLE
lvr2: 20.7.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5075,7 +5075,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/lvr2-release.git
-      version: 19.12.1-1
+      version: 20.7.1-1
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `20.7.1-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/uos-gbp/lvr2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `19.12.1-1`

## lvr2

```
* removed cl2.hpp, FeatureProjector.cpp from lib
* added meta information factory with slam6d and yaml support
* add debian folder from deb-lvr2 repo.
* add read vertex normals and colors from MeshBuffer, e.g., ply files
* add std arrays to conversion proxy for attribute map to channel conversion
* the large scale reconstruction chunk size is now dictated by the chunk manager
* make most things configurable for chunked mesh visualization
* hyperspectral meta information can be saved and loaded
* implemented basic load and save function of new IO features
* added function to save the tsdf-values in the chunk manager
* switched to new hdf5 io scheme for chunks and added a chunking pipeline with a multiple layer support
* integrated unoptimized hdf5-input for partial reconstruction
* fully integrated existing approach of dmc
* Contributors: Alexander Mock, Bao Tran, Benedikt Schumacher, Kevin Rüter, Lennart Niecksch, Malte kl. Piening, Marcel Wiegand, Raphael Marx, Sebastian Pütz, Thomas Wiemann, Timo Osterkamp, Wilko Müller
```
