### PR TITLE
rcl: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1234,7 +1234,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.2.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.0-1`

## rcl

```
* Implement a generic way to change logging levels (#664 <https://github.com/ros2/rcl/issues/664>)
* Remove domain_id and localhost_only from node_options (#708 <https://github.com/ros2/rcl/issues/708>)
* Add coverage tests (#703 <https://github.com/ros2/rcl/issues/703>)
* Add bad arguments tests for coverage (#698 <https://github.com/ros2/rcl/issues/698>)
* Remove unused internal prototypes (#699 <https://github.com/ros2/rcl/issues/699>)
* Update quality declaration and coverage (#674 <https://github.com/ros2/rcl/issues/674>)
* Add setter and getter for domain_id in rcl_init_options_t (#678 <https://github.com/ros2/rcl/issues/678>)
* Remove unused pytest dependency from rcl. (#695 <https://github.com/ros2/rcl/issues/695>)
* Fix link to latest API docs (#692 <https://github.com/ros2/rcl/issues/692>)
* Keep domain id if ROS_DOMAIN_ID is invalid. (#689 <https://github.com/ros2/rcl/issues/689>)
* Remove unused check context.c (#691 <https://github.com/ros2/rcl/issues/691>)
* Add check rcl_node_options_copy invalid out (#671 <https://github.com/ros2/rcl/issues/671>)
* Update tracetools' QL to 2 in rcl's QD (#690 <https://github.com/ros2/rcl/issues/690>)
* Improve subscription coverage (#681 <https://github.com/ros2/rcl/issues/681>)
* Improve rcl timer test coverage (#680 <https://github.com/ros2/rcl/issues/680>)
* Improve wait sets test coverage (#683 <https://github.com/ros2/rcl/issues/683>)
* Contributors: Alejandro Hernández Cordero, Chen Lihui, Chris Lalancette, Christophe Bedard, Ivan Santiago Paunovic, Jorge Perez, Michel Hidalgo, tomoya
```

## rcl_action

```
* Update quality declaration and coverage (#674 <https://github.com/ros2/rcl/issues/674>)
* Contributors: Alejandro Hernández Cordero
```

## rcl_lifecycle

```
* Update quality declaration and coverage (#674 <https://github.com/ros2/rcl/issues/674>)
* Contributors: Alejandro Hernández Cordero
```

## rcl_yaml_param_parser

```
* Update quality declaration and coverage (#674 <https://github.com/ros2/rcl/issues/674>)
* Contributors: Alejandro Hernández Cordero
```
