### PR TITLE
rclcpp: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1320,7 +1320,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 3.0.0-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.0.0-1`

## rclcpp

```
* Fix rclcpp::NodeOptions::operator= (#1211 <https://github.com/ros2/rclcpp/issues/1211>)
* Link against thread library where necessary (#1210 <https://github.com/ros2/rclcpp/issues/1210>)
* Unit tests for node interfaces (#1202 <https://github.com/ros2/rclcpp/issues/1202>)
* Remove usage of domain id in node options (#1205 <https://github.com/ros2/rclcpp/issues/1205>)
* Remove deprecated set_on_parameters_set_callback function (#1199 <https://github.com/ros2/rclcpp/issues/1199>)
* Fix conversion of negative durations to messages (#1188 <https://github.com/ros2/rclcpp/issues/1188>)
* Fix implementation of NodeOptions::use_global_arguments() (#1176 <https://github.com/ros2/rclcpp/issues/1176>)
* Bump to QD to level 3 and fixed links (#1158 <https://github.com/ros2/rclcpp/issues/1158>)
* Fix pub/sub count API tests (#1203 <https://github.com/ros2/rclcpp/issues/1203>)
* Update tracetools' QL to 2 in rclcpp's QD (#1187 <https://github.com/ros2/rclcpp/issues/1187>)
* Fix exception message on rcl_clock_init (#1182 <https://github.com/ros2/rclcpp/issues/1182>)
* Throw exception if rcl_timer_init fails (#1179 <https://github.com/ros2/rclcpp/issues/1179>)
* Unit tests for some header-only functions/classes (#1181 <https://github.com/ros2/rclcpp/issues/1181>)
* Callback should be perfectly-forwarded (#1183 <https://github.com/ros2/rclcpp/issues/1183>)
* Add unit tests for logging functionality (#1184 <https://github.com/ros2/rclcpp/issues/1184>)
* Add create_publisher include to create_subscription (#1180 <https://github.com/ros2/rclcpp/issues/1180>)
* Contributors: Alejandro Hernández Cordero, Christophe Bedard, Claire Wang, Dirk Thomas, Ivan Santiago Paunovic, Johannes Meyer, Michel Hidalgo, Stephen Brawner, tomoya
```

## rclcpp_action

```
* Bump to QD to level 3 and fixed links (#1158 <https://github.com/ros2/rclcpp/issues/1158>)
* Contributors: Alejandro Hernández Cordero
```

## rclcpp_components

```
* Bump to QD to level 3 and fixed links (#1158 <https://github.com/ros2/rclcpp/issues/1158>)
* Include original exception in ComponentManagerException (#1157 <https://github.com/ros2/rclcpp/issues/1157>)
* Contributors: Alejandro Hernández Cordero, Martijn Buijs, tomoya
```

## rclcpp_lifecycle

```
* Remove deprecated set_on_parameters_set_callback function (#1199 <https://github.com/ros2/rclcpp/issues/1199>)
* Bump to QD to level 3 and fixed links (#1158 <https://github.com/ros2/rclcpp/issues/1158>)
* Fix race in test_lifecycle_service_client (#1204 <https://github.com/ros2/rclcpp/issues/1204>)
* Contributors: Alejandro Hernández Cordero, Claire Wang, Dirk Thomas
```
