### PR TITLE
usb_cam_hardware: 0.0.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16718,7 +16718,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
-      version: 0.0.3-0
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/usb_cam_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam_hardware` to `0.0.6-1`:

- upstream repository: https://github.com/yoshito-n-students/usb_cam_hardware.git
- release repository: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.3-0`

## usb_cam_controllers

- No changes

## usb_cam_hardware

```
* Fix typo in default pixel_format ("mpjeg" -> "mjpeg")
```

## usb_cam_hardware_interface

- No changes
