### PR TITLE
usb_cam_hardware: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11906,7 +11906,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
-      version: 0.0.4-0
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/usb_cam_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam_hardware` to `0.1.1-1`:

- upstream repository: https://github.com/yoshito-n-students/usb_cam_hardware.git
- release repository: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.4-0`

## usb_cam_controllers

```
* Bump minor version to 0.1.X to indicate melodic release
```

## usb_cam_hardware

```
* Fix typo in default pixel_format ("mpjeg" -> "mjpeg")
* Bump minor version to 0.1.X to indicate melodic release
```

## usb_cam_hardware_interface

```
* Bump minor version to 0.1.X to indicate melodic release
```
