### PR TITLE
usb_cam_hardware: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4170,7 +4170,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
-      version: 0.0.5-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/usb_cam_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam_hardware` to `0.2.1-1`:

- upstream repository: https://github.com/yoshito-n-students/usb_cam_hardware.git
- release repository: https://github.com/yoshito-n-students/usb_cam_hardware-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.5-1`

## usb_cam_controllers

```
* Bump minor version to 0.2.X to indicate noetic release
```

## usb_cam_hardware

```
* Fix typo in default pixel_format ("mpjeg" -> "mjpeg")
* Bump minor version to 0.2.X to indicate noetic release
```

## usb_cam_hardware_interface

```
* Bump minor version to 0.2.X to indicate noetic release
```
