### PR TITLE
ros2-lgsvl-bridge: 0.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2178,6 +2178,19 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: eloquent
     status: maintained
+  ros2-lgsvl-bridge:
+    release:
+      packages:
+      - lgsvl_bridge
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/lgsvl/ros2-lgsvl-bridge.git
+      version: master
+    status: developed
   ros2_ouster_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2-lgsvl-bridge` to `0.1.0-1`:

- upstream repository: https://github.com/lgsvl/ros2-lgsvl-bridge.git
- release repository: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
