### PR TITLE
ros2-lgsvl-bridge: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1700,6 +1700,19 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: foxy
     status: maintained
+  ros2-lgsvl-bridge:
+    release:
+      packages:
+      - lgsvl_bridge
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/lgsvl/ros2-lgsvl-bridge.git
+      version: master
+    status: developed
   ros2_intel_realsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2-lgsvl-bridge` to `0.1.0-1`:

- upstream repository: https://github.com/lgsvl/ros2-lgsvl-bridge.git
- release repository: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
