### PR TITLE
phm_tools: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9915,6 +9915,25 @@ repositories:
       type: git
       url: https://github.com/inomuh/phm_tools.git
       version: master
+    release:
+      packages:
+      - agv_msgs
+      - phm_hazard_rate_calculation
+      - phm_msgs
+      - phm_reliability_calculation
+      - phm_robot_task_completion
+      - phm_start
+      - phm_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/inomuh/phm_tools-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/inomuh/phm_tools.git
+      version: master
+    status: developed
   phoxi_camera:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `phm_tools` to `1.0.1-1`:

- upstream repository: https://github.com/inomuh/phm_tools.git
- release repository: https://github.com/inomuh/phm_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## agv_msgs

```
* No change
```

## phm_hazard_rate_calculation

```
* No change
```

## phm_msgs

```
* No change
```

## phm_reliability_calculation

```
* No change
```

## phm_robot_task_completion

```
* No change
```

## phm_start

```
* Updated module delete function in monitoring tab
```

## phm_tools

```
* No change
```
