### PR TITLE
dbw_fca_ros: 1.0.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -565,6 +565,27 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/dataspeed_ulc_ros.git
       version: master
     status: developed
+  dbw_fca_ros:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
+      version: master
+    release:
+      packages:
+      - dbw_fca
+      - dbw_fca_can
+      - dbw_fca_description
+      - dbw_fca_joystick_demo
+      - dbw_fca_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
+      version: 1.0.10-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
+      version: master
+    status: developed
   dbw_mkz_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_fca_ros` to `1.0.10-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dbw_fca

```
* Add Ubuntu Focal and ROS Noetic to ROS install script
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Contributors: Kevin Hallenbeck
```

## dbw_fca_can

```
* Add gear reject enumerations
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Remove unused parameter from launch file
* Add sensor reports for wiper, highbeam, and hazard light
* Add sensor reports for gyro, accelerometer, GPS, and tire pressure
* Contributors: Kevin Hallenbeck, Sreedevi Adukkathayar, Sun Hwang
```

## dbw_fca_description

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Contributors: Kevin Hallenbeck
```

## dbw_fca_joystick_demo

```
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Contributors: Kevin Hallenbeck
```

## dbw_fca_msgs

```
* Add gear reject enumerations
* Increase CMake minimum version to 3.0.2 to avoid warning about CMP0048
  http://wiki.ros.org/noetic/Migration#Increase_required_CMake_version_to_avoid_author_warning
* Add sensor reports for wiper, highbeam, and hazard light
* Add sensor reports for gyro, accelerometer, GPS, and tire pressure
* Contributors: Kevin Hallenbeck, Sreedevi Adukkathayar, Sun Hwang
```
