### PR TITLE
diagnostics: 2.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -408,7 +408,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.0.3-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.0.2-1`

## diagnostic_aggregator

```
* restore alphabetical order (#148 <https://github.com/ros/diagnostics/issues/148>) (#150 <https://github.com/ros/diagnostics/issues/150>)
  Signed-off-by: Karsten Knese <mailto:karsten.knese@us.bosch.com>
* Fixes toplevel diagnostic status calculation (#149 <https://github.com/ros/diagnostics/issues/149>)
  See https://github.com/ros/diagnostics/issues/146
  Signed-off-by: Arne Nordmann <mailto:arne.nordmann@de.bosch.com>
* Contributors: Arne Nordmann, Karsten Knese
```

## diagnostic_updater

- No changes

## self_test

- No changes
