### PR TITLE
velodyne: 2.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3391,6 +3391,27 @@ repositories:
       url: https://github.com/kobuki-base/velocity_smoother.git
       version: devel
     status: maintained
+  velodyne:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/velodyne-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    status: developed
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.1.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## velodyne

- No changes

## velodyne_driver

```
* Fixing Foxy-specific uncrustify errors.
* Contributors: Joshua Whitley
```

## velodyne_laserscan

```
* Fixing Foxy-specific uncrustify errors.
* Contributors: Joshua Whitley
```

## velodyne_msgs

- No changes

## velodyne_pointcloud

- No changes
