### PR TITLE
velodyne: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2747,6 +2747,27 @@ repositories:
       url: https://github.com/ros2/variants.git
       version: master
     status: maintained
+  velodyne:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/velodyne-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.1.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## velodyne

- No changes

## velodyne_driver

```
* Fixing Foxy-specific uncrustify errors.
* Contributors: Joshua Whitley
```

## velodyne_laserscan

```
* Fixing Foxy-specific uncrustify errors.
* Contributors: Joshua Whitley
```

## velodyne_msgs

- No changes

## velodyne_pointcloud

- No changes
