### PR TITLE
rcl: 0.7.9-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2037,7 +2037,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.7.8-1
+      version: 0.7.9-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.7.9-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.8-1`

## rcl

```
* Fixed doxygen warnings. (#702 <https://github.com/ros2/rcl/issues/702>)
* Allow get_node_names to return result in any order. (#592 <https://github.com/ros2/rcl/issues/592>)
* Don't check history depth if RMW_QOS_POLICY_HISTORY_KEEP_ALL. (#595 <https://github.com/ros2/rcl/issues/595>)
* Contributors: Alejandro Hernández Cordero, Dan Rose
```

## rcl_action

```
* Fixed doxygen warnings. (#702 <https://github.com/ros2/rcl/issues/702>)
* Contributors: Alejandro Hernández Cordero
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Added rcl yaml param parser Doxyfile. (#701 <https://github.com/ros2/rcl/issues/701>)
* Contributors: Alejandro Hernández Cordero
```
