### PR TITLE
resource_retriever: 2.1.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2224,7 +2224,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.1.3-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.1.2-1`

## libcurl_vendor

```
* Ignore broken curl-config.cmake. (#49 <https://github.com/ros/resource_retriever/issues/49>)
* Contributors: Steven! Ragnarök
```

## resource_retriever

- No changes
