### PR TITLE
rclpy: 0.7.11-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2138,7 +2138,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.7.10-1
+      version: 0.7.11-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.7.11-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.10-1`

## rclpy

```
* Fix moved troubleshooting url. (#590 <https://github.com/ros2/rclpy/issues/590>)
* Improve error message if rclpy C extensions are not found. (#592 <https://github.com/ros2/rclpy/issues/592>)
* Contributors: Dirk Thomas
```
