### PR TITLE
ros1_bridge: 0.7.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2379,7 +2379,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.7.6-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.5-1`
