### PR TITLE
mqtt_bridge: 0.1.7-7 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5762,6 +5762,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
       version: melodic-devel
     status: developed
+  mqtt_bridge:
+    doc:
+      type: git
+      url: https://github.com/groove-x/mqtt_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/groove-x/mqtt_bridge-release.git
+      version: 0.1.7-7
+    source:
+      type: git
+      url: https://github.com/groove-x/mqtt_bridge.git
+      version: master
+    status: maintained
   mrpt1:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge` to `0.1.7-7`:

- upstream repository: https://github.com/groove-x/mqtt_bridge.git
- release repository: https://github.com/groove-x/mqtt_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## mqtt_bridge

```
* Fix mqtt subscribing to private path (#27 <https://github.com/groove-x/mqtt_bridge/issues/27>)
* Fix frequency limit (#26 <https://github.com/groove-x/mqtt_bridge/issues/26>)
* Add bson module in requirements.txt (#10 <https://github.com/groove-x/mqtt_bridge/issues/10>)
* Fix Bridge not to fall when ros msg cannot be created (#4 <https://github.com/groove-x/mqtt_bridge/issues/4>)
* Contributors: 5tan, Junya Hayashi, Tomas Cernik, Yuma Mihira, kapilPython
```
