### PR TITLE
jsk_common: 2.2.11-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1348,6 +1348,32 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: master
     status: maintained
+  jsk_common:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
+    release:
+      packages:
+      - dynamic_tf_publisher
+      - image_view2
+      - jsk_common
+      - jsk_data
+      - jsk_network_tools
+      - jsk_tilt_laser
+      - jsk_tools
+      - jsk_topic_tools
+      - multi_map_server
+      - virtual_force_publisher
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_common-release.git
+      version: 2.2.11-2
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_common.git
+      version: master
+    status: developed
   jsk_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.11-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## dynamic_tf_publisher

```
* Fix for noetic build (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * fix for python3, except, print ....
    * upgrade package.xml to format=3
  
* Update package name so it does not produce extra lines in rospack list (#1625 <https://github.com/jsk-ros-pkg/jsk_common/issues/1625>)
* Contributors: J-Rojas, Kei Okada
```

## image_view2

```
* fix for noetic build (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * fox for opencv4
    * remove signals from find_package(Boost COMPONENTS ...)
    * migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
    * upgrade package.xml to format=3
  
* Add sample code for image_view2f( #1646 <https://github.com/jsk-ros-pkg/jsk_common/issues/1646>)
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## jsk_common

```
* upgrade package.xml to format=3 for noetic (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
* Contributors: Kei Okada
```

## jsk_data

```
* [jsk_data] Add common rosbag_record and play file for fetch (#1611 <https://github.com/jsk-ros-pkg/jsk_common/issues/1611>)
  
    * enable to give rosbag option to fetch_play.sh like pr2_play.sh
    * add option to launch rqt_bag and rviz in fetch_play.launch
    * [jsk_data/CMakeLists.txt] Add roslaunch_add_file_check for fetch's launch files
    * [jsk_data] Add fetch_play.sh
    * [jsk_data] Add fetch_play and fetch_record.launch
  
* use xdg-open for ubuntu16.04 and above (#1638 <https://github.com/jsk-ros-pkg/jsk_common/issues/1638>)
* [jsk_data/common_record.launch] Add tf_static recordf( #1641 <https://github.com/jsk-ros-pkg/jsk_common/issues/1641>)
* Fix for noetic build (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * fix for python3, except, print ....
    * pytho3 dislike d in regrex, src/test_topic_published.py:50:37: W605 invalid escape sequence 'd'
    * jsk_data/tests/test_data_collection_server.py use python3 as interpreter
      
      python code under scripts/ installed with catkin_python_install as http://wiki.ros.org/UsingPython3/SourceCodeChanges, to dynamically change shebangs on install timeThis installs tests/test_data_collection_server.py under CATKIN_PACKAGE_SHARE/tests, which outputs
      ```
      $ rosrun jsk_data test_data_collection_server.py
      [rosrun] You have chosen a non-unique executable, please pick one of the following:
      1) /home/user/devel/share/jsk_data/tests/test_data_collection_server.py
      2) /home/user/src/jsk_common/jsk_data/tests/test_data_collection_server.py
      ```
      we can ignore this message
    * fix jsk_data/src/jsk_data/cli.py:57:44: E741 ambiguous variable name 'l'
    * migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
    * upgrade package.xml to format=3
    * use distutils.spawn
  
* Fix download_data.py for Python3f( #1637 <https://github.com/jsk-ros-pkg/jsk_common/issues/1637>)
* [jsk_data] Skip extracting files which already existf( #1626 <https://github.com/jsk-ros-pkg/jsk_common/issues/1626>)
  
    * Print message when skip extracting
    * Use isinstance() for checking file type
    * Skip extracting files which already exist
  
* pr2_play.launch: support indigo ( #1620 <https://github.com/jsk-ros-pkg/jsk_common/issues/1620>)
* [download_data.py] generate error log when downloaded fils's md5 is incorrect (#1610 <https://github.com/jsk-ros-pkg/jsk_common/issues/1610>)
* Contributors: Yuki Furuta, Kei Okada, Kentaro Wada, Naoya Yamaguchi, Shingo Kitagawa, Yuto Uchimi, Iori Yanokura
```

## jsk_network_tools

```
* Fix for noetic buid (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * fix jsk_network_tools for python3
    * jsk_network_tools: set queue_size=1
    * fix for python3, except, print ....
    * upgrade package.xml to format=3
  
* [network_status.py] add queue_size (#1642 <https://github.com/jsk-ros-pkg/jsk_common/issues/1642>)
* Contributors: Kei Okada, Naoki Hiraoka, Shingo Kitagawa
```

## jsk_tilt_laser

```
* Fix for noetic build (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * fix for python3, except, print ....
    * upgrade package.xml to format=3
  
* Contributors: Kei Okada
```

## jsk_tools

```
* Fix for noetic build (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * fix for python3, except, print ....
    * jsk_tools: fix for python3
    * pytho3 dislike d in regrex, src/test_topic_published.py:50:37: W605 invalid escape sequence 'd'
    * python3 need to use a in dict, instead of dict.has_key(a)
    * fix print(), Exception as e for python3
    * migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
    * upgrade package.xml to format=3
  
* fix failure on finally clause (#1645 <https://github.com/jsk-ros-pkg/jsk_common/issues/1645>)
* Add debian in generate_deb_status_table.pyf( #1633 <https://github.com/jsk-ros-pkg/jsk_common/issues/1633>)
* write comment on how to generate deb status section. (#1631 <https://github.com/jsk-ros-pkg/jsk_common/issues/1631>)
  
    * remove --rosdistro-from and --rosdistro-to, get current active rosdistro list from index file
    * write comment on how to generate deb status section.  https://stackoverflow.com/questions/4823468/comments-in-markdown
  
* [jsk_tools] Add --ping-trials option to roscore_regardless.py (#1632 <https://github.com/jsk-ros-pkg/jsk_common/issues/1632>)
  
    * Sometimes ping is not stable. --ping-trials option enables roscore_regardless.py to verify host computer of rosmaster is alive by multi-times ping commands.
  
* [jsk_tools] Show voltage in battery_capacity_summary.py (#1628 <https://github.com/jsk-ros-pkg/jsk_common/issues/1628>)
  
    * Fix output format in battery_capacity_summary.py
    * Show voltage as well in battery_capacity_summary.py
    * Show unit of full/remaining capacity in battery_capacity_summary.py
  
* [jsk_tools/roscore_regardless.py] Do not send SIGTERM before roslaunch sends SIGTERMf( #1627 <https://github.com/jsk-ros-pkg/jsk_common/issues/1627>)
  
    * Add option to change timeout duration to escalate signals
  
* [jsk_tools] Add --timeout option to roscore_regardless.py ( #1622 <https://github.com/jsk-ros-pkg/jsk_common/issues/1622>)
  
    * Add --timeout option to change timeout duration of ping command towards rosmaster computer.
    * --timeout option defaults to 10 seconds.
  
* battery_capacity_summary.py: fix order of columns (#1619 <https://github.com/jsk-ros-pkg/jsk_common/issues/1619>)
* Contributors: Yuki Furuta, Kei Okada, Ryohei Ueda, Shingo Kitagawa, Yuto Uchimi
```

## jsk_topic_tools

```
* [jsk_topic_tools] check nodelet version>=1.9.10 (#1647 <https://github.com/jsk-ros-pkg/jsk_common/issues/1647>)
* [jsk_topic_tools/scripts/pose_stamped_publisher.py] fix orientation bug (#1649 <https://github.com/jsk-ros-pkg/jsk_common/issues/1649>)
* Fix for noetic build (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * fix for python3, except, print ....
    * fix print(), Exception as e for python3
    * fox for boost 1.67 (20.04)
    * migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
    * upgrade package.xml to format=3
  
* call ros::param::get before set not to overwrite (#1643 <https://github.com/jsk-ros-pkg/jsk_common/issues/1643>)
  
    * run test_standalone_complexed_nodelet.test
    * add test code for standalone_complexed_nodelet
    * call ros::param::get before set not to overwrite
  
* [jsk_topic_tools/SynchronizedThrottle] Reset sync policy in destructor (#1640 <https://github.com/jsk-ros-pkg/jsk_common/issues/1640>)
* [jsk_topic_tools] import _pickle as pickle for python3 (#1636 <https://github.com/jsk-ros-pkg/jsk_common/issues/1636>)
  
    * add comment in log_utils
    * import _pickle as pickle for python3, cpickle is no more used in python3
  
* add SoundRequest.volume for kinetic (#1635 <https://github.com/jsk-ros-pkg/jsk_common/issues/1635>)
* Create tf.TransformListener before run timerf( #1634 <https://github.com/jsk-ros-pkg/jsk_common/issues/1634>)
  
    * Assign listener varaible before run timer and the callback in order, not to lookup listener variable before it is assigned.
  
* [jsk_tools] Add --ping-trials option to roscore_regardless.pyf( #1632 <https://github.com/jsk-ros-pkg/jsk_common/issues/1632>)
  
    * Sometimes ping is not stable. --ping-trials option enables roscore_regardless.py to verify host computer of rosmaster is alive by multi-times ping commands.
  
* [deprecated_relay] print warning message only when relayed topic is subscribed (#1624 <https://github.com/jsk-ros-pkg/jsk_common/issues/1624>)
  
    * print warn only when the msg is subscribed
    * print warn only once in starting
  
* [jsk_tools] Add --timeout option to roscore_regardless.py (#1622 <https://github.com/jsk-ros-pkg/jsk_common/issues/1622>)
* standalone_complexed_nodelet: add params key for each nodelet (#1614 <https://github.com/jsk-ros-pkg/jsk_common/issues/1614>)
  
    * Add --timeout option to change timeout duration of ping command towards rosmaster computer.
    * --timeout option defaults to 10 seconds.
  
* jsk_nodelet: fix overwritting find_package(boost) (#1618 <https://github.com/jsk-ros-pkg/jsk_common/issues/1618>)
* synchronized_throttle: add some more infos (#1615 <https://github.com/jsk-ros-pkg/jsk_common/issues/1615>)
* stealth_relay_nodelet: fix error double free or corruption (fasttop) (#1613 <https://github.com/jsk-ros-pkg/jsk_common/issues/1613>)
  
    * update standalone_complexed_nodelet sample launch
    * standalone_complexed_ndoelet: support params tag
  
* Contributors: Furushchev, Kei Okada, Ryo Koyama, Ryohei Ueda, Shingo Kitagawa, Yuki Furuta, Iory Yanokura
```

## multi_map_server

```
* migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
  
    * upgrade package.xml to format=3
  
* Contributors: Kei Okada
```

## virtual_force_publisher

```
* upgrade package.xml to format=3 (#1648 <https://github.com/jsk-ros-pkg/jsk_common/issues/1648>)
* Contributors: Kei Okada
```
