### PR TITLE
Alpine Linux ROS2 Foxy ros_base remaining dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -110,6 +110,7 @@ asio:
   rhel: [asio-devel]
   ubuntu: [libasio-dev]
 assimp:
+  alpine: [assimp]
   arch: [assimp]
   debian: [libassimp-dev]
   fedora: [assimp]
@@ -127,6 +128,7 @@ assimp:
     oneiric: [assimp-dev]
     trusty_python3: [libassimp-dev]
 assimp-dev:
+  alpine: [assimp-dev]
   arch: [assimp]
   debian: [libassimp-dev]
   fedora: [assimp-devel]
@@ -311,6 +313,7 @@ box2d-dev:
   fedora: [Box2D-devel]
   ubuntu: [libbox2d-dev]
 bullet:
+  alpine: [bullet-dev]
   arch: [bullet]
   debian: [libbullet-dev]
   fedora: [bullet-devel]
@@ -404,6 +407,7 @@ clang:
   gentoo: [sys-devel/clang]
   ubuntu: [clang]
 clang-format:
+  alpine: [clang]
   debian:
     buster: [clang-format]
     stretch: [clang-format]
@@ -415,6 +419,7 @@ clang-format:
   rhel: [clang]
   ubuntu: [clang-format]
 clang-tidy:
+  alpine: [clang-extra-tools]
   debian:
     buster: [clang-tidy]
     stretch: [clang-tidy]
@@ -1074,6 +1079,7 @@ gimp:
   gentoo: [media-gfx/gimp]
   ubuntu: [gimp]
 git:
+  alpine: [git]
   arch: [git]
   debian: [git]
   fedora: [git]
@@ -1481,6 +1487,7 @@ jasper:
     xenial: [libjasper-dev]
     yakkety: [libjasper-dev]
 java:
+  alpine: [openjdk8-jre]
   arch: [jdk7-openjdk]
   debian:
     '*': [default-jdk]
@@ -1988,6 +1995,7 @@ libcpprest-dev:
   fedora: [cpprest-devel]
   ubuntu: [libcpprest-dev]
 libcunit-dev:
+  alpine: [cunit-dev]
   arch: [cunit]
   debian: [libcunit1-dev]
   fedora: [CUnit-devel]
@@ -3587,6 +3595,7 @@ libqt5-concurrent:
   slackware: [qt5]
   ubuntu: [libqt5concurrent5]
 libqt5-core:
+  alpine: [qt5-qtbase]
   arch: [qt5-base]
   debian: [libqt5core5a]
   fedora: [qt5-qtbase]
@@ -3601,6 +3610,7 @@ libqt5-gstreamer-dev:
   debian: [libqt5gstreamer-dev]
   ubuntu: [libqt5gstreamer-dev]
 libqt5-gui:
+  alpine: [qt5-qtbase]
   arch: [qt5-base]
   debian: [libqt5gui5]
   fedora: [qt5-qtbase-gui]
@@ -3622,6 +3632,7 @@ libqt5-network:
   gentoo: ['dev-qt/qtnetwork:5']
   ubuntu: [libqt5network5]
 libqt5-opengl:
+  alpine: [qt5-qtbase-dev]
   arch: [qt5-base]
   debian: [libqt5opengl5]
   fedora: [qt5-qtbase]
@@ -3842,6 +3853,7 @@ libspnav-dev:
   gentoo: [dev-libs/libspnav]
   ubuntu: [libspnav-dev]
 libsqlite3-dev:
+  alpine: [sqlite-dev]
   arch: [sqlite]
   debian: [libsqlite3-dev]
   fedora: [libsq3-devel]
@@ -4316,6 +4328,7 @@ libwebsocketpp-dev:
   gentoo: [websocketpp]
   ubuntu: [libwebsocketpp-dev]
 libx11:
+  alpine: [libx11]
   arch: [libx11]
   debian: [libx11-dev]
   fedora: [libX11]
@@ -4323,6 +4336,7 @@ libx11:
   macports: [xorg-libX11]
   ubuntu: [libx11-dev]
 libx11-dev:
+  alpine: [libx11-dev]
   arch: [libx11]
   debian: [libx11-dev]
   fedora: [libX11-devel]
@@ -4336,6 +4350,7 @@ libx264-dev:
   gentoo: [media-libs/x264]
   ubuntu: [libx264-dev]
 libxaw:
+  alpine: [libxaw-dev]
   arch: [libxaw]
   debian: [libxaw7-dev]
   fedora: [libXaw-devel]
@@ -4401,6 +4416,7 @@ libxml2:
   rhel: [libxml2-devel]
   ubuntu: [libxml2-dev]
 libxml2-utils:
+  alpine: [libxml2-utils]
   debian: [libxml2-utils]
   fedora: [libxml2]
   gentoo: [dev-libs/libxml2]
@@ -4425,6 +4441,7 @@ libxmu-dev:
   rhel: [libXmu-devel]
   ubuntu: [libxmu-dev]
 libxrandr:
+  alpine: [libxrandr-dev]
   arch: [libxrandr]
   debian: [libxrandr-dev]
   fedora: [libXrandr-devel]
@@ -4487,6 +4504,7 @@ libzmqpp3:
   gentoo: [net-libs/cppzmq]
   ubuntu: [libzmqpp3]
 libzstd-dev:
+  alpine: [zstd-dev]
   arch: [zstd]
   debian: [libzstd-dev]
   fedora: [libzstd-devel]
@@ -4626,6 +4644,7 @@ matio:
   fedora: [matio-devel]
   ubuntu: [libmatio-dev]
 maven:
+  alpine: [maven]
   arch: [maven]
   debian: [maven]
   fedora: [maven]
@@ -4974,6 +4993,7 @@ opende:
   gentoo: [dev-games/ode]
   ubuntu: [libode-dev]
 opengl:
+  alpine: [mesa-dev]
   arch: [mesa]
   debian: [libgl1-mesa-dev, libglu1-mesa-dev]
   fedora: [mesa-libGL-devel, mesa-libGLU-devel]
@@ -5025,6 +5045,7 @@ openssh-server:
   gentoo: [net-misc/openssh]
   ubuntu: [openssh-server]
 openssl:
+  alpine: [openssl]
   arch: [openssl]
   debian: [openssl]
   fedora: [openssl]
@@ -5053,6 +5074,7 @@ pandoc:
   rhel: [pandoc]
   ubuntu: [pandoc]
 pcre:
+  alpine: [pcre-dev]
   arch: [pcre]
   debian: [libpcre3-dev]
   fedora: [pcre-devel]
@@ -5354,6 +5376,7 @@ qt5-image-formats-plugins:
   debian: [qt5-image-formats-plugins]
   ubuntu: [qt5-image-formats-plugins]
 qt5-qmake:
+  alpine: [qt5-qtbase-dev]
   arch: [qt5-base]
   debian: [qt5-qmake]
   fedora: [qt5-qtbase-devel]
@@ -5660,6 +5683,7 @@ sparsehash:
     yakkety: [libsparsehash-dev]
     zesty: [libsparsehash-dev]
 spdlog:
+  alpine: [spdlog-dev]
   debian: [libspdlog-dev]
   fedora: [spdlog-devel]
   gentoo: [dev-libs/spdlog]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1395,7 +1395,6 @@ python-easygui:
   fedora: [python-easygui]
   ubuntu: [python-easygui]
 python-empy:
-  alpine: [py3-empy]
   arch: [python2-empy]
   debian: [python-empy]
   fedora: [python-empy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -254,6 +254,7 @@ pika:
       packages: [pika]
   ubuntu: [python-pika]
 pydocstyle:
+  alpine: [py3-pydocstyle]
   debian:
     buster: [pydocstyle]
     stretch: [pydocstyle]
@@ -278,6 +279,7 @@ pydrive-pip:
     pip:
       packages: [PyDrive]
 pyflakes3:
+  alpine: [py3-pyflakes]
   debian: [pyflakes3]
   fedora: [python3-pyflakes]
   gentoo: [dev-python/pyflakes]
@@ -1393,9 +1395,7 @@ python-easygui:
   fedora: [python-easygui]
   ubuntu: [python-easygui]
 python-empy:
-  alpine:
-    pip:
-      packages: [empy]
+  alpine: [py3-empy]
   arch: [python2-empy]
   debian: [python-empy]
   fedora: [python-empy]
@@ -5311,6 +5311,7 @@ python3-autobahn:
     '7': null
   ubuntu: [python3-autobahn]
 python3-babeltrace:
+  alpine: [py3-babeltrace]
   debian: [python3-babeltrace]
   fedora: [python3-babeltrace]
   gentoo: [dev-util/babeltrace]
@@ -5387,12 +5388,14 @@ python3-catkin-lint:
     bionic: null
     xenial: null
 python3-catkin-pkg:
+  alpine: [py3-catkin-pkg]
   debian: [python3-catkin-pkg]
   fedora: [python3-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]
   rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg]
 python3-catkin-pkg-modules:
+  alpine: [py3-catkin-pkg]
   debian: [python3-catkin-pkg-modules]
   fedora: [python3-catkin_pkg]
   gentoo: [dev-python/catkin_pkg]
@@ -5444,6 +5447,7 @@ python3-coverage:
   rhel: ['python%{python3_pkgversion}-coverage']
   ubuntu: [python3-coverage]
 python3-cryptography:
+  alpine: [py3-cryptography]
   debian: [python3-cryptography]
   fedora: [python3-cryptography]
   gentoo: [dev-python/cryptography]
@@ -5507,6 +5511,7 @@ python3-docutils:
   gentoo: [dev-python/docutils]
   ubuntu: [python3-docutils]
 python3-empy:
+  alpine: [py3-empy]
   debian:
     buster: [python3-empy]
     jessie: [python3-empy]
@@ -5530,6 +5535,7 @@ python3-filterpy-pip:
     pip:
       packages: [filterpy]
 python3-flake8:
+  alpine: [py3-flake8]
   debian:
     buster: [python3-flake8]
     jessie: [python3-flake8]
@@ -5668,6 +5674,7 @@ python3-kitchen:
     '*': [python3-kitchen]
     xenial: null
 python3-lark-parser:
+  alpine: [py3-lark-parser]
   debian:
     buster: [python3-lark-parser]
     stretch: [python3-lark-parser]
@@ -5680,6 +5687,7 @@ python3-lark-parser:
     focal: [python3-lark]
     xenial: [python3-lark-parser]
 python3-lttng:
+  alpine: [py3-lttng]
   debian: [python3-lttng]
   fedora:
     '*': [python3-lttng]
@@ -5687,6 +5695,7 @@ python3-lttng:
     '31': null
   ubuntu: [python3-lttng]
 python3-lxml:
+  alpine: [py3-lxml]
   debian: [python3-lxml]
   fedora: [python3-lxml]
   freebsd: [py36-lxml]
@@ -5706,6 +5715,7 @@ python3-markdown:
   gentoo: [dev-python/markdown]
   ubuntu: [python3-markdown]
 python3-matplotlib:
+  alpine: [py3-matplotlib]
   arch: [python-matplotlib]
   debian: [python3-matplotlib]
   fedora: [python3-matplotlib]
@@ -5722,6 +5732,7 @@ python3-matplotlib:
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mock:
+  alpine: [py3-mock]
   debian: [python3-mock]
   fedora: [python3-mock]
   gentoo: [dev-python/mock]
@@ -5729,6 +5740,7 @@ python3-mock:
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-mypy:
+  alpine: [py3-mypy]
   arch: [mypy]
   debian:
     buster: [python3-mypy]
@@ -5737,6 +5749,7 @@ python3-mypy:
   gentoo: [dev-python/mypy]
   ubuntu: [python3-mypy]
 python3-netifaces:
+  alpine: [py3-netifaces]
   debian: [python3-netifaces]
   fedora: [python3-netifaces]
   gentoo: [dev-python/netifaces]
@@ -5758,6 +5771,7 @@ python3-nose-yanc:
   openembedded: [python3-nose-yanc@meta-ros]
   ubuntu: [python3-nose-yanc]
 python3-numpy:
+  alpine: [py3-numpy]
   debian: [python3-numpy]
   fedora: [python3-numpy]
   gentoo: [dev-python/numpy]
@@ -5849,6 +5863,7 @@ python3-pip:
   fedora: [python3-pip]
   ubuntu: [python3-pip]
 python3-pkg-resources:
+  alpine: [py3-setuptools]
   debian: [python3-pkg-resources]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
@@ -5891,6 +5906,7 @@ python3-pyaudio:
       packages: [pyaudio]
   ubuntu: [python3-pyaudio]
 python3-pycodestyle:
+  alpine: [py3-pycodestyle]
   arch: [python-pycodestyle]
   debian: [python3-pycodestyle]
   fedora: [python3-pycodestyle]
@@ -5909,6 +5925,7 @@ python3-pycryptodome:
   rhel: ['python%{python3_pkgversion}-pycryptodomex']
   ubuntu: [python3-pycryptodome]
 python3-pydot:
+  alpine: [py3-pydot]
   arch: [python-pydot]
   debian: [python3-pydot]
   fedora: [python3-pydot]
@@ -6088,6 +6105,7 @@ python3-retrying:
       packages: [retrying]
   ubuntu: [python3-retrying]
 python3-rosdep:
+  alpine: [rosdep]
   debian: [python3-rosdep]
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
@@ -6101,6 +6119,7 @@ python3-rosdep-modules:
   rhel: ['python%{python3_pkgversion}-rosdep']
   ubuntu: [python3-rosdep-modules]
 python3-rosdistro-modules:
+  alpine: [py3-rosdistro]
   debian: [python3-rosdistro-modules]
   fedora: [python3-rosdistro]
   gentoo: [dev-python/rosdistro]
@@ -6108,9 +6127,7 @@ python3-rosdistro-modules:
   rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
 python3-rospkg:
-  alpine:
-    pip:
-      packages: [rospkg]
+  alpine: [py3-rospkg]
   debian: [python3-rospkg]
   fedora: [python3-rospkg]
   freebsd:
@@ -6180,6 +6197,7 @@ python3-serial:
   fedora: [python3-pyserial]
   ubuntu: [python3-serial]
 python3-setuptools:
+  alpine: [py3-setuptools]
   debian: [python3-setuptools]
   fedora: [python3-setuptools]
   gentoo: [dev-python/setuptools]
@@ -6347,6 +6365,7 @@ python3-usb:
   gentoo: [dev-python/pyusb]
   ubuntu: [python3-usb]
 python3-vcstool:
+  alpine: [vcstool]
   debian:
     pip:
       packages: [vcstool]


### PR DESCRIPTION
I have finally got around to finishing what I started a year ago. This should be all the dependencies for ROS2 foxy ros_base (and probably a lot of desktop).

All keys added have links to their alpine pkgs, and merge requests if I did the work in getting it added to Alpine Linux.

Thanks to the super helpful Alpine Linux maintainers.

### Merged:
- [x] pydocstyle https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-pydocstyle (https://github.com/alpinelinux/aports/pull/12002)
- [x] python3-lark-parser https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-lark-parser (https://github.com/alpinelinux/aports/pull/12001)
- [x] python3-pydot https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-pydot (https://github.com/alpinelinux/aports/pull/12000)
- [x]  python3-empy https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-empy (https://github.com/alpinelinux/aports/pull/7635)
- [x]  python3-catkin-pkg-modules https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-catkin-pkg-modules (https://github.com/alpinelinux/aports/pull/7641)
- [x]  assimp https://pkgs.alpinelinux.org/package/edge/testing/x86_64/assimp (https://github.com/alpinelinux/aports/pull/7762)
- [x] clang-tidy https://pkgs.alpinelinux.org/package/edge/main/x86_64/clang-extra-tools (https://gitlab.alpinelinux.org/alpine/aports/merge_requests/2249)
- [x] python3-babeltrace - https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3_babeltrace (https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/8946)
- [x] python3-lttng -  https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-lttng https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/8952
- [x] vcstool - https://pkgs.alpinelinux.org/package/edge/testing/x86_64/vcstool - https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/8967
- [x] rosdep - https://pkgs.alpinelinux.org/package/edge/testing/x86_64/rosdep - https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/8976
- [x] python3-rospkg - https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-rospkg - https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/8976
- [x] python3-rosdistro-modules - https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-rosdistro - https://github.com/ros-infrastructure/rosdistro - https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/8976

### Already packaged:
- python3-qt5-bindings https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-qt5
- opengl https://pkgs.alpinelinux.org/package/edge/main/x86_64/mesa-dev
- clang-format https://pkgs.alpinelinux.org/package/edge/main/x86_64/clang
- python3-lxml https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-lxml
- python3-pkg-resources https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-setuptools
- python3-flake8 https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-flake8
- libqt5-opengl https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt5-qtbase-dev
- libxml2-utils https://pkgs.alpinelinux.org/package/edge/main/x86_64/libxml2-utils
- pcre https://pkgs.alpinelinux.org/package/edge/main/x86_64/pcre-dev
- qt5-qmake https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt5-qtbase-dev
- pyflakes3 https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-pyflakes
- python3-setuptools https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-setuptools
- libqt5-gui https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt5-qtbase
- openssl https://pkgs.alpinelinux.org/package/edge/main/x86_64/openssl
- libxrandr https://pkgs.alpinelinux.org/package/edge/main/x86_64/libxrandr-dev
- libqt5-core https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt5-qtbase
- python3-qt5-bindings https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-qt5
- libxaw https://pkgs.alpinelinux.org/package/edge/main/x86_64/libxaw
- python3-numpy https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-numpy
- python3-matplotlib https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-matplotlib
- libx11 https://pkgs.alpinelinux.org/package/edge/main/x86_64/libx11
- libx11-dev https://pkgs.alpinelinux.org/package/edge/main/x86_64/libx11-dev
- python3-mock https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-mock
- libsqlite3-dev https://pkgs.alpinelinux.org/package/edge/main/x86_64/sqlite-dev
- git https://pkgs.alpinelinux.org/package/edge/main/x86_64/git
- spdlog https://pkgs.alpinelinux.org/package/edge/community/x86_64/spdlog-dev
- libzstd-dev https://pkgs.alpinelinux.org/package/edge/main/x86_64/zstd-dev
- libcunit-dev https://pkgs.alpinelinux.org/package/edge/main/x86_64/cunit-dev
- bullet https://pkgs.alpinelinux.org/package/edge/testing/x86_64/bullet-dev
- python3-pycodestyle https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-pycodestyle
- python3-netifaces https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-netifaces
- python3-mypy https://pkgs.alpinelinux.org/package/edge/testing/x86_64/py3-mypy
- python3-cryptography https://pkgs.alpinelinux.org/package/edge/main/x86_64/py3-cryptography
- maven https://pkgs.alpinelinux.org/package/edge/community/x86_64/maven
- java https://pkgs.alpinelinux.org/package/edge/community/x86_64/openjdk8-jre
- opencv (was moved back into testing) - https://pkgs.alpinelinux.org/package/edge/testing/x86_64/opencv