### PR TITLE
realsense2_camera: 2.2.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11474,7 +11474,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.14-1
+      version: 2.2.15-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.15-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.2.14-1`

## realsense2_camera

```
* Check runtime version of librealsense2 vs. compiled version and issue a warning is mismatch occurs.
* Support both L515 and L515 pre-prq versions.
* set infra, fisheye, IMU and pose streams to be false by default.
* add d435i-xacro
* comply to ROS Noetic xacro rules (backcompatible with ROS Melodic)
* Contributors: Marco Camurri, doronhi
```

## realsense2_description

```
* Merge remote-tracking branch 'origin/development' into development
* Merge pull request #1126 <https://github.com/intel-ros/realsense/issues/1126> from mcamurri/add-d435i-xacro
  add D435i modules, urdf and launchfile
* comply to ROS Noetic xacro rules (backcompatible with ROS Melodic)
* Merge branch 'development' into add-d435i-xacro
* Merge branch 'development' of https://github.com/IntelRealSense/realsense-ros into development
  realsense2_description/urdf/test_d435_multiple_cameras.urdf.xacro
* move xml start line in the right place
* add D435i modules, urdf and launchfile
* fix use_nominal_extrinsics arg/property
* add D435i modules, urdf and launchfile
* Contributors: Marco Camurri, doronhi
```
