### PR TITLE
ros2cli_common_extensions: 0.1.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1647,6 +1647,17 @@ repositories:
       url: https://github.com/ros2/ros2cli.git
       version: master
     status: maintained
+  ros2cli_common_extensions:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
+      version: 0.1.0-4
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.1.0-4`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ros2cli_common_extensions

```
* First implementation (#2 <https://github.com/ros2/ros2cli_common_extensions/issues/2>)
* Contributors: Bo Sun
```
