### PR TITLE
Update Ignition rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2549,7 +2549,7 @@ libicu-dev:
   fedora: [libicu-devel]
   gentoo: [dev-libs/icu]
   ubuntu: [libicu-dev]
-libignition-cmake2-dev:
+ignition-cmake2:
   debian:
     buster: [libignition-cmake2-dev]
   ubuntu:
@@ -2559,7 +2559,7 @@ libignition-common3:
     buster: [libignition-common3]
   ubuntu:
     focal: [libignition-common3]
-libignition-common3-dev:
+ignition-common3:
   debian:
     buster: [libignition-common3-dev]
   ubuntu:
@@ -2569,7 +2569,7 @@ libignition-fuel-tools4:
     buster: [libignition-fuel-tools4]
   ubuntu:
     focal: [libignition-fuel-tools4]
-libignition-fuel-tools4-dev:
+ignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4-dev]
   ubuntu:
@@ -2579,7 +2579,7 @@ libignition-gazebo3:
     buster: [libignition-gazebo3]
   ubuntu:
     focal: [libignition-gazebo3]
-libignition-gazebo3-dev:
+ignition-gazebo3:
   debian:
     buster: [libignition-gazebo3-dev]
   ubuntu:
@@ -2589,7 +2589,7 @@ libignition-gui3:
     buster: [libignition-gui3]
   ubuntu:
     focal: [libignition-gui3]
-libignition-gui3-dev:
+ignition-gui3:
   debian:
     buster: [libignition-gui3-dev]
   ubuntu:
@@ -2599,7 +2599,7 @@ libignition-launch2:
     buster: [libignition-launch2]
   ubuntu:
     focal: [libignition-launch2]
-libignition-launch2-dev:
+ignition-launch2:
   debian:
     buster: [libignition-launch2-dev]
   ubuntu:
@@ -2609,12 +2609,12 @@ libignition-math6:
     buster: [libignition-math6]
   ubuntu:
     focal: [libignition-math6]
-libignition-math6-dev:
+ignition-math6:
   debian:
     buster: [libignition-math6-dev]
   ubuntu:
     focal: [libignition-math6-dev]
-libignition-math6-eigen3-dev:
+ignition-math6-eigen3:
   debian:
     buster: [libignition-math6-eigen3-dev]
   ubuntu:
@@ -2624,7 +2624,7 @@ libignition-msgs5:
     buster: [libignition-msgs5]
   ubuntu:
     focal: [libignition-msgs5]
-libignition-msgs5-dev:
+ignition-msgs5:
   debian:
     buster: [libignition-msgs5-dev]
   ubuntu:
@@ -2634,12 +2634,12 @@ libignition-physics2:
     buster: [libignition-physics2]
   ubuntu:
     focal: [libignition-physics2]
-libignition-physics2-dev:
+ignition-physics2:
   debian:
     buster: [libignition-physics2-dev]
   ubuntu:
     focal: [libignition-physics2-dev]
-libignition-plugin-dev:
+ignition-plugin:
   debian:
     buster: [libignition-plugin-dev]
   ubuntu:
@@ -2649,7 +2649,7 @@ libignition-rendering3:
     buster: [libignition-rendering3]
   ubuntu:
     focal: [libignition-rendering3]
-libignition-rendering3-dev:
+ignition-rendering3:
   debian:
     buster: [libignition-rendering3-dev]
   ubuntu:
@@ -2659,12 +2659,12 @@ libignition-sensors3:
     buster: [libignition-sensors3]
   ubuntu:
     focal: [libignition-sensors3]
-libignition-sensors3-dev:
+ignition-sensors3:
   debian:
     buster: [libignition-sensors3-dev]
   ubuntu:
     focal: [libignition-sensors3-dev]
-libignition-tools-dev:
+ignition-tools:
   debian:
     buster: [libignition-tools-dev]
   ubuntu:
@@ -2674,7 +2674,7 @@ libignition-transport8:
     buster: [libignition-transport8]
   ubuntu:
     focal: [libignition-transport8]
-libignition-transport8-dev:
+ignition-transport8:
   debian:
     buster: [libignition-transport8-dev]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1404,11 +1404,81 @@ ignition-citadel:
     buster: [ignition-citadel]
   ubuntu:
     focal: [ignition-citadel]
+ignition-cmake2:
+  debian:
+    buster: [libignition-cmake2-dev]
+  ubuntu:
+    focal: [libignition-cmake2-dev]
+ignition-common3:
+  debian:
+    buster: [libignition-common3-dev]
+  ubuntu:
+    focal: [libignition-common3-dev]
+ignition-fuel-tools4:
+  debian:
+    buster: [libignition-fuel-tools4-dev]
+  ubuntu:
+    focal: [libignition-fuel-tools4-dev]
+ignition-gazebo3:
+  debian:
+    buster: [libignition-gazebo3-dev]
+  ubuntu:
+    focal: [libignition-gazebo3-dev]
+ignition-gui3:
+  debian:
+    buster: [libignition-gui3-dev]
+  ubuntu:
+    focal: [libignition-gui3-dev]
+ignition-launch2:
+  debian:
+    buster: [libignition-launch2-dev]
+  ubuntu:
+    focal: [libignition-launch2-dev]
+ignition-math6:
+  debian:
+    buster: [libignition-math6-dev]
+  ubuntu:
+    focal: [libignition-math6-dev]
+ignition-math6-eigen3:
+  debian:
+    buster: [libignition-math6-eigen3-dev]
+  ubuntu:
+    focal: [libignition-math6-eigen3-dev]
+ignition-msgs5:
+  debian:
+    buster: [libignition-msgs5-dev]
+  ubuntu:
+    focal: [libignition-msgs5-dev]
+ignition-physics2:
+  debian:
+    buster: [libignition-physics2-dev]
+  ubuntu:
+    focal: [libignition-physics2-dev]
+ignition-plugin:
+  debian:
+    buster: [libignition-plugin-dev]
+  ubuntu:
+    focal: [libignition-plugin-dev]
+ignition-rendering3:
+  debian:
+    buster: [libignition-rendering3-dev]
+  ubuntu:
+    focal: [libignition-rendering3-dev]
+ignition-sensors3:
+  debian:
+    buster: [libignition-sensors3-dev]
+  ubuntu:
+    focal: [libignition-sensors3-dev]
 ignition-tools:
   debian:
-    buster: [ignition-tools]
+    buster: [libignition-tools-dev]
   ubuntu:
-    focal: [ignition-tools]
+    focal: [libignition-tools-dev]
+ignition-transport8:
+  debian:
+    buster: [libignition-transport8-dev]
+  ubuntu:
+    focal: [libignition-transport8-dev]
 imagemagick:
   arch: [imagemagick]
   debian: [imagemagick]
@@ -2549,136 +2619,61 @@ libicu-dev:
   fedora: [libicu-devel]
   gentoo: [dev-libs/icu]
   ubuntu: [libicu-dev]
-ignition-cmake2:
-  debian:
-    buster: [libignition-cmake2-dev]
-  ubuntu:
-    focal: [libignition-cmake2-dev]
 libignition-common3:
   debian:
     buster: [libignition-common3]
   ubuntu:
     focal: [libignition-common3]
-ignition-common3:
-  debian:
-    buster: [libignition-common3-dev]
-  ubuntu:
-    focal: [libignition-common3-dev]
 libignition-fuel-tools4:
   debian:
     buster: [libignition-fuel-tools4]
   ubuntu:
     focal: [libignition-fuel-tools4]
-ignition-fuel-tools4:
-  debian:
-    buster: [libignition-fuel-tools4-dev]
-  ubuntu:
-    focal: [libignition-fuel-tools4-dev]
 libignition-gazebo3:
   debian:
     buster: [libignition-gazebo3]
   ubuntu:
     focal: [libignition-gazebo3]
-ignition-gazebo3:
-  debian:
-    buster: [libignition-gazebo3-dev]
-  ubuntu:
-    focal: [libignition-gazebo3-dev]
 libignition-gui3:
   debian:
     buster: [libignition-gui3]
   ubuntu:
     focal: [libignition-gui3]
-ignition-gui3:
-  debian:
-    buster: [libignition-gui3-dev]
-  ubuntu:
-    focal: [libignition-gui3-dev]
 libignition-launch2:
   debian:
     buster: [libignition-launch2]
   ubuntu:
     focal: [libignition-launch2]
-ignition-launch2:
-  debian:
-    buster: [libignition-launch2-dev]
-  ubuntu:
-    focal: [libignition-launch2-dev]
 libignition-math6:
   debian:
     buster: [libignition-math6]
   ubuntu:
     focal: [libignition-math6]
-ignition-math6:
-  debian:
-    buster: [libignition-math6-dev]
-  ubuntu:
-    focal: [libignition-math6-dev]
-ignition-math6-eigen3:
-  debian:
-    buster: [libignition-math6-eigen3-dev]
-  ubuntu:
-    focal: [libignition-math6-eigen3-dev]
 libignition-msgs5:
   debian:
     buster: [libignition-msgs5]
   ubuntu:
     focal: [libignition-msgs5]
-ignition-msgs5:
-  debian:
-    buster: [libignition-msgs5-dev]
-  ubuntu:
-    focal: [libignition-msgs5-dev]
 libignition-physics2:
   debian:
     buster: [libignition-physics2]
   ubuntu:
     focal: [libignition-physics2]
-ignition-physics2:
-  debian:
-    buster: [libignition-physics2-dev]
-  ubuntu:
-    focal: [libignition-physics2-dev]
-ignition-plugin:
-  debian:
-    buster: [libignition-plugin-dev]
-  ubuntu:
-    focal: [libignition-plugin-dev]
 libignition-rendering3:
   debian:
     buster: [libignition-rendering3]
   ubuntu:
     focal: [libignition-rendering3]
-ignition-rendering3:
-  debian:
-    buster: [libignition-rendering3-dev]
-  ubuntu:
-    focal: [libignition-rendering3-dev]
 libignition-sensors3:
   debian:
     buster: [libignition-sensors3]
   ubuntu:
     focal: [libignition-sensors3]
-ignition-sensors3:
-  debian:
-    buster: [libignition-sensors3-dev]
-  ubuntu:
-    focal: [libignition-sensors3-dev]
-ignition-tools:
-  debian:
-    buster: [libignition-tools-dev]
-  ubuntu:
-    focal: [libignition-tools-dev]
 libignition-transport8:
   debian:
     buster: [libignition-transport8]
   ubuntu:
     focal: [libignition-transport8]
-ignition-transport8:
-  debian:
-    buster: [libignition-transport8-dev]
-  ubuntu:
-    focal: [libignition-transport8-dev]
 libimage-exiftool-perl:
   arch: [perl-image-exiftool]
   debian: [libimage-exiftool-perl]


### PR DESCRIPTION
Originally on #24934 we added rosdep keys that matched the debian package names as recommended by the reviewers: https://github.com/ros/rosdistro/pull/24934#discussion_r427444961.

However, this makes usage of these keys complicated when compiling Ignition libraries (pure CMake packages) and ROS packages together in the same colcon workspace (our team often does this). 

[Here](https://github.com/ignitionrobotics/ros_ign/blob/e2feecf0cbba07a2f2b630c3dd42a674d251bc61/ros_ign_bridge/package.xml#L15-L16)'s an example that can be in the same colcon workspace as Ignition:

```.xml
  <depend>ignition-msgs5</depend>
  <depend>ignition-transport8</depend>
```

However, the above doesn't work with `rosdep install`. Ideally, we'd declare Ignition dependencies once, and they would work with either `rosdep` or `colcon`.

Therefore, I propose here that we change the `-dev` keys to match the CMake project names.

Let me know if this is a big taboo and we can discuss alternatives.

CC @j-rivero @sloretz @dirk-thomas 