### PR TITLE
sick_scan: 1.7.6-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10695,7 +10695,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 1.7.6-1
+      version: 1.7.6-2
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `1.7.6-2`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.7.6-1`
