### PR TITLE
ros2cli_common_extensions: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1825,12 +1825,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: master
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
       version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: foxy
     status: maintained
   ros_environment:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1821,6 +1821,17 @@ repositories:
       url: https://github.com/ros2/ros2cli.git
       version: foxy
     status: maintained
+  ros2cli_common_extensions:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
+      version: 0.1.0-1
+    status: maintained
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ros2cli_common_extensions

```
* First implementation (#2 <https://github.com/ros2/ros2cli_common_extensions/issues/2>)
* Contributors: Bo Sun
```
