### PR TITLE
add python3-requests-oauthlib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6078,6 +6078,12 @@ python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]
   ubuntu: [python3-requests]
+python3-requests-oauthlib:
+  debian: [python3-requests-oauthlib]
+  fedora: [python3-requests-oauthlib]
+  gentoo: [dev-python/requests-oauthlib]
+  rhel: ['python%{python3_pkgversion}-requests-oauthlib']
+  ubuntu: [python3-requests-oauthlib]
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]


### PR DESCRIPTION
`debian`: https://packages.debian.org/buster/python3-requests-oauthlib
`fedora`: https://fedora.pkgs.org/30/fedora-x86_64/python3-requests-oauthlib-1.0.0-1.fc29.noarch.rpm.html
`gentoo`: https://packages.gentoo.org/packages/dev-python/requests-oauthlib
`rhel`: https://centos.pkgs.org/8/centos-baseos-x86_64/python3-requests-oauthlib-1.0.0-1.el8.noarch.rpm.html
`ubuntu`: https://packages.ubuntu.com/focal/python3-requests-oauthlib

c.f. https://pkgs.org/search/?q=python3-requests-oauthlib