### PR TITLE
Enable pull request testing for system_tests.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2476,6 +2476,7 @@ repositories:
     status: developed
   system_tests:
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/system_tests.git
       version: foxy

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2271,6 +2271,7 @@ repositories:
     status: developed
   system_tests:
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/system_tests.git
       version: master


### PR DESCRIPTION
From the discussion in https://github.com/ros2/system_tests/pull/441#issuecomment-657741298 enables pull request testing for the system_tests repository on Rolling.