### PR TITLE
catkin_virtualenv: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -265,6 +265,22 @@ repositories:
       url: https://github.com/ros/catkin.git
       version: noetic-devel
     status: maintained
+  catkin_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/locusrobotics/catkin_virtualenv-release.git
+      version: 0.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/catkin_virtualenv.git
+      version: master
+    status: maintained
   class_loader:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.6.0-1`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## catkin_virtualenv

```
* Don't require catkin_package to be called before catkin_generate_virtualenv (#67 <https://github.com/locusrobotics/catkin_virtualenv/issues/67>)
* Revert "Downgrade docutils so that boto works (#66 <https://github.com/locusrobotics/catkin_virtualenv/issues/66>)"
  This reverts commit 998cd6add2e43e12036d0db15a7c4d58fe3411cf.
* Downgrade docutils so that boto works (#66 <https://github.com/locusrobotics/catkin_virtualenv/issues/66>)
  See https://github.com/boto/botocore/issues/1942 and related threads.
* Make regex for Python bytecode more selective (#65 <https://github.com/locusrobotics/catkin_virtualenv/issues/65>)
  Fix regex to match only files ending in ".py[co]" and not files ending
  in "py[co]".
* Remove user specific paths (#63 <https://github.com/locusrobotics/catkin_virtualenv/issues/63>)
  * Remove user specific paths
  * Change working directory of venv_lock command
  * Lock catkin_virtualenv base requirements
  Co-authored-by: Paul Bovbel <mailto:paul@bovbel.com>
* RST-3172 Check that requirements file is locked (#62 <https://github.com/locusrobotics/catkin_virtualenv/issues/62>)
* Two helpful hints (#61 <https://github.com/locusrobotics/catkin_virtualenv/issues/61>)
* Fix input requirements warning (#58 <https://github.com/locusrobotics/catkin_virtualenv/issues/58>)
  * Only warn about INPUT_REQUIREMENTS if a package exports requirements to begin with
  * Update catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
  Co-authored-by: Andrew Blakey <mailto:ablakey@gmail.com>
  Co-authored-by: Andrew Blakey <mailto:ablakey@gmail.com>
* Preserve symlinks during copy (#57 <https://github.com/locusrobotics/catkin_virtualenv/issues/57>)
* Don't ignore unknown args
* RST-3172 Refactor catkin_virtualenv to allow locking dependencies (#55 <https://github.com/locusrobotics/catkin_virtualenv/issues/55>)
  * Remove unused options
  * Fix regex for comments
  * Migrate scripts
  * Remove old code
  * Move common requirements to an export file
  * Minor cleanup
  * Remove requirement-parsing unit tests
  * Fix logging config
  * Fix test builds
  * Generate lock files
  * Fix tests
  * Move dh-virtualenv functions into separate file
  * Fix roslint
  * Update docs
  * Update requirements
  * CMake comments
  * Fix pip-args
  * README fixup
  * Correct ARG_LOCK_FILE handling
  * Remove headers
  * Use set comprehension
  * Add migration doc
  * Respin
* Use exec to dive into python (#51 <https://github.com/locusrobotics/catkin_virtualenv/issues/51>)
* First python2 issue of 2020 (#49 <https://github.com/locusrobotics/catkin_virtualenv/issues/49>)
  * Clean up options, virtualenv installs setuptools by default
  * Make sure we install a compatible setuptools version for py2 venv
* catkin-pkg-modules has disappeared off pypi (#46 <https://github.com/locusrobotics/catkin_virtualenv/issues/46>)
  * catkin-pkg-modules has disappeared off pypi, but catkin-pkg is still there
  * Version all requirements
* Contributors: David V. Lu!!, Michael Johnson, Paul Bovbel, abencz
```
