### PR TITLE
catkin: 0.7.27-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1056,7 +1056,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.26-1
+      version: 0.7.27-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.27-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.26-1`

## catkin

```
* explicitly call project() in toplevel CMakeLists.txt (#1106 <https://github.com/ros/catkin/issues/1106>)
* add Arch Linux gtest path (#1105 <https://github.com/ros/catkin/issues/1105>)
* fix symlink install python when shebang line is rewritten (#1100 <https://github.com/ros/catkin/issues/1100>)
* fix CATKIN_SYMLINK_INSTALL with add_subdirectory() (#1102 <https://github.com/ros/catkin/issues/1102>)
* define GMOCK_* and GTEST_* variables in a new subproject (#1101 <https://github.com/ros/catkin/issues/1101>)
```
