### PR TITLE
collada_urdf: 1.12.13-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1629,7 +1629,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/collada_urdf-release.git
-      version: 1.12.12-0
+      version: 1.12.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `collada_urdf` to `1.12.13-1`:

- upstream repository: https://github.com/ros/collada_urdf.git
- release repository: https://github.com/ros-gbp/collada_urdf-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.12.12-0`

## collada_parser

```
* Update to newer CMake to get rid of CMP0048 warning (#38 <https://github.com/ros/collada_urdf/issues/38>)
* Contributors: Chris Lalancette
```

## collada_urdf

```
* Update to newer CMake to get rid of CMP0048 warning (#38 <https://github.com/ros/collada_urdf/issues/38>)
* Enable to output transmission_interface instead of pr2_mechanism_model (#35 <https://github.com/ros/collada_urdf/issues/35>)
* Contributors: Chris Lalancette, Shun Hasegawa
```
