### PR TITLE
Enable test_abi for Foxy: class_loader, console_bridge_vendor, libyaml_vendor, spdlog_vendor, unique_identifier_msgs

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -970,7 +970,7 @@ repositories:
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
       version: 1.0.2-1
     source:
-      n test_abi: true
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -251,6 +251,7 @@ repositories:
       url: https://github.com/ros2-gbp/class_loader-release.git
       version: 2.0.1-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
@@ -296,6 +297,7 @@ repositories:
       url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
       version: 1.2.1-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
@@ -968,6 +970,7 @@ repositories:
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
       version: 1.0.2-1
     source:
+      n test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
@@ -2446,6 +2449,7 @@ repositories:
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
       version: 1.1.2-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/spdlog_vendor.git
@@ -2669,6 +2673,7 @@ repositories:
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
       version: 2.1.2-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git


### PR DESCRIPTION
Following pull 25638, more ABI checker for Foxy packages under quality level
//cc @chapulina 