### PR TITLE
collada_urdf: 1.12.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -349,6 +349,25 @@ repositories:
       url: https://github.com/yoshito-n-students/codec_image_transport.git
       version: noetic-devel
     status: maintained
+  collada_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: kinetic-devel
+    release:
+      packages:
+      - collada_parser
+      - collada_urdf
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/collada_urdf-release.git
+      version: 1.12.13-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/collada_urdf.git
+      version: kinetic-devel
+    status: maintained
   common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `collada_urdf` to `1.12.13-1`:

- upstream repository: https://github.com/ros/collada_urdf.git
- release repository: https://github.com/ros-gbp/collada_urdf-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## collada_parser

```
* Update to newer CMake to get rid of CMP0048 warning (#38 <https://github.com/ros/collada_urdf/issues/38>)
* Contributors: Chris Lalancette
```

## collada_urdf

```
* Update to newer CMake to get rid of CMP0048 warning (#38 <https://github.com/ros/collada_urdf/issues/38>)
* Enable to output transmission_interface instead of pr2_mechanism_model (#35 <https://github.com/ros/collada_urdf/issues/35>)
* Contributors: Chris Lalancette, Shun Hasegawa
```
