### PR TITLE
remove realsense related repos from Foxy, and Rolling

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1347,23 +1347,6 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: dashing-devel
-  librealsense:
-    doc:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
-    release:
-      packages:
-      - librealsense2
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.34.0-1
-    source:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
-    status: maintained
   libyaml_vendor:
     release:
       tags:
@@ -2440,24 +2423,6 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: dashing
     status: developed
-  ros2_intel_realsense:
-    doc:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
-    release:
-      packages:
-      - realsense_camera_msgs
-      - realsense_ros2_camera
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.4-2
-    source:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: master
-    status: maintained
   ros2_object_analytics:
     doc:
       type: git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1347,6 +1347,23 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: dashing-devel
+  librealsense:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    release:
+      packages:
+      - librealsense2
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/librealsense-release.git
+      version: 2.34.0-1
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    status: maintained
   libyaml_vendor:
     release:
       tags:
@@ -2423,6 +2440,24 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: dashing
     status: developed
+  ros2_intel_realsense:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: master
+    release:
+      packages:
+      - realsense_camera_msgs
+      - realsense_ros2_camera
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
+      version: 2.0.4-2
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: master
+    status: maintained
   ros2_object_analytics:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -929,23 +929,6 @@ repositories:
       url: https://github.com/ros2-gbp/libg2o-release.git
       version: 2020.5.29-1
     status: maintained
-  librealsense:
-    doc:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
-    release:
-      packages:
-      - librealsense2
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.34.0-1
-    source:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
-    status: maintained
   libstatistics_collector:
     doc:
       type: git
@@ -1744,26 +1727,6 @@ repositories:
       url: https://github.com/lgsvl/ros2-lgsvl-bridge.git
       version: master
     status: developed
-  ros2_intel_realsense:
-    doc:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: refactor
-    release:
-      packages:
-      - realsense_examples
-      - realsense_msgs
-      - realsense_node
-      - realsense_ros
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.8-2
-    source:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: refactor
-    status: maintained
   ros2_ouster_drivers:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -890,23 +890,6 @@ repositories:
       url: https://github.com/ros2-gbp/libg2o-release.git
       version: 2020.5.29-2
     status: maintained
-  librealsense:
-    doc:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
-    release:
-      packages:
-      - librealsense2
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.34.0-2
-    source:
-      type: git
-      url: https://github.com/IntelRealSense/librealsense.git
-      version: ros2debian
-    status: maintained
   libstatistics_collector:
     doc:
       type: git
@@ -1554,26 +1537,6 @@ repositories:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master
-    status: maintained
-  ros2_intel_realsense:
-    doc:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: refactor
-    release:
-      packages:
-      - realsense_examples
-      - realsense_msgs
-      - realsense_node
-      - realsense_ros
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.8-3
-    source:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: refactor
     status: maintained
   ros2_ouster_drivers:
     doc:


### PR DESCRIPTION
All realsense related builds have been failing since they have been added and the maintainers are not responsive. To get rid of the jobs failing on a daily base this PR removes the repos from all active ROS 2 distros.

See https://github.com/ros/rosdistro/pull/24528#issuecomment-645452181

@sharronliu @doronhi FYI