### PR TITLE
moveit: 1.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5582,7 +5582,6 @@ repositories:
       - moveit_commander
       - moveit_controller_manager_example
       - moveit_core
-      - moveit_experimental
       - moveit_fake_controller_manager
       - moveit_kinematics
       - moveit_planners
@@ -5602,12 +5601,13 @@ repositories:
       - moveit_ros_visualization
       - moveit_ros_warehouse
       - moveit_runtime
+      - moveit_servo
       - moveit_setup_assistant
       - moveit_simple_controller_manager
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.0.5-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.4-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* [fix]   Python 3 fix (#2030 <https://github.com/ros-planning/moveit/issues/2030>)
* Contributors: Henning Kayser, Michael Görner, Robert Haschke
```

## moveit_controller_manager_example

- No changes

## moveit_core

```
* [fix]     Fix memory leaks related to geometric shapes usage (#2138 <https://github.com/ros-planning/moveit/issues/2138>)
* [fix]     Prevent collision checking segfault if octomap has NULL root pointer (#2104 <https://github.com/ros-planning/moveit/issues/2104>)
* [feature] Allow to parameterize input trajectory density of Time Optimal trajectory generation (#2185 <https://github.com/ros-planning/moveit/issues/2185>)
* [maint]   Optional C++ version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [maint]   Added missing boost::regex dependency (#2163 <https://github.com/ros-planning/moveit/issues/2163>)
* [maint]   PropagationDistanceField: Replace eucDistSq with squaredNorm (#2101 <https://github.com/ros-planning/moveit/issues/2101>)
* [fix]     Fix getTransform() (#2113 <https://github.com/ros-planning/moveit/issues/2113>)
  - PlanningScene::getTransforms().getTransform() -> PlanningScene::getFrameTransform()
  - PlanningScene::getTransforms().canTransform() -> PlanningScene::knowsFrameTransform()
* [fix]     Change FloatingJointModel::getStateSpaceDimension return value to 7 (#2106 <https://github.com/ros-planning/moveit/issues/2106>)
* [fix]     Check for empty quaternion message (#2089 <https://github.com/ros-planning/moveit/issues/2089>)
* [fix]     TOTG: Fix parameterization for single-waypoint trajectories (#2054 <https://github.com/ros-planning/moveit/issues/2054>)
  - RobotState: Added interfaces to zero and remove dynamics
* [maint]   Remove unused angles.h includes (#1985 <https://github.com/ros-planning/moveit/issues/1985>)
* Contributors: Felix von Drigalski, Henning Kayser, Michael Görner, Jere Liukkonen, John Stechschulte, Patrick Beeson, Robert Haschke, Tyler Weaver, Wolfgang Merkt
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* [feature] Added support for hybridize/interpolate flags in ModelBasedPlanningContext via ompl_planning.yaml (#2171 <https://github.com/ros-planning/moveit/issues/2171>, #2172 <https://github.com/ros-planning/moveit/issues/2172>)
* Contributors: Constantinos, Mark Moll
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* [maint] Fix mesh_filter test (#2044 <https://github.com/ros-planning/moveit/issues/2044>)
* Contributors: Bjar Ne
```

## moveit_ros_planning

```
* [feature] Trajectory Execution: fix check for start state position (#2157 <https://github.com/ros-planning/moveit/issues/2157>)
* [feature] Improve responsiveness of PlanningSceneDisplay (#2049 <https://github.com/ros-planning/moveit/issues/2049>)
  - PlanningSceneMonitor: increate update frequency from 10Hz to 30Hz
  - send RobotState diff if only position changed
* Contributors: Michael Görner, Robert Haschke, Simon Schmeisser
```

## moveit_ros_planning_interface

```
* [maint]   Remove dependency on panda_moveit_config (#2194 <https://github.com/ros-planning/moveit/issues/2194>`_, #2197 <https://github.com/ros-planning/moveit/issues/2197>`_)
* [maint]   Adapt linking to eigenpy (#2118 <https://github.com/ros-planning/moveit/issues/2118>)
* [maint]   Replace robot_model and robot_state namespaces with moveit::core (#2135 <https://github.com/ros-planning/moveit/issues/2135>)
* [feature] PlanningComponent: Load plan_request_params (#2033 <https://github.com/ros-planning/moveit/issues/2033>)
* [feature] MoveItCpp: a high-level C++ planning API (#1656 <https://github.com/ros-planning/moveit/issues/1656>)
* [fix]     Validate action client pointer before access
* [fix]     Wait and check for the grasp service
* [maint]   Add tests for move_group interface (#1995 <https://github.com/ros-planning/moveit/issues/1995>)
* Contributors: AndyZe, Henning Kayser, Jafar Abdi, Michael Görner, Robert Haschke, Tyler Weaver, Yeshwanth
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* [feature] Improve rviz GUI to add PlanningScene objects. Ask for scaling large meshes. (#2142 <https://github.com/ros-planning/moveit/issues/2142>)
* [maint]   Replace robot_model and robot_state namespaces with moveit::core (#2135 <https://github.com/ros-planning/moveit/issues/2135>)
* [maint]   Fix catkin_lint issues (#2120 <https://github.com/ros-planning/moveit/issues/2120>)
* [feature] PlanningSceneDisplay speedup (#2049 <https://github.com/ros-planning/moveit/issues/2049>)
* [feature] Added support for PS4 joystick (#2060 <https://github.com/ros-planning/moveit/issues/2060>)
* [fix]     MP display: planning attempts are natural numbers (#2076 <https://github.com/ros-planning/moveit/issues/2076>, #2082 <https://github.com/ros-planning/moveit/issues/2082>)
* Contributors: Felix von Drigalski, Henning Kayser, Jafar Abdi, Michael Görner, Robert Haschke, Simon Schmeisser, TrippleBender
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* [maint]   Minor moveit_servo header cleanup (#2173 <https://github.com/ros-planning/moveit/issues/2173>)
* [maint]   Move and rename to moveit_ros/moveit_servo (#2165 <https://github.com/ros-planning/moveit/issues/2165>)
* [maint]   Changes before porting to ROS2 (#2151 <https://github.com/ros-planning/moveit/issues/2151>)
  * throttle warning logs
  * ROS1 Basic improvements and changes
  * Fixes to drift dimensions, singularity velocity scaling
  * tf name changes, const fixes, slight logic changes
  * Move ROS_LOG_THROTTLE_PERIOD to cpp files
  * Track staleness of joint and twist seperately
  * Ensure joint_trajectory output is always populated with something, even when no jog
  * Fix joint trajectory redundant points for gazebo pub
  * Fix crazy joint jog from bad Eigen init
  * Fix variable type in addJointIncrements()
  * Initialize last sent command in constructor
  * More explicit joint_jog_cmdand twist_stamped_cmdnames
  * Add comment clarying transform calculation / use
* [fix]     Fix access past end of array bug (#2155 <https://github.com/ros-planning/moveit/issues/2155>)
* [maint]   Remove duplicate line (#2154 <https://github.com/ros-planning/moveit/issues/2154>)
* [maint]   pragma once in jog_arm.h (#2152 <https://github.com/ros-planning/moveit/issues/2152>)
* [feature] Simplify communication between threads (#2103 <https://github.com/ros-planning/moveit/issues/2103>)
  * get latest joint state c++ api
  * throttle warning logs
  * publish from jog calcs timer, removing redundant timer and internal messaging to main timer
  * outgoing message as pool allocated shared pointer for zero copy
  * replace jog_arm shared variables with ros pub/sub
  * use built in zero copy message passing instead of spsc_queues
  * use ros timers instead of threads in jog_arm
* [feature] Added throttle to jogarm accel limit warning (#2141 <https://github.com/ros-planning/moveit/issues/2141>)
* [feature] Time-based collision avoidance (#2100 <https://github.com/ros-planning/moveit/issues/2100>)
* [fix]     Fix crash on empty jog msgs (#2094 <https://github.com/ros-planning/moveit/issues/2094>)
* [feature] Jog arm dimensions (#1724 <https://github.com/ros-planning/moveit/issues/1724>)
* [maint]   Clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>)
* [feature] Keep updating joints, even while waiting for a valid command (#2027 <https://github.com/ros-planning/moveit/issues/2027>)
* [fix]     Fix param logic bug for self- and scene-collision proximity thresholds (#2022 <https://github.com/ros-planning/moveit/issues/2022>)
* [feature] Split collision proximity threshold (#2008 <https://github.com/ros-planning/moveit/issues/2008>)
  * separate proximity threshold values for self-collisions and scene collisions
  * increase default value of scene collision proximity threshold
  * deprecate old parameters
* [fix]     Fix valid command flags (#2013 <https://github.com/ros-planning/moveit/issues/2013>)
  * Rename the 'zero command flag' variables for readability
  * Reset flags when incoming commands timeout
  * Remove debug line, clang format
* [maint]   Use default move constructor + assignment operators for MoveItCpp. (#2004 <https://github.com/ros-planning/moveit/issues/2004>)
* [fix]     Fix low-pass filter initialization (#1982 <https://github.com/ros-planning/moveit/issues/1982>)
  * Pause/stop JogArm threads using shared atomic bool variables
  * Add pause/unpause flags for jog thread
  * Verify valid joints by filtering for active joint models only
  * Remove redundant joint state increments
  * Wait for initial jog commands in main loop
* [fix]     Remove duplicate collision check in JogArm (#1986 <https://github.com/ros-planning/moveit/issues/1986>)
* [feature] Add a binary collision check (#1978 <https://github.com/ros-planning/moveit/issues/1978>)
* [feature] Publish more detailed warnings (#1915 <https://github.com/ros-planning/moveit/issues/1915>)
* [feature] Use wait_for_service() to fix flaky tests (#1946 <https://github.com/ros-planning/moveit/issues/1946>)
* [maint]   Fix versioning (#1948 <https://github.com/ros-planning/moveit/issues/1948>)
* [feature] SRDF velocity and acceleration limit enforcement (#1863 <https://github.com/ros-planning/moveit/issues/1863>)
* [maint]   Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [fix]     JogArm C++ API fixes (#1911 <https://github.com/ros-planning/moveit/issues/1911>)
* [feature] A ROS service to enable task redundancy (#1855 <https://github.com/ros-planning/moveit/issues/1855>)
* [fix]     Fix segfault with uninitialized JogArm thread (#1882 <https://github.com/ros-planning/moveit/issues/1882>)
* [feature] Add warnings to moveit_jog_arm low pass filter (#1872 <https://github.com/ros-planning/moveit/issues/1872>)
* [maint]   Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix]     Fix initial end effector transform jump (#1871 <https://github.com/ros-planning/moveit/issues/1871>)
* [feature] Rework the halt msg functionality (#1868 <https://github.com/ros-planning/moveit/issues/1868>)
* [fix]     Various small fixes (#1859 <https://github.com/ros-planning/moveit/issues/1859>)
* [maint]   Improve formatting in comments
* [fix]     Prevent a crash at velocity limit (#1837 <https://github.com/ros-planning/moveit/issues/1837>)
* [feature] Remove scale/joint parameter (#1838 <https://github.com/ros-planning/moveit/issues/1838>)
* [feature] Pass planning scene monitor into cpp interface (#1849 <https://github.com/ros-planning/moveit/issues/1849>)
* [maint]   Move attribution below license file, standardize with MoveIt (#1847 <https://github.com/ros-planning/moveit/issues/1847>)
* [maint]   Reduce console output warnings (#1845 <https://github.com/ros-planning/moveit/issues/1845>)
* [fix]     Fix command frame transform computation (#1842 <https://github.com/ros-planning/moveit/issues/1842>)
* [maint]   Fix dependencies + catkin_lint issues
* [feature] Update link transforms before calling checkCollision on robot state in jog_arm (#1825 <https://github.com/ros-planning/moveit/issues/1825>)
* [feature] Add atomic bool flags for terminating JogArm threads gracefully (#1816 <https://github.com/ros-planning/moveit/issues/1816>)
* [feature] Get transforms from RobotState instead of TF (#1803 <https://github.com/ros-planning/moveit/issues/1803>)
* [feature] Add a C++ API (#1763 <https://github.com/ros-planning/moveit/issues/1763>)
* [maint]   Fix unused parameter warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint]   Update license formatting (#1764 <https://github.com/ros-planning/moveit/issues/1764>)
* [maint]   Unify jog_arm package to be C++14 (#1762 <https://github.com/ros-planning/moveit/issues/1762>)
* [fix]     Fix jog_arm segfault (#1692 <https://github.com/ros-planning/moveit/issues/1692>)
* [fix]     Fix double mutex unlock (#1672 <https://github.com/ros-planning/moveit/issues/1672>)
* [maint]   Rename jog_arm->moveit_jog_arm (#1663 <https://github.com/ros-planning/moveit/issues/1663>)
* [feature] Do not wait for command msg to start spinning (#1603 <https://github.com/ros-planning/moveit/issues/1603>)
* [maint]   Update jog_arm README with rviz config (#1614 <https://github.com/ros-planning/moveit/issues/1614>)
* [maint]   Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint]   Separate moveit_experimental packages (#1606 <https://github.com/ros-planning/moveit/issues/1606>)
* [feature] Use UR5 example (#1605 <https://github.com/ros-planning/moveit/issues/1605>)
* [feature] Sudden stop for critical issues, filtered deceleration otherwise (#1468 <https://github.com/ros-planning/moveit/issues/1468>)
* [feature] Change 2nd order Butterworth low pass filter to 1st order (#1483 <https://github.com/ros-planning/moveit/issues/1483>)
* [maint]   Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* [feature] JogArm: Remove dependency on move_group node (#1569 <https://github.com/ros-planning/moveit/issues/1569>)
* [fix]     Fix jog arm CI integration test (#1466 <https://github.com/ros-planning/moveit/issues/1466>)
* [feature] A jogging PR for Melodic. (#1360 <https://github.com/ros-planning/moveit/issues/1360>)
  * Allow for joints in the msg that are not part of the MoveGroup.
  * Switching to the Panda robot model for tests.
  * Blacklist the test as I can't get it to pass Travis (fine locally).
  * Throttling all warnings. Fix build warning re. unit vs int comparison.
  * Continue to publish commands even if stationary
  * Scale for 'unitless' commands is not tied to publish_period.
  * New function name for checkIfJointsWithinBounds()
  * Configure the number of msgs to publish when stationary.
  * Run jog_calcs at the same rate as the publishing thread.
  * Better comments in config file, add spacenav_node dependency
  * Add spacenav_node to CMakeLists.
* Contributors: AdamPettinger, AndyZe, Ayush Garg, Dale Koenig, Dave Coleman, Jonathan Binney, Paul Verhoeckx, Henning Kayser, Jafar Abdi, John Stechschulte, Mike Lautman, Robert Haschke, SansoneG, jschleicher, Tyler Weaver, rfeistenauer
```

## moveit_setup_assistant

```
* [fix]     Fix catkin_lint issues (#2120 <https://github.com/ros-planning/moveit/issues/2120>)
* [feature] Add use_rviz to demo.launch in setup_assistant (#2019 <https://github.com/ros-planning/moveit/issues/2019>)
* Contributors: Henning Kayser, Jafar Abdi, Michael Görner, Robert Haschke, Tyler Weaver
```

## moveit_simple_controller_manager

- No changes
