### PR TITLE
Fix benchmark rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -233,9 +233,9 @@ benchmark:
   debian:
     '*': [libbenchmark-dev]
     stretch: null
-  fedora: [google-benchmark]
+  fedora: [google-benchmark-devel]
   rhel:
-    '*': [google-benchmark]
+    '*': [google-benchmark-devel]
     '7': null
   ubuntu:
     '*': [libbenchmark-dev]


### PR DESCRIPTION
Install `-devel` to get the headers and CMake config and to match the `libbenchmark-dev` Ubuntu rule.