### PR TITLE
apriltag_ros: 3.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -201,7 +201,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag_ros-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.1.2-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.1.1-1`

## apriltag_ros

```
* Add support for tagCircle21h7, tagCircle49h12 (#69 <https://github.com/AprilRobotics/apriltag_ros/issues/69>)
* Add support for tagCustom48h12 (#65 <https://github.com/AprilRobotics/apriltag_ros/issues/65>)
* Contributors: Anthony Biviano, Kyle Saltmarsh, Wolfgang Merkt, kai wu
```
