### PR TITLE
apriltag_ros: 3.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -75,6 +75,17 @@ repositories:
       url: https://github.com/aprilrobotics/apriltag.git
       version: master
     status: maintained
+  apriltag_ros:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/AprilRobotics/apriltag_ros-release.git
+      version: 3.1.2-1
+    source:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag_ros.git
+      version: master
+    status: maintained
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.1.2-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag_ros.git
- release repository: https://github.com/AprilRobotics/apriltag_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## apriltag_ros

```
* Add support for tagCircle21h7, tagCircle49h12 (#69 <https://github.com/AprilRobotics/apriltag_ros/issues/69>)
* Add support for tagCustom48h12 (#65 <https://github.com/AprilRobotics/apriltag_ros/issues/65>)
* Contributors: Anthony Biviano, Kyle Saltmarsh, Wolfgang Merkt, kai wu
```
