### PR TITLE
rplidar_ros: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2120,6 +2120,18 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: foxy
     status: developed
+  rplidar_ros:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/allenh1/rplidar_ros-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/allenh1/rplidar_ros.git
+      version: ros2
+    status: maintained
   rpyutils:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.0.0-1`:

- upstream repository: https://github.com/allenh1/rplidar_ros
- release repository: https://github.com/allenh1/rplidar_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rplidar_ros

```
* Update SDK to Version 0.12.0 (#14 <https://github.com/allenh1/rplidar_ros/issues/14>)
  * Register the rclcpp component
  * Update RPLIDAR SDK to version 1.12.0
* Update ROS 2 parameters and use node's clock instance (#9 <https://github.com/allenh1/rplidar_ros/issues/9>)
  * Update ROS 2 parameters and use node's clock instance
  * Fix scan_mode listing output
  * Stop motors and exit when set_scan_mode() call fails
* Fix compilation with eloquent (#6 <https://github.com/allenh1/rplidar_ros/issues/6>)
* Use Composition node with launch files (#4 <https://github.com/allenh1/rplidar_ros/issues/4>)
* Composable nodes (#3 <https://github.com/allenh1/rplidar_ros/issues/3>)
  * Begin implementation of composable rplidar_ros::rplidar_node
  * Declare composition node library in CMake, as well as continue the port
  * Get to a compiling state
  * Add start/stop motor callbacks + more driver setup
  * Add publish loop for scans
  * Add composition node
  * Lint
* Port rviz and launch files to ROS2 (#2 <https://github.com/allenh1/rplidar_ros/issues/2>)
  * Port non-rviz launch files to ROS2
  * Compatibility with rviz2
  * revert whitespace changes
  * Port the remaining launch files to ROS2
  * Revert more whitespace changes
  * Fix luanch and rviz install path indent level
* Ros2 port (#1 <https://github.com/allenh1/rplidar_ros/issues/1>)
  ROS 2 port
  * Port CMakeLists.txt
  * Port package.xml
  * Port client.cpp
  * Port node.cpp
  Fix compilation
* Support TCP
* upgrade sdk 1.10.0
* upgrade sdk 1.9.0
  [new feature] support baudrate 57600 and 1382400, support HQ scan response
  [bugfix] TCP channel doesn't work
  [improvement] Print warning messages when deprecated APIs are called; imporve angular accuracy for ultra capsuled scan points
* [bugfix]modify scan_mode at test_rplidar.launch and test_rplidar_a3.launch
* Contributors: Dan Rose, Hunter L. Allen, WubinXia, kint
```
