### PR TITLE
ecl_tools: 1.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -614,7 +614,6 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_tools-release.git
       version: 1.0.2-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_tools.git
       version: devel

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -417,6 +417,26 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: foxy
     status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0.x
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_tools-release.git
+      version: 1.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0.x
+    status: maintained
   eigen3_cmake_module:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -435,7 +435,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_tools.git
-      version: release/1.0.x
+      version: devel
     status: maintained
   eigen3_cmake_module:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_tools` to `1.0.2-2`:

- upstream repository: https://github.com/stonier/ecl_tools.git
- release repository: https://github.com/yujinrobot-release/ecl_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ecl_build

```
* Cross-platform req and enable cxx11, cxx14
* Decouple warning levels from enabling standards
```
