### PR TITLE
py_trees_ros_interfaces: 2.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1330,6 +1330,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: foxy
     status: maintained
+  py_trees_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: release/1.2.x
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros_interfaces-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: release/1.2.x
+    status: developed
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `2.0.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces.git
- release repository: https://github.com/stonier/py_trees_ros_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
