### PR TITLE
pilz_industrial_motion: 0.4.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7269,11 +7269,12 @@ repositories:
       - pilz_industrial_motion_testutils
       - pilz_msgs
       - pilz_robot_programming
+      - pilz_store_positions
       - pilz_trajectory_generation
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.11-1`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.10-1`

## pilz_extensions

```
* Add feature to store points in package 'pilz_store_positions'.
* Fix CodeCoverage warnings (Remove warnings on normal builds).
* Contributors: Pilz GmbH and Co. KG
```

## pilz_industrial_motion

- No changes

## pilz_industrial_motion_testutils

- No changes

## pilz_msgs

```
* Add msg definition for speed frame
* Add srv definition for speed limit
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robot_programming

```
* Add Attribute based equivalence for commands.
* Add feature to store points.
* Add PoseStamped and tuple goals.
* Add get_current_pose_stamped to robot api
* Replace tf by tf2 in pilz_robot_programming.
* Rename _BaseCmd -> BaseCmd.
* Remove outdated add_python_coverage() function.
* Remove outdated/superfluous documents.
* Remove static version from doc.
* Remove unused import of prbt_hardware_support.
* Fix acceptance tests.
* Fix segfault on shutdown.
* Fix python 3 compatibility issues.
* Contributors: Pilz GmbH and Co. KG
```

## pilz_store_positions

```
* Add feature to storage positions to file.
* Contributors: Pilz GmbH and Co. KG
* Add ability to store one position
* Contributors: Pilz GmbH and Co. KG
```

## pilz_trajectory_generation

```
* Fix CodeCoverage warnings (Remove warnings on normal builds).
* Contributors: Pilz GmbH and Co. KG
```
