### PR TITLE
Revert "librealsense: 2.34.0-1 in 'dashing/distribution.yaml' [bloom]"

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1358,7 +1358,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/librealsense-release.git
-      version: 2.34.0-1
+      version: 2.16.5-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Reverts #24521

This release has not built on Dashing but previous releases have.
Since the maintainers currently have other priorities[[1]] reverting to a
working release is the best course of action available.

[1]: https://github.com/IntelRealSense/librealsense/issues/5825#issuecomment-626057335