### PR TITLE
udp_com: 0.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4189,6 +4189,21 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: master
     status: maintained
+  udp_com:
+    doc:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: ros1-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/flynneva/udp_com-release.git
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: 0.0.6
+    status: developed
   unique_identifier:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_com` to `0.0.6-1`:

- upstream repository: https://github.com/continental/udp_com.git
- release repository: https://github.com/flynneva/udp_com-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## udp_com

```
* switched branch to ros1-devel
* change branch name to ros1-devel
* switched destination branch to melodic-devel
* Contributors: Evan Flynn
```
