### PR TITLE
udp_com: 0.0.6-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16440,6 +16440,21 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: master
     status: maintained
+  udp_com:
+    doc:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: ros1-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/flynneva/udp_com-release.git
+      version: 0.0.6-2
+    source:
+      type: git
+      url: https://github.com/flynneva/udp_com-release.git
+      version: 0.0.6-2
+    status: maintained
   ueye:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_com` to `0.0.6-2`:

- upstream repository: https://github.com/continental/udp_com.git
- release repository: https://github.com/flynneva/udp_com-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## udp_com

```
* switched branch to ros1-devel
* change branch name to ros1-devel
* switched destination branch to melodic-devel
* Contributors: Evan Flynn
```
