### PR TITLE
transport_drivers: 0.0.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3414,7 +3414,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-drivers-gbp/transport_drivers-release.git
-      version: 0.0.4-3
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `0.0.5-1`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros-drivers-gbp/transport_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.4-3`

## serial_driver

```
* Remove Autoware.AUTO Dependencies (#15 <https://github.com/ros-drivers/transport_drivers/issues/15>)
  * Removing autoware dependencies.
  * Fixing linting errors.
  * Addressing review feedback.
* Be specific about which parts of Boost are necessary (#10 <https://github.com/ros-drivers/transport_drivers/issues/10>)
  * serial: be specific about Boost dependency.
  * udp: be specific about Boost dependency.
* Contributors: G.A. vd. Hoorn, Joshua Whitley
```

## udp_driver

```
* Be specific about which parts of Boost are necessary (#10 <https://github.com/ros-drivers/transport_drivers/issues/10>)
  * serial: be specific about Boost dependency.
  * udp: be specific about Boost dependency.
* Fix doxygen
* Contributors: Esteve Fernandez, G.A. vd. Hoorn
```
