### PR TITLE
dynamixel_sdk: 3.7.30-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -685,7 +685,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
-      version: 3.7.20-1
+      version: 3.7.30-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.30-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.7.20-1`

## dynamixel_sdk

```
* ROS 2 Eloquent Elusor supported
* ROS 2 Foxy Fitzroy supported
* 3x faster getError member function of GroupSync&BulkRead Class #388
* Contributors: developer0hye, Zerom, Will Son
```
