### PR TITLE
dynamixel_sdk: 3.7.30-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -532,6 +532,21 @@ repositories:
       url: https://github.com/chapulina/dolly.git
       version: master
     status: maintained
+  dynamixel_sdk:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
+      version: 3.7.30-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: eloquent-devel
+    status: developed
   ecl_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.30-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/robotis-ros2-release/dynamixel_sdk-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dynamixel_sdk

```
* ROS 2 Eloquent Elusor supported
* ROS 2 Foxy Fitzroy supported
* 3x faster getError member function of GroupSync&BulkRead Class #388
* Contributors: developer0hye, Zerom, Will Son
```
