### PR TITLE
Updating joystick_drivers branches.

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4272,7 +4272,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: master
+      version: melodic-devel
     release:
       packages:
       - joy
@@ -4287,7 +4287,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: master
+      version: melodic-devel
     status: developed
   jsk_3rdparty:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1399,7 +1399,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: master
+      version: main
     release:
       packages:
       - joy
@@ -1414,7 +1414,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: master
+      version: main
     status: maintained
   jsk_common:
     doc:


### PR DESCRIPTION
As discussed [on ROS Discourse](https://discourse.ros.org/t/consider-renaming-default-branches/15385), this PR changes the default branch for `joystick_drivers` in Noetic and corrects the branch for Melodic.