### PR TITLE
omni_turtlesim: 2.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1628,6 +1628,21 @@ repositories:
       url: https://github.com/octomap/octomap.git
       version: devel
     status: maintained
+  omni_turtlesim:
+    doc:
+      type: git
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2.git
+      version: dashing-devel
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_turtlesim` to `2.0.0-1`:

- upstream repository: https://github.com/Tiryoh/omni_turtlesim_ros2.git
- release repository: https://github.com/Tiryoh/omni_turtlesim_ros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## omni_turtlesim

```
* docs: Update CI badge
* chore: Specify the license
* feat: Update package description
* docs: Add usage in README
* fix: Rename package name in launch
* ci: Limit target branch
* docs: Update status badge
* ci: Add industrial_ci test settings (#2 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/2>)
* docs: Add README (#1 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/1>)
* feat: Add omni control
* feat: Rename package
* Contributors: Daisuke Sato, Tiryoh
```
