### PR TITLE
omni_turtlesim: 2.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1427,6 +1427,21 @@ repositories:
       url: https://github.com/octomap/octomap.git
       version: devel
     status: maintained
+  omni_turtlesim:
+    doc:
+      type: git
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2.git
+      version: eloquent-devel
+    status: maintained
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_turtlesim` to `2.1.0-1`:

- upstream repository: https://github.com/Tiryoh/omni_turtlesim_ros2.git
- release repository: https://github.com/Tiryoh/omni_turtlesim_ros2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## omni_turtlesim

```
* docs: Add README and LICENSE (#14 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/14>)
* feat: Update package description (#13 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/13>)
* fix: Rename package name in launch (#11 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/11>)
* feat: Add omni control (#10 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/10>)
* feat: Rename package (#8 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/8>)
* ci: Add industrial_ci settings
* Contributors: Daisuke Sato, Tiryoh
```
