### PR TITLE
omni_turtlesim: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1229,6 +1229,21 @@ repositories:
       url: https://github.com/octomap/octomap_msgs.git
       version: ros2
     status: maintained
+  omni_turtlesim:
+    doc:
+      type: git
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/Tiryoh/omni_turtlesim_ros2.git
+      version: foxy-devel
+    status: maintained
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_turtlesim` to `2.2.0-1`:

- upstream repository: https://github.com/Tiryoh/omni_turtlesim_ros2.git
- release repository: https://github.com/Tiryoh/omni_turtlesim_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## omni_turtlesim

```
* docs: Add README and LICENSE (#17 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/17>)
* ci: Update CI name for logging (#18 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/18>)
* feat: Update package description (#16 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/16>)
* fix: Rename package name in launch (#5 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/5>)
* feat: Add omni control (#4 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/4>)
* feat: Rename package (#3 <https://github.com/Tiryoh/omni_turtlesim_ros2/issues/3>)
* ci: Add industrial_ci settings
* Contributors: Daisuke Sato, Tiryoh
```
