### PR TITLE
popf: 0.0.12-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1375,6 +1375,21 @@ repositories:
       type: git
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: foxy
+  popf:
+    doc:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/fmrico/popf-release.git
+      version: 0.0.12-1
+    source:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: foxy-devel
+    status: developed
   py_trees_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `popf` to `0.0.12-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/fmrico/popf-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## popf

```
* Foxy initial version
* Fix conflicts in changelog
* Functional version
* 0.0.3
* Updated changelog
* Contributors: Francisco Martin Rico
```
