### PR TITLE
py_trees_msgs: 0.3.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2524,6 +2524,21 @@ repositories:
       type: git
       url: https://github.com/fetchrobotics/power_msgs.git
       version: ros1
+  py_trees_msgs:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_msgs.git
+      version: release/0.3.x
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stonier/py_trees_msgs-release.git
+      version: 0.3.6-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_msgs.git
+      version: release/0.3.x
+    status: maintained
   pybind11_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_msgs` to `0.3.6-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_msgs.git
- release repository: https://github.com/stonier/py_trees_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
