### PR TITLE
ecl_lite: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -594,10 +594,9 @@ repositories:
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
       version: 1.0.6-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/stonier/ecl_lite.git
-      version: devel
+      version: release/1.0.x
     status: maintained
   ecl_tools:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -432,6 +432,31 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: foxy-devel
     status: developed
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.1.x
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_lite-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: devel
+    status: maintained
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_lite` to `1.1.0-1`:

- upstream repository: https://github.com/stonier/ecl_lite.git
- release repository: https://github.com/yujinrobot-release/ecl_lite-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
