### PR TITLE
add catkin_tools for python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5404,6 +5404,10 @@ python3-catkin-pkg-modules:
       packages: [catkin-pkg]
   rhel: ['python%{python3_pkgversion}-catkin_pkg']
   ubuntu: [python3-catkin-pkg-modules]
+python3-catkin-tools:
+  debian: [python3-catkin-tools]
+  fedora: [python3-catkin_tools]
+  ubuntu: [python3-catkin-tools]
 python3-cherrypy3:
   debian: [python3-cherrypy3]
   ubuntu: [python3-cherrypy3]


### PR DESCRIPTION
`ubuntu`: http://packages.ros.org/ros-testing/ubuntu/pool/main/p/python3-catkin-tools/
`debian` : http://packages.ros.org/ros-testing/ubuntu/pool/main/p/python3-catkin-tools/
`fedora` : http://www.rpmfind.net/linux/rpm2html/search.php?query=python3dist(catkin-tools)