### PR TITLE
rmw_connext: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1455,7 +1455,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-1`

## rmw_connext_cpp

```
* Fix topic creation race condition (#442 <https://github.com/ros2/rmw_connext/issues/442>)
* Ensure compliant node construction/destruction API (#439 <https://github.com/ros2/rmw_connext/issues/439>)
* Improve error message when failing to create topic (#441 <https://github.com/ros2/rmw_connext/issues/441>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_connext_shared_cpp

```
* Fix topic creation race condition (#442 <https://github.com/ros2/rmw_connext/issues/442>)
* Ensure compliant node construction/destruction API (#439 <https://github.com/ros2/rmw_connext/issues/439>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```
