### PR TITLE
ros: 1.15.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2828,7 +2828,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.4-1
+      version: 1.15.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.6-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.15.4-1`

## mk

- No changes

## rosbash

- No changes

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

```
* fix string encoding in roscreate-pkg with Python 3 (#267 <https://github.com/ros/ros/issues/267>)
```

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

- No changes
