### PR TITLE
Fix python3-importlib-metadata rules for Fedora/RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5646,8 +5646,13 @@ python3-importlib-metadata:
     stretch:
       pip:
         packages: [importlib-metadata]
-  fedora: [python3-importlib-metadata]
+  fedora:
+    '*': [python3]
+    '31': [python3-importlib-metadata]
   gentoo: [dev-python/importlib_metadata]
+  rhel:
+    '*': ['python%{python3_pkgversion}-importlib-metadata']
+    '7': null
   ubuntu:
     '*': [python3-importlib-metadata]
     bionic:


### PR DESCRIPTION
The python3-importlib-metadata package is not present in Fedora 32 and newer, where Python 3.8 is used and the package is no longer needed.

This package is not currently available for RHEL 7, but it is packaged in EPEL 8.

https://src.fedoraproject.org/rpms/python-importlib-metadata#bodhi_updates