### PR TITLE
rosconsole: 1.13.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9346,7 +9346,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole-release.git
-      version: 1.13.11-1
+      version: 1.13.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole` to `1.13.16-1`:

- upstream repository: https://github.com/ros/rosconsole.git
- release repository: https://github.com/ros-gbp/rosconsole-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.13.11-1`

## rosconsole

```
* fix message in filter parameters (#43 <https://github.com/ros/rosconsole/issues/43>)
```
