### PR TITLE
dynamixel_sdk: 3.7.31-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2208,7 +2208,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
-      version: 3.7.21-1
+      version: 3.7.31-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.7.31-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.7.21-1`

## dynamixel_sdk

```
* ROS 1 Noetic Ninjemys support
* 3x faster getError member function of GroupSyncRead Class
* Contributors: developer0hye, Zerom, Will Son
```
