### PR TITLE
rcl_logging: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1275,7 +1275,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.0.1-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-1`

## rcl_logging_interface

- No changes

## rcl_logging_log4cxx

```
* Remove unused pytest dependency. (#43 <https://github.com/ros2/rcl_logging/issues/43>)
* Contributors: Chris Lalancette
```

## rcl_logging_noop

```
* Remove unused pytest dependency. (#43 <https://github.com/ros2/rcl_logging/issues/43>)
* Contributors: Chris Lalancette
```

## rcl_logging_spdlog

```
* Bump QD to level 3 and updated QD (#44 <https://github.com/ros2/rcl_logging/issues/44>)
* Added Doxyfile and fixed related warnings (#42 <https://github.com/ros2/rcl_logging/issues/42>)
* Contributors: Alejandro Hernández Cordero
```
