### PR TITLE
rcl_logging: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1549,7 +1549,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## rcl_logging_log4cxx

```
* Include rcutils/allocator.h in logging_interface.h (#47 <https://github.com/ros2/rcl_logging/issues/47>)
* Contributors: Jose Luis Rivero
```

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* Include rcutils/allocator.h in logging_interface.h (#47 <https://github.com/ros2/rcl_logging/issues/47>)
* Added Doxyfile and fixed related warnings (#42 <https://github.com/ros2/rcl_logging/issues/42>) (#46 <https://github.com/ros2/rcl_logging/issues/46>)
* Add Security Vulnerability Policy pointing to REP-2006.
* Rename Quality_Declaration.md -> QUALITY_DECLARATION.md
* Contributors: Chris Lalancette, Jacob Perron, Jose Luis Rivero
```
