### PR TITLE
common_interfaces: 2.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -297,7 +297,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 2.0.1-1
+      version: 2.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `2.0.3-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.1-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

```
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette
```

## geometry_msgs

```
* Finish up API documentation (#123 <https://github.com/ros2/common_interfaces/issues/123>)
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette, brawner
```

## nav_msgs

```
* Finish up API documentation (#123 <https://github.com/ros2/common_interfaces/issues/123>)
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette, brawner
```

## sensor_msgs

```
* Missing cstring header for memcpy in fill_image.hpp
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette, Jose Luis Rivero
```

## shape_msgs

```
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette
```

## std_msgs

```
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette
```

## std_srvs

```
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette
```

## stereo_msgs

```
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette
```

## trajectory_msgs

```
* Finish up API documentation (#123 <https://github.com/ros2/common_interfaces/issues/123>)
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette, brawner
```

## visualization_msgs

```
* Add Security Vulnerability Policy pointing to REP-2006. (#120 <https://github.com/ros2/common_interfaces/issues/120>)
* Contributors: Chris Lalancette
```
