### PR TITLE
rcpputils: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1347,7 +1347,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 1.2.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.0-1`

## rcpputils

```
* Removed doxygen warnings (#86 <https://github.com/ros2/rcpputils/issues/86>) (#87 <https://github.com/ros2/rcpputils/issues/87>)
* Add clamp header (#85 <https://github.com/ros2/rcpputils/issues/85>)
* Removed doxygen warnings (#86 <https://github.com/ros2/rcpputils/issues/86>)
* Split get_env_var() into header and implementation (#83 <https://github.com/ros2/rcpputils/issues/83>)
* Add cstring include for strcmp (#81 <https://github.com/ros2/rcpputils/issues/81>)
* filesystem helpers: adding remove_all to remove non-empty directories (#79 <https://github.com/ros2/rcpputils/issues/79>)
* Contributors: Alejandro Hernández Cordero, Christophe Bedard, Hunter L. Allen, Karsten Knese, Victor Lopez
```
