### PR TITLE
rcpputils: 1.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1639,7 +1639,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 1.1.0-1
+      version: 1.3.0-1
     source:
       test_abi: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## rcpputils

```
* Removed doxygen warnings (#86 <https://github.com/ros2/rcpputils/issues/86>) (#90 <https://github.com/ros2/rcpputils/issues/90>)
* Add clamp header (#85 <https://github.com/ros2/rcpputils/issues/85>) (#88 <https://github.com/ros2/rcpputils/issues/88>)
* Add remove_all to remove non-empty directories… (#80 <https://github.com/ros2/rcpputils/issues/80>)
* Contributors: Alejandro Hernández Cordero, Hunter L. Allen, Karsten Knese, Victor Lopez
```
