### PR TITLE
rmw_fastrtps: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1801,7 +1801,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.0.2-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-1`

## rmw_fastrtps_cpp

```
* Make service wait for response reader (#390 <https://github.com/ros2/rmw_fastrtps/issues/390>) (#412 <https://github.com/ros2/rmw_fastrtps/issues/412>)
* Contributors: Miguel Company
```

## rmw_fastrtps_dynamic_cpp

```
* Make service wait for response reader (#390 <https://github.com/ros2/rmw_fastrtps/issues/390>) (#412 <https://github.com/ros2/rmw_fastrtps/issues/412>)
* Contributors: Miguel Company
```

## rmw_fastrtps_shared_cpp

```
* Add missing thread-safety annotation in ServicePubListener (#409 <https://github.com/ros2/rmw_fastrtps/issues/409>) (#413 <https://github.com/ros2/rmw_fastrtps/issues/413>)
* Make service wait for response reader (#390 <https://github.com/ros2/rmw_fastrtps/issues/390>) (#412 <https://github.com/ros2/rmw_fastrtps/issues/412>)
* Contributors: Michel Hidalgo, Miguel Company
```
