### PR TITLE
Add libXext-devel to Fedora rule for python3-qt5-bindings

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6057,7 +6057,7 @@ python3-qt5-bindings:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
     jessie: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
     stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
-  fedora: [python3-qt5-devel, sip]
+  fedora: [python3-qt5-devel, libXext-devel]
   gentoo: [dev-python/PyQt5]
   opensuse: [python3-qt5]
   rhel: ['python%{python3_pkgversion}-qt5-devel']


### PR DESCRIPTION
Also drop the explicit sip dependency, which is pulled in by python3-qt5-devel already.

https://src.fedoraproject.org/rpms/libXext#bodhi_updates

On Debian, this gets brought in by qtbase5-dev. I'm guessing it isn't a dependency on Fedora for some reason related to the Wayland switch, but I can't be sure. In any case, the generated makefile for `sip` is what is explicitly adding the dependency, so I'm not sure which package should have the dependency in Fedora, if any. Listing it here seems like the right thing to do for now.

Closes  ros-visualization/qt_gui_core#230