### PR TITLE
PyPy sense-hat sense-emu x Raspberry Pi Sense HAT

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4186,6 +4186,20 @@ python-semver:
   debian: [python-semver]
   fedora: [python-semver]
   ubuntu: [python-semver]
+python-sense-emu-pip:
+  debian:
+    pip:
+      packages: [sense-emu]
+  ubuntu:
+    pip:
+      packages: [sense-emu]
+python-sense-hat-pip:
+  debian:
+    pip:
+      packages: [sense-hat]
+  ubuntu:
+    pip:
+      packages: [sense-hat]
 python-serial:
   arch: [python2-pyserial]
   debian: [python-serial]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4186,14 +4186,14 @@ python-semver:
   debian: [python-semver]
   fedora: [python-semver]
   ubuntu: [python-semver]
-python-sense-emu-pip:
+python3-sense-emu-pip:
   debian:
     pip:
       packages: [sense-emu]
   ubuntu:
     pip:
       packages: [sense-emu]
-python-sense-hat-pip:
+python3-sense-hat-pip:
   debian:
     pip:
       packages: [sense-hat]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4186,20 +4186,6 @@ python-semver:
   debian: [python-semver]
   fedora: [python-semver]
   ubuntu: [python-semver]
-python3-sense-emu-pip:
-  debian:
-    pip:
-      packages: [sense-emu]
-  ubuntu:
-    pip:
-      packages: [sense-emu]
-python3-sense-hat-pip:
-  debian:
-    pip:
-      packages: [sense-hat]
-  ubuntu:
-    pip:
-      packages: [sense-hat]
 python-serial:
   arch: [python2-pyserial]
   debian: [python-serial]
@@ -6215,6 +6201,20 @@ python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
   ubuntu: [python3-scp]
+python3-sense-emu-pip:
+  debian:
+    pip:
+      packages: [sense-emu]
+  ubuntu:
+    pip:
+      packages: [sense-emu]
+python3-sense-hat-pip:
+  debian:
+    pip:
+      packages: [sense-hat]
+  ubuntu:
+    pip:
+      packages: [sense-hat]
 python3-serial:
   debian: [python3-serial]
   fedora: [python3-pyserial]


### PR DESCRIPTION
Pip-only Python packages:
- add `python-sense-hat-pip` entry for `ubuntu` and `debian` to support Raspberry Pi Sense HAT (https://pypi.org/project/sense-hat/)
- add `python-sense-emu-pip` entry for `ubuntu` and `debian` to support tests and emulation (https://pypi.org/project/sense-emu/)