### PR TITLE
rmw: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1419,7 +1419,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-1`

## rmw

```
* Add actual domain id to rmw_context_t (#251 <https://github.com/ros2/rmw/issues/251>)
* Update node creation/destruction API documentation. (#249 <https://github.com/ros2/rmw/issues/249>)
* Correct parameter names to match documentation (#250 <https://github.com/ros2/rmw/issues/250>)
* Contributors: Geoffrey Biggs, Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_implementation_cmake

- No changes
