### PR TITLE
fkie_multimaster: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -898,6 +898,28 @@ repositories:
       url: https://github.com/fkie/message_filters.git
       version: master
     status: maintained
+  fkie_multimaster:
+    doc:
+      type: git
+      url: https://github.com/fkie/multimaster_fkie.git
+      version: noetic-devel
+    release:
+      packages:
+      - fkie_master_discovery
+      - fkie_master_sync
+      - fkie_multimaster
+      - fkie_multimaster_msgs
+      - fkie_node_manager
+      - fkie_node_manager_daemon
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fkie-release/multimaster_fkie-release.git
+      version: 1.2.1-1
+    source:
+      type: git
+      url: https://github.com/fkie/multimaster_fkie.git
+      version: noetic-devel
+    status: maintained
   fmi_adapter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_multimaster` to `1.2.1-1`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## fkie_master_discovery

```
* fkie_multimaster: added conditions for python3 dependencies in package xml
* Contributors: Alexander Tiderko
```

## fkie_master_sync

```
* fkie_multimaster: added conditions for python3 dependencies in package xml
* Contributors: Alexander Tiderko
```

## fkie_multimaster

```
* fkie_multimaster: added conditions for python3 dependencies in package xml
* Contributors: Alexander Tiderko
```

## fkie_multimaster_msgs

```
* fkie_multimaster: added conditions for python3 dependencies in package xml
* Contributors: Alexander Tiderko
```

## fkie_node_manager

```
* fkie_multimaster: added conditions for python3 dependencies in package xml
* Contributors: Alexander Tiderko
```

## fkie_node_manager_daemon

```
* fkie_multimaster: added conditions for python3 dependencies in package xml
* Contributors: Alexander Tiderko
```
