### PR TITLE
ament_cmake: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -24,6 +24,7 @@ repositories:
       - ament_cmake_export_link_flags
       - ament_cmake_export_targets
       - ament_cmake_gmock
+      - ament_cmake_google_benchmark
       - ament_cmake_gtest
       - ament_cmake_include_directories
       - ament_cmake_libraries
@@ -36,7 +37,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.9.6-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `1.0.0-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.6-1`
