### PR TITLE
rcl: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1230,7 +1230,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-1`

## rcl

```
* Add test for subscription message lost event (#705 <https://github.com/ros2/rcl/issues/705>)
* Add function rcl_event_is_valid (#720 <https://github.com/ros2/rcl/issues/720>)
* Move actual domain id from node to context (#718 <https://github.com/ros2/rcl/issues/718>)
* Removed doxygen warnings (#712 <https://github.com/ros2/rcl/issues/712>)
* Remove some dead code.
* Make sure to call rcl_arguments_fini at the end of the test.
* Add remap needed null check (#711 <https://github.com/ros2/rcl/issues/711>)
* Make public init/fini rosout publisher (#704 <https://github.com/ros2/rcl/issues/704>)
* Move rcl_remap_copy to public header (#709 <https://github.com/ros2/rcl/issues/709>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Ivan Santiago Paunovic, Jorge Perez
```

## rcl_action

```
* Removed doxygen warnings (#712 <https://github.com/ros2/rcl/issues/712>)
* Address issue 716 by zero initializing pointers and freeing memory (#717 <https://github.com/ros2/rcl/issues/717>)
* Contributors: Alejandro Hernández Cordero, brawner
```

## rcl_lifecycle

```
* Topic fix rcl lifecycle test issue (#715 <https://github.com/ros2/rcl/issues/715>)
* Removed doxygen warnings (#712 <https://github.com/ros2/rcl/issues/712>)
* Contributors: Alejandro Hernández Cordero, Barry Xu
```

## rcl_yaml_param_parser

```
* Removed doxygen warnings (#712 <https://github.com/ros2/rcl/issues/712>)
* Contributors: Alejandro Hernández Cordero
```
