### PR TITLE
[rosdep] Add gurumdds-2.6.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1343,6 +1343,8 @@ gtk3:
     slackpkg:
       packages: [gtk+3]
   ubuntu: [libgtk-3-dev]
+gurumdds-2.6:
+  ubuntu: [gurumdds-2.6]
 gv:
   arch: [gv]
   debian: [gv]


### PR DESCRIPTION
This package has been imported into the ROS bootstrap repository in order to release and package rmw_gurumdds.