### PR TITLE
system_modes: 0.2.1-7 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3254,6 +3254,10 @@ repositories:
       version: dashing-devel
     status: developed
   system_modes:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: dashing
     release:
       packages:
       - system_modes
@@ -3261,11 +3265,11 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.2.1-1
+      version: 0.2.1-7
     source:
       type: git
-      url: https://github.com/microROS/system_modes.git
-      version: master
+      url: https://github.com/micro-ROS/system_modes.git
+      version: dashing
     status: developed
   teleop_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.2.1-7`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.1-1`
