### PR TITLE
Remove packages which are not building on any platform

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12661,7 +12661,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/gleichaufjo/ros_cvb_camera_driver_release.git
-      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
@@ -12945,7 +12944,6 @@ repositories:
       version: main
     release:
       packages:
-      - rosbag_snapshot
       - rosbag_snapshot_msgs
       tags:
         release: release/kinetic/{package}/{version}
@@ -14806,7 +14804,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/sicktoolbox_wrapper-release.git
-      version: 2.5.4-1
     source:
       test_pull_requests: true
       type: git
@@ -15346,7 +15343,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
-      version: 0.3.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This is unreleaing the 4 packages that are continuously failing to build on all platforms. 

https://discourse.ros.org/t/preparing-for-kinetic-sync-2020-07-21/15517/2