### PR TITLE
performance_test_fixture: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1114,6 +1114,18 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: foxy-devel
     status: maintained
+  performance_test_fixture:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test_fixture-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/performance_test_fixture.git
+      version: main
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.0.2-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## performance_test_fixture

```
* Add missing dependency on ament_cmake_google_benchmark (#2 <https://github.com/ros2/performance_test_fixture/issues/2>)
* Contributors: Scott K Logan
```
