### PR TITLE
ros_comm: 1.15.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2935,7 +2935,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.7-1
+      version: 1.15.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.8-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.15.7-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

```
* change is_async_connected to use epoll when available (#1983 <https://github.com/ros/ros_comm/issues/1983>)
* allow mixing latched and unlatched publishers (#1991 <https://github.com/ros/ros_comm/issues/1991>)
```

## rosgraph

- No changes

## roslaunch

```
* fix bad relative import (still Python 2 style) (#1973 <https://github.com/ros/ros_comm/issues/1973>)
```

## roslz4

- No changes

## rosmaster

```
* improve shutdown message with duplicate node name (#1992 <https://github.com/ros/ros_comm/issues/1992>)
```

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* remove not existing NodeProxy from rospy __all__ (#2007 <https://github.com/ros/ros_comm/issues/2007>)
* fix typo in topics.py (#1977 <https://github.com/ros/ros_comm/issues/1977>)
```

## rosservice

- No changes

## rostest

```
* remove dependency on rostopic from rostest package (#2002 <https://github.com/ros/ros_comm/issues/2002>)
* fix missing reload() function in Python 3 (#1968 <https://github.com/ros/ros_comm/issues/1968>)
```

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* add latch param to throttle (#1944 <https://github.com/ros/ros_comm/issues/1944>)
```

## xmlrpcpp

```
* add const versions of XmlRpcValue converting operators (#1978 <https://github.com/ros/ros_comm/issues/1978>)
```
