### PR TITLE
udp_com: 0.0.6-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11674,11 +11674,20 @@ repositories:
       version: master
     status: developed
   udp_com:
+    doc:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: 0.0.6
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/flynneva/udp_com-release.git
-      version: 0.0.6-1
+      version: 0.0.6-5
+    source:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: 0.0.6
+    status: developed
   um6:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_com` to `0.0.6-5`:

- upstream repository: https://github.com/continental/udp_com.git
- release repository: https://github.com/flynneva/udp_com-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.6-1`

## udp_com

```
* switched branch to ros1-devel
* change branch name to ros1-devel
* switched destination branch to melodic-devel
* Contributors: Evan Flynn
```
