### PR TITLE
ros_ign: 0.221.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2009,6 +2009,28 @@ repositories:
       url: https://github.com/ros/ros_environment.git
       version: foxy
     status: maintained
+  ros_ign:
+    doc:
+      type: git
+      url: https://github.com/ignitionrobotics/ros_ign.git
+      version: ros2
+    release:
+      packages:
+      - ros_ign
+      - ros_ign_bridge
+      - ros_ign_gazebo
+      - ros_ign_gazebo_demos
+      - ros_ign_image
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_ign-release.git
+      version: 0.221.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignitionrobotics/ros_ign.git
+      version: ros2
+    status: developed
   ros_testing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ign` to `0.221.0-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ros_ign

```
* Added ros_ign_gazebo to ros_ign package.xml (#81 <https://github.com/osrf/ros_ign/issues/81>)
* Update Dashing docs (#62 <https://github.com/osrf/ros_ign/issues/62>)
* Port ign_ros_gazebo_demos to ROS2 (#58 <https://github.com/osrf/ros_ign/issues/58>)
* Enable ROS2 CI for Dashing branch (#43 <https://github.com/osrf/ros_ign/issues/43>)
* Rename packages and fix compilation + tests
* Move files ros1 -> ros
* Contributors: Alejandro Hernández Cordero, Jose Luis Rivero, Louise Poubel, chapulina
```

## ros_ign_bridge

```
* Install only what's necessary, rename builtin_interfaces (#95 <https://github.com/osrf/ros_ign/issues/95>)
* Move headers to src, rename builtin_interfaces (#95 <https://github.com/osrf/ros_ign/issues/95>)
* Integer support (#91 <https://github.com/osrf/ros_ign/issues/91>)
  Adds Int32 to the bridge.
* [ros2] Fixed CI - Added Foxy (#89 <https://github.com/osrf/ros_ign/issues/89>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Ignore ros-args in parameter bridge (#65 <https://github.com/osrf/ros_ign/issues/65>)
* Update Dashing docs (#62 <https://github.com/osrf/ros_ign/issues/62>)
* Update dependencies to Citadel (#57 <https://github.com/osrf/ros_ign/issues/57>)
* [WIP] Port ign_ros_gazebo_demos to ROS2 (#58 <https://github.com/osrf/ros_ign/issues/58>)
  Port ros_ign_image to ROS2
  Port ros_ign_gazebo_demos to ROS2
* Add support for std_msgs/Empty (#53 <https://github.com/osrf/ros_ign/issues/53>)
* Add support for std_msgs/Bool (#50 <https://github.com/osrf/ros_ign/issues/50>)
* [ros2] Port ros_ign_bridge to ROS2 (#45 <https://github.com/osrf/ros_ign/issues/45>)
* Enable ROS2 CI for Dashing branch (#43 <https://github.com/osrf/ros_ign/issues/43>)
* Make all API and comments ROS-version agnostic
* Rename packages and fix compilation + tests
* Move files ros1 -> ros
* Contributors: Addisu Taddese, Alejandro Hernández Cordero, Jose Luis Rivero, Louise Poubel, Luca Della Vedova, Michael Carroll, Mohamed Ahmed, Shivesh Khaitan, chapulina
```

## ros_ign_gazebo

```
* [ros2] Fixed CI - Added Foxy (#89 <https://github.com/osrf/ros_ign/issues/89>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Added ros_ign_gazebo for ros2 (#80 <https://github.com/osrf/ros_ign/issues/80>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Update Dashing docs (#62 <https://github.com/osrf/ros_ign/issues/62>)
* Contributors: Alejandro Hernández Cordero, Louise Poubel, chapulina
```

## ros_ign_gazebo_demos

```
* Updated launch file to use ros_ign_gazebo (#82 <https://github.com/osrf/ros_ign/issues/82>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Use new ros_ign_gazebo package on ROS 2 demos (#85 <https://github.com/osrf/ros_ign/issues/85>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* [WIP] Port ign_ros_gazebo_demos to ROS2 (#58 <https://github.com/osrf/ros_ign/issues/58>)
  Port ros_ign_image to ROS2
  Port ros_ign_gazebo_demos to ROS2
* Enable ROS2 CI for Dashing branch (#43 <https://github.com/osrf/ros_ign/issues/43>)
* Make all API and comments ROS-version agnostic
* Rename packages and fix compilation + tests
* Move files ros1 -> ros
* Contributors: Alejandro Hernández Cordero, Jose Luis Rivero, Louise Poubel, chapulina
```

## ros_ign_image

```
* Install only what's necessary, rename builtin_interfaces (#95 <https://github.com/osrf/ros_ign/issues/95>)
* Add CI for Eloquent (#86 <https://github.com/osrf/ros_ign/issues/86>)
* Avoid the use of --ros-args arguments outside ros (#84 <https://github.com/osrf/ros_ign/issues/84>)
* [WIP] Port ign_ros_gazebo_demos to ROS2 (#58 <https://github.com/osrf/ros_ign/issues/58>)
  Port ros_ign_image to ROS2
  Port ros_ign_gazebo_demos to ROS2
* Enable ROS2 CI for Dashing branch (#43 <https://github.com/osrf/ros_ign/issues/43>)
* Make all API and comments ROS-version agnostic
* Rename packages and fix compilation + tests
* Move files ros1 -> ros
* Contributors: Alejandro Hernández Cordero, Jose Luis Rivero, Louise Poubel, chapulina
```
