### PR TITLE
common_tutorials: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -437,7 +437,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/common_tutorials-release.git
-      version: 0.1.12-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros/common_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_tutorials` to `0.2.0-1`:

- upstream repository: https://github.com/ros/common_tutorials.git
- release repository: https://github.com/ros-gbp/common_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.12-1`
