### PR TITLE
py_trees_ros: 2.0.11-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1437,6 +1437,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees.git
       version: devel
     status: developed
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/2.0.x
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros-release.git
+      version: 2.0.11-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: devel
+    status: developed
   py_trees_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.0.11-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## py_trees_ros

```
* [blackboards] log a one-shot warning instead of exceptions when pickle fails, #156 <https://github.com/splintered-reality/py_trees_ros/pull/156>
```
