### PR TITLE
object_recognition_msgs: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1226,6 +1226,17 @@ repositories:
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
       version: foxy-devel
     status: maintained
+  object_recognition_msgs:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/object_recognition_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_msgs.git
+      version: ros2
+    status: maintained
   octomap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `object_recognition_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/wg-perception/object_recognition_msgs.git
- release repository: https://github.com/ros-gbp/object_recognition_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## object_recognition_msgs

```
* Merge pull request #11 <https://github.com/wg-perception/object_recognition_msgs/issues/11> from PickNikRobotics/master
  Port to ROS2
* Suppress -Wredundant-decls warnings (#1 <https://github.com/wg-perception/object_recognition_msgs/issues/1>)
* fixing msg port
* Update package.xml build tool & enable message generation
* Update package.xml format
* Update package.xml dependencies
* Update CMakeLists package command
* Update CMakeLists file list & interface generator command
* Update CMakeLists find_package list
* Default to C++ 14 & cmake C++ flags
* Update CMakeLists cmake version
* Specify Header origin
* Contributors: Jonathan Binney, Michael Lautman, Yu, Yan, ibaiape
```
