### PR TITLE
knowledge_representation: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1517,6 +1517,11 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
       version: 0.9.1-1
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/utexas-bwi/knowledge_representation.git
+      version: master
     status: developed
   laser_assembler:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1511,6 +1511,13 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: noetic-devel
     status: maintained
+  knowledge_representation:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
+      version: 0.9.1-1
+    status: developed
   laser_assembler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `knowledge_representation` to `0.9.1-1`:

- upstream repository: https://github.com/utexas-bwi/knowledge_representation.git
- release repository: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## knowledge_representation

```
* Update YAML knowledge_loader
* Support passing multiple maps to the map loader
* Update rosdeps for Noetic
```
