### PR TITLE
knowledge_representation: 0.9.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4588,7 +4588,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `knowledge_representation` to `0.9.1-1`:

- upstream repository: https://github.com/utexas-bwi/knowledge_representation.git
- release repository: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.0-1`

## knowledge_representation

```
* Update YAML knowledge_loader
* Support passing multiple maps to the map loader
* Update rosdeps for Noetic
```
