### PR TITLE
qt_gui_core: 0.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8048,7 +8048,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.4.2-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.1-1`

## qt_dotgraph

- No changes

## qt_gui

```
* fix exporting perspective for Python 3.6 (#228 <https://github.com/ros-visualization/qt_gui_core/issues/228>)
```

## qt_gui_app

```
* fix shebang line for python3 (#223 <https://github.com/ros-visualization/qt_gui_core/issues/223>)
```

## qt_gui_cpp

```
* quiet upstream Qt5 warnings (#210 <https://github.com/ros-visualization/qt_gui_core/issues/210>) (#229 <https://github.com/ros-visualization/qt_gui_core/issues/229>)
* declare private assignment operator for SIP (#226 <https://github.com/ros-visualization/qt_gui_core/issues/226>)
```

## qt_gui_py_common

- No changes
