### PR TITLE
catkin: 0.8.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -269,7 +269,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.6-1
+      version: 0.8.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.8-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.6-1`

## catkin

```
* use single quote for cached environment values without old values (#1108 <https://github.com/ros/catkin/issues/1108>)
* [Windows] avoid file COPY for symlink sources (#1109 <https://github.com/ros/catkin/issues/1109>)
* [Windows] add .lib into the symlink install file list (#1110 <https://github.com/ros/catkin/issues/1110>)
```
