### PR TITLE
catkin: 0.7.28-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1056,7 +1056,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.26-1
+      version: 0.7.28-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.28-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.26-1`

## catkin

```
* use single quote for cached environment values without old values (#1108 <https://github.com/ros/catkin/issues/1108>)
* [Windows] avoid file COPY for symlink sources (#1109 <https://github.com/ros/catkin/issues/1109>)
* [Windows] add .lib into the symlink install file list (#1110 <https://github.com/ros/catkin/issues/1110>)
```
