### PR TITLE
open3d_ros: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6691,6 +6691,17 @@ repositories:
       url: https://github.com/siyandong/CoScan.git
       version: master
     status: maintained
+  open3d_ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/unr-arl/open3d_ros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/unr-arl/open3d_ros.git
+      version: main
+    status: developed
   open_karto:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open3d_ros` to `0.1.0-1`:

- upstream repository: https://github.com/unr-arl/open3d_ros.git
- release repository: https://github.com/unr-arl/open3d_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## open3d_ros

```
* Initial working package
* Contributors: Nikhil Khedekar, Pranay Mathur
```
