### PR TITLE
dataspeed_pds: 1.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -580,13 +580,14 @@ repositories:
       packages:
       - dataspeed_pds
       - dataspeed_pds_can
+      - dataspeed_pds_lcm
       - dataspeed_pds_msgs
       - dataspeed_pds_rqt
       - dataspeed_pds_scripts
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dataspeed_pds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.4-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.3-1`

## dataspeed_pds

```
* Add dataspeed_pds_lcm to dataspeed_pds metapackage
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_can

- No changes

## dataspeed_pds_lcm

```
* Don't extract the LCM binaries for the buildfarm since they're available for modern distributions
* Change liblcm dependency to match official rosdep rule
  https://github.com/ros/rosdistro/pull/25736
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_msgs

- No changes

## dataspeed_pds_rqt

- No changes

## dataspeed_pds_scripts

- No changes
