### PR TITLE
omnibase: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6645,19 +6645,19 @@ repositories:
       type: git
       url: https://github.com/ERC-BPGC/omnibase.git
       version: master
-    source:
-      type: git
-      url: https://github.com/ERC-BPGC/omnibase.git
-      version: master
     release:
       packages:
       - omnibase_control
-      - omnibase_gazebo
       - omnibase_description
+      - omnibase_gazebo
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ERC-BPGC/omnibase-release.git
       version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/ERC-BPGC/omnibase.git
+      version: master
     status: maintained
   ompl:
     release:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6649,7 +6649,8 @@ repositories:
       type: git
       url: https://github.com/ERC-BPGC/omnibase.git
       version: master
-    packages:
+    release:
+      packages:
       - omnibase_control
       - omnibase_gazebo
       - omnibase_description

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6649,6 +6649,14 @@ repositories:
       type: git
       url: https://github.com/ERC-BPGC/omnibase.git
       version: master
+    packages:
+      - omnibase_control
+      - omnibase_gazebo
+      - omnibase_description
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ERC-BPGC/omnibase-release.git
+      version: 0.0.2-1
     status: maintained
   ompl:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository omnibase to 0.0.2-1:

- upstream repository: https://github.com/ERC-BPGC/omnibase.git
- release repository: https://github.com/ERC-BPGC/omnibase-release.git
- distro file: melodic/distribution.yaml
- bloom version: 0.9.7
- previous version for package: null

## omnibase_control
- Initial working package
- Contributors: Harshal Deshpande, Mihir Kulkarni

## omnibase_description
- Initial working package
- Contributors: Harshal Deshpande, Mihir Kulkarni

## omnibase_gazebo
- Initial working package
- Contributors: Harshal Deshpande, Mihir Kulkarni