### PR TITLE
roscpp_core: 0.6.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9396,7 +9396,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/roscpp_core-release.git
-      version: 0.6.13-1
+      version: 0.6.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscpp_core` to `0.6.14-1`:

- upstream repository: git@github.com:ros/roscpp_core.git
- release repository: https://github.com/ros-gbp/roscpp_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.6.13-1`

## cpp_common

```
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```

## roscpp_serialization

```
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```

## roscpp_traits

```
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```

## rostime

```
* [Windows] Using C++11 std::chrono for ros_walltime & ros_steadytime (#121 <https://github.com/ros/roscpp_core/issues/121>)
* various code cleanup (#116 <https://github.com/ros/roscpp_core/issues/116>)
* Bump CMake version to avoid CMP0048 warning (#115 <https://github.com/ros/roscpp_core/issues/115>)
```
