### PR TITLE
Fix libzmq3-dev rule for Fedora/RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4490,10 +4490,10 @@ libzip-dev:
 libzmq3-dev:
   arch: [zeromq]
   debian: [libzmq3-dev]
-  fedora: [zeromq-devel]
+  fedora: [cppzmq-devel]
   gentoo: [net-libs/cppzmq]
   openembedded: [zeromq@meta-oe]
-  rhel: [zeromq-devel]
+  rhel: [cppzmq-devel]
   ubuntu: [libzmq3-dev]
 libzmqpp-dev:
   ubuntu: [libzmqpp-dev]


### PR DESCRIPTION
In Ubuntu, the cppzmq header (zmq.hpp) seems to be bundled in the libzmq3-dev package. In Fedora and EPEL, there is a separate package for cppzmq that supplies the additional header, which complements the existing zeromq package.

In Fedora and EPEL 8, this package has its own source package:
https://src.fedoraproject.org/rpms/cppzmq#bodhi_updates

In RHEL 7, it is a subpackage of the `zeromq` package:
https://src.fedoraproject.org/rpms/zeromq#bodhi_updates