### PR TITLE
Fix and add coinor-* rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -451,30 +451,37 @@ cmake:
   ubuntu: [cmake]
 coinor-libcbc-dev:
   debian: [coinor-libcbc-dev]
+  fedora: [coin-or-Cbc-devel]
   gentoo: [sci-libs/coinor-cbc]
   ubuntu: [coinor-libcbc-dev]
 coinor-libcbc3:
   debian: [coinor-libcbc3]
+  fedora: [coin-or-Cbc]
   ubuntu: [coinor-libcbc3]
 coinor-libcgl-dev:
   debian: [coinor-libcgl-dev]
+  fedora: [coin-or-Cgl-devel]
   gentoo: [sci-libs/coinor-cgl]
   ubuntu: [coinor-libcgl-dev]
 coinor-libclp-dev:
   debian: [coinor-libclp-dev]
+  fedora: [coin-or-Clp-devel]
   gentoo: [sci-libs/coinor-clp]
   ubuntu: [coinor-libclp-dev]
 coinor-libcoinutils-dev:
   debian: [coinor-libcoinutils-dev]
+  fedora: [coin-or-CoinUtils-devel]
   gentoo: [sci-libs/coinor-utils]
+  rhel:
+    '7': [coin-or-CoinUtils-devel]
   ubuntu: [coinor-libcoinutils-dev]
 coinor-libipopt-dev:
   arch: [coinor-all]
   debian: [coinor-libipopt-dev]
-  fedora: [coin-or-CoinUtils-devel]
+  fedora: [coin-or-Ipopt-devel]
   gentoo: [sci-libs/ipopt]
   rhel:
-    '7': [coin-or-CoinUtils-devel]
+    '7': [coin-or-Ipopt-devel]
   ubuntu: [coinor-libipopt-dev]
 coinor-libosi-dev:
   debian: [coinor-libosi-dev]


### PR DESCRIPTION
Most of these rules are not available for RHEL 7, and none are available for RHEL 8 at this time.

https://src.fedoraproject.org/rpms/coin-or-Cbc#bodhi_updates
https://src.fedoraproject.org/rpms/coin-or-Cgl#bodhi_updates
https://src.fedoraproject.org/rpms/coin-or-Clp#bodhi_updates
https://src.fedoraproject.org/rpms/coin-or-CoinUtils#bodhi_updates
https://src.fedoraproject.org/rpms/coin-or-Ipopt#bodhi_updates