### PR TITLE
ezrassor_controller_server: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2574,6 +2574,12 @@ repositories:
       url: https://github.com/eyeware/eyeware-ros.git
       version: master
     status: maintained
+  ezrassor_controller_server:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/EZRASSOR/ezrassor_controller_server-release.git
+      version: 1.0.0-1
   fadecandy_ros:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `ezrassor_controller_server` to `1.0.0-1`:

- upstream repository: https://github.com/EZRASSOR/ezrassor_controller_server.git
- release repository: https://github.com/EZRASSOR/ezrassor_controller_server-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
