### PR TITLE
audibot: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -748,6 +748,10 @@ repositories:
       url: https://github.com/joaoquintas/auction_methods_stack.git
       version: master
   audibot:
+    doc:
+      type: git
+      url: https://github.com/robustify/audibot.git
+      version: 0.1.1
     release:
       packages:
       - audibot
@@ -756,7 +760,12 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/robustify/audibot-release.git
-      version: 0.1.0-0
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/robustify/audibot.git
+      version: master
+    status: maintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audibot` to `0.1.1-1`:

- upstream repository: https://github.com/robustify/audibot.git
- release repository: https://github.com/robustify/audibot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-0`

## audibot

- No changes

## audibot_description

```
* Removes logo texture from the hood
* Contributors: Micho Radovnikovich
```

## audibot_gazebo

```
* Increases max braking torque to 8000 Nm
* Adds simulation of Drive and Reverse gears
* Contributors: Micho Radovnikovich
```
