### PR TITLE
audibot: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -112,6 +112,25 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: master
     status: maintained
+  audibot:
+    doc:
+      type: git
+      url: https://github.com/robustify/audibot.git
+      version: 0.2.0
+    release:
+      packages:
+      - audibot
+      - audibot_description
+      - audibot_gazebo
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/robustify/audibot-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/robustify/audibot.git
+      version: noetic-devel
+    status: maintained
   audio_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `audibot` to `0.2.0-1`:

- upstream repository: https://github.com/robustify/audibot.git
- release repository: https://github.com/robustify/audibot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## audibot

- No changes

## audibot_description

```
* Implements tf_prefix functionality that was removed from robot_state_publisher
* Changes names of joints to be different from links
* Contributors: Micho Radovnikovich
```

## audibot_gazebo

```
* Implements tf_prefix functionality that was removed from robot_state_publisher
* Migrates from tf to tf2
* Prevents publishing TF frame transforms with the same timestamp
* Changes names of joints to be different from links
* Contributors: Micho Radovnikovich
```
