### PR TITLE
radial_menu_ros: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8141,6 +8141,27 @@ repositories:
       url: https://github.com/TUC-ProAut/ros_radar.git
       version: master
     status: maintained
+  radial_menu_ros:
+    doc:
+      type: git
+      url: https://github.com/yoshito-n-students/radial_menu_ros.git
+      version: master
+    release:
+      packages:
+      - radial_menu
+      - radial_menu_backend
+      - radial_menu_example
+      - radial_menu_msgs
+      - radial_menu_rviz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yoshito-n-students/radial_menu_ros-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/yoshito-n-students/radial_menu_ros.git
+      version: master
+    status: developed
   rail_manipulation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `radial_menu_ros` to `0.2.0-1`:

- upstream repository: https://github.com/yoshito-n-students/radial_menu_ros.git
- release repository: https://github.com/yoshito-n-students/radial_menu_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## radial_menu

```
* No changes
```

## radial_menu_backend

```
* Install targets
```

## radial_menu_example

```
* Install targets
```

## radial_menu_msgs

```
* Install targets
```

## radial_menu_rviz

```
* Install targets
```
