### PR TITLE
sophus: 1.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2668,7 +2668,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/stonier/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.2.1-1`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.0-1`
