### PR TITLE
sophus: 1.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4076,7 +4076,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/yujinrobot-release/sophus-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/stonier/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.2.1-1`:

- upstream repository: https://github.com/stonier/sophus.git
- release repository: https://github.com/yujinrobot-release/sophus-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.0-1`
