### PR TITLE
librealsense: 2.34.0-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1014,6 +1014,23 @@ repositories:
       url: https://github.com/ros2-gbp/libg2o-release.git
       version: 2020.5.29-1
     status: maintained
+  librealsense:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    release:
+      packages:
+      - librealsense2
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/librealsense-release.git
+      version: 2.34.0-3
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: ros2debian
+    status: maintained
   libstatistics_collector:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense` to `2.34.0-3`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/ros2-gbp/librealsense-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
