### PR TITLE
ros2_intel_realsense: 2.0.8-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1931,6 +1931,26 @@ repositories:
       url: https://github.com/lgsvl/ros2-lgsvl-bridge.git
       version: master
     status: developed
+  ros2_intel_realsense:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: refactor
+    release:
+      packages:
+      - realsense_examples
+      - realsense_msgs
+      - realsense_node
+      - realsense_ros
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
+      version: 2.0.8-2
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: refactor
+    status: maintained
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_intel_realsense` to `2.0.8-2`:

- upstream repository: https://github.com/intel/ros2_intel_realsense.git
- release repository: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
