### PR TITLE
knowledge_representation: 0.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1540,6 +1540,7 @@ repositories:
       url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
       version: 0.9.2-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/utexas-bwi/knowledge_representation.git
       version: master

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1533,6 +1533,17 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: noetic-devel
     status: maintained
+  knowledge_representation:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
+      version: 0.9.2-1
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/knowledge_representation.git
+      version: master
+    status: developed
   laser_assembler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `knowledge_representation` to `0.9.2-1`:

- upstream repository: https://github.com/utexas-bwi/knowledge_representation.git
- release repository: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## knowledge_representation

```
* Fix errant Python2 style print
* Build Python3 bindings for new distributions
* Conditional dependencies for Python2/Python3 image library
* Use setuptools always
* Bump CMake version to avoid CMP0048
* Contributors: Nick Walker, Shane Loretz
```
