### PR TITLE
fastrtps: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -593,7 +593,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.0.0-3
+      version: 2.0.1-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `2.0.1-1`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-3`
