### PR TITLE
rmw_gurumdds: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1512,6 +1512,24 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: master
     status: developed
+  rmw_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: master
+    release:
+      packages:
+      - rmw_gurumdds_cpp
+      - rmw_gurumdds_shared_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: master
+    status: developed
   rmw_implementation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rmw_gurumdds_cpp

```
* Removed parameters domain_id and localhost_only from rmw_create_node()
* Updated init/shutdown/init option functions
* Contributors: junho
```

## rmw_gurumdds_shared_cpp

```
* Removed parameters domain_id and localhost_only from rmw_create_node()
* Contributors: junho
```
