### PR TITLE
image_pipeline: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -824,7 +824,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `2.2.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.1.1-1`

## camera_calibration

```
* Removed basestring (no longer exists in new python 3 version). (#554 <https://github.com/ros-perception/image_pipeline/issues/554>)
  Fixes #551 <https://github.com/ros-perception/image_pipeline/issues/551>
* Initial ROS2 commit.
* Contributors: Michael Carroll, PfeifferMicha
```

## depth_image_proc

```
* Replacing deprecated header includes with new HPP versions. (#566 <https://github.com/ros-perception/image_pipeline/issues/566>)
  * Replacing deprecated header includes with new HPP versions.
  * CI: Switching to official Foxy Docker container.
  * Fixing headers which don't work correctly.
* Contributors: Joshua Whitley
* make parameters work in depth_image_proc (#544 <https://github.com/ros-perception/image_pipeline/issues/544>)
* update depth_image_proc components (#543 <https://github.com/ros-perception/image_pipeline/issues/543>)
  * update depth_image_proc components
  This makes them loadable with the rclcpp_components
  interface. I've fully tested PointCloudXYZRGB and
  ConvertMetric, my use case doesn't use the others.
  I also lack a setup to test the launch files fully,
  but ran them with the realsense commented out and
  they appear to be OK.
  * fix linting
* Contributors: Michael Ferguson
```

## image_pipeline

```
* Initial ROS2 commit.
* Contributors: Michael Carroll
```

## image_proc

```
* Replacing deprecated header includes with new HPP versions. (#566 <https://github.com/ros-perception/image_pipeline/issues/566>)
* Opencv 3 compatibility (#564 <https://github.com/ros-perception/image_pipeline/issues/564>)
  * Remove GTK from image_view.
  * Reinstate OpenCV 3 compatibility.
* Fix bad quotes in image_proc launch file (#563 <https://github.com/ros-perception/image_pipeline/issues/563>)
  This fixes a flake8 error.
* Contributors: Chris Lalancette, Jacob Perron, Joshua Whitley
* Initial ROS2 commit.
* Contributors: Michael Carroll
```

## image_publisher

```
* Replacing deprecated header includes with new HPP versions. (#566 <https://github.com/ros-perception/image_pipeline/issues/566>)
  * Replacing deprecated header includes with new HPP versions.
  * CI: Switching to official Foxy Docker container.
  * Fixing headers which don't work correctly.
* Opencv 3 compatibility (#564 <https://github.com/ros-perception/image_pipeline/issues/564>)
  * Remove GTK from image_view.
  It is no longer used at all in image_view.
  * Reinstate OpenCV 3 compatibility.
  While Foxy only supports Ubuntu 20.04 (and hence OpenCV 4),
  we still strive to maintain Ubuntu 18.04 (which has OpenCV 3).
  In this case, it is trivial to keep keep image_pipeline working
  with OpenCV 3, so reintroduce compatibility with it.
  * Fixes from review.
  * One more fix.
* Use newer 'add_on_set_parameters_callback' API (#562 <https://github.com/ros-perception/image_pipeline/issues/562>)
  The old API was deprecated in Foxy and since removed in https://github.com/ros2/rclcpp/pull/1199.
* Remove redundant install call in CMakeLists.txt (#555 <https://github.com/ros-perception/image_pipeline/issues/555>)
* Contributors: Chris Lalancette, Jacob Perron, Joshua Whitley, sgvandijk
```

## image_rotate

```
* Replacing deprecated header includes with new HPP versions. (#566 <https://github.com/ros-perception/image_pipeline/issues/566>)
* Use newer 'add_on_set_parameters_callback' API (#562 <https://github.com/ros-perception/image_pipeline/issues/562>)
  The old API was deprecated in Foxy and since removed in https://github.com/ros2/rclcpp/pull/1199.
* Contributors: Jacob Perron, Joshua Whitley
* Initial ROS2 commit.
* Contributors: Michael Carroll
```

## image_view

```
* Replacing deprecated header includes with new HPP versions. (#566 <https://github.com/ros-perception/image_pipeline/issues/566>)
* Opencv 3 compatibility (#564 <https://github.com/ros-perception/image_pipeline/issues/564>)
  * Remove GTK from image_view.
  * Reinstate OpenCV 3 compatibility.
* Use newer 'add_on_set_parameters_callback' API (#562 <https://github.com/ros-perception/image_pipeline/issues/562>)
  The old API was deprecated in Foxy and since removed in https://github.com/ros2/rclcpp/pull/1199.
* Contributors: Chris Lalancette, Jacob Perron, Joshua Whitley
* Patch boost failure in image_view (#541 <https://github.com/ros-perception/image_pipeline/issues/541>)
  * Patch boost failure in image_view
  * remove ros2_deps from circle with new releases
  * readd deps
* Contributors: Steve Macenski
* Initial ROS2 commit.
* Contributors: Michael Carroll
```

## stereo_image_proc

```
* Replacing deprecated header includes with new HPP versions. (#566 <https://github.com/ros-perception/image_pipeline/issues/566>)
* Use newer 'add_on_set_parameters_callback' API (#562 <https://github.com/ros-perception/image_pipeline/issues/562>)
  The old API was deprecated in Foxy and since removed in https://github.com/ros2/rclcpp/pull/1199.
* Contributors: Jacob Perron, Joshua Whitley
* Initial ROS2 commit.
* Contributors: Michael Carroll
```
