### PR TITLE
image_pipeline: 2.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1119,6 +1119,30 @@ repositories:
       url: https://github.com/ros-perception/image_common.git
       version: dashing
     status: maintained
+  image_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: dashing
+    release:
+      packages:
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/image_pipeline-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: dashing
+    status: maintained
   image_transport_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `2.1.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## camera_calibration

```
* ROS2 Dashing Image calibration (#447 <https://github.com/ros-perception/image_pipeline/issues/447>)
  Co-authored-by: Luca Della Vedova <mailto:luca@openrobotics.org>
* Initial ROS2 commit.
* Contributors: Andreas Klintberg, Joshua Whitley, Kei Okada, Michael Carroll, Philipp, Yoshito Okada, stevemacenski
```

## depth_image_proc

```
* cleanup any last reference to nodelets & register image publisher as a component (#473 <https://github.com/ros-perception/image_pipeline/issues/473>)
* Merge pull request #470 <https://github.com/ros-perception/image_pipeline/issues/470> from ros-perception/crop_ros2
* fix linter and adding components dependencies to packages requiring them
* patch API changes for depth image pipeline
* Merge pull request #425 <https://github.com/ros-perception/image_pipeline/issues/425> from klintan/ros2
  Dashing: Adapted for Dashing
* Fixed CMakeLists.txt for Dashing
* Contributors: Andreas Klintberg, Chris Ye, Joshua Whitley, Michael Carroll, Steven Macenski, Yoshito Okada, stevemacenski
```

## image_pipeline

```
* ROS2 Dashing Image calibration (#447 <https://github.com/ros-perception/image_pipeline/issues/447>)
  Co-authored-by: Luca Della Vedova <mailto:luca@openrobotics.org>
* Merge pull request #470 <https://github.com/ros-perception/image_pipeline/issues/470> from ros-perception/crop_ros2
* add default compiler flags for image pipeline metapackage
* reactivate ros2 image pipeline metapackage
* Changelogs.
* Initial ROS2 commit.
* Contributors: Andreas Klintberg, Joshua Whitley, Michael Carroll, Steven Macenski, Yoshito Okada, stevemacenski
```

## image_proc

```
* Fixing flake8 error in image_proc.
* Opencv 3 compatibility (#564 <https://github.com/ros-perception/image_pipeline/issues/564>) (#565 <https://github.com/ros-perception/image_pipeline/issues/565>)
  * Remove GTK from image_view.
  * Reinstate OpenCV 3 compatibility.
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Removed namespaces as parameters and added launch file example in image_proc (#519 <https://github.com/ros-perception/image_pipeline/issues/519>)
* Commented out getNumSubscribers on resize.cpp (#523 <https://github.com/ros-perception/image_pipeline/issues/523>)
* Switched default interpolation in recitfy.cpp to mode 1 (#522 <https://github.com/ros-perception/image_pipeline/issues/522>)
* Build image_proc as shared library and export (#513 <https://github.com/ros-perception/image_pipeline/issues/513>)
* Add image_proc launch file (#492 <https://github.com/ros-perception/image_pipeline/issues/492>)
  * Add image_proc launch file
  * Install launch file
* [image_proc] Install include directory and export (#485 <https://github.com/ros-perception/image_pipeline/issues/485>)
* Port image processor library to ROS 2 (#484 <https://github.com/ros-perception/image_pipeline/issues/484>)
* Merge pull request #459 <https://github.com/ros-perception/image_pipeline/issues/459> from klintan/image-proc-resize-crop
  ROS2: Image proc non zero crop
* fixed linting issues
* ROS2: Lint/Uncrustify image_proc (#474 <https://github.com/ros-perception/image_pipeline/issues/474>)
* cleanup any last reference to nodelets & register image publisher as a component (#473 <https://github.com/ros-perception/image_pipeline/issues/473>)
* Merge pull request #471 <https://github.com/ros-perception/image_pipeline/issues/471> from ros-perception/crop_d
  ROS2 port of crop decimate in image proc
* Merge pull request #470 <https://github.com/ros-perception/image_pipeline/issues/470> from ros-perception/crop_ros2
* fix linter and adding components dependencies to packages requiring them
* ROS2: Added resize component (#465 <https://github.com/ros-perception/image_pipeline/issues/465>)
* Merge pull request #450 <https://github.com/ros-perception/image_pipeline/issues/450> from ros-perception/revert-443-dashing-launch-file
* Revert "ROS2 Image proc refactoring using components and added launch file"
* Merge pull request #443 <https://github.com/ros-perception/image_pipeline/issues/443> from klintan/dashing-launch-file
  ROS2 Image proc refactoring using components and added launch file
* Merge pull request #426 <https://github.com/ros-perception/image_pipeline/issues/426> from klintan/image-proc-dashing
  Dashing: Image_proc with old PR comments fixed
* Initial ROS2 commit.
* Contributors: Andreas Klintberg, Jacob Perron, Joshua Whitley, Michael Carroll, Steven Macenski, Yoshito Okada, caelinsutch, stevemacenski
```

## image_publisher

```
* Opencv 3 compatibility (#564 <https://github.com/ros-perception/image_pipeline/issues/564>) (#565 <https://github.com/ros-perception/image_pipeline/issues/565>)
  * Remove GTK from image_view.
  It is no longer used at all in image_view.
  * Reinstate OpenCV 3 compatibility.
  While Foxy only supports Ubuntu 20.04 (and hence OpenCV 4),
  we still strive to maintain Ubuntu 18.04 (which has OpenCV 3).
  In this case, it is trivial to keep keep image_pipeline working
  with OpenCV 3, so reintroduce compatibility with it.
  * Fixes from review.
  * One more fix.
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* cleanup any last reference to nodelets & register image publisher as a component (#473 <https://github.com/ros-perception/image_pipeline/issues/473>)
  * cleanup any last reference to nodelets & register image publisher as a component properly
  * moving depth image proc's launch files to main dir
  * linting
* Merge pull request #470 <https://github.com/ros-perception/image_pipeline/issues/470> from ros-perception/crop_ros2
  Hot hot hot patches for ROS2
* properly adding dependencies for image publisher
* add launch examples for image and mono and stereo (#386 <https://github.com/ros-perception/image_pipeline/issues/386>)
  * [image_publisher] launch examples for file and mono and stereo
  launch examples to support:
  1) load local image file and publish to the ros topic
  1) load mono usb camera /dev/video0 and publish to the ros topic
  1) load two usb cameras /dev/video0 amd /dev/video1, and publish to the left and right ros topic, this could simulate stereo camera.
  * Publish image file to topic
  $ros2 launch image_publisher image_publisher_file.launch.py
  /camera/camera_info
  /camera/image_raw
  * Publish monocular camera (/dev/video0)
  $ros2 launch image_publisher image_publisher_mono.launch.py
  /camera/camera_info
  /camera/image_raw
  * Publish stereo camera (/dev/video0 and /dev/video1)
  $ros2 launch image_publisher image_publisher_stereo.launch.py
  /left/camera_info
  /left/image_raw
  /right/camera_info
  /right/image_raw
  * [image_publisher] fix for lint check issue
  fix lint check error in launch file
* Fix uninitialised parameters in image_publisher (#452 <https://github.com/ros-perception/image_pipeline/issues/452>)
  declare_parameters() returns either the parameter value or the default. Since it was ignored the parameters were uninitialised (especially publish_rate, which lead to undefined behavior).
* Merge pull request #425 <https://github.com/ros-perception/image_pipeline/issues/425> from klintan/ros2
  Dashing: Adapted for Dashing
* image_proc updates, PR comments
* fixed parameter changes
* Fixed CMakeLists.txt for Dashing
* 2.0.0
* Changelogs.
* port image_publisher on ROS2 (#366 <https://github.com/ros-perception/image_pipeline/issues/366>)
  * port image_publisher on ROS2
  * switch to use cmake 3.5
  * change nodelet to classloader
  * change ros::param to ros2 parameter APIs
  * use ros2 code style
  * enable ros2 camera_info_manager
* Initial ROS2 commit.
* Merge pull request #358 <https://github.com/ros-perception/image_pipeline/issues/358> from lucasw/image_pub_dr_private_namespace
  Use a shared_ptr for the dynamic reconfigure pointer, and create it w…
* Use a shared_ptr for the dynamic reconfigure pointer, and create it with the private node handle so that the parameters for the dynamic reconfigure server are in the private namespace and two image publishers can coexist in the same manager #357 <https://github.com/ros-perception/image_pipeline/issues/357>
* Merge branch 'indigo' into fix_image_view_nodelet
* Merge pull request #395 <https://github.com/ros-perception/image_pipeline/issues/395> from ros-perception/steve_maintain
  adding stevemacenski as maintainer to get emails on release issues
* adding autonomoustuff mainainer
* adding stevemacenski as maintainer to get emails
* Contributors: Andreas Klintberg, Chris Ye, Joshua Whitley, Luca Della Vedova, Lucas Walter, Michael Carroll, Steven Macenski, Yoshito Okada, stevemacenski
```

## image_rotate

```
* cleanup any last reference to nodelets & register image publisher as a component (#473 <https://github.com/ros-perception/image_pipeline/issues/473>)
* Merge pull request #470 <https://github.com/ros-perception/image_pipeline/issues/470> from ros-perception/crop_ros2
* fix linter and adding components dependencies to packages requiring them
* Fixed double free crash, removed deprecation warnings. (#453 <https://github.com/ros-perception/image_pipeline/issues/453>)
  * Fixed double free crash, removed deprecation warnings.
  Also removed deprecation warnings by changing to the new ROS2 API functions.
* Merge pull request #426 <https://github.com/ros-perception/image_pipeline/issues/426> from klintan/image-proc-dashing
* Merge pull request #425 <https://github.com/ros-perception/image_pipeline/issues/425> from klintan/ros2
  Dashing: Adapted for Dashing
* Merge pull request #385 <https://github.com/ros-perception/image_pipeline/issues/385> from yechun1/ros2_image_rotate
  port image_rotate on ros2
* rename filename and strings from nodelet to node
  Nodelet is probably not the correct designation for this anymore since there is no longer a concept of a "nodelet" in ROS2, use "_node" instead.
* update package.xml and cmakelist for readable
* modify code to follow ros2 coding style
* port image_rotate on ros2
* Initial ROS2 commit.
* Contributors: Andreas Klintberg, Chris Ye, Joshua Whitley, Luca Della Vedova, Michael Carroll, Ryohei Ueda, Steven Macenski, Yoshito Okada, stevemacenski
```

## image_view

```
* Opencv 3 compatibility (#564 <https://github.com/ros-perception/image_pipeline/issues/564>) (#565 <https://github.com/ros-perception/image_pipeline/issues/565>)
  * Remove GTK from image_view.
  * Reinstate OpenCV 3 compatibility.
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* image_view: add missing depends to package.xml (#511 <https://github.com/ros-perception/image_pipeline/issues/511>)
  * image_view: depend on rclcpp_components
  * image_view: don't find rosidl_default_generators
* ROS2 image_view: lint/uncrustify. (#482 <https://github.com/ros-perception/image_pipeline/issues/482>)
  * image_view: lint/uncrustify.
  * image_view: fixing typos.
* Merge pull request #480 <https://github.com/ros-perception/image_pipeline/issues/480> from ros-perception/image-view/maint/remove-useless-callback
  image_view: Removing useless callback in image_view node.
* ROS2: Port image_view (#475 <https://github.com/ros-perception/image_pipeline/issues/475>)
* Changelogs.
* Initial ROS2 commit.
* Contributors: Joshua Whitley, Maarten de Vries, Michael Carroll, Steven Macenski, Steven Peters, Timo Röhling, Yoshito Okada, angeltop, stevemacenski
```

## stereo_image_proc

```
* Add parameter to avoid points2 padding (#524 <https://github.com/ros-perception/image_pipeline/issues/524>)
  * Add parameter to allow avoiding padding in the generated pointcloud message
  Co-authored-by: Jacob Perron <mailto:jacob@openrobotics.org>
  * Actually use the created parameter descriptor
  Co-authored-by: Jacob Perron <mailto:jacob@openrobotics.org>
* Add parameter to use system default QoS for image subscriptions in stereo_image_proc (#521 <https://github.com/ros-perception/image_pipeline/issues/521>)
  * Add parameter for image subscription reliability QoS to point cloud node
  * Add parameter for image subscription reliability QoS to disparity node
  * Add argument for setting reliability QoS to stereo_image_proc launch file
  * Change parameter to use_system_default_qos
  * Only use system default QoS for subscriptions
* Use sensor data QoS profile (#494 <https://github.com/ros-perception/image_pipeline/issues/494>)
* Expand range for min_disparity and disparity_range (#495 <https://github.com/ros-perception/image_pipeline/issues/495>)
  Forward port of #431 <https://github.com/ros-perception/image_pipeline/issues/431>
* Add reconfigurable parameters to disparity node (#490 <https://github.com/ros-perception/image_pipeline/issues/490>)
  * Add reconfigurable parameters to disparity node
  * Remove old dynamic reconfigure config file
* Fix get/set speckle size methods (#491 <https://github.com/ros-perception/image_pipeline/issues/491>)
* Port stereo_image_proc to ROS 2 (#486 <https://github.com/ros-perception/image_pipeline/issues/486>)
* Initial ROS2 commit.
* Contributors: Ivan Santiago Paunovic, Jacob Perron, Joshua Whitley, Kei Okada, Michael Carroll, Steven Macenski, Yoshito Okada, bknight-i3drobotics, stevemacenski
```
