### PR TITLE
rosidl_typesupport_gurumdds: 1.0.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2365,6 +2365,23 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: foxy
     status: developed
+  rosidl_typesupport_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
+      version: foxy
+    release:
+      packages:
+      - gurumdds_cmake_module
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
+      version: foxy
+    status: developed
   rplidar_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_gurumdds` to `1.0.1-2`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_gurumdds.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## gurumdds_cmake_module

- No changes
