### PR TITLE
control_toolbox: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -352,6 +352,21 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: foxy-devel
     status: maintained
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/control_toolbox-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    status: maintained
   cyclonedds:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `2.0.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## control_toolbox

```
* Refactor the Pid class to be completely ROS agnostic and added a ROS 2 wrapper
* Avoid crash when the type of the parameter doesn't match
* Added topic_prefix to publisher topic name (#95 <https://github.com/ros-controls/control_toolbox/issues/95>)
* Created a shared library (#93 <https://github.com/ros-controls/control_toolbox/issues/93>)
* Aliases not part of the public API are now private
* Removing pid_gains_setter
* Removed unnecessary dependencies
* Cleared empty non virtual destructors
* Removed unused limited proxy variables
* Added pid state real-time publisher
* Removed all references to tinyxml
* Removed tune_pid.py
* Adding missing copyright licenses
* Adapted dither, sine_sweep and sinusoid to ROS2
* Removed dynamic reconfigure completely
* Removed deprecated functions
* Contributors: Alejandro Hernández Cordero, Bence Magyar, James Xu, Jordan Palacios, Shane Loretz, ahcorde
```
