### PR TITLE
Add dynamic-graph-python to melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2130,6 +2130,22 @@ repositories:
       url: https://github.com/stack-of-tasks/dynamic-graph.git
       version: devel
     status: maintained
+  dynamic-graph-python:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-python.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stack-of-tasks/dynamic-graph-python-ros-release.git
+      version: 3.5.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-python.git
+      version: devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Release dynamic-graph-python a third-party package from SOT on melodic
It is dependent on dynamic-graph that is already released on melodic : #25488 for reference