### PR TITLE
Add dynamic-graph-python to noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -716,6 +716,22 @@ repositories:
       url: https://github.com/stack-of-tasks/dynamic-graph.git
       version: devel
     status: maintained
+  dynamic-graph-python:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-python.git
+      version: devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stack-of-tasks/dynamic-graph-python-ros-release.git
+      version: 3.5.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-python.git
+      version: devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Release dynamic-graph-python a third-party package from SOT on noetic
It is dependent on dynamic-graph that is already released on noetic : #25949 for reference