### PR TITLE
dataspeed_pds: 1.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -587,7 +587,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dataspeed_pds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.5-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.4-1`

## dataspeed_pds

- No changes

## dataspeed_pds_can

- No changes

## dataspeed_pds_lcm

```
* Add missing rostest dependency
* Contributors: Kevin Hallenbeck
```

## dataspeed_pds_msgs

- No changes

## dataspeed_pds_rqt

- No changes

## dataspeed_pds_scripts

- No changes
