### PR TITLE
perception_open3d: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7189,6 +7189,20 @@ repositories:
       url: https://github.com/dillenberger/pepperl_fuchs.git
       version: master
     status: maintained
+  perception_open3d:
+    release:
+      packages:
+      - open3d_conversions
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/perception_open3d-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_open3d.git
+      version: melodic-devel
+    status: developed
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_open3d` to `0.0.2-1`:

- upstream repository: https://github.com/ros-perception/perception_open3d.git
- release repository: https://github.com/ros-gbp/perception_open3d-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## open3d_conversions

```
* Initial port of code from unr-arl/open3d_ros
```
