### PR TITLE
Update libpqxx key for buster

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3391,7 +3391,7 @@ libpq-dev:
   ubuntu: [libpq-dev]
 libpqxx:
   debian:
-    buster: [libpqxx-4.0v5]
+    buster: [libpqxx-6.2]
     jessie: [libpqxx-4.0]
     stretch: [libpqxx-4.0v5]
     wheezy: [libpqxx-3.1]


### PR DESCRIPTION
https://packages.debian.org/buster/libpqxx-6.2
This key was originally set in #15349 but seems to have bumped before buster was released.