### PR TITLE
perception_open3d: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2448,6 +2448,20 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: noetic-devel
     status: maintained
+  perception_open3d:
+    release:
+      packages:
+      - open3d_conversions
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/perception_open3d-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_open3d.git
+      version: melodic-devel
+    status: developed
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_open3d` to `0.0.2-1`:

- upstream repository: https://github.com/ros-perception/perception_open3d.git
- release repository: https://github.com/ros-gbp/perception_open3d-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## open3d_conversions

```
* Initial port of code from unr-arl/open3d_ros
```
