### PR TITLE
py_trees_ros_viewer: 0.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1559,6 +1559,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
       version: devel
     status: developed
+  py_trees_ros_viewer:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: release/0.2.x
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros_viewer-release.git
+      version: 0.2.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    status: developed
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_viewer` to `0.2.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_viewer.git
- release repository: https://github.com/stonier/py_trees_ros_viewer-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## py_trees_ros_viewer

```
* [backend] capture paralell policy details
```
