### PR TITLE
Libcxxtools

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2078,6 +2078,9 @@ libcunit-dev:
   gentoo: [dev-util/cunit]
   rhel: [CUnit-devel]
   ubuntu: [libcunit1-dev]
+libcxxtools-dev:
+  debian: [libcxxtools-dev]
+  ubuntu: [libcxxtools-dev]
 libdbus-dev:
   arch: [dbus-core]
   debian: [libdbus-1-dev]


### PR DESCRIPTION
https://packages.debian.org/buster/libcxxtools-dev
https://packages.ubuntu.com/eoan/libcxxtools-dev

Contains many useful tools including an argument parser