### PR TITLE
py_trees: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2606,6 +2606,22 @@ repositories:
       type: git
       url: https://github.com/fetchrobotics/power_msgs.git
       version: ros1
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/0.7.x
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stonier/py_trees-release.git
+      version: 0.7.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: release/0.7.x
+    status: maintained
   py_trees_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.7.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
