### PR TITLE
mapviz: 1.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5125,7 +5125,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.4.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.3.0-1`

## mapviz

```
* Support ROS Noetic (#696 <https://github.com/swri-robotics/mapviz/issues/696>)
* Separate Save and Save As and open file dialogs in better locations. (#700 <https://github.com/swri-robotics/mapviz/issues/700>)
* Contributors: Matthew, P. J. Reed
```

## mapviz_plugins

```
* Support ROS Noetic (#696 <https://github.com/swri-robotics/mapviz/issues/696>)
* Add Visualization for marti_nav_msgs::TrackedObjectArray and marti_nav_msgs::ObstacleArray (#701 <https://github.com/swri-robotics/mapviz/issues/701>)
* Merge pull request #689 <https://github.com/swri-robotics/mapviz/issues/689> from mdgrogan/update-distance-on-move-point
* Use higher precision in the coordinate picker for wgs84 (#692 <https://github.com/swri-robotics/mapviz/issues/692>)
* Clear the namespace list after hitting the clear button. (#691 <https://github.com/swri-robotics/mapviz/issues/691>)
* Update the displayed distance continuously while moving a point.
* Contributors: Matt Grogan, Matthew, P. J. Reed
```

## multires_image

```
* Support ROS Noetic (#696 <https://github.com/swri-robotics/mapviz/issues/696>)
* Contributors: P. J. Reed
```

## tile_map

```
* Support ROS Noetic (#696 <https://github.com/swri-robotics/mapviz/issues/696>)
* Contributors: P. J. Reed
```
