### PR TITLE
nerian_stereo: 3.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2216,6 +2216,21 @@ repositories:
       url: https://github.com/at-wat/neonavigation_rviz_plugins.git
       version: master
     status: developed
+  nerian_stereo:
+    doc:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nerian-vision/nerian_stereo-release.git
+      version: 3.8.0-1
+    source:
+      type: git
+      url: https://github.com/nerian-vision/nerian_stereo.git
+      version: master
+    status: developed
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `3.8.0-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## nerian_stereo

```
* Updated to nerian software release version 8.1.0
* Support for Support for 1 to 3 images in result set
* Added new device configuration variables
* Contributors: Konstantin Schauwecker, Ramin Yaghoubzadeh Torky
```
