### PR TITLE
add keypress_monitor

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4551,6 +4551,16 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: melodic-devel
     status: maintained
+  keypress_monitor:
+    doc:
+      type: git
+      url: https://repo.ijs.si/msimonic/keypress_monitor.git
+      version: master
+    source:
+      type: git
+      url: https://repo.ijs.si/msimonic/keypress_monitor.git
+      version: master
+    status: maintained
   kinesis_manager:
     doc:
       type: git


### PR DESCRIPTION
Added keypress_monitor to index for melodic according to http://wiki.ros.org/ROS/ReleasingAPackage#Adding_your_package_to_the_index.

It's a simple tool to monitor whether a key has been pressed or not. Useful to map keys on bluetooth media keyboards to robot actions. Similar but more general than not actively maintained [keyboard package](http://wiki.ros.org/keyboard).