### PR TITLE
mimick_vendor: 0.1.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -999,6 +999,21 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: master
     status: maintained
+  mimick_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mimick_vendor-release.git
+      version: 0.1.1-3
+    source:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: master
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.1.1-3`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## mimick_vendor

```
* Change imported dep to match ROS 2 fork (#4 <https://github.com/ros2/mimick_vendor/issues/4>)
* Contributors: Jorge Perez
```
