### PR TITLE
Add pyqtgraph to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6020,6 +6020,8 @@ python3-pyqt5.qtwebengine:
   ubuntu: [python3-pyqt5.qtwebengine]
 python3-pyqtgraph:
   debian: [python3-pyqtgraph]
+  fedora: [python3-pyqtgraph]
+  gentoo: [dev-python/pyqtgraph]
   ubuntu: [python3-pyqtgraph]
 python3-pyswarms-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6018,6 +6018,9 @@ python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
   fedora: [python3-qt5-webengine]
   ubuntu: [python3-pyqt5.qtwebengine]
+python3-pyqtgraph:
+  debian: [python3-pyqtgraph]
+  ubuntu: [python3-pyqtgraph]
 python3-pyswarms-pip:
   debian:
     pip:


### PR DESCRIPTION
Adding `python3-pyqtgraph` to rosdep for:
- `debian`: https://packages.debian.org/search?searchon=names&keywords=pyqtgraph
- `ubuntu`: https://packages.ubuntu.com/search?keywords=pyqtgraph&searchon=names&suite=all&section=all

