### PR TITLE
Adding libboost-serialization to rosdep.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1917,6 +1917,23 @@ libboost-regex-dev:
   gentoo: [dev-libs/boost]
   rhel: [boost-devel]
   ubuntu: [libboost-regex-dev]
+libboost-serialization:
+  debian:
+    buster: [libboost-serialization1.67.0]
+    stretch: [libboost-serialization1.62.0]
+  fedora: [boost-serialization]
+  gentoo: [dev-libs/boost]
+  ubuntu:
+    bionic: [libboost-serialization1.62.0]
+    eoan: [libboost-serialization1.67.0]
+    focal: [libboost-serialization1.67.0]
+    xenial: [libboost-serialization1.58.0]
+libboost-serialization-dev:
+  debian: [libboost-serialization-dev]
+  fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
+  ubuntu: [libboost-serialization-dev]
 libboost-system:
   debian:
     buster: [libboost-system1.67.0]


### PR DESCRIPTION
libboost-serialization:
  - debian:
      - buster: https://packages.debian.org/buster/libboost-serialization1.67.0
      - stretch: https://packages.debian.org/stretch/libboost-serialization1.62.0
  - fedora: https://pkgs.org/download/boost-serialization [official portal currently offline]
  - gentoo: https://packages.gentoo.org/packages/dev-libs/boost
  - ubuntu:
      - bionic: https://packages.ubuntu.com/bionic/libboost-serialization1.62.0
      - eoan: https://packages.ubuntu.com/eoan/libboost-serialization1.67.0
      - focal: https://packages.ubuntu.com/focal/libboost-serialization1.67.0
      - xenial: https://packages.ubuntu.com/xenial/libboost-serialization1.58.0

libboost-serialization-dev:
  - debian: https://packages.debian.org/search?keywords=libboost-serialization-dev&searchon=names&suite=all&section=all
  - fedora: https://pkgs.org/download/boost-devel [official portal currently offline]
  - gentoo: https://packages.gentoo.org/packages/dev-libs/boost
  - rhel: [copying previous entries]
  - ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=libboost-serialization-dev&searchon=names