### PR TITLE
ros2_tracing: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1619,7 +1619,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-      version: foxy
+      version: master
     release:
       packages:
       - ros2trace
@@ -1630,12 +1630,12 @@ repositories:
       - tracetools_trace
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 1.0.1-3
+      url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
+      version: 1.0.3-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
-      version: foxy
+      version: master
     status: developed
   ros2cli:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `1.0.3-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-3`
