### PR TITLE
rmw_gurumdds: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1992,6 +1992,24 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: foxy
     status: developed
+  rmw_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: foxy
+    release:
+      packages:
+      - rmw_gurumdds_cpp
+      - rmw_gurumdds_shared_cpp
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: foxy
+    status: developed
   rmw_implementation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rmw_gurumdds_cpp

```
* Change maintainer
* Contributors: junho
```

## rmw_gurumdds_shared_cpp

```
* Change maintainer
* Contributors: junho
```
