### PR TITLE
rmw_gurumdds: 0.7.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2333,6 +2333,24 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: dashing
     status: developed
+  rmw_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: dashing
+    release:
+      packages:
+      - rmw_gurumdds_cpp
+      - rmw_gurumdds_shared_cpp
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+      version: 0.7.8-1
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: dashing
+    status: developed
   rmw_implementation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `0.7.8-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rmw_gurumdds_cpp

```
* Change maintainer
* Contributors: junho
```

## rmw_gurumdds_shared_cpp

```
* Change maintainer
* Contributors: junho
```
