### PR TITLE
audibot: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -125,7 +125,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/robustify/audibot-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/robustify/audibot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audibot` to `0.2.1-1`:

- upstream repository: https://github.com/robustify/audibot.git
- release repository: https://github.com/robustify/audibot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.0-1`

## audibot

```
* Bump minimum CMake version to 3.0.2 as recommended for ROS Noetic
* Contributors: Micho Radovnikovich
```

## audibot_description

```
* Bump minimum CMake version to 3.0.2 as recommended for ROS Noetic
* Contributors: Micho Radovnikovich
```

## audibot_gazebo

```
* Bump minimum CMake version to 3.0.2 as recommended for ROS Noetic
* Adds dependency on tf2_geometry_msgs
* Contributors: Micho Radovnikovich
```
