### PR TITLE
add libboost-{math,timer,serialization} keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1842,6 +1842,24 @@ libboost-iostreams-dev:
   gentoo: [dev-libs/boost]
   rhel: [boost-devel]
   ubuntu: [libboost-iostreams-dev]
+libboost-math:
+  debian:
+    buster: [libboost-math1.67.0]
+    stretch: [libboost-math1.62.0]
+  fedora: [boost-math]
+  gentoo: [dev-libs/boost]
+  rhel: [boost-math]
+  ubuntu:
+    bionic: [libboost-math1.65.1]
+    eoan: [libboost-math1.67.0]
+    focal: [libboost-math1.71.0]
+    xenial: [libboost-math1.58.0]
+libboost-math-dev:
+  debian: [libboost-math-dev]
+  fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
+  ubuntu: [libboost-math-dev]
 libboost-program-options:
   debian:
     buster: [libboost-program-options1.67.0]
@@ -1930,10 +1948,11 @@ libboost-serialization:
     stretch: [libboost-serialization1.62.0]
   fedora: [boost-serialization]
   gentoo: [dev-libs/boost]
+  rhel: [boost-serialization]
   ubuntu:
-    bionic: [libboost-serialization1.62.0]
+    bionic: [libboost-serialization1.65.1]
     eoan: [libboost-serialization1.67.0]
-    focal: [libboost-serialization1.67.0]
+    focal: [libboost-serialization1.71.0]
     xenial: [libboost-serialization1.58.0]
 libboost-serialization-dev:
   debian: [libboost-serialization-dev]
@@ -1980,6 +1999,24 @@ libboost-thread-dev:
   gentoo: ['dev-libs/boost[threads]']
   rhel: [boost-devel]
   ubuntu: [libboost-thread-dev]
+libboost-timer:
+  debian:
+    buster: [libboost-timer1.67.0]
+    stretch: [libboost-timer1.62.0]
+  fedora: [boost-timer]
+  gentoo: [dev-libs/boost]
+  rhel: [boost-timer]
+  ubuntu:
+    bionic: [libboost-timer1.65.1]
+    eoan: [libboost-timer1.67.0]
+    focal: [libboost-timer1.71.0]
+    xenial: [libboost-timer1.58.0]
+libboost-timer-dev:
+  debian: [libboost-timer-dev]
+  fedora: [boost-devel]
+  gentoo: [dev-libs/boost]
+  rhel: [boost-devel]
+  ubuntu: [libboost-timer-dev]
 libcairo2-dev:
   arch: [cairo]
   debian: [libcairo2-dev]


### PR DESCRIPTION
Needed for some common packages like random_numbers and geometric_shapes

This is a follow-up of https://github.com/ros/rosdistro/pull/23624#issuecomment-624977689

Math:
Debian: https://packages.debian.org/buster/libboost-math-dev
Ubuntu: https://packages.ubuntu.com/focal/libboost-math-dev
Gentoo: https://packages.gentoo.org/packages/dev-libs/boost
Fedora/RHEL: https://pkgs.org/download/boost-math(x86-64)

Serialization:
Ubuntu: https://packages.ubuntu.com/focal/libboost-serialization-dev
Debian: https://packages.debian.org/buster/libboost-serialization-dev
Gentoo: https://packages.gentoo.org/packages/dev-libs/boost
Fedora/RHEL: https://pkgs.org/download/boost-serialization(x86-64)


Timer:
Debian: https://packages.debian.org/buster/libboost-timer-dev
Ubuntu: https://packages.ubuntu.com/focal/libboost-timer-dev
Gentoo: https://packages.gentoo.org/packages/dev-libs/boost
Fedora/RHEL: https://pkgs.org/download/boost-timer(x86-64)

cc @gavanderhoorn @ruffsl 