### PR TITLE
nerian_stereo: 3.8.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2321,7 +2321,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.8.0-1
+      version: 3.8.1-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nerian_stereo` to `3.8.1-1`:

- upstream repository: https://github.com/nerian-vision/nerian_stereo.git
- release repository: https://github.com/nerian-vision/nerian_stereo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.8.0`
- previous version for package: `3.8.0-1`

## nerian_stereo

```
* Build fix for Ubuntu 20.04
* Contributors: Konstantin Schauwecker
```
