### PR TITLE
webots_ros: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4729,6 +4729,21 @@ repositories:
       url: https://github.com/ros-visualization/webkit_dependency.git
       version: kinetic-devel
     status: maintained
+  webots_ros:
+    doc:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/cyberbotics/webots_ros-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros.git
+      version: master
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
## webots_ros (noetic) - 2.1.0-1

The packages in the `webots_ros` repository were released into the `noetic` distro by running `/usr/bin/bloom-release --rosdistro noetic --track noetic webots_ros --edit` on `Thu, 30 Jul 2020 11:57:58 -0000`

The `webots_ros` package was released.

Version of package(s) in repository `webots_ros`:

- upstream repository: https://github.com/cyberbotics/webots_ros.git
- release repository: unknown
- rosdistro version: `null`
- old version: `null`
- new version: `2.1.0-1`

Versions of tools used:

- bloom version: `0.9.7`
- catkin_pkg version: `0.4.22`
- rosdep version: `0.19.0`
- rosdistro version: `0.8.2`
- vcstools version: `0.1.42`