### PR TITLE
rmw_cyclonedds: 0.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1484,7 +1484,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.12.0-1
+      version: 0.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.13.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.12.0-1`

## rmw_cyclonedds_cpp

```
* Ensure compliant publisher API (#210 <https://github.com/ros2/rmw_cyclonedds/issues/210>)
* rmw_destroy_node must remove node from graph cache (#213 <https://github.com/ros2/rmw_cyclonedds/issues/213>)
* Add space between 'ROS' and '2' (#195 <https://github.com/ros2/rmw_cyclonedds/issues/195>)
* Contributors: Christophe Bedard, Erik Boasson, Michel Hidalgo
```
