### PR TITLE
code_coverage: 0.4.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1591,7 +1591,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/code_coverage-gbp.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/mikeferguson/code_coverage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `code_coverage` to `0.4.3-1`:

- upstream repository: https://github.com/mikeferguson/code_coverage.git
- release repository: https://github.com/mikeferguson/code_coverage-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.2-1`

## code_coverage

```
* Use multiple python coverage files (#23 <https://github.com/mikeferguson/code_coverage/issues/23>)
  Co-authored-by: hslusarek <mailto:h.slusarek@pilz.de>
* add note that robot_calibration uses this package
* fix #25 <https://github.com/mikeferguson/code_coverage/issues/25>
* Add new report formats (#24 <https://github.com/mikeferguson/code_coverage/issues/24>)
  * Add html report format
  * Add console report format
  * Add '--include'  and '--omit' flag to python-coverage commands
* Contributors: Alexander Gutenkunst, Michael Ferguson, hslusarek
```
