### PR TITLE
Revert "perception_open3d: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]"

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2559,20 +2559,6 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: noetic-devel
     status: maintained
-  perception_open3d:
-    release:
-      packages:
-      - open3d_conversions
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/ros-gbp/perception_open3d-release.git
-      version: 0.0.2-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-perception/perception_open3d.git
-      version: melodic-devel
-    status: developed
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#25970. We need to wait for an Open3D release. Refer: https://github.com/ros-perception/perception_open3d/issues/9