### PR TITLE
yp-spur: 1.18.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17787,7 +17787,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.18.1-1
+      version: 1.18.2-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.18.2-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.18.1-1`

## ypspur

```
* Fallback message if unable to get git revision (#142 <https://github.com/openspur/yp-spur/issues/142>)
* Contributors: Atsushi Watanabe
```
