### PR TITLE
psen_scan: 1.0.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7814,7 +7814,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan` to `1.0.7-1`:

- upstream repository: https://github.com/PilzDE/psen_scan.git
- release repository: https://github.com/PilzDE/psen_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.6-1`

## psen_scan

```
* Introducing an acceptance test to avoid high cpu usage
* Refactor read timeout in psen_scan_upd_interface.h (#45)
* Improve/integrationtest psen scan upd interface (#42)
* Contributors: Pilz GmbH & Co KG
```
