### PR TITLE
ros_comm: 1.14.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8962,7 +8962,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.14.6-1
+      version: 1.14.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.14.7-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.14.6-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

```
* fix subscription busy wait melodic (#1684 <https://github.com/ros/ros_comm/issues/1684>, #2014 <https://github.com/ros/ros_comm/issues/2014>)
* use an internal implementation of boost::condition_variable with monotonic clock (#1932 <https://github.com/ros/ros_comm/issues/1932>)
```

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

```
* add node name to shutdown message for duplicate nodes (#1992 <https://github.com/ros/ros_comm/issues/1992>)
```

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* remove not existing NodeProxy from rospy __all__ (#2007 <https://github.com/ros/ros_comm/issues/2007>)
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* add latch param to throttle (#1944 <https://github.com/ros/ros_comm/issues/1944>)
```

## xmlrpcpp

```
* add const versions of XmlRpcValue converting operators (#1978 <https://github.com/ros/ros_comm/issues/1978>)
```
