### PR TITLE
control_toolbox: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -361,7 +361,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/control_toolbox-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `2.0.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros-gbp/control_toolbox-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.0-1`

## control_toolbox

```
* Fix dependencies
* Export ament_cmake build type
* Contributors: ahcorde
```
