### PR TITLE
py_trees_ros: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1563,7 +1563,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.0.11-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1558,7 +1558,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros.git
-      version: release/2.0.x
+      version: release/2.1.x
     release:
       tags:
         release: release/foxy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.1.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.11-1`

## py_trees_ros

```
* [infra] update for api changes in py_trees 2.1.0 (Chooser no longer supported)
* [infra] update for api changes in ros2 foxy (not breaking changes)
```
