### PR TITLE
py_trees_ros_tutorials: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1589,7 +1589,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
-      version: release/2.0.x
+      version: release/2.1.x
     release:
       tags:
         release: release/foxy/{package}/{version}

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1594,7 +1594,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_tutorials-release.git
-      version: 2.0.2-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `2.1.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/stonier/py_trees_ros_tutorials-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.2-1`

## py_trees_ros_tutorials

```
* [infra] api updates for py_trees 2.1.x and ros2/foxy compatibility
* [infra] spelling fix for tutorial eight
```
