### PR TITLE
py_trees: 0.7.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2726,7 +2726,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.7.1-1
+      version: 0.7.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.7.3-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.7.1-1`
