### PR TITLE
fkie_multimaster: 1.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1006,7 +1006,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_multimaster` to `1.2.3-1`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.2-1`

## fkie_master_discovery

- No changes

## fkie_master_sync

- No changes

## fkie_multimaster

```
* use ${PYTHON_EXECUTABLE} instead of ${PYTHON}
```

## fkie_multimaster_msgs

```
* use ${PYTHON_EXECUTABLE} instead of search by itself
* Contributors: Alexander Tiderko
```

## fkie_node_manager

- No changes

## fkie_node_manager_daemon

- No changes
