### PR TITLE
rmw_connext: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1466,7 +1466,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 2.2.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.2.0-1`

## rmw_connext_cpp

```
* Remove internal rmw_connext_cpp headers from public API. (#447 <https://github.com/ros2/rmw_connext/issues/447>)
  * Update rmw_connext_cpp after internal headers relocation.
  * Relocate internal rmw_connext_cpp headers.
* Decouple rmw_destroy_publisher() outcome from global RMW error state. (#449 <https://github.com/ros2/rmw_connext/issues/449>)
* Ensure compliant publisher API. (#445 <https://github.com/ros2/rmw_connext/issues/445>)
* Avoid leaking DDS::Topic objects. (#444 <https://github.com/ros2/rmw_connext/issues/444>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_connext_shared_cpp

```
* Ensure compliant publisher API. (#445 <https://github.com/ros2/rmw_connext/issues/445>)
* Avoid leaking DDS::Topic objects. (#444 <https://github.com/ros2/rmw_connext/issues/444>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```
