### PR TITLE
Unrelease mrpt2 in ROS Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2106,11 +2106,6 @@ repositories:
       type: git
       url: https://github.com/mrpt/mrpt.git
       version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
-      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/mrpt/mrpt.git


### PR DESCRIPTION
It looks like the builds have always failed on all platforms https://github.com/MRPT/mrpt/issues/1076

Partially reverts https://github.com/ros/rosdistro/pull/25550 and https://github.com/ros/rosdistro/pull/24945

@jlblancoc FYI