### PR TITLE
soem: 1.4.1003-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10881,7 +10881,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mgruhler/soem-gbp.git
-      version: 1.4.1002-1
+      version: 1.4.1003-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `soem` to `1.4.1003-1`:

- upstream repository: https://github.com/mgruhler/soem.git
- release repository: https://github.com/mgruhler/soem-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.4.1002-1`

## soem

```
* fixes #40 <https://github.com/mgruhler/soem/issues/40>: export include directories properly
* Contributors: Matthias Gruhler
```
