### PR TITLE
velodyne_simulator: 1.0.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12171,7 +12171,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 1.0.9-0
+      version: 1.0.10-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.10-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.9-0`

## velodyne_description

```
* Change PointCloud visualization type from flat squares to points in example rviz config
* Bump minimum CMake version to 3.0.2 in all CMakeLists.txt
* Fix xacro macro instantiation
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## velodyne_gazebo_plugins

```
* Change PointCloud2 structure to match updated velodyne_pointcloud package
* Bump minimum CMake version to 3.0.2 in all CMakeLists.txt
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## velodyne_simulator

```
* Bump minimum CMake version to 3.0.2 in all CMakeLists.txt
* Contributors: Micho Radovnikovich
```
