### PR TITLE
velodyne_simulator: 1.0.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4626,6 +4626,25 @@ repositories:
       url: https://github.com/ros-drivers/velodyne.git
       version: master
     status: developed
+  velodyne_simulator:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: master
+    release:
+      packages:
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
+      version: 1.0.10-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
+      version: master
+    status: maintained
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.10-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## velodyne_description

```
* Change PointCloud visualization type from flat squares to points in example rviz config
* Bump minimum CMake version to 3.0.2 in all CMakeLists.txt
* Fix xacro macro instantiation
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## velodyne_gazebo_plugins

```
* Change PointCloud2 structure to match updated velodyne_pointcloud package
* Bump minimum CMake version to 3.0.2 in all CMakeLists.txt
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## velodyne_simulator

```
* Bump minimum CMake version to 3.0.2 in all CMakeLists.txt
* Contributors: Micho Radovnikovich
```
