### PR TITLE
py_trees_ros: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2748,6 +2748,21 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_msgs.git
       version: release/0.3.x
     status: maintained
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/0.6.x
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stonier/py_trees_ros-release.git
+      version: 0.6.1-1
+    source:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: release/0.6.x
+    status: maintained
   pybind11_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `0.6.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros.git
- release repository: https://github.com/stonier/py_trees_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## py_trees_ros

```
* [infra] python-setuptools -> python3-setuptools dependency fix
```
