### PR TITLE
rqt_py_trees: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3824,6 +3824,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_py_console.git
       version: master
     status: maintained
+  rqt_py_trees:
+    doc:
+      type: git
+      url: https://github.com/stonier/rqt_py_trees.git
+      version: release/0.4.x
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stonier/rqt_py_trees-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/stonier/rqt_py_trees.git
+      version: release/0.4.x
+    status: maintained
   rqt_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_trees` to `0.4.0-1`:

- upstream repository: https://github.com/stonier/rqt_py_trees.git
- release repository: https://github.com/stonier/rqt_py_trees-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rqt_py_trees

```
* python3 and noetic upgrades
```
