### PR TITLE
qt_gui_core: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1236,7 +1236,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-2`

## qt_dotgraph

- No changes

## qt_gui

```
* add logic to load qt_gui_icons on windows and macOS (#222 <https://github.com/ros-visualization/qt_gui_core/issues/222>)
* fix exporting perspective for Python 3.6 (#228 <https://github.com/ros-visualization/qt_gui_core/issues/228>)
* remove tango-icon-theme dependency (#224 <https://github.com/ros-visualization/qt_gui_core/issues/224>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

```
* avoid a warning about C++ plugins on Windows (#232 <https://github.com/ros-visualization/qt_gui_core/issues/232>)
* qt_gui_cpp_sip: declare private assignment operator for SIP (#226 <https://github.com/ros-visualization/qt_gui_core/issues/226>)
```

## qt_gui_py_common

- No changes
