### PR TITLE
rclcpp: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1788,7 +1788,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 2.0.2-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.2-1`

## rclcpp

```
* Warn about unused result of add_on_set_parameters_callback (#1238 <https://github.com/ros2/rclcpp/issues/1238>) (#1244 <https://github.com/ros2/rclcpp/issues/1244>)
* Add missing RCLCPP_PUBLIC to ~StaticExecutorEntitiesCollector (#1227 <https://github.com/ros2/rclcpp/issues/1227>) (#1228 <https://github.com/ros2/rclcpp/issues/1228>)
* Remove recreation of entities_collector (#1217 <https://github.com/ros2/rclcpp/issues/1217>) (#1224 <https://github.com/ros2/rclcpp/issues/1224>)
* Contributors: Jacob Perron, brawner
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Warn about unused result of add_on_set_parameters_callback (#1238 <https://github.com/ros2/rclcpp/issues/1238>) (#1244 <https://github.com/ros2/rclcpp/issues/1244>)
* Contributors: Jacob Perron
```
