### PR TITLE
console_bridge_vendor: 1.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -313,7 +313,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge_vendor` to `1.2.2-1`:

- upstream repository: https://github.com/ros2/console_bridge_vendor.git
- release repository: https://github.com/ros2-gbp/console_bridge_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.1-1`
