### PR TITLE
rqt_reconfigure: 1.0.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2788,7 +2788,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.0.4-1
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.0.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.4-1`

## rqt_reconfigure

```
* Save instance state in rqt settings (#90 <https://github.com/ros-visualization/rqt_reconfigure/issues/90>)
* Use safe YAML loader (#89 <https://github.com/ros-visualization/rqt_reconfigure/issues/89>)
* Don't process scroll events unless specifically focused (#88 <https://github.com/ros-visualization/rqt_reconfigure/issues/88>)
* Fix node selection from command line (#87 <https://github.com/ros-visualization/rqt_reconfigure/issues/87>)
* Add pytest.ini so local tests don't display warning (#91 <https://github.com/ros-visualization/rqt_reconfigure/issues/91>)
* Support PEP 338 invocation of rqt_reconfigure (#85 <https://github.com/ros-visualization/rqt_reconfigure/issues/85>)
* Fixed package to run with ros2 run (#81 <https://github.com/ros-visualization/rqt_reconfigure/issues/81>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Scott K Logan
```
