### PR TITLE
multisense_ros: 4.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2163,7 +2163,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/carnegieroboticsllc/multisense_ros-release.git
-      version: 4.0.4-1
+      version: 4.0.5-1
     source:
       type: git
       url: https://github.com/carnegierobotics/multisense_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisense_ros` to `4.0.5-1`:

    * upstream repository: https://github.com/carnegierobotics/multisense_ros.git

    * release repository: https://github.com/carnegieroboticsllc/multisense_ros-release.git

    * distro file: `noetic/distribution.yaml`

    * bloom version: `0.9.7`

    * previous version for package: `4.0.4-1`


## multisense

```
* Update for OpenCV 4.2, and updated launch file for ROS Noetic compatibility
```

## multisense_bringup

```
* Update for OpenCV 4.2, and updated launch file for ROS Noetic compatibility                                                                                                                                                                                                   
```

## multisense_cal_check

```
* Update for OpenCV 4.2, and updated launch file for ROS Noetic compatibility
```

## multisense_description

```
* Update for OpenCV 4.2, and updated launch file for ROS Noetic compatibility
```

## multisense_lib

```
* Update for OpenCV 4.2, and updated launch file for ROS Noetic compatibility
```

## multisense_ros

```
* Update for OpenCV 4.2, and updated launch file for ROS Noetic compatibility
```
