### PR TITLE
launch: 0.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -859,7 +859,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.2-2
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.10.2-2`

## launch

```
* Handle empty strings in type coercion. (#443 <https://github.com/ros2/launch/issues/443>)
* Consolidate type_utils in a way that can be reused in substitution results that need to be coerced to a specific type (#438 <https://github.com/ros2/launch/issues/438>)
* Delete unnecessary loading of 'launch.frontend.interpolate_substitution_method' entry point that was never used (#434 <https://github.com/ros2/launch/issues/434>)
* Avoid side effect, defer until needed (#432 <https://github.com/ros2/launch/issues/432>)
* Remove pkg_resources, replace it with the use of the more modern importlib* libraries. (#430 <https://github.com/ros2/launch/issues/430>)
* Remove the asyncio.wait loop parameter. (#429 <https://github.com/ros2/launch/issues/429>)
* Add pytest.ini so local tests don't display warning (#428 <https://github.com/ros2/launch/issues/428>)
* Defer shutdown if already running (#427 <https://github.com/ros2/launch/issues/427>)
* Add respawn and respawn_delay support (#426 <https://github.com/ros2/launch/issues/426>)
* Fix up parser.py (#414 <https://github.com/ros2/launch/issues/414>)
* Contributors: CHEN, Chris Lalancette, Dan Rose, Dirk Thomas, Ivan Santiago Paunovic, Jorge Perez, Michel Hidalgo
```

## launch_testing

```
* Disable cleanup of test cases once they have been run (#406 <https://github.com/ros2/launch/issues/406>)
* Fix max() with empty sequence (#440 <https://github.com/ros2/launch/issues/440>)
* Use unittest.TestCase.id() for pytest failure reprs. (#436 <https://github.com/ros2/launch/issues/436>)
* Use unittest.TestCase.id() to put together jUnit XML output. (#435 <https://github.com/ros2/launch/issues/435>)
* Claim ownership (#433 <https://github.com/ros2/launch/issues/433>)
* Contributors: Dirk Thomas, Michel Hidalgo, Scott K Logan, William Woodall
```

## launch_testing_ament_cmake

```
* Find Python debug interpreter on Windows (#437 <https://github.com/ros2/launch/issues/437>)
* Contributors: Dirk Thomas
```

## launch_xml

```
* Use new type_utils functions (#438 <https://github.com/ros2/launch/issues/438>)
* Add pytest.ini so local tests don't display warning (#428 <https://github.com/ros2/launch/issues/428>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## launch_yaml

```
* Use new type_utils functions (#438 <https://github.com/ros2/launch/issues/438>)
* Close YAML file when we're done. (#415 <https://github.com/ros2/launch/issues/415>)
* Add pytest.ini so local tests don't display warning (#428 <https://github.com/ros2/launch/issues/428>)
* Contributors: Chris Lalancette, Dan Rose, Ivan Santiago Paunovic
```
