### PR TITLE
kobuki_core: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1057,7 +1057,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/kobuki-base/kobuki_core.git
-      version: devel
+      version: release/1.0.x
     status: maintained
   kobuki_firmware:
     release:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -996,6 +996,25 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: foxy
     status: maintained
+  kobuki_core:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.1.x
+    release:
+      packages:
+      - kobuki_dock_drive
+      - kobuki_driver
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stonier/kobuki_core-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: devel
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.1.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/stonier/kobuki_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## kobuki_dock_drive

```
* [infra] ament_export_interfaces -> ament_export_targets
* [infra] license links updated, #15 <https://github.com/kobuki-base/kobuki_core/pull/15>.
```

## kobuki_driver

```
* [infra] ament_export_interfaces -> ament_export_targets
* [driver] bugfix correct size for pyaload length lookup, #19 <https://github.com/kobuki-base/kobuki_core/pull/19>`_.
* [infra] license links updated, #15 <https://github.com/kobuki-base/kobuki_core/pull/15>.
```
