### PR TITLE
kobuki_firmware: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -996,6 +996,17 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: foxy
     status: maintained
+  kobuki_firmware:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_firmware.git
+      version: release/1.2.x
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stonier/kobuki_firmware-release.git
+      version: 1.2.0-1
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_firmware` to `1.2.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_firmware.git
- release repository: https://github.com/stonier/kobuki_firmware-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## kobuki_firmware

```
* Custom PID gain setting of wheel velocity controlled added
```
