### PR TITLE
Enable test_abi for Foxy repositories: common_interfaces, rcl_logging

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -299,6 +299,7 @@ repositories:
       url: https://github.com/ros2-gbp/common_interfaces-release.git
       version: 2.0.3-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/common_interfaces.git
@@ -1780,6 +1781,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcl_logging-release.git
       version: 1.0.1-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_logging.git


### PR DESCRIPTION
Following #25967, more ABI checker for Foxy packages under quality level //cc @chapulina 