### PR TITLE
ros_tutorials: 0.9.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9237,7 +9237,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `0.9.3-1`:

- upstream repository: git@github.com:ros/ros_tutorials.git
- release repository: https://github.com/ros-gbp/ros_tutorials-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.2-1`

## ros_tutorials

- No changes

## roscpp_tutorials

- No changes

## rospy_tutorials

- No changes

## turtlesim

```
* add holonomic motion for turtlesim (#94 <https://github.com/ros/ros_tutorials/issues/94>)
```
