### PR TITLE
rc_visard: 3.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8376,7 +8376,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `3.0.2-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.0.1-1`

## rc_visard_driver

```
* Fixed filtering out images with projection if stereo matching is used single shot and controls a random dot projector
* Removed parameter depth_median as it will be removed on rc_visard >= 20.10.0
* rc_pick_client: fix grasp markers
* Fixed dockerfiles
* Update readme
```
