### PR TITLE
[rosdep] add python3 keys for pymodbus and urllib3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6408,6 +6408,11 @@ python3-twisted:
     '*': ['python%{python3_pkgversion}-twisted']
     '7': null
   ubuntu: [python3-twisted]
+python3-urllib3:
+  debian: [python3-urllib3]
+  fedora: [python3-urllib3]
+  gentoo: [dev-python/urllib3]
+  ubuntu: [python3-urllib3]
 python3-usb:
   debian: [python3-usb]
   gentoo: [dev-python/pyusb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5998,6 +5998,10 @@ python3-pykdl:
     '*': [python3-pykdl]
     'bionic': null
     'xenial': null
+python3-pymodbus:
+  debian: [python3-pymodbus]
+  fedora: [python3-pymodbus]
+  ubuntu: [python3-pymodbus]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5999,9 +5999,13 @@ python3-pykdl:
     'bionic': null
     'xenial': null
 python3-pymodbus:
-  debian: [python3-pymodbus]
+  debian:
+    '*': [python3-pymodbus]
+    stretch: null
   fedora: [python3-pymodbus]
-  ubuntu: [python3-pymodbus]
+  ubuntu:
+    '*': [python3-pymodbus]
+    xenial: null
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]


### PR DESCRIPTION
pymodbus:
debian: https://packages.debian.org/buster/python3-pymodbus
fedora: https://fedora.pkgs.org/32/fedora-x86_64/python3-pymodbus-2.3.0-2.fc32.noarch.rpm.html
ubuntu: https://packages.ubuntu.com/focal/python3-pymodbus

urllib3:
debian: https://packages.debian.org/buster/python3-urllib3
fedora: https://fedora.pkgs.org/32/fedora-x86_64/python3-urllib3-1.25.7-3.fc32.noarch.rpm.html
gentoo: https://packages.gentoo.org/packages/dev-python/urllib3
ubuntu: https://packages.ubuntu.com/focal/python3-urllib3