### PR TITLE
rc_visard: 3.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2902,6 +2902,31 @@ repositories:
       url: https://github.com/roboception/rc_genicam_api.git
       version: master
     status: developed
+  rc_visard:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_visard_ros.git
+      version: master
+    release:
+      packages:
+      - rc_hand_eye_calibration_client
+      - rc_pick_client
+      - rc_roi_manager_gui
+      - rc_silhouettematch_client
+      - rc_tagdetect_client
+      - rc_visard
+      - rc_visard_description
+      - rc_visard_driver
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_visard-release.git
+      version: 3.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_visard_ros.git
+      version: master
+    status: developed
   rcdiscover:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `3.0.2-1`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## rc_visard_driver

```
* Fixed filtering out images with projection if stereo matching is used single shot and controls a random dot projector
* Removed parameter depth_median as it will be removed on rc_visard >= 20.10.0
* rc_pick_client: fix grasp markers
* Fixed dockerfiles
* Update readme
```
