### PR TITLE
diagnostics: 2.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -444,7 +444,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.0.4-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `2.0.3-1`

## diagnostic_aggregator

```
* Fix installation of diagnostic aggregator example. (#159 <https://github.com/ros/diagnostics/issues/159>) (#160 <https://github.com/ros/diagnostics/issues/160>)
* Contributors: Georg Bartels
```

## diagnostic_updater

- No changes

## self_test

- No changes
