### PR TITLE
geometry2: 0.13.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -795,7 +795,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.4-1
+      version: 0.13.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.5-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.13.4-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Make static_transform_broadcaster consistent with its command line description (#294 <https://github.com/ros2/geometry2/issues/294>) (#296 <https://github.com/ros2/geometry2/issues/296>)
* Fix dependencies in tf2_ros (#269 <https://github.com/ros2/geometry2/issues/269>) (#288 <https://github.com/ros2/geometry2/issues/288>)
* Moved unique_lock of messages_mutex_ to guarantee pointer (#279 <https://github.com/ros2/geometry2/issues/279>) (#283 <https://github.com/ros2/geometry2/issues/283>)
* Contributors: Chris Lalancette, Hunter L. Allen, Martin Ganeff
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
