### PR TITLE
teleop_twist_joy: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2340,7 +2340,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: dashing
+      version: eloquent
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2350,7 +2350,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: dashing
+      version: eloquent
     status: maintained
   teleop_twist_keyboard:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2345,7 +2345,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.2.2-2
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.3.0-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.2.2-2`

## teleop_twist_joy

```
* Make Parameters dynamic (#16 <https://github.com/ros2/teleop_twist_joy/issues/16>)
* Contributors: aravindsrj
```
