### PR TITLE
rosbag2: 0.3.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2320,7 +2320,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.4-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.3-1`

## ros2bag

```
* Validate QoS profile values are not negative. (#483 <https://github.com/ros2/rosbag2/issues/483>) (#490 <https://github.com/ros2/rosbag2/issues/490>)
  Co-authored-by: Jesse Ikawa <mailto:64169356+jikawa-az@users.noreply.github.com>
* Contributors: Devin Bonnie
```

## rosbag2

- No changes

## rosbag2_compression

```
* Fix exception thrown given invalid arguments with compression enabled (#488 <https://github.com/ros2/rosbag2/issues/488>) (#489 <https://github.com/ros2/rosbag2/issues/489>)
* Contributors: Devin Bonnie
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* fix missing target dependencies (#479 <https://github.com/ros2/rosbag2/issues/479>) (#481 <https://github.com/ros2/rosbag2/issues/481>)
  Co-authored-by: Dirk Thomas <mailto:dirk-thomas@users.noreply.github.com>
* Contributors: Karsten Knese
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
