### PR TITLE
udp_com: 1.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16445,6 +16445,21 @@ repositories:
       url: https://github.com/KumarRobotics/ublox.git
       version: master
     status: maintained
+  udp_com:
+    doc:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: gh-pages
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/flynneva/udp_com-release.git
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: ros1/main
+    status: maintained
   ueye:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16449,7 +16449,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/continental/udp_com.git
-      version: gh-pages
+      version: ros1/main
     release:
       tags:
         release: release/kinetic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_com` to `1.1.0-2`:

- upstream repository: https://github.com/continental/udp_com.git
- release repository: https://github.com/flynneva/udp_com-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## udp_com

```
* create pr to rosdistro
* remove docs from non-docs branches
* Merge pull request #64 <https://github.com/continental/udp_com/issues/64> from continental/ros1/main
* changed remote url
* Contributors: Evan Flynn
```
