### PR TITLE
udp_com: 1.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11762,11 +11762,20 @@ repositories:
       version: master
     status: developed
   udp_com:
+    doc:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: gh-pages
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/flynneva/udp_com-release.git
-      version: 0.0.6-1
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/continental/udp_com.git
+      version: ros1/main
+    status: maintained
   um6:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11765,7 +11765,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/continental/udp_com.git
-      version: gh-pages
+      version: ros1/main
     release:
       tags:
         release: release/melodic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_com` to `1.1.0-2`:

- upstream repository: https://github.com/continental/udp_com.git
- release repository: https://github.com/flynneva/udp_com-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.6-1`

## udp_com

```
* create pr to rosdistro
* remove docs from non-docs branches
* Merge pull request #64 <https://github.com/continental/udp_com/issues/64> from continental/ros1/main
* changed remote url
* Contributors: Evan Flynn
```
