### PR TITLE
pluginlib: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1182,7 +1182,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 2.5.2-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `4.0.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.5.2-2`

## pluginlib

```
* Remove deprecated boost functions (#199 <https://github.com/ros/pluginlib/issues/199>)
* Contributors: Shane Loretz
```
