### PR TITLE
rmw_fastrtps: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1520,7 +1520,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `2.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.0-1`

## rmw_fastrtps_cpp

```
* Ensure compliant subscription API. (#419 <https://github.com/ros2/rmw_fastrtps/issues/419>)
* Contributors: Michel Hidalgo
```

## rmw_fastrtps_dynamic_cpp

```
* Ensure compliant subscription API. (#419 <https://github.com/ros2/rmw_fastrtps/issues/419>)
* Contributors: Michel Hidalgo
```

## rmw_fastrtps_shared_cpp

```
* Ensure compliant subscription API. (#419 <https://github.com/ros2/rmw_fastrtps/issues/419>)
* Use package path to TypeSupport.hpp headers in ServiceTypeSupport and MessageTypeSupport (#415 <https://github.com/ros2/rmw_fastrtps/issues/415>)
  Use package in path to TypeSupport header for ServiceTypeSupport/MessageTypeSupport
* Contributors: Jose Luis Rivero, Michel Hidalgo
```
