### PR TITLE
rmw_connext: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1466,7 +1466,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.0.0-1`

## rmw_connext_cpp

```
* Ensure compliant subscription API. (#450 <https://github.com/ros2/rmw_connext/issues/450>)
* Contributors: Michel Hidalgo
```

## rmw_connext_shared_cpp

- No changes
