### PR TITLE
neonavigation: 0.10.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6257,7 +6257,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.9.1-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.10.0-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.9.1-1`

## costmap_cspace

- No changes

## joystick_interrupt

```
* joystick_interrupt: improve test stability (#538 <https://github.com/at-wat/neonavigation/issues/538>)
* Increase initialization timeout in the tests (#536 <https://github.com/at-wat/neonavigation/issues/536>)
* joystick_interrupt: increase JoystickMuxTest wait (#524 <https://github.com/at-wat/neonavigation/issues/524>)
* joystick_interrupt: send zero twist when interrupt button is released (#517 <https://github.com/at-wat/neonavigation/issues/517>)
* Contributors: Atsushi Watanabe, f-fl0
```

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

```
* neonavigation_common: add unit tests (#525 <https://github.com/at-wat/neonavigation/issues/525>)
* Contributors: Atsushi Watanabe
```

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: add test to MoveWithToleranceAction (#528 <https://github.com/at-wat/neonavigation/issues/528>)
* planner_cspace: add test to distance map debug output (#526 <https://github.com/at-wat/neonavigation/issues/526>)
* planner_cspace: periodically update local map in the test (#522 <https://github.com/at-wat/neonavigation/issues/522>)
* Merge rostest coverage profiles (#520 <https://github.com/at-wat/neonavigation/issues/520>)
* planner_cspace: fix search range of minimum cost in fast_map_update mode (#518 <https://github.com/at-wat/neonavigation/issues/518>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```

## safety_limiter

```
* Merge rostest coverage profiles (#520 <https://github.com/at-wat/neonavigation/issues/520>)
* Contributors: Atsushi Watanabe
```

## track_odometry

```
* Increase initialization timeout in the tests (#536 <https://github.com/at-wat/neonavigation/issues/536>)
* Contributors: Atsushi Watanabe
```

## trajectory_tracker

```
* trajectory_tracker: add a mode to apply the same control method during turning in place (#513 <https://github.com/at-wat/neonavigation/issues/513>)
* trajectory_tracker: relax test tolerance on tf mode (#545 <https://github.com/at-wat/neonavigation/issues/545>)
* trajectory_tracker: goal if both raw and predicted pose is in tolerance (#540 <https://github.com/at-wat/neonavigation/issues/540>)
* trajectory_tracker: fix wrong tracking target just after new path is received (#537 <https://github.com/at-wat/neonavigation/issues/537>)
* Increase initialization timeout in the tests (#536 <https://github.com/at-wat/neonavigation/issues/536>)
* trajectory_tracker: add odometry timeout checking (#534 <https://github.com/at-wat/neonavigation/issues/534>)
* trajectory_tracker: predict odometry by extrapolation (#529 <https://github.com/at-wat/neonavigation/issues/529>)
* trajectory_tracker: add use_odom option (#523 <https://github.com/at-wat/neonavigation/issues/523>)
* trajectory_tracker: make trajectory_tracker dynamic-reconfigurable (#521 <https://github.com/at-wat/neonavigation/issues/521>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```
