### PR TITLE
robot_self_filter: 0.1.32-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3030,6 +3030,21 @@ repositories:
       url: https://github.com/locusrobotics/robot_navigation.git
       version: noetic
     status: developed
+  robot_self_filter:
+    doc:
+      type: git
+      url: https://github.com/PR2/robot_self_filter.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/robot_self_filter-gbp.git
+      version: 0.1.32-1
+    source:
+      type: git
+      url: https://github.com/pr2/robot_self_filter.git
+      version: indigo-devel
+    status: unmaintained
   robot_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_self_filter` to `0.1.32-1`:

- upstream repository: https://github.com/pr2/robot_self_filter.git
- release repository: https://github.com/pr2-gbp/robot_self_filter-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## robot_self_filter

```
* PCL > 1.10 uses c++ 14
* find_package(Boost signals) no longer required for noetic, use find_package(Boost)
* remove indigo/lunar from .travis.yml
* add noetic and fix .travs.yml
* Contributors: Kei Okada
```
