### PR TITLE
ros2_planning_system: 0.0.14-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2276,7 +2276,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 0.0.13-1
+      version: 0.0.14-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `0.0.14-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.13-1`

## plansys2_bringup

```
* Merge pull request #26 <https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/26> from mjcarroll/reduce_deps
  [Eloquent] Reduce unnecessary dependencies
* Remove CMAKE_BUILD_TYPE
* Contributors: Francisco Martín Rico, Michael Carroll
```

## plansys2_domain_expert

- No changes

## plansys2_executor

```
* Merge pull request #26 <https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/26> from mjcarroll/reduce_deps
  [Eloquent] Reduce unnecessary dependencies
* Prune test_dependencies
* Remove CMAKE_BUILD_TYPE
* Contributors: Francisco Martín Rico, Michael Carroll
```

## plansys2_lifecycle_manager

```
* Merge pull request #26 <https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/26> from mjcarroll/reduce_deps
  [Eloquent] Reduce unnecessary dependencies
* Remove CMAKE_BUILD_TYPE
* Contributors: Francisco Martín Rico, Michael Carroll
```

## plansys2_msgs

- No changes

## plansys2_pddl_parser

```
* Merge pull request #26 <https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/26> from mjcarroll/reduce_deps
  [Eloquent] Reduce unnecessary dependencies
* Remove CMAKE_BUILD_TYPE
* Contributors: Francisco Martín Rico, Michael Carroll
```

## plansys2_planner

```
* Merge pull request #26 <https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/26> from mjcarroll/reduce_deps
  [Eloquent] Reduce unnecessary dependencies
* Remove CMAKE_BUILD_TYPE
* Contributors: Francisco Martín Rico, Michael Carroll
```

## plansys2_problem_expert

```
* Merge pull request #26 <https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/26> from mjcarroll/reduce_deps
  [Eloquent] Reduce unnecessary dependencies
* Remove CMAKE_BUILD_TYPE
* Contributors: Francisco Martín Rico, Michael Carroll
```

## plansys2_terminal

```
* Merge pull request #26 <https://github.com/IntelligentRoboticsLabs/ros2_planning_system/issues/26> from mjcarroll/reduce_deps
  [Eloquent] Reduce unnecessary dependencies
* Remove CMAKE_BUILD_TYPE
* Contributors: Francisco Martín Rico, Michael Carroll
```
