### PR TITLE
oxford_gps_eth: 1.2.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9532,7 +9532,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
-      version: 1.2.0-1
+      version: 1.2.1-2
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git


### PR DESCRIPTION
Increasing version of package(s) in repository `oxford_gps_eth` to `1.2.1-2`:

- upstream repository: https://bitbucket.org/DataspeedInc/oxford_gps_eth.git
- release repository: https://github.com/DataspeedInc-release/oxford_gps_eth-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.0-1`

## oxford_gps_eth

```
* Changes to make ntrip_forwarding.py support both Python 2 and Python 3
* Contributors: Micho Radovnikovich
```
