### PR TITLE
autoware_auto_msgs: 0.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -321,7 +321,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
-      version: 0.0.2-2
+      version: 0.1.0-1
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_auto_msgs` to `0.1.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.2-2`

## autoware_auto_msgs

```
* Merge branch 'add-hadmap-msgs' into 'master'
  had map msgs - respect idl constant naming conventions
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!5 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/5>
* Merge branch 'add-hadmap-msgs' into 'master'
  Add hadmap msgs
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!4 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/4>
* Add hadmap msgs
* Merge branch '3-convert-messages-from-rosmsg-to-idl' into 'master'
  Resolve "Convert messages from ROSmsg to IDL"
  Closes #3 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/issues/3>
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!2 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/2>
* Resolve "Convert messages from ROSmsg to IDL"
* Contributors: Esteve Fernandez, Joshua Whitley, simon-t4
```
