### PR TITLE
autoware_auto_msgs: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -188,6 +188,21 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    status: developed
   behaviortree_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_auto_msgs` to `0.1.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## autoware_auto_msgs

```
* Merge branch 'add-hadmap-msgs' into 'master'
  had map msgs - respect idl constant naming conventions
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!5 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/5>
* Merge branch 'add-hadmap-msgs' into 'master'
  Add hadmap msgs
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!4 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/4>
* Add hadmap msgs
* Merge branch '3-convert-messages-from-rosmsg-to-idl' into 'master'
  Resolve "Convert messages from ROSmsg to IDL"
  Closes #3 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/issues/3>
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!2 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/2>
* Resolve "Convert messages from ROSmsg to IDL"
* Contributors: Esteve Fernandez, Joshua Whitley, simon-t4
```
