### PR TITLE
audio_common: 0.3.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -146,7 +146,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.6-1
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.7-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.6-1`

## audio_capture

```
* Merge pull request #150 <https://github.com/ros-drivers/audio_common/issues/150> from sktometometo/fix_mp3_options
  Fix property of lamemp3enc element in audio_capture so that the bitrate parameter work properly.
* fix property of lamemp3enc element so that it will use the specified bitrate
* Merge pull request #146 <https://github.com/ros-drivers/audio_common/issues/146> from knorth55/mp3-support
* use space instead of tab
* use same caps
* support channls for mp3
* Merge pull request #145 <https://github.com/ros-drivers/audio_common/issues/145> from knorth55/mp3-channel-rate
  [audio_capture] add sample_format in audio_capture
* Merge pull request #147 <https://github.com/ros-drivers/audio_common/issues/147> from knorth55/fix-filesink
  [audio_capture] fix filesink for wave format
* add sample_format arg in capture_to_file.launch
* fix filesink for wave format
* add sample_format in audio_capture
* Contributors: Koki Shinjo, Shingo Kitagawa
```

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

```
* Merge pull request #146 <https://github.com/ros-drivers/audio_common/issues/146> from knorth55/mp3-support
* support format, rate, channels in mp3
* Merge pull request #127 <https://github.com/ros-drivers/audio_common/issues/127> from knorth55/audio-play-wave
  [audio_play] support wave format
* add sample_format param in audio_play
* add channels and sample_rate in audio_play/play.launch
* add channels and sample_rate in audio_play.cpp
* add format arg in play.launch
* support wave in audio_play
* Merge pull request #144 <https://github.com/ros-drivers/audio_common/issues/144> from ros-drivers/knorth55-patch-1
* add gstreamer1.0-alsa for run_depend in audio_play
* Contributors: Shingo Kitagawa
```

## sound_play

```
* Merge pull request #149 <https://github.com/ros-drivers/audio_common/issues/149> from garaemon/specify-topic-to-play-sound
  Support use different topic and actionlib to play sound
* Support use different topic and actionlib to play sound
  * Add two keywords to the constructor of SoundClient class in order to
  specify actionlib namespace and topic name to play sound.
  * See #119 <https://github.com/ros-drivers/audio_common/issues/119>.
* Merge pull request #144 <https://github.com/ros-drivers/audio_common/issues/144> from ros-drivers/knorth55-patch-1
* add gstreamer1.0-alsa exec_depend in sound_play
* Contributors: Ryohei Ueda, Shingo Kitagawa
```
