### PR TITLE
rqt_image_view: 1.0.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3027,7 +3027,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `1.0.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.4-1`

## rqt_image_view

```
* fix segfault on topic change (#40 <https://github.com/ros-visualization/rqt_image_view/issues/40>)
* fix ImportError in image_publisher script (#39 <https://github.com/ros-visualization/rqt_image_view/issues/39>)
```
