### PR TITLE
rqt_bag: 0.4.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9843,7 +9843,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_bag-release.git
-      version: 0.4.12-0
+      version: 0.4.14-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `0.4.14-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros-gbp/rqt_bag-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.12-0`

## rqt_bag

```
* save last directory opened to load a bag file (#40 <https://github.com/ros-visualization/rqt_bag/issues/40>)
* fix shebang line for Python 3 (#48 <https://github.com/ros-visualization/rqt_bag/issues/48>)
* bump CMake minimum version to avoid CMP0048 warning
```

## rqt_bag_plugins

```
* support 16-bit bayer images (#45 <https://github.com/ros-visualization/rqt_bag/issues/45>)
* maintain image aspect ratio (#32 <https://github.com/ros-visualization/rqt_bag/issues/32>)
* fix Python 3 issue: long/int (#51 <https://github.com/ros-visualization/rqt_bag/issues/51>)
* fix Python 3 issue: ensure str is encoded before decoding (#50 <https://github.com/ros-visualization/rqt_bag/issues/50>)
* bump CMake minimum version to avoid CMP0048 warning
```
