### PR TITLE
open_karto: 1.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2475,7 +2475,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/open_karto-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-perception/open_karto.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_karto` to `1.2.2-1`:

- upstream repository: https://github.com/ros-perception/open_karto.git
- release repository: https://github.com/ros-gbp/open_karto-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.1-1`

## open_karto

```
* Move the C++ classes and definitions of inline functions from the Mapper.cpp file to the Mapper.h file (#22 <https://github.com/ros-perception/open_karto/issues/22>)
* add Hokuyo configuration in SetAngularResolution function (#20 <https://github.com/ros-perception/open_karto/issues/20>)
  Karto has five kinds of lidar parameter configurations (LMS100, LMS200, LMS291, UTM_30LX, URG_04LX), but there are only the first three configurations in the SetAngularResolution function, so I added the parameter configuration of UTM_30LX and URG_04LX.
* Contributors: Jian Wen, Zezhou.Sun
```
