### PR TITLE
radial_menu_ros: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8202,12 +8202,13 @@ repositories:
       - radial_menu
       - radial_menu_backend
       - radial_menu_example
+      - radial_menu_model
       - radial_menu_msgs
       - radial_menu_rviz
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yoshito-n-students/radial_menu_ros-release.git
-      version: 0.2.0-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/radial_menu_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `radial_menu_ros` to `0.3.2-1`:

- upstream repository: https://github.com/yoshito-n-students/radial_menu_ros.git
- release repository: https://github.com/yoshito-n-students/radial_menu_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.0-1`

## radial_menu

```
* No changes
```

## radial_menu_backend

```
* No changes
```

## radial_menu_example

```
* No changes
```

## radial_menu_model

```
* Rename attribute 'url' to 'imgurl'
* Install targets
```

## radial_menu_msgs

```
* No changes
```

## radial_menu_rviz

```
* Fix system dependency (rviz)
* Support the latest model description
```
