### PR TITLE
mavros: 1.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7238,7 +7238,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.3.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.2.0-1`

## libmavconn

```
* allow mavros to compile in CI environment
* Contributors: Marcelino
```

## mavros

```
* fake_gps.cpp: implement speed accuracy
* fake_gps.cpp: Add mocap_withcovariance configuration parameter
* fake_gps.cpp: add initial support for GPS_INPUT MAVLink message
* apm.launch: Avoid warning:
  Warning: You are using <arg> inside an <include> tag with the default=XY attribute - which is superfluous.
  Use value=XY instead for less confusion.
  Attribute name: respawn_mavros
* Added support for MavProxy parameter file format
* Ignore read-only parameters and statistics parameters in push operations
* fix indentation
* transform based on coordinate_frame
* wind plugin: fix ArduPilot wind transformation
* Contributors: Ben Wolsieffer, Dr.-Ing. Amilcar do Carmo Lucas, Yuan, Yuan Xu
```

## mavros_extras

```
* Take into account message count for message size
* Add esc_status plugin.
* fake_gps.cpp: Implement GPS time data
* fake_gps.cpp: implement speed accuracy
* fake_gps.cpp: Added horiz_accuracy and vert_accuracy parameters
* fake_gps.cpp: Add mocap_withcovariance configuration parameter
* fake_gps.cpp: add initial support for GPS_INPUT MAVLink message
* fake_gps.cpp: uncrustify
* Add gps_status plugin to publish GPS_RAW and GPS_RTK messages from FCU.
  The timestamps for the gps_status topics take into account the mavlink time and uses the convienence function
* uncrustify gps_rtk plugin
* adding support for publishing rtkbaseline msgs over ROS
* Contributors: CSCE439, Dr.-Ing. Amilcar do Carmo Lucas, Ricardo Marques
```

## mavros_msgs

```
* Add esc_status plugin.
* Add gps_status plugin to publish GPS_RAW and GPS_RTK messages from FCU.
  The timestamps for the gps_status topics take into account the mavlink time and uses the convienence function
* adding support for publishing rtkbaseline msgs over ROS
* Contributors: CSCE439, Dr.-Ing. Amilcar do Carmo Lucas, Ricardo Marques
```

## test_mavros

- No changes
