### PR TITLE
pr2_mechanism_msgs: 1.8.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2781,6 +2781,21 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: melodic-devel
     status: unmaintained
+  pr2_mechanism_msgs:
+    doc:
+      type: git
+      url: https://github.com/PR2/pr2_mechanism_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
+      version: 1.8.2-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism_msgs.git
+      version: master
+    status: unmaintained
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism_msgs` to `1.8.2-1`:

- upstream repository: https://github.com/PR2/pr2_mechanism_msgs.git
- release repository: https://github.com/ros-gbp/pr2_mechanism_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## pr2_mechanism_msgs

```
* change maintainer to ROS orphaned package maintainer
* Contributors: Kei Okada
```
