### PR TITLE
realsense2_camera: 2.2.16-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11483,7 +11483,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.15-1
+      version: 2.2.16-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.16-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.2.15-1`

## realsense2_camera

```
* Add PID to support D455.
* Improve instability of dynamic reconfigurable options.
* rs_camera.lauch: add "enable_infra" for L515 support.
* Contributors: doronhi
```

## realsense2_description

- No changes
