### PR TITLE
xacro: 1.14.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4813,7 +4813,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.3-2
+      version: 1.14.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.4-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.14.3-2`

## xacro

```
* [fix] Rework YamlDictWrapper to restore dict properties (#250 <https://github.com/ros/xacro/issues/250>)
* [fix] Ignore underscores when parsing literal numeric values (#247 <https://github.com/ros/xacro/issues/247>)
* Contributors: Robert Haschke
```
