### PR TITLE
dolly: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -451,6 +451,27 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: foxy
     status: maintained
+  dolly:
+    doc:
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: foxy
+    release:
+      packages:
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      - dolly_ignition
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/chapulina/dolly-release.git
+      version: 0.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: foxy
+    status: maintained
   dynamic-graph:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dolly` to `0.3.0-1`:

- upstream repository: https://github.com/chapulina/dolly.git
- release repository: https://github.com/chapulina/dolly-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dolly

```
* Ignition support (#13 <https://github.com/chapulina/dolly/issues/13>)
* Contributors: Louise Poubel
```

## dolly_follow

- No changes

## dolly_gazebo

```
* More detailed collision for CPU lidar (#19 <https://github.com/chapulina/dolly/issues/19>)
* Foxy support (#18 <https://github.com/chapulina/dolly/issues/18>)
* Ignition support (#13 <https://github.com/chapulina/dolly/issues/13>)
* Use env hooks to set environment variables (#12 <https://github.com/chapulina/dolly/issues/12>)
  also dsv example - only used from eloquent
* Changed gpu_ray to ray in the dolly model, to make laser_scan work on the CPU instead of a GPU. (#10 <https://github.com/chapulina/dolly/issues/10>)
* Contributors: FrankHx9, Louise Poubel
```

## dolly_ignition

```
* Foxy support (#18 <https://github.com/chapulina/dolly/issues/18>)
* A few tweaks to the Ignition package (#14 <https://github.com/chapulina/dolly/issues/14>)
* Ignition support (#13 <https://github.com/chapulina/dolly/issues/13>)
* Contributors: Louise Poubel
* Foxy support (#18 <https://github.com/chapulina/dolly/issues/18>)
* A few tweaks to the Ignition package (#14 <https://github.com/chapulina/dolly/issues/14>)
* Ignition support (#13 <https://github.com/chapulina/dolly/issues/13>)
* Contributors: Louise Poubel
```
