### PR TITLE
Added gettext-base rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1064,6 +1064,7 @@ geos:
 gettext-base:
   debian: [gettext-base]
   fedora: [gettext]
+  gentoo: [sys-devel/gettext]
   ubuntu: [gettext-base]
 gforth:
   arch: [gforth]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1062,6 +1062,7 @@ geos:
   gentoo: [sci-libs/geos]
   ubuntu: [libgeos-dev]
 gettext-base:
+  arch: [gettext]
   debian: [gettext-base]
   fedora: [gettext]
   gentoo: [sys-devel/gettext]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1063,7 +1063,7 @@ geos:
   ubuntu: [libgeos-dev]
 gettext-base:
   debian: [gettext-base]
-  ubuntu: [gettext-base] 
+  ubuntu: [gettext-base]
 gforth:
   arch: [gforth]
   debian: [gforth]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1061,6 +1061,9 @@ geos:
   fedora: [geos-devel]
   gentoo: [sci-libs/geos]
   ubuntu: [libgeos-dev]
+gettext-base:
+  debian: [gettext-base]
+  ubuntu: [gettext-base] 
 gforth:
   arch: [gforth]
   debian: [gforth]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1063,6 +1063,7 @@ geos:
   ubuntu: [libgeos-dev]
 gettext-base:
   debian: [gettext-base]
+  fedora: [gettext]
   ubuntu: [gettext-base]
 gforth:
   arch: [gforth]


### PR DESCRIPTION
The gettext-base package includes the gettext and ngettext programs which allow other packages to internationalize the messages given by shell scripts.
Ubuntu: https://packages.ubuntu.com/bionic/gettext-base
debian: https://packages.debian.org/stretch/gettext-base