### PR TITLE
dingo: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2051,6 +2051,26 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  dingo:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo.git
+      version: master
+    release:
+      packages:
+      - dingo_control
+      - dingo_description
+      - dingo_msgs
+      - dingo_navigation
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo.git
+      version: master
+    status: developed
   distance_map:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dingo_control

```
* Fix the controller parameters for omni control; behaviour is now the same as ridgeback
* Unified Dingo folders/files as much as possible, updated meshes, bumped CMake version and made roslaunch a test depend.
* Added dingo_control; split dingo_description into separate Dingo-D and Dingo-O flavours; still much work to be done here, but preparing hand-off for Tony
* Contributors: Chris Iverach-Brereton, Jason Higgins, Tony Baltovski
```

## dingo_description

```
* Unified Dingo folders/files as much as possible, updated meshes, bumped CMake version and made roslaunch a test depend.
* Added dingo_control; split dingo_description into separate Dingo-D and Dingo-O flavours; still much work to be done here, but preparing hand-off for Tony
* Moved IMU
* Updated joint names for simplicity
* Fixed collision
* Added description
* Contributors: Dave Niewinski, Jason Higgins, Tony Baltovski
```

## dingo_msgs

```
* Redefined corner light order in Lights.msg
* Added firmware_version string to Status message
* Unified Dingo folders/files as much as possible, updated meshes, bumped CMake version and made roslaunch a test depend.
* Updated naming for 12V power good variable in Status.msg based on code review
* Update messages based on merge request feedback
* Remove files added accidentally
* Adding first draft of Dingo messages for communication between computer and MCU
* Contributors: Jason Higgins, Roni Kreinin, Tony Baltovski
```

## dingo_navigation

```
* [dingo_navigation] Removed maps from install.
* [dingo_navigation] Unified launch files, made roslaunch a test depend and bumped CMake version.
* Added dingo_control; split dingo_description into separate Dingo-D and Dingo-O flavours; still much work to be done here, but preparing hand-off for Tony
* Initial commit of dingo_navigation
* Contributors: Dave Niewinski, Jason Higgins, Tony Baltovski
```
