### PR TITLE
ros_comm: 1.12.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12563,7 +12563,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.12.14-0
+      version: 1.12.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.15-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.12.14-0`

## message_filters

```
* add 'template' to resolve compile error (#1685 <https://github.com/ros/ros_comm/issues/1685>)
```

## ros_comm

- No changes

## rosbag

```
* fix roslib not being imported (#1818 <https://github.com/ros/ros_comm/issues/1818>)
* remove deadcode (#1786 <https://github.com/ros/ros_comm/issues/1786>)
* record: fix signed int overflow (#1741 <https://github.com/ros/ros_comm/issues/1741>)
* fix topic message count for rosbag indexed v1.2 (#1648 <https://github.com/ros/ros_comm/issues/1648>)
* fix wrong error handling in migration. (#1639 <https://github.com/ros/ros_comm/issues/1639>)
* fix waitForSubscribers hanging with simtime (#1543 <https://github.com/ros/ros_comm/issues/1543>)
```

## rosbag_storage

```
* fix brief description comments after members (#1920 <https://github.com/ros/ros_comm/issues/1920>)
* check for fclose returning 0 in rosbag_storage (#1750 <https://github.com/ros/ros_comm/issues/1750>)
* fix infinite loop in rosbag buffer resize (#1623 <https://github.com/ros/ros_comm/issues/1623>)
* add rosbag::Bag::isOpen (#1190 <https://github.com/ros/ros_comm/issues/1190>) (#1789 <https://github.com/ros/ros_comm/issues/1789>)
```

## rosconsole

```
* don't use 0 as null pointer in macros (#1730 <https://github.com/ros/ros_comm/issues/1730>)
```

## roscpp

```
* close sockets when server responds with HTTP/1.0 (#1284 <https://github.com/ros/ros_comm/issues/1284>)
* fix a bug that using a destroyed connection object (#1950 <https://github.com/ros/ros_comm/issues/1950>)
* remove extra n in ROS_DEBUG (#1925 <https://github.com/ros/ros_comm/issues/1925>)
* do not display error message if poll yields EINTR (#1868 <https://github.com/ros/ros_comm/issues/1868>)
* TransportTCP: Allow socket() to return 0 (#1707 <https://github.com/ros/ros_comm/issues/1707>)
* add Timer::isValid() const (#1779 <https://github.com/ros/ros_comm/issues/1779>)
* transport_tcp: enable poll event POLLRDHUP to detect dead (#1704 <https://github.com/ros/ros_comm/issues/1704>)
* unregisterService returns result of execute("unregisterService") (#1751 <https://github.com/ros/ros_comm/issues/1751>)
* fix string check (#1771 <https://github.com/ros/ros_comm/issues/1771>)
* resolve memory leak (#1503 <https://github.com/ros/ros_comm/issues/1503>)
* fix Exception boost::lock_error thrown from shutdown method (#1656 <https://github.com/ros/ros_comm/issues/1656>)
* TopicManager: avoid deadlock (#1645 <https://github.com/ros/ros_comm/issues/1645>)
* service: use WallTime/WallDuration for waiting (#1638 <https://github.com/ros/ros_comm/issues/1638>)
* fix bug in statistics decision making if one should publish (#1625 <https://github.com/ros/ros_comm/issues/1625>)
* fix race due unprotected access to callbacks_ in roscpp client (#1595 <https://github.com/ros/ros_comm/issues/1595>)
* remove nullptr access from Timer().hasStarted() (#1541 <https://github.com/ros/ros_comm/issues/1541>)
* add const specifier to NodeHandle::param(param_name, default_val). (#1539 <https://github.com/ros/ros_comm/issues/1539>)
* fix stamp_age_mean overflow when stamp age very big (#1526 <https://github.com/ros/ros_comm/issues/1526>)
* use an internal implementation of boost::condition_variable with monotonic clock [kinetic-devel] (#2011 <https://github.com/ros/ros_comm/issues/2011>)
* fix compiler warnings about unused variables (#1428 <https://github.com/ros/ros_comm/issues/1428>) (#1576 <https://github.com/ros/ros_comm/issues/1576>)
```

## rosgraph

- No changes

## roslaunch

```
* fix NameError in launch error handling (#1965 <https://github.com/ros/ros_comm/issues/1965>)
* allow empty ssh password for remote launching (#1826 <https://github.com/ros/ros_comm/issues/1826>)
* fix missing args (#1733 <https://github.com/ros/ros_comm/issues/1733>)
* fix $(dirname) for roslaunch-check. (#1624 <https://github.com/ros/ros_comm/issues/1624>)
* make roslaunch-check respect arg remappings with command line argument (#1653 <https://github.com/ros/ros_comm/issues/1653>)
* respawn if process died while checking should_respawn() (#1590 <https://github.com/ros/ros_comm/issues/1590>)
* normalize strings to utf-8 before setting as environment variable (#1593 <https://github.com/ros/ros_comm/issues/1593>)
* exclude unused args check if pass_all_args is set (#1520 <https://github.com/ros/ros_comm/issues/1520>)
```

## roslz4

```
* check for XXH_malloc NULL return (#1778 <https://github.com/ros/ros_comm/issues/1778>)
```

## rosmaster

```
* use thread local storage for caching instances of ServerProxy (#1732 <https://github.com/ros/ros_comm/issues/1732>)
* fix issue occuring during alternating calls of getParamCached and setParam (#1439 <https://github.com/ros/ros_comm/issues/1439>)
* fix docstring in unregisterSubscriber (#1553 <https://github.com/ros/ros_comm/issues/1553>)
* set correctly typed @apivalidate default return values (#1472 <https://github.com/ros/ros_comm/issues/1472>)
```

## rosmsg

- No changes

## rosnode

```
* explicitly handle socket.timeout in rosnode ping (#1517 <https://github.com/ros/ros_comm/issues/1517>)
```

## rosout

```
* fix use-after-free issue in rosout (#1764 <https://github.com/ros/ros_comm/issues/1764>)
```

## rosparam

- No changes

## rospy

```
* remove not existing NodeProxy from rospy __all__ (#2007 <https://github.com/ros/ros_comm/issues/2007>)
* fix dictionary changed size during iteration (#1894 <https://github.com/ros/ros_comm/issues/1894>)
* do not raise socket exception during shutdown (#1720 <https://github.com/ros/ros_comm/issues/1720>)
* add missing comma in the list of strings (#1760 <https://github.com/ros/ros_comm/issues/1760>)
* fix error handling for Topic constructor (#1701 <https://github.com/ros/ros_comm/issues/1701>)
```

## rosservice

```
* catch exeption when searching for services and a single service fails (#1519 <https://github.com/ros/ros_comm/issues/1519>)
```

## rostest

- No changes

## rostopic

```
* publisher/subscriber lists have correct type now (#1780 <https://github.com/ros/ros_comm/issues/1780>)
```

## roswtf

```
* do not try to run online checks if there are no roslaunch uris (#1848 <https://github.com/ros/ros_comm/issues/1848>)
* print exception content to show better idea why loading plugin failed (#1721 <https://github.com/ros/ros_comm/issues/1721>)
```

## topic_tools

```
* transfom: create publisher before subscriber, because callback may use the publisher (#1669 <https://github.com/ros/ros_comm/issues/1669>)
* mux: do not dereference the end-iterator (#1579 <https://github.com/ros/ros_comm/issues/1579>)
* fix topic_tools environment hook (#1486 <https://github.com/ros/ros_comm/issues/1486>)
```

## xmlrpcpp

```
* close sockets when server responds with HTTP/1.0 (#1284 <https://github.com/ros/ros_comm/issues/1284>)
* add bool assignment operator (#1709 <https://github.com/ros/ros_comm/issues/1709>)
* add const indexer for xmlrpc (#1759 <https://github.com/ros/ros_comm/issues/1759>)
```
