### PR TITLE
costmap_tf_layer: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1762,6 +1762,17 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: developed
+  costmap_tf_layer:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/igorbanfi/costmap_tf_layer-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/igorbanfi/costmap_tf_layer.git
+      version: melodic-devel
+    status: developed
   cpr_multimaster_tools:
     doc:
       type: git
@@ -11283,17 +11294,6 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: master
     status: maintained
-  tf_layer:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/igorbanfi/tf_layer-release.git
-      version: 1.0.1-1
-    source:
-      type: git
-      url: https://github.com/igorbanfi/tf_layer.git
-      version: melodic-devel
-    status: developed
   tf_remapper_cpp:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11283,6 +11283,17 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: master
     status: maintained
+  tf_layer:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/igorbanfi/tf_layer-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/igorbanfi/tf_layer.git
+      version: melodic-devel
+    status: developed
   tf_remapper_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `costmap_tf_layer` to `1.0.1-1`:

- upstream repository: https://github.com/igorbanfi/costmap_tf_layer.git
- release repository: https://github.com/igorbanfi/costmap_tf_layer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## costmap_tf_layer

```
* Initial commit
* Contributors: Igor Banfi
```
