### PR TITLE
pr2_common: 1.13.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2717,6 +2717,27 @@ repositories:
       type: git
       url: https://github.com/fetchrobotics/power_msgs.git
       version: ros1
+  pr2_common:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: melodic-devel
+    release:
+      packages:
+      - pr2_common
+      - pr2_dashboard_aggregator
+      - pr2_description
+      - pr2_machine
+      - pr2_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_common-release.git
+      version: 1.13.0-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_common.git
+      version: melodic-devel
+    status: unmaintained
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_common` to `1.13.0-1`:

- upstream repository: https://github.com/pr2/pr2_common.git
- release repository: https://github.com/pr2-gbp/pr2_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## pr2_common

- No changes

## pr2_dashboard_aggregator

- No changes

## pr2_description

```
* Cleanup collision/auxiliary shapes in urdf (#280 <https://github.com/pr2/pr2_common/issues/280>)
  
    * remove auxiliary shapes from kinect2 links
      If one wants to see the frames, just enable the frame in RViz.
      There is no need whatsoever to keep these in the description.
    * provide bounding box for kinect2 spoiler
      to enable *some* collision checking.
      It was not enabled at all before and it's barely in the workspace of the arms at all (without tool use).
      So a rough bounding box is fine.
    * remove useless visual geometry
      MoveIt master recently changed its policy w.r.t. empty collision geometries.
      The current version complains:
      ros.moveit_core.robot_model.empty_collision_geometry: Link sensor_mount_link has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
      ros.moveit_core.robot_model.empty_collision_geometry: Link double_stereo_link has visual geometry but no collision geometry. Collision geometry will be left empty. Fix your URDF file by explicitly specifying collision geometry.
      As these visuals are not helpful and do not add anything to the description, I just remove them.
    * remove guessed inertia on base_footprint
      These values are obviously fictitious (the whole link is...)
      Additionally, KDL datastructures have been complaining about this for ages
      because KDL does not support inertials for the model root
      (whatever that means).
  
* cleanup rviz errors (#278 <https://github.com/pr2/pr2_common/issues/278>)
  
    * use collada to store kinect mesh
      The STL produced the following warning with RViz:
      [ WARN]: The STL file 'package://pr2_description/meshes/sensors/kinect2_v0/kinect2_assembly.STL' is malformed. It starts with the word 'solid', indicating that it's an ASCII STL file, but it does not contain the word 'endsolid' so it is either a malformed ASCII STL file or it is actually a binary STL file. Trying to interpret it as a binary STL file instead.
    * fix TIFFFieldWithTag errors by converting to png files
      The error seems to stem from a problem in libtiff, so a reasonable
      way to resolve it was to change to a different file format.
      The texture files should not be used in isolation from the corresponding
      dae file, so removing the old tiff files retains API.
  
* Contributors: Kei Okada, v4hn
```

## pr2_machine

- No changes

## pr2_msgs

- No changes
