### PR TITLE
Enable test_abi for Foxy repositories: rclcpp, rcutils

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1890,6 +1890,7 @@ repositories:
       url: https://github.com/ros2-gbp/rclcpp-release.git
       version: 2.1.0-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
@@ -1938,6 +1939,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcutils-release.git
       version: 1.0.1-1
     source:
+      test_abi: true
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcutils.git


### PR DESCRIPTION
Following #26048. More ABI checker for Foxy packages under quality level //cc @chapulina