### PR TITLE
Put rosbag_snapshot back

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12953,6 +12953,7 @@ repositories:
       version: main
     release:
       packages:
+      - rosbag_snapshot
       - rosbag_snapshot_msgs
       tags:
         release: release/kinetic/{package}/{version}


### PR DESCRIPTION
This undoes part of https://github.com/ros/rosdistro/pull/25905 since we now have https://github.com/ros/rosdistro/pull/26148