### PR TITLE
urg_stamped: 0.0.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12028,7 +12028,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.6-2
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.7-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.6-2`

## urg_stamped

```
* Remove travis_retry from prerelease_test.sh (#78 <https://github.com/seqsense/urg_stamped/issues/78>)
* Use downloaded gh-pr-comment binary in docker container (#77 <https://github.com/seqsense/urg_stamped/issues/77>)
* Download gh-pr-comment binary instead of using pip (#75 <https://github.com/seqsense/urg_stamped/issues/75>)
* Reboot lidar when it is in abnormal state (#71 <https://github.com/seqsense/urg_stamped/issues/71>)
* Create GitHub Release after bloom release (#72 <https://github.com/seqsense/urg_stamped/issues/72>)
* Update CI config (#69 <https://github.com/seqsense/urg_stamped/issues/69>)
* Contributors: Atsushi Watanabe, Yuta Koga
```
