### PR TITLE
mrt_cmake_modules: 1.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2168,7 +2168,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.4-1`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.3-1`

## mrt_cmake_modules

```
* Deleted deprecated configuration files
* Fix cuda host compiler used for cuda 11
* Fix __init__.py template for python3
* Fix target handling for ros2
* Fix build failures on ROS1
* Fix the conan support
* Add a dependency on ros_environment to ensure ROS_VERSION is set
* Default to building shared libraries
* Add QtScript to the list of qt components
* Change license to BSD
* Remove traces of GPL-licensed libgps
* Remove unnecessary includes of cuda files
* Update tensorflow c findscript to set new tensorflow include paths
* Add cuda support for node and nodelet.
* Remove usage of ast package for evaulating package.xml conditions
* Fix crash if eval_coverage.py runs with python3
* Ensure that coverage is also generated for cpp code called from plain rostests
* Contributors: Fabian Poggenhans, Ilia Baltashov, Sven Richter
```
