### PR TITLE
toposens: 2.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15928,7 +15928,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.0.3-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.2-1`

## toposens

- No changes

## toposens_description

- No changes

## toposens_driver

```
* Added param directory to install
* Changed address of server for testing files
* Contributors: Sebastian Dengler
```

## toposens_markers

- No changes

## toposens_msgs

- No changes

## toposens_pointcloud

- No changes

## toposens_sync

- No changes
