### PR TITLE
resource_retriever: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1428,7 +1428,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 2.3.2-2
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.4.0-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.2-2`

## libcurl_vendor

```
* bump curl version to 7.68 (#47 <https://github.com/ros/resource_retriever/issues/47>)
* Contributors: Dirk Thomas
```

## resource_retriever

```
* Add .hpp header and deprecate .h (#51 <https://github.com/ros/resource_retriever/issues/51>)
* Add pytest.ini so local tests don't display warning (#48 <https://github.com/ros/resource_retriever/issues/48>)
* Contributors: Chris Lalancette, Shane Loretz
```
