### PR TITLE
Revert "ezrassor_controller_server: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2620,12 +2620,6 @@ repositories:
       url: https://github.com/eyeware/eyeware-ros.git
       version: master
     status: maintained
-  ezrassor_controller_server:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/EZRASSOR/ezrassor_controller_server-release.git
-      version: 1.0.0-1
   fadecandy_ros:
     release:
       packages:


### PR DESCRIPTION
Reverts ros/rosdistro#25936 since the release and upstream repositories now 404.