### PR TITLE
ros2-lgsvl-bridge: 0.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2232,11 +2232,11 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/lgsvl/ros2-lgsvl-bridge.git
-      version: master
+      version: eloquent-devel
     status: developed
   ros2_ouster_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2-lgsvl-bridge` to `0.1.1-1`:

- upstream repository: https://github.com/lgsvl/ros2-lgsvl-bridge.git
- release repository: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-1`

## lgsvl_bridge

```
* Initial commit
* Contributors: Martins Mozeiko
```
