### PR TITLE
ros2-lgsvl-bridge: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2184,11 +2184,11 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
-      version: 0.1.0-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/lgsvl/ros2-lgsvl-bridge.git
-      version: master
+      version: foxy-devel
     status: developed
   ros2_intel_realsense:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2-lgsvl-bridge` to `0.1.2-1`:

- upstream repository: https://github.com/lgsvl/ros2-lgsvl-bridge.git
- release repository: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-1`

## lgsvl_bridge

```
* Rename rosidl_runtime_c to rosidl_runtime_c
* Update package.xml
* Initial commit
* Contributors: Martins Mozeiko, Hadi Tabatabaee
```
