### PR TITLE
moveit_resources: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2124,6 +2124,28 @@ repositories:
       url: https://github.com/magazino/move_base_flex.git
       version: noetic
     status: developed
+  moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    release:
+      packages:
+      - moveit_resources
+      - moveit_resources_fanuc_description
+      - moveit_resources_fanuc_moveit_config
+      - moveit_resources_panda_description
+      - moveit_resources_panda_moveit_config
+      - moveit_resources_pr2_description
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_resources-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: master
+    status: maintained
   mpc_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `0.7.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros-gbp/moveit_resources-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## moveit_resources

```
* Split resources into multiple packages (#36 <https://github.com/ros-planning/moveit_resources/issues/36>)
* Contributors: Robert Haschke, Michael Görner
```

## moveit_resources_fanuc_description

```
* Split resources into multiple packages (#36 <https://github.com/ros-planning/moveit_resources/issues/36>)
* Contributors: Robert Haschke, Michael Görner
```

## moveit_resources_fanuc_moveit_config

```
* Split resources into multiple packages (#36 <https://github.com/ros-planning/moveit_resources/issues/36>)
* Contributors: Robert Haschke, Michael Görner
```

## moveit_resources_panda_description

```
* Split resources into multiple packages (#36 <https://github.com/ros-planning/moveit_resources/issues/36>)
* Contributors: Robert Haschke, Michael Görner
```

## moveit_resources_panda_moveit_config

```
* Split resources into multiple packages (#36 <https://github.com/ros-planning/moveit_resources/issues/36>)
* Remove solver attempts (#35 <https://github.com/ros-planning/moveit_resources/issues/35>)
* Contributors: Michael Görner, Robert Haschke
```

## moveit_resources_pr2_description

```
* Split resources into multiple packages (#36 <https://github.com/ros-planning/moveit_resources/issues/36>)
* Contributors: Robert Haschke, Michael Görner
```
