### PR TITLE
dingo_desktop: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2071,6 +2071,24 @@ repositories:
       url: https://github.com/dingo-cpr/dingo.git
       version: master
     status: developed
+  dingo_desktop:
+    doc:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_desktop.git
+      version: master
+    release:
+      packages:
+      - dingo_desktop
+      - dingo_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/dingo_desktop-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/dingo-cpr/dingo_desktop.git
+      version: master
+    status: maintained
   dingo_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo_desktop` to `0.1.0-1`:

- upstream repository: https://github.com/dingo-cpr/dingo_desktop.git
- release repository: https://github.com/clearpath-gbp/dingo_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## dingo_desktop

```
* Consolidated launch files.
* Split the single launch file into separate launch files for Dingo-D vs Dingo-O; updated project maintainer to Tony
* Added viz and desktop packages
* Contributors: Dave Niewinski, Jason Higgins, Tony Baltovski
```

## dingo_viz

```
* Consolidated launch files.
* Split the single launch file into separate launch files for Dingo-D vs Dingo-O; updated project maintainer to Tony
* Added viz and desktop packages
* Contributors: Dave Niewinski, Jason Higgins, Tony Baltovski
```
