### PR TITLE
rosidl_typesupport_connext: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1904,7 +1904,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-2`

## connext_cmake_module

```
* remove pthread link flags for Android NDK cross-compiling (#56 <https://github.com/ros2/rosidl_typesupport_connext/issues/56>)
* Contributors: jayhou
```

## rosidl_typesupport_connext_c

```
* fix capacity of serialized messages (#58 <https://github.com/ros2/rosidl_typesupport_connext/issues/58>)
* Contributors: Dirk Thomas
```

## rosidl_typesupport_connext_cpp

```
* fix capacity of serialized messages (#58 <https://github.com/ros2/rosidl_typesupport_connext/issues/58>)
* Contributors: Dirk Thomas
```
