### PR TITLE
husky: 0.4.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3762,7 +3762,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.4.3-1
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.4.4-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.4.3-1`

## husky_base

```
* Removed Paul Bovbel as maintainer.
* Contributors: Tony Baltovski
```

## husky_bringup

```
* Set default for optenv HUSKY_MAG_CONFIG
* Removed env-hooks
* Removed Paul Bovbel as maintainer.
* Add support for some environment variables to override realsense defaults
* Sort the dependencies alphabetically
* Finish adding the simulated realsense to the topbar, add support for the physical realsense. Tidy up some parameters that were copied in last night but not yet configured.
* Mark the Kinect for Xbox 360 as deprecated, start adding support for the Intel Realsense D400 series as a replacement
* Contributors: Chris I-B, Dave Niewinski, Tony Baltovski
```

## husky_control

```
* clearer wording
* change if to unless
* added env var and if-statement to disable robot ekf
* Remove support for the Kinect for Xbox 360. We've had the deprecation warning around for a while, so let's finally do it.  Realsense support is in-place as a drop-in replacement that gets added to the top rollbar, just like the old Kinect would have.
* Removed Paul Bovbel as maintainer.
* Finish adding the simulated realsense to the topbar, add support for the physical realsense. Tidy up some parameters that were copied in last night but not yet configured.
* Contributors: Chris I-B, Chris Iverach-Brereton, Jose Mastrangelo, Tony Baltovski
```

## husky_description

```
* Remove support for the Kinect for Xbox 360. We've had the deprecation warning around for a while, so let's finally do it.  Realsense support is in-place as a drop-in replacement that gets added to the top rollbar, just like the old Kinect would have.
* Changed intertial to inertial
  fixed a minor typo
* Removed Paul Bovbel as maintainer.
* Fix the warnings the ROS buildfarm was giving for Melodic
* Add support for some environment variables to override realsense defaults
* Use the STL from realsense2_description, rotated as necessary. Add realsense2_description to the dependencies
* Refactor so that the sensor bar only gets added once if either the realsense OR the kinect is enabled. Adding both will still cause issues because they'll mount to the same point on the bracket, but at least the URDF won't fail.
* Finish adding the simulated realsense to the topbar, add support for the physical realsense. Tidy up some parameters that were copied in last night but not yet configured.
* Mark the Kinect for Xbox 360 as deprecated, start adding support for the Intel Realsense D400 series as a replacement
* Contributors: Cedric Martens, Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## husky_desktop

```
* Removed Paul Bovbel as maintainer.
* Contributors: Tony Baltovski
```

## husky_gazebo

```
* Remove support for the Kinect for Xbox 360. We've had the deprecation warning around for a while, so let's finally do it.  Realsense support is in-place as a drop-in replacement that gets added to the top rollbar, just like the old Kinect would have.
* Enable teleop in the Husky simulation
* Removed Paul Bovbel as maintainer.
* Finish adding the simulated realsense to the topbar, add support for the physical realsense. Tidy up some parameters that were copied in last night but not yet configured.
* Mark the Kinect for Xbox 360 as deprecated, start adding support for the Intel Realsense D400 series as a replacement
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## husky_msgs

```
* Removed Paul Bovbel as maintainer.
* Contributors: Tony Baltovski
```

## husky_navigation

```
* Removed Paul Bovbel as maintainer.
* Contributors: Tony Baltovski
```

## husky_robot

```
* Removed Paul Bovbel as maintainer.
* Contributors: Tony Baltovski
```

## husky_simulator

```
* Removed Paul Bovbel as maintainer.
* Contributors: Tony Baltovski
```

## husky_viz

```
* Remove support for the Kinect for Xbox 360. We've had the deprecation warning around for a while, so let's finally do it.  Realsense support is in-place as a drop-in replacement that gets added to the top rollbar, just like the old Kinect would have.
* Removed Paul Bovbel as maintainer.
* Mark the Kinect for Xbox 360 as deprecated, start adding support for the Intel Realsense D400 series as a replacement
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```
