### PR TITLE
Add Python3 versions for geopy and toml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6415,6 +6415,11 @@ python3-tk:
   debian: [python3-tk]
   fedora: [python3-tkinter]
   ubuntu: [python3-tk]
+python3-toml:
+  debian: [python3-toml]
+  fedora: [python3-toml]
+  gentoo: [dev-python/toml]
+  ubuntu: [python3-toml]
 python3-tornado:
   arch: [python-tornado]
   debian: [python3-tornado]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5596,6 +5596,11 @@ python3-future:
   gentoo: [dev-python/future]
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
+python3-geopy:
+  debian: [python3-geopy]
+  fedora: [python3-geopy]
+  gentoo: [dev-python/geopy]
+  ubuntu: [python3-geopy]
 python3-gi:
   arch: [python-gobject]
   debian: [python3-gi]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5599,7 +5599,6 @@ python3-future:
 python3-geopy:
   debian: [python3-geopy]
   fedora: [python3-geopy]
-  gentoo: [dev-python/geopy]
   ubuntu: [python3-geopy]
 python3-gi:
   arch: [python-gobject]


### PR DESCRIPTION
python3-geopy:
  - debian: https://packages.debian.org/buster/python3-geopy
  - fedora: https://fedora.pkgs.org/32/fedora-x86_64/python3-geopy-1.21.0-1.fc32.noarch.rpm.html
  - ubuntu: https://packages.ubuntu.com/focal/python3-geopy

python3-toml:
  - debian: https://packages.debian.org/buster/python3-toml
  - fedora: https://fedora.pkgs.org/32/fedora-x86_64/python3-toml-0.10.0-7.fc32.noarch.rpm.html
  - gentoo: https://packages.gentoo.org/packages/dev-python/toml
  - ubuntu: https://packages.ubuntu.com/focal/python3-toml