### PR TITLE
melodic: Add doc info for sensehat_ros

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10748,6 +10748,11 @@ repositories:
       url: https://github.com/seed-solutions/seed_smartactuator_sdk.git
       version: master
     status: developed
+  sensehat_ros:
+    doc:
+      type: git
+      url: https://github.com/allxone/sensehat_ros.git
+      version: master
   serial:
     release:
       tags:


### PR DESCRIPTION
I'd like sensehat_ros to be indexed and documented on ros.org.