### PR TITLE
moose_simulator: 0.1.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7626,7 +7626,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/moose_simulator-release.git
-      version: 0.1.1-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/moose-cpr/moose_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_simulator` to `0.1.3-1`:

- upstream repository: https://github.com/moose-cpr/moose_simulator.git
- release repository: https://github.com/clearpath-gbp/moose_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.1-1`

## moose_gazebo

```
* Add the yaw argument to spawn_moose
* Rename spawn launch (#5 <https://github.com/moose-cpr/moose_simulator/issues/5>)
  * Add the scripts folder to the install target too
  * Rename moose_sim to spawn_moose to stay consistent with the recent changes for the new sim environments
  * Remove the duplicate scripts from the install paths
* [moose_gazebo] Minor clean-up.
  - Removed env_run since it wasn't used
  - Dropped .py
  - Updated install in CMakeLists.txt
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## moose_simulator

- No changes
