### PR TITLE
warthog_simulator: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17299,7 +17299,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog_simulator-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_simulator` to `0.1.1-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_simulator.git
- release repository: https://github.com/clearpath-gbp/warthog_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-1`

## warthog_gazebo

```
* Add yaw to the arguments for spawn_warthog
* Moved spawning into a specific launch, so this is more portable to other packages
* Include the same playpen world that we use with the Moose & use it as the warthog_world's map.  Add additional launch files for the race world & empty world
* Contributors: Chris I-B, Chris Iverach-Brereton, Dave Niewinski
```

## warthog_simulator

- No changes
