### PR TITLE
warthog_simulator: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12527,7 +12527,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog_simulator-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_simulator` to `0.2.1-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_simulator.git
- release repository: https://github.com/clearpath-gbp/warthog_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.0-1`

## warthog_gazebo

```
* Add yaw to the arguments for spawn_warthog
* Moved spawning into a specific launch, so this is more portable to other packages
* Include the same playpen world that we use with the Moose & use it as the warthog_world's map.  Add additional launch files for the race world & empty world
* Contributors: Chris I-B, Chris Iverach-Brereton, Dave Niewinski
```

## warthog_simulator

- No changes
