### PR TITLE
Bump version number for rosbag_snapshot

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12968,7 +12968,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rosbag_snapshot-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros/rosbag_snapshot.git


### PR DESCRIPTION
This is why you shouldn't make PRs without bloom sometimes. I forgot I bumped the version number after I fixed a bug in https://github.com/ros/rosbag_snapshot/pull/4