### PR TITLE
plotjuggler: 2.8.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2693,7 +2693,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.8.3-1
+      version: 2.8.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.8.4-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.8.3-1`

## plotjuggler

```
* readme updated
* fix issue #318 <https://github.com/facontidavide/PlotJuggler/issues/318>
* fix  #170 <https://github.com/facontidavide/PlotJuggler/issues/170> : problem with ULOG parser in Windows
* build fixes to work on ROS2 eloquent (#314 <https://github.com/facontidavide/PlotJuggler/issues/314>)
* add qtpainterpath.h (#313 <https://github.com/facontidavide/PlotJuggler/issues/313>)
* Update datastream_sample.cpp
* Update contributors.txt
* Fix another sprintf buffer size warning (#303 <https://github.com/facontidavide/PlotJuggler/issues/303>)
* Contributors: Akash Patel, Davide Faconti, Lucas, Mike Purvis
```
