### PR TITLE
launch: 0.11.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -860,7 +860,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.11.0-1`

## launch

```
* Refactor launch service run_async loop to wait on futures and queued events (#449 <https://github.com/ros2/launch/issues/449>)
* Fix documentation typo (#446 <https://github.com/ros2/launch/issues/446>)
* Fix type_utils.extract_type() function. (#445 <https://github.com/ros2/launch/issues/445>)
* Contributors: Jacob Perron, Michel Hidalgo
```

## launch_testing

- No changes

## launch_testing_ament_cmake

```
* Use launch_test CMake target as output file basename (#448 <https://github.com/ros2/launch/issues/448>)
* Contributors: Michel Hidalgo
```

## launch_xml

- No changes

## launch_yaml

- No changes
