### PR TITLE
gps_umd: 1.0.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1016,7 +1016,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 1.0.2-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.4-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-1`

## gps_msgs

```
* Add support for ros1 bridge (#32 <https://github.com/swri-robotics/gps_umd/issues/32>)
* Contributors: Andrew Palmer
```

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

- No changes
