### PR TITLE
gps_umd: 1.0.4-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -899,7 +899,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 1.0.2-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.4-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/swri-robotics-gbp/gps_umd-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.2-1`

## gps_msgs

```
* Add support for ros1 bridge (#32 <https://github.com/swri-robotics/gps_umd/issues/32>)
* Contributors: Andrew Palmer
```

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

- No changes
