### PR TITLE
udp_com: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4608,7 +4608,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/flynneva/udp_com-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/continental/udp_com.git


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_com` to `1.1.1-1`:

- upstream repository: https://github.com/continental/udp_com.git
- release repository: https://github.com/flynneva/udp_com-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## udp_com

```
* find rostest once
* add roslint to testdepend
* add roslint within test conditional
* removed roslint dependency
* removed find gtest
* set vcs repo url
* bumped ros ci action
* go back to manual ros_ci
* added back in setup directories
* trying in home directory
* removed ros2 target
* added ros2 foxy to help with ci
* package name incorrect
* updated ros ci
* updated version for docs
* doc not docs
* updated docs action
* added gitignore
* update github release step
* create pr to rosdistro
* remove docs from non-docs branches
* Merge pull request #64 <https://github.com/continental/udp_com/issues/64> from continental/ros1/main
* changed remote url
* Contributors: Evan Flynn
```
