### PR TITLE
gazebo_video_monitor_plugins: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1064,6 +1064,21 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: noetic-devel
     status: maintained
+  gazebo_video_monitor_plugins:
+    doc:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
+      version: master
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitor_plugins` to `0.4.0-1`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
- release repository: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## gazebo_video_monitor_plugins

```
* Add multi view monitor plugin
  Support quadrant camera streams in the video recorder
```
