### PR TITLE
use noetic-devel branch for pluginlib

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2718,7 +2718,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: melodic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -2728,7 +2728,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   pointcloud_to_laserscan:
     doc:


### PR DESCRIPTION
Otherwise `rosinstall_generator` doesn't return the right branch when compiling from source