### PR TITLE
Adding new repository for indexing: gpio_control

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4260,6 +4260,11 @@ repositories:
         release: release/kinetic/{package}/{version}
       url: https://github.com/robustify/gmplot_ros-release.git
       version: 1.0.1-0
+  gpio_control:
+    doc:
+      type: git
+      url: https://github.com/cst0/gpio_control-release
+      version: master
   gps_goal:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4265,6 +4265,7 @@ repositories:
       type: git
       url: https://github.com/cst0/gpio_control-release
       version: master
+    status: maintained
   gps_goal:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4266,6 +4266,7 @@ repositories:
       url: https://github.com/cst0/gpio_control-release
       version: master
     status: maintained
+    version: 1.0.0
   gps_goal:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3352,6 +3352,7 @@ repositories:
       type: git
       url: https://github.com/cst0/gpio_control-release
       version: master
+    status: maintained
   gps_umd:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3347,6 +3347,11 @@ repositories:
       url: https://github.com/ros-visualization/gl_dependency.git
       version: kinetic-devel
     status: maintained
+  gpio_control:
+    doc:
+      type: git
+      url: https://github.com/cst0/gpio_control-release
+      version: master
   gps_umd:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3353,6 +3353,7 @@ repositories:
       url: https://github.com/cst0/gpio_control-release
       version: master
     status: maintained
+    version: 1.0.0
   gps_umd:
     doc:
       type: git


### PR DESCRIPTION
This package provides control of GPIO pins from ROS. Support is offered both through hardware-specific API's of popular platforms (most notably the Raspberry Pi and Nvidia Jetson) which come bundled with the official operating system for the device, as well as through the Linux filesystem hierarchy standard, which allows for control of GPIO pins through manipulating the contents of the /sys/class/gpio directory. This in turn allows for support of a wide variety of Linux devices with GPIO pins. Additionally, pieces of the implementation of the node are made available in a utilities class, which provides a platform-agnostic implementation of GPIO pin control to aid with software stacks that attempt to avoid locking themselves into one platform.

This code has been tested on Melodic and Kinetic on a handful of platforms in a handful of different configurations. This is my first time contributing code to the ROS index, so please let me know if there are any additional steps I need to take or things I need to change.