### PR TITLE
ros_control: 0.19.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3293,7 +3293,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.19.1-1
+      version: 0.19.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.19.2-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.19.1-1`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## controller_manager_tests

```
* Fixes part 2 of issue`#448 <https://github.com/ros-controls/ros_control/issues/448>`_ [Noetic] Rework and re-enable spawning and switching CLI tests (#462 <https://github.com/ros-controls/ros_control/issues/462>)
  * [tests] Split controller_manager_scripts.txt in two parts.
  The second part is now called controller_manager_interface_test.
  This fixes part 2 of issue #448 <https://github.com/ros-controls/ros_control/issues/448>
  * [test] Modification of the validation test.
  When commenting the first test (cm_msg_utils_test.py) the output
  is correct, while uncommented an inversion of the output happens.
  As this test is a pure python with no interaction with the
  controller_manager, it is very likely a race condition due either to
  Python or to the operating system. As the output is not fundamentally
  wrong, and as the tests are heavily relying on timing and subprocesses
  which are making the reproducibility difficult, this PR accepts both
  solution:
  [my_controller1, my_controller3] order
  or
  [my_controller3, my_controller1] order
* Contributors: Olivier Stasse
```

## hardware_interface

- No changes

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

```
* Use an explicit relative import path instead of implicit. (#471 <https://github.com/ros-controls/ros_control/issues/471>)
  On python3 system the implicit relative import will not work. The explicit
  notation, however, should work on python >= 2.5
* Contributors: Felix Exner
```

## transmission_interface

- No changes
