### PR TITLE
Add jupyter-nbconvert

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -204,6 +204,7 @@ jupyter-nbconvert:
   arch: [jupyter-nbconvert]
   debian: [jupyter-nbconvert]
   fedora: [jupyter-nbconvert]
+  gentoo: [dev-python/nbconvert]
   ubuntu: 
     '*': [jupyter-nbconvert]
     xenial: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -205,7 +205,7 @@ jupyter-nbconvert:
   debian: [jupyter-nbconvert]
   fedora: [jupyter-nbconvert]
   gentoo: [dev-python/nbconvert]
-  ubuntu: 
+  ubuntu:
     '*': [jupyter-nbconvert]
     xenial: null
 jupyter-notebook:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -200,6 +200,10 @@ ipython3:
   debian: [ipython3]
   fedora: [ipython3]
   ubuntu: [ipython3]
+jupyter-nbconvert:
+  arch: [jupyter-nbconvert]
+  debian: [jupyter-nbconvert]
+  ubuntu: [jupyter-nbconvert]
 jupyter-notebook:
   debian:
     '*': [jupyter-notebook]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,7 +203,7 @@ ipython3:
 jupyter-nbconvert:
   arch: [jupyter-nbconvert]
   debian: [jupyter-nbconvert]
-  fedora: [jupyter-nbconvert]
+  fedora: [python3-nbconvert]
   gentoo: [dev-python/nbconvert]
   ubuntu:
     '*': [jupyter-nbconvert]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -203,7 +203,10 @@ ipython3:
 jupyter-nbconvert:
   arch: [jupyter-nbconvert]
   debian: [jupyter-nbconvert]
-  ubuntu: [jupyter-nbconvert]
+  fedora: [jupyter-nbconvert]
+  ubuntu: 
+    '*': [jupyter-nbconvert]
+    xenial: null
 jupyter-notebook:
   debian:
     '*': [jupyter-notebook]


### PR DESCRIPTION
Package Name: `jupyter-nbconvert`
 - arch: https://www.archlinux.org/packages/community/any/jupyter-nbconvert/
 - debian: https://packages.debian.org/buster/jupyter-nbconvert
 - ubuntu: https://packages.ubuntu.com/eoan/jupyter-nbconvert

It makes it simple to implement ROS executables as notebooks. ([example](https://github.com/azazdeaz/ros-grpc-api-generator/blob/ros/scripts/generate#L3))