### PR TITLE
Revert "jsk_3rdparty: 2.1.20-1 in 'melodic/distribution.yaml' [bloom]…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4408,7 +4408,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.20-1
+      version: 2.1.17-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
… (#26090)"

This reverts commit 50ca1fb3762a2dd695c8eae33480ce6d4534081a.

This has been failing to build several of its sub-packages since it was merged on August 7th:

* http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__bayesian_belief_networks__ubuntu_bionic_amd64__binary/
* http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__collada_urdf_jsk_patch__ubuntu_bionic_amd64__binary/
* http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ros_speech_recognition__ubuntu_bionic_amd64__binary/

@k-okada FYI