### PR TITLE
pybind11_vendor: 2.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1190,6 +1190,22 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: ros2
     status: maintained
+  pybind11_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/pybind11_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_vendor-release.git
+      version: 2.2.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/pybind11_vendor.git
+      version: master
+    status: maintained
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `2.2.5-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## pybind11_vendor

```
* Merge pull request #3 <https://github.com/ros2/pybind11_vendor/issues/3> from ros2/fix_windows_warning
* remove passing in CMAKE_BUILD_TYPE
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* cleanup
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* do not define CMAKE_BUILD_TYPE on windows
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* suppress all developer warnings
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* suppress warning on windows
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* attempt to fix windows warning
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* Disable building pybind11 tests (#1 <https://github.com/ros2/pybind11_vendor/issues/1>)
  Signed-off-by: Karsten Knese <mailto:karsten@openrobotics.org>
* Update to pybind 2.5.0 (#2 <https://github.com/ros2/pybind11_vendor/issues/2>)
  Signed-off-by: Mabel Zhang <mailto:mabel@openrobotics.org>
* Create pybind11 vendor package.
  Signed-off-by: Michael Carroll <mailto:michael@openrobotics.org>
* Contributors: Karsten Knese, Mabel Zhang, Michael Carroll
```
