### PR TITLE
resource_retriever: 2.3.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1991,7 +1991,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 2.3.2-1
+      version: 2.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.3.3-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.2-1`

## libcurl_vendor

- No changes

## resource_retriever

```
* Add pytest.ini so local tests don't display warning (#48 <https://github.com/ros/resource_retriever/issues/48>) (#52 <https://github.com/ros/resource_retriever/issues/52>)
* Contributors: Chris Lalancette
```
