### PR TITLE
rosidl: 1.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2436,7 +2436,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.1-1`

## rosidl_adapter

```
* Refactor regex for valid package/field names (#508 <https://github.com/ros2/rosidl/issues/508>)
* Add pytest.ini so tests succeed locally (#502 <https://github.com/ros2/rosidl/issues/502>)
* Contributors: Chris Lalancette, Dirk Thomas
```

## rosidl_cmake

```
* Modifications to python generator lib to return generated files (#511 <https://github.com/ros2/rosidl/issues/511>)
* Contributors: Alex Tyshka
```

## rosidl_generator_c

```
* Do not depend on rosidl_runtime_c when tests are disabled (#503 <https://github.com/ros2/rosidl/issues/503>)
* Contributors: Ben Wolsieffer
```

## rosidl_generator_cpp

```
* Add function for getting a types fully qualified name (#514 <https://github.com/ros2/rosidl/issues/514>)
* Declaring is_message in namespace rosidl_generator_traits (#512 <https://github.com/ros2/rosidl/issues/512>)
* Contributors: Jacob Perron, Sebastian Höffner
```

## rosidl_parser

```
* Allow zero length string constants (#507 <https://github.com/ros2/rosidl/issues/507>)
* Add pytest.ini so tests succeed locally (#502 <https://github.com/ros2/rosidl/issues/502>)
* Contributors: Chris Lalancette, Dirk Thomas
```

## rosidl_runtime_c

```
* Update rosidl_runtime_c QD to QL 2 (#500 <https://github.com/ros2/rosidl/issues/500>)
* Contributors: Stephen Brawner
```

## rosidl_runtime_cpp

```
* Add function for getting a types fully qualified name (#514 <https://github.com/ros2/rosidl/issues/514>)
* Fix misuses of input iterators in BoundedVector (#493 <https://github.com/ros2/rosidl/issues/493>)
* Update QD to reflect QL 2 statuses (#499 <https://github.com/ros2/rosidl/issues/499>)
* Contributors: Jacob Perron, Jonathan Wakely, Stephen Brawner
```

## rosidl_typesupport_interface

```
* Update QD to reflect QL 2 statuses (#499 <https://github.com/ros2/rosidl/issues/499>)
* Contributors: Stephen Brawner
```

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
