### PR TITLE
noetic: Add doc info for sensehat_ros

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4303,6 +4303,11 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.3.1-3
+  sensehat_ros:
+    doc:
+      type: git
+      url: https://github.com/allxone/sensehat_ros.git
+      version: master
   sick_ldmrs_laser:
     doc:
       type: git


### PR DESCRIPTION
I'd like sensehat_ros to be indexed and documented on ros.org.