### PR TITLE
Revert "moveit_resources: 0.7.0-1 in 'melodic/distribution.yaml' [blo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5808,17 +5808,10 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     release:
-      packages:
-      - moveit_resources
-      - moveit_resources_fanuc_description
-      - moveit_resources_fanuc_moveit_config
-      - moveit_resources_panda_description
-      - moveit_resources_panda_moveit_config
-      - moveit_resources_pr2_description
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.7.0-1
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
…om] (#26180)"

This reverts commit e672bbf95b6447e488dc9d102883c983826df8e5.

I believe this is what is causing moveit_core (and a lot of downstream packages) to fail in Melodic: http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__moveit_core__ubuntu_bionic_amd64__binary/

@rhaschke FYI