### PR TITLE
nodl: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1402,7 +1402,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodl` to `0.3.0-1`:

- upstream repository: https://github.com/ubuntu-robotics/nodl.git
- release repository: https://github.com/ros2-gbp/nodl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.0-1`

## nodl_python

```
* Add role field, replacing bool pairs
* Bump ros-tooling action versions
* Contributors: Ted Kern
```

## ros2nodl

```
* Add role field, replacing bool pairs
* Bump ros-tooling action versions
* Contributors: Ted Kern
```
