### PR TITLE
srdfdom: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4450,7 +4450,6 @@ repositories:
       url: https://github.com/ros-gbp/srdfdom-release.git
       version: 0.6.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/ros-planning/srdfdom.git
       version: noetic-devel

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4440,6 +4440,15 @@ repositories:
       version: melodic-devel
     status: maintained
   srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/srdfdom-release.git
+      version: 0.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.6.0-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## srdfdom

```
* [maint] Switch from TinyXML to TinyXML2 (#60 <https://github.com/ros-planning/srdfdom/issues/60>)
* [maint] add soname to library (#63 <https://github.com/ros-planning/srdfdom/issues/63>)
* Contributors: Robert Haschke, Tyler Weaver
```
