### PR TITLE
kobuki_core: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1075,7 +1075,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/kobuki_core-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.1.1-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/stonier/kobuki_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## kobuki_driver

```
* [udev] bugfix low latency ftdi operation, #28 <https://github.com/kobuki-base/kobuki_core/pull/28>.
* [demos] added an event demo, also minor cleanup, #27 <https://github.com/kobuki-base/kobuki_core/pull/27>.
* [infra] don't use system headers for dependencies, #27 <https://github.com/kobuki-base/kobuki_core/pull/27>.
```
