### PR TITLE
ros_ign: 0.221.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2345,7 +2345,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.221.0-1
+      version: 0.221.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_ign` to `0.221.1-1`:

- upstream repository: https://github.com/ignitionrobotics/ros_ign
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.221.0-1`

## ros_ign

- No changes

## ros_ign_bridge

```
* Add pkg-config as a buildtool dependency (#102 <https://github.com/osrf/ros_ign/issues/102>)
* Port ros_ign_bridge tests to ROS 2 (#98 <https://github.com/osrf/ros_ign/issues/98>)
* Rename test_utils.hpp (#98 <https://github.com/osrf/ros_ign/issues/98>)
* Contributors: Louise Poubel, ahcorde
```

## ros_ign_gazebo

```
* Add pkg-config as a buildtool dependency (#102 <https://github.com/osrf/ros_ign/issues/102>)
* Contributors: Louise Poubel
```

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

```
* Add pkg-config as a buildtool dependency (#102 <https://github.com/osrf/ros_ign/issues/102>)
* Contributors: Louise Poubel
```
