### PR TITLE
rospy_message_converter: 0.5.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3739,7 +3739,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/rospy_message_converter-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.3-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.5.2-1`

## rospy_message_converter

```
* Add check_types parameter to convert_dictionary_to_ros_message (#42 <https://github.com/uos/rospy_message_converter/issues/42>)
* Allow numpy numeric types in numeric fields  (#41 <https://github.com/uos/rospy_message_converter/issues/41>)
  Fixes #39 <https://github.com/uos/rospy_message_converter/issues/39>.
* perf: Remove remaining regexes
  This is only a small speedup of about 1.03x.
* perf: Avoid regex in _is_field_type_a_primitive_array
  This makes the function almost 3x faster.
* perf: Reorder type checks
  Perform the cheaper checks first. This results in a speedup of about
  1.2x.
* perf: Avoid regex in is_ros_binary_type
  This makes is_ros_binary_type almost 5x faster and as a result the whole
  convert_ros_message_to_dictionary function almost 2x faster.
* Compare types, not type names; improve error message
  Old error message:
  TypeError: Wrong type: '1.0' must be float64
  New error message:
  TypeError: Field 'x' has wrong type <type 'numpy.float64'> (valid types: [<type 'int'>, <type 'float'>])
* Remove unused python_to_ros_type_map
* added test for convert_dictionary_to_ros_message with int8 array
* python 3 fix for _convert_to_ros_binary
* Contributors: Martin Günther, Steffen Rühl
```
