### PR TITLE
remove pyros_interface_ros and downstream pyros and rostful from Kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10730,7 +10730,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosrelease.git
-      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/asmodehn/pyros.git
@@ -10759,7 +10758,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/asmodehn/pyros-rosinterface-rosrelease.git
-      version: 0.4.2-0
     source:
       test_pull_requests: true
       type: git
@@ -13446,7 +13444,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/pyros-dev/rostful-rosrelease.git
-      version: 0.2.1-0
     status: developed
   rostune:
     release:


### PR DESCRIPTION
They have regressed due to `more-itertools` 6.0.0 the new version dropping support for python2.
https://github.com/pyros-dev/pyros-rosinterface/issues/17