### PR TITLE
gazebo_video_monitor_plugins: 0.4.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3154,6 +3154,21 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: melodic-devel
     status: developed
+  gazebo_video_monitor_plugins:
+    doc:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
+      version: 0.4.1-2
+    source:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
+      version: master
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitor_plugins` to `0.4.1-2`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
- release repository: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## gazebo_video_monitor_plugins

```
* Add multicamera sensor and video monitor plugin
* Set path of temporary recording
* Add fix for initial camera attachment
* Parameterize log prefixes
* Drop specific OpenCV version
* Refactor gazebo video monitor plugin
  * Introduce gazebo video recorder to host recording functionality and enable reusability
  * Introduce gazebo monitor base plugin to host common members and structure plugin initialization
  * Add option to disable the window in the gazebo video monitor plugin
  * Update documentation
* Various fixes
  * Fix bug with reading the cameraReference configurations
  * Fix success field on result when discarding in stop recording
  * Add a walking actor in video monitor plugin world as a dynamic element
  * Expose recorder library
* Add multi video monitor plugin
* Add multi camera monitor plugin
  * Add camera contains plugin and box marker visualizer
  * Add test world for multi camera monitor and camera contains plugins
  * Use default video name in the recorder when one is not provided
  * Fix gazebo topic names for camera images in multicamera sensor
* Add multi view monitor plugin
  Support quadrant camera streams in the video recorder
* Add license notice
* Fix cmake and compiler warnings
```
