### PR TITLE
Target RHEL 7 in ROS 2 Eloquent

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
+  rhel:
+  - '7'
   ubuntu:
   - bionic
 repositories:


### PR DESCRIPTION
It is currently possible to build a substantial amount of ROS 2 Eloquent for RHEL/CentOS 7 using devtoolset 8. I was able to build about 505 of the 551 packages currently released.

Some packages will require patching beyond the patching we're already doing for debs, but for the most part, the vast majority of the dependencies are satisfied and many packages can be built.

Here are some of the packages that will need to be excluded from builds:
- **cartographer**
  Requires Lua 5.2, system packages 5.1
- **cv_bridge**
  Requires OpenCV 3, system packages OpenCV 2
- **gazebo_ros**
  No Gazebo system package
- **image_tools**
  Requires OpenCV 3, system packages OpenCV 2
- **kobuki_ftdi**
  System libftdi is too old
- **popf**
  Several unsatisfied system package dependencies
- **slam_toolbox**
  System tbb is too old
- **spatio_temporal_voxel_layer**
  No openvdb system package

Here's a list of some of the rosdep keys that are currently unsatisfied:
- **clang-tidy**
- **coinor-libcoinutils-dev**
- **ffmpeg**
  This is actually available in RPMFusion, but that isn't part of our list of supported package sources for Fedora/RHEL.
- **gazebo9**/**libgazebo9-dev**
- **libopensplice69**
  In Eloquent, we packaged and distributed a deb for this. I've created an RPM package for it, but I'm not sure how much effort we want to put into it since it has been dropped in the more recent ROS distros.
- **libqglviewer-qt4**/**libqglviewer-qt4-dev**
- **pydocstyle**
- **pyqt5-dev-tools**
- **python3-babeltrace**
- **python3-flake8**
  This one is really unfortunate, but since it's only a test dependency, we can ignore it for package builds. It would be great to see it in EPEL 7, though.
- **python3-lttng**
- **python3-matplotlib**
- **python3-mypy**
- **python3-pep8**
- **python3-pydot**
- **python3-pyqt5.qtwebengine**
- **python3-pytest-mock**
- **py_trees**
- **rti-connext-dds-5.3.1**
  It would be really great to see RTI provide an RPM...
- **sophus**

This change will cause Bloom releases of packages which depend on any of these keys to require manual interaction to skip the RPM spec generation or changes to the actions list to drop RPM generation entirely. Some of these packages can also be patched to exclude the dependency if the package can still be built and installed without it, such as `ament_pep8` and `ament_flake8`. **The vast majority of packages, however, can be built from the spec files generated by Bloom without any additional configuration or patching.**

One of the major hurdles moving forward will be the Python 3 version. EPEL, where a substantial amount of the python 3 packages we need are coming from, is targeting Python 3.6 right now. This will prevent us from rolling forward to ROS 2 Foxy or Galactic. This is one of several reasons we're starting with ROS 2 Eloquent.