### PR TITLE
ecl_navigation: 0.60.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -846,6 +846,24 @@ repositories:
       url: https://github.com/stonier/ecl_lite.git
       version: release/0.61-noetic
     status: maintained
+  ecl_navigation:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_navigation.git
+      version: relase/0.60-noetic
+    release:
+      packages:
+      - ecl_mobile_robot
+      - ecl_navigation
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/ecl_navigation-release.git
+      version: 0.60.3-1
+    source:
+      type: git
+      url: https://github.com/stonier/ecl_navigation.git
+      version: release/0.60-noetic
+    status: maintained
   ecl_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_navigation` to `0.60.3-1`:

- upstream repository: https://github.com/stonier/ecl_navigation.git
- release repository: https://github.com/yujinrobot-release/ecl_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
