### PR TITLE
kobuki_msgs: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1695,6 +1695,21 @@ repositories:
       url: https://github.com/utexas-bwi/knowledge_representation.git
       version: master
     status: developed
+  kobuki_msgs:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_msgs.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_msgs.git
+      version: noetic
+    status: maintained
   laser_assembler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_msgs` to `0.7.0-1`:

- upstream repository: https://github.com/yujinrobot/kobuki_msgs.git
- release repository: https://github.com/yujinrobot-release/kobuki_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`
