### PR TITLE
actionlib: 1.13.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -37,7 +37,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.13.1-1
+      version: 1.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.13.2-1`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.13.1-1`

## actionlib

```
* narrow down required boost dependencies (#168 <https://github.com/ros/actionlib/issues/168>)
* Contributors: Mikael Arguedas
```

## actionlib_tools

```
* Port actionlib_tools to Python 3 (#169 <https://github.com/ros/actionlib/issues/169>)
* Address RVD`#2401 <https://github.com/ros/actionlib/issues/2401>`_ (#171 <https://github.com/ros/actionlib/issues/171>)
* Contributors: Mikael Arguedas, Víctor Mayoral Vilches
```
