### PR TITLE
actionlib: 1.11.16-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -122,7 +122,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/actionlib-release.git
-      version: 1.11.13-0
+      version: 1.11.16-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `actionlib` to `1.11.16-2`:

- upstream repository: https://github.com/ros/actionlib.git
- release repository: https://github.com/ros-gbp/actionlib-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.11.13-0`

## actionlib

```
* Address RVD`#2401 <https://github.com/ros/actionlib/issues/2401>`_ (#170 <https://github.com/ros/actionlib/issues/170>) (#172 <https://github.com/ros/actionlib/issues/172>)
* Fix tiny typo in docs (#141 <https://github.com/ros/actionlib/issues/141>)
* fix: Corrected spelling recieved --> received (#136 <https://github.com/ros/actionlib/issues/136>)
* Fixed warnings when compiling with -Wpedantic. (#135 <https://github.com/ros/actionlib/issues/135>)
* action_server: call ActionServer<ActionSpec>::initialize() in constructor (#120 <https://github.com/ros/actionlib/issues/120>)
* Print the correct error on waiting for result (#123 <https://github.com/ros/actionlib/issues/123>)
* Merge pull request #97 <https://github.com/ros/actionlib/issues/97> from synapticon/remove-get-state-spam-error
* Merge pull request #122 <https://github.com/ros/actionlib/issues/122> from ros/update-maintainer
* Update maintainer.
* fix(actionlib): Remove getState error output
* Contributors: Alireza, Bence Magyar, Carl Saldanha, Christopher Wecht, Michael Carroll, Rein Appeldoorn, Remo Diethelm, Shane Loretz, methylDragon
```
