### PR TITLE
ros_canopen: 0.8.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9062,7 +9062,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_canopen` to `0.8.4-1`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.8.3-1`

## can_msgs

- No changes

## canopen_402

```
* handle illegal states in nextStateForEnabling
* tranistion -> transition
* Contributors: Mathias Lüdtke, Mikael Arguedas
```

## canopen_chain_node

```
* pass settings from ROS node to SocketCANInterface
* Contributors: Mathias Lüdtke
```

## canopen_master

```
* added settings parameter to DriverInterface::init
* moved canopen::Settings into can namespace
* Contributors: Mathias Lüdtke
```

## canopen_motor_node

```
* moved XmlRpcSettings to socketcan_interface
* Contributors: Mathias Lüdtke
```

## ros_canopen

- No changes

## socketcan_bridge

```
* pass settings from ROS node to SocketCANInterface
* Contributors: Mathias Lüdtke
```

## socketcan_interface

```
* make parse_error_mask a static member function
* pass settings from ROS node to SocketCANInterface
* add support for recursive XmlRpcSettings lookups
* implemented report-only and fatal errors for SocketCANInterface
* added settings parameter to DriverInterface::init
* moved XmlRpcSettings to socketcan_interface
* moved canopen::Settings into can namespace
* Contributors: Mathias Lüdtke
```
