### PR TITLE
core_perception: 1.14.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1746,6 +1746,19 @@ repositories:
       url: https://github.com/ros-gbp/convex_decomposition-release.git
       version: 0.1.12-0
     status: unmaintained
+  core_perception:
+    release:
+      packages:
+      - points_preprocessor
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/core_perception-release.git
+      version: 1.14.9-1
+    source:
+      type: git
+      url: https://github.com/nobleo/core_perception.git
+      version: points_preprocessor_release
+    status: maintained
   costmap_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `core_perception` to `1.14.9-1`:

- upstream repository: https://github.com/nobleo/core_perception.git
- release repository: https://github.com/nobleo/core_perception-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## points_preprocessor

```
* Remove Autoware Health Checker as dependency
* Contributors: Tim Clephas
```
