### PR TITLE
jackal_simulator: 0.3.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4265,7 +4265,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal_simulator-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
     source:
       type: git
       url: https://github.com/jackal/jackal_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal_simulator` to `0.3.0-2`:

- upstream repository: https://github.com/jackal/jackal_simulator
- release repository: https://github.com/clearpath-gbp/jackal_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.0-1`

## jackal_gazebo

```
* Add small hack to continue supporting the front_laser:=true arg, since that was prominently documented.
* Change from individual accessory args to a single "config" arg.
* Contributors: Mike Purvis
```

## jackal_simulator

- No changes
