### PR TITLE
kdl_parser: 1.14.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1691,10 +1691,13 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: noetic-devel
     release:
+      packages:
+      - kdl_parser
+      - kdl_parser_py
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/kdl_parser-release.git
-      version: 1.14.0-1
+      version: 1.14.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `1.14.1-1`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros-gbp/kdl_parser-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.14.0-1`

## kdl_parser

- No changes

## kdl_parser_py

```
* Drop CATKIN_IGNORE (#42 <https://github.com/ros/kdl_parser/issues/42>)
* Contributors: Jochen Sprickerhof
```
