### PR TITLE
rosidl_typesupport_connext: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2576,7 +2576,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.0.0-1`

## connext_cmake_module

```
* remove pthread link flags for Android NDK cross-compiling (#56 <https://github.com/ros2/rosidl_typesupport_connext/issues/56>)
* Contributors: jayhou
```

## rosidl_typesupport_connext_c

```
* fix capacity of serialized messages (#58 <https://github.com/ros2/rosidl_typesupport_connext/issues/58>)
* Contributors: Dirk Thomas
```

## rosidl_typesupport_connext_cpp

```
* fix capacity of serialized messages (#58 <https://github.com/ros2/rosidl_typesupport_connext/issues/58>)
* Contributors: Dirk Thomas
```
