### PR TITLE
ridgeback_simulator: 0.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11690,7 +11690,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
-      version: 0.0.3-0
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.0.4-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.3-0`

## mecanum_gazebo_plugin

- No changes

## ridgeback_gazebo

```
* Enable the joystick by default, add an option to disable it
* Split spawning platform into dedicated launch
* Contributors: Chris Iverach-Brereton, Dave Niewinski
```

## ridgeback_gazebo_plugins

- No changes

## ridgeback_simulator

- No changes
