### PR TITLE
ridgeback_simulator: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8675,7 +8675,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback_simulator` to `0.1.1-1`:

- upstream repository: https://github.com/ridgeback/ridgeback_simulator.git
- release repository: https://github.com/clearpath-gbp/ridgeback_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-1`

## mecanum_gazebo_plugin

- No changes

## ridgeback_gazebo

```
* Apply the config argument properly
* Move spawning the ridgeback into a separate file for use with the new sim environments. Enable teleoperation by default
* Add Robot Spawn Pose Launch Args
  Adds x,y,z,yaw arguments to set pose where the robot spawns.
  New arguments are defaulted to their previous values.
  Example:
  ```
  roslaunch ridgeback_gazebo ridgeback_world.launch x:=10 y:=10
  world_name:=/path/to/my/world.sdf
  ```
* Contributors: Alex Moriarty, Chris Iverach-Brereton
```

## ridgeback_gazebo_plugins

- No changes

## ridgeback_simulator

- No changes
