### PR TITLE
hfl_driver: 0.0.12-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4792,6 +4792,21 @@ repositories:
       url: https://github.com/heron/heron_desktop.git
       version: kinetic-devel
     status: maintained
+  hfl_driver:
+    doc:
+      type: git
+      url: https://github.com/continental/hfl_driver.git
+      version: ros1/main
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/flynneva/hfl_driver-release.git
+      version: 0.0.12-1
+    source:
+      type: git
+      url: https://github.com/continental/hfl_driver.git
+      version: ros1/main
+    status: developed
   hls-lfcd-lds-driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hfl_driver` to `0.0.12-1`:

- upstream repository: https://github.com/continental/hfl_driver.git
- release repository: https://github.com/flynneva/hfl_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## hfl_driver

```
* removed unnecessary install files
* fix udp_com linking error
* update suppoted platforms
* test depend roslint
* move roslint within conditional
* fixed rostest and arpa warning
* should be catkin_add_gtest
* removed arpa
* fixed for kinetic
* fixed cmake warnings and kinetic error
* added archive destination to install step
* switch back to action-ros-ci
* switch back to manual ros ci
* gh-pages should be html directory
* Update ros_ci.yml
* Merge pull request #13 <https://github.com/continental/hfl_driver/issues/13> from continental/ros1/main
* Contributors: Evan Flynn
```
