### PR TITLE
hfl_driver: 0.0.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1357,6 +1357,21 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: master
     status: developed
+  hfl_driver:
+    doc:
+      type: git
+      url: https://github.com/continental/hfl_driver.git
+      version: ros1/main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/flynneva/hfl_driver-release.git
+      version: 0.0.12-1
+    source:
+      type: git
+      url: https://github.com/hfl_driver.git
+      version: ros1/main
+    status: developed
   hls-lfcd-lds-driver:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1369,7 +1369,7 @@ repositories:
       version: 0.0.12-1
     source:
       type: git
-      url: https://github.com/hfl_driver.git
+      url: https://github.com/continental/hfl_driver.git
       version: ros1/main
     status: developed
   hls-lfcd-lds-driver:


### PR DESCRIPTION
Increasing version of package(s) in repository `hfl_driver` to `0.0.12-1`:

- upstream repository: https://github.com/continental/hfl_driver.git
- release repository: https://github.com/flynneva/hfl_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## hfl_driver

```
* removed unnecessary install files
* fix udp_com linking error
* update suppoted platforms
* test depend roslint
* move roslint within conditional
* fixed rostest and arpa warning
* should be catkin_add_gtest
* removed arpa
* fixed for kinetic
* fixed cmake warnings and kinetic error
* added archive destination to install step
* switch back to action-ros-ci
* switch back to manual ros ci
* gh-pages should be html directory
* Update ros_ci.yml
* Merge pull request #13 <https://github.com/continental/hfl_driver/issues/13> from continental/ros1/main
* Contributors: Evan Flynn
```
