### PR TITLE
executive_smach_visualization: 3.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -935,6 +935,24 @@ repositories:
       url: https://github.com/ros/executive_smach.git
       version: noetic-devel
     status: maintained
+  executive_smach_visualization:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/executive_smach_visualization.git
+      version: melodic-devel
+    release:
+      packages:
+      - executive_smach_visualization
+      - smach_viewer
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/jbohren/executive_smach_visualization-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/executive_smach_visualization.git
+      version: melodic-devel
+    status: unmaintained
   exotica_val_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_visualization` to `3.0.1-1`:

- upstream repository: https://github.com/ros-visualization/executive_smach_visualization.git
- release repository: https://github.com/jbohren/executive_smach_visualization-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## executive_smach_visualization

- No changes

## smach_viewer

```
* Merge pull request #30 <https://github.com/ros-visualization/executive_smach_visualization//issues/30> from k-okada/add_noetic
  add noetic, remove indigo/lunar
* fix syntax for python3
* Contributors: Kei Okada
```
