### PR TITLE
Add dynamic-graph-tutorial to melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2222,6 +2222,22 @@ repositories:
       url: https://github.com/stack-of-tasks/dynamic-graph-python.git
       version: devel
     status: maintained
+  dynamic-graph-tutorial:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-tutorial.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
+      version: 1.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-tutorial.git
+      version: devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Release dynamic-graph-tutorial a third-party package from SoT on Melodic
It is dependent on dynamic-graph and dynamic-graph-python that are already released on melodic: #25488 and #25963 for reference