### PR TITLE
 Add dynamic-graph-tutorial to noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -751,6 +751,22 @@ repositories:
       url: https://github.com/stack-of-tasks/dynamic-graph-python.git
       version: devel
     status: maintained
+  dynamic-graph-tutorial:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-tutorial.git
+      version: devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
+      version: 1.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/dynamic-graph-tutorial.git
+      version: devel
+    status: maintained
   dynamic_reconfigure:
     doc:
       type: git


### PR DESCRIPTION
Release dynamic-graph-tutorial a third-party package from SoT on Noetic
It is dependent on dynamic-graph and dynamic-graph-python that are already released on noetic: #25949  and #25965 for reference