### PR TITLE
swri_profiler: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4605,6 +4605,25 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: master
     status: developed
+  swri_profiler:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: master
+    release:
+      packages:
+      - swri_profiler
+      - swri_profiler_msgs
+      - swri_profiler_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/swri_profiler-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_profiler.git
+      version: master
+    status: developed
   teb_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_profiler` to `0.2.2-1`:

- upstream repository: https://github.com/swri-robotics/swri_profiler.git
- release repository: https://github.com/swri-robotics-gbp/swri_profiler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## swri_profiler

```
* Update catkin dependencies for swri_profiler_tools
* Enable c++11 support
* Contributors: P. J. Reed
```

## swri_profiler_msgs

- No changes

## swri_profiler_tools

```
* Enable c++11 support
* Update catkin dependencies for swri_profiler_tools
* Contributors: P. J. Reed
```
