### PR TITLE
Add rosdep rules for mockito

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2938,6 +2938,7 @@ libmlpack-dev:
   fedora: [mlpack-devel]
   ubuntu: [libmlpack-dev]
 libmockito-java:
+  arch: [mockito]
   debian: [libmockito-java]
   fedora: [mockito]
   gentoo: [dev-java/mockito]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2937,6 +2937,12 @@ libmlpack-dev:
   debian: [libmlpack-dev]
   fedora: [mlpack-devel]
   ubuntu: [libmlpack-dev]
+libmockito-java:
+  debian: [libmockito-java]
+  fedora: [mockito]
+  gentoo: [dev-java/mockito]
+  rhel: [mockito]
+  ubuntu: [libmockito-java]
 libmodbus-dev:
   debian: [libmodbus-dev]
   fedora: [libmodbus-devel]


### PR DESCRIPTION
Mockito is a "tasty" mocking framework for unit tests in Java.

https://site.mockito.org/

I'd like to use mockito in some ROS 2 Java unit tests.

- Debian: https://packages.debian.org/search?keywords=libmockito-java
- Fedora: https://src.fedoraproject.org/rpms/mockito
- Gentoo: https://packages.gentoo.org/packages/dev-java/mockito
- Ubuntu: https://packages.ubuntu.com/focal/libmockito-java