### PR TITLE
geometry2: 0.7.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1255,7 +1255,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.7.3-1`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.7.2-1`

## geometry2

- No changes

## tf2

```
* Use snprintf instead of stringstream to increase performance of lookupTransform() in error cases.
* Do not waste time constructing error string if nobody is interested in it in canTransform(). (#469 <https://github.com/ros/geometry2/issues/469>)
* Output time difference of extrapolation exceptions (#477 <https://github.com/ros/geometry2/issues/477>)
* Cherry-picking various commits from Melodic (#471 <https://github.com/ros/geometry2/issues/471>)
  * Revert "rework Eigen functions namespace hack" (#436 <https://github.com/ros/geometry2/issues/436>)
  * Fixed warnings in message_filter.h (#434 <https://github.com/ros/geometry2/issues/434>)
  the variables are not used in function body and caused -Wunused-parameter to trigger with -Wall
  * Fix ambiguous call for tf2::convert on MSVC (#444 <https://github.com/ros/geometry2/issues/444>)
  * rework ambiguous call on MSVC.
* Contributors: Lucas Walter, Martin Pecka, Robert Haschke
```

## tf2_bullet

- No changes

## tf2_eigen

```
* Cherry-picking various commits from Melodic (#471 <https://github.com/ros/geometry2/issues/471>)
  * Revert "rework Eigen functions namespace hack" (#436 <https://github.com/ros/geometry2/issues/436>)
  * Fixed warnings in message_filter.h (#434 <https://github.com/ros/geometry2/issues/434>)
  the variables are not used in function body and caused -Wunused-parameter to trigger with -Wall
  * Fix ambiguous call for tf2::convert on MSVC (#444 <https://github.com/ros/geometry2/issues/444>)
  * rework ambiguous call on MSVC.
* Contributors: Robert Haschke
```

## tf2_geometry_msgs

```
* Use list instead of set to make build reproducible (#473 <https://github.com/ros/geometry2/issues/473>)
* Contributors: Jochen Sprickerhof
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* avoid name collision b/t tf2_py and tf2 (#478 <https://github.com/ros/geometry2/issues/478>)
* Contributors: Sean Yen
```

## tf2_ros

```
* Use correct frame service name in docstrings. (#476 <https://github.com/ros/geometry2/issues/476>)
  Replaces the deprecated names
  {tf_frames, view_frames} -> tf2_frames
* Cherry-picking various commits from Melodic (#471 <https://github.com/ros/geometry2/issues/471>)
  * Revert "rework Eigen functions namespace hack" (#436 <https://github.com/ros/geometry2/issues/436>)
  * Fixed warnings in message_filter.h (#434 <https://github.com/ros/geometry2/issues/434>)
  the variables are not used in function body and caused -Wunused-parameter to trigger with -Wall
  * Fix ambiguous call for tf2::convert on MSVC (#444 <https://github.com/ros/geometry2/issues/444>)
  * rework ambiguous call on MSVC.
* Contributors: Michael Grupp, Robert Haschke
```

## tf2_sensor_msgs

```
* Use list instead of set to make build reproducible (#473 <https://github.com/ros/geometry2/issues/473>)
* Contributors: Jochen Sprickerhof
```

## tf2_tools

- No changes
