### PR TITLE
rosserial: 0.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3797,6 +3797,26 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/rosserial.git
       version: noetic-devel
+    release:
+      packages:
+      - rosserial
+      - rosserial_arduino
+      - rosserial_chibios
+      - rosserial_client
+      - rosserial_embeddedlinux
+      - rosserial_mbed
+      - rosserial_msgs
+      - rosserial_python
+      - rosserial_server
+      - rosserial_tivac
+      - rosserial_vex_cortex
+      - rosserial_vex_v5
+      - rosserial_windows
+      - rosserial_xbee
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosserial-release.git
+      version: 0.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.9.0-1`:

- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## rosserial

```
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Contributors: Mike Purvis
```

## rosserial_arduino

```
* Install arduino_python scripts to bin destination (#506 <https://github.com/ros-drivers/rosserial/issues/506>)
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Added target ID to support Teensy 4.0 (#460 <https://github.com/ros-drivers/rosserial/issues/460>)
* Bump minimum CMake version to 3.7.2 (Melodic).
* Allow user code to change Arduino port used by client (#472 <https://github.com/ros-drivers/rosserial/issues/472>)
* Avoid looping over write buffer in Arduino client. (#475 <https://github.com/ros-drivers/rosserial/issues/475>)
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Contributors: André Araújo, D. Petrini, Hermann von Kleist, Mike Purvis, Rik Baehnemann, acxz, schnaubelt
```

## rosserial_chibios

```
* Added support for ChibiOS clients (#493 <https://github.com/ros-drivers/rosserial/issues/493>)
* Contributors: Hermann von Kleist
```

## rosserial_client

```
* Method to compute duration between time stamps (#498 <https://github.com/ros-drivers/rosserial/issues/498>)
* Python 3 and GCC7+ fixes (#508 <https://github.com/ros-drivers/rosserial/issues/508>)
  * Fixes for new warnings/behaviours in GCC 7+.
  * Resolve uninitMemberVar warnings in NodeHandle.
  * Use nullptr consistently.
* Correctly handle seconds overflow in client time (#497 <https://github.com/ros-drivers/rosserial/issues/497>)
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Do not fail when trying to update ros_lib which already exists (#494 <https://github.com/ros-drivers/rosserial/issues/494>)
* ros_lib: Removed code duplication in node_handle.h (#483 <https://github.com/ros-drivers/rosserial/issues/483>)
* AVR Float64: fix cases like denormal numbers & inf (#442 <https://github.com/ros-drivers/rosserial/issues/442>)
* Bump minimum CMake version to 3.7.2 (Melodic).
* Change the access modifiers in NodeHandle_ from "private" to "protected" to make it easier to derive. (#426 <https://github.com/ros-drivers/rosserial/issues/426>)
* Small Python 3 fixes for rosserial scripts. (#420 <https://github.com/ros-drivers/rosserial/issues/420>)
* Contributors: Asuki Kono, Hermann von Kleist, Mike Purvis, Petteri Aimonen, Rik Baehnemann, 趙　漠居(Zhao, Moju)
```

## rosserial_embeddedlinux

```
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Bump minimum CMake version to 3.7.2 (Melodic).
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Contributors: Hermann von Kleist, Mike Purvis, acxz
```

## rosserial_mbed

```
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Bump minimum CMake version to 3.7.2 (Melodic).
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Contributors: Hermann von Kleist, Mike Purvis, acxz
```

## rosserial_msgs

```
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Drop separate node for message service (#446 <https://github.com/ros-drivers/rosserial/issues/446>)
* Contributors: Mike Purvis
```

## rosserial_python

```
* Python 3 and GCC7+ fixes (#508 <https://github.com/ros-drivers/rosserial/issues/508>)
  * Port of rosserial_python to py3.
  * Throw from inside the BrokenPipeError.
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Update pyserial rosdep.
* Use time.sleep instead of rospy.sleep. (#489 <https://github.com/ros-drivers/rosserial/issues/489>)
* Make deprecation message a warning and more specific (#479 <https://github.com/ros-drivers/rosserial/issues/479>)
* Properly initialize message_info stub, drop from test.
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Drop separate node for message service (#446 <https://github.com/ros-drivers/rosserial/issues/446>)
* Fix reconnection of rosserial-python (#445 <https://github.com/ros-drivers/rosserial/issues/445>)
* Contributors: Asuki Kono, Daisuke Sato, Hermann von Kleist, Hikaru Sugiura, Mike Purvis, acxz
```

## rosserial_server

```
* Only initialize embedded python interpreter once. (#491 <https://github.com/ros-drivers/rosserial/issues/491>)
* Port 482 and 483 forward from Melodic branch (#492 <https://github.com/ros-drivers/rosserial/issues/492>)
* Fix warning when using std_msgs/Empty (#482 <https://github.com/ros-drivers/rosserial/issues/482>)
* Bump minimum CMake version to 3.7.2 (Melodic).
* Removed unused service client for message info service (#481 <https://github.com/ros-drivers/rosserial/issues/481>)
* Call io_service.stop() when ros::ok() returns false (#477 <https://github.com/ros-drivers/rosserial/issues/477>)
* Call Py_Finalize before throwing exception (#476 <https://github.com/ros-drivers/rosserial/issues/476>)
* [Windows] use c++ signed trait to replace ssize_t for better portability. (#463 <https://github.com/ros-drivers/rosserial/issues/463>)
* Port rosserial_server to Boost 1.71. (#468 <https://github.com/ros-drivers/rosserial/issues/468>)
* rosserial_server: update install rules for binary targets (#457 <https://github.com/ros-drivers/rosserial/issues/457>)
* Fix bug: assign the md5 for service (#449 <https://github.com/ros-drivers/rosserial/issues/449>)
* Contributors: Hermann von Kleist, Johannes Meyer, Mike Purvis, Sean Yen, 趙　漠居(Zhao, Moju)
```

## rosserial_tivac

```
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Contributors: Hermann von Kleist, Mike Purvis
```

## rosserial_vex_cortex

```
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Contributors: Hermann von Kleist, Mike Purvis, acxz
```

## rosserial_vex_v5

```
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Contributors: Hermann von Kleist, Mike Purvis, acxz
```

## rosserial_windows

```
* Use os.path.join for path concatenation (#495 <https://github.com/ros-drivers/rosserial/issues/495>)
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Contributors: Hermann von Kleist, Mike Purvis, acxz
```

## rosserial_xbee

```
* Fix Travis for Noetic + Python 3
* Bump minimum CMake version to 3.7.2 (Melodic).
* Update pyserial rosdep.
* Fix py3 print usages and trailing whitespaces (#469 <https://github.com/ros-drivers/rosserial/issues/469>)
* Contributors: Mike Purvis, acxz
```
