### PR TITLE
eigenpy: 2.5.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -679,6 +679,21 @@ repositories:
       url: https://github.com/ros/eigen_stl_containers.git
       version: ros2
     status: maintained
+  eigenpy:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
+      version: 2.5.0-2
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
+    status: developed
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `2.5.0-2`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
