### PR TITLE
ixblue_stdbin_decoder: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4199,6 +4199,18 @@ repositories:
       url: https://github.com/ros-gbp/ivcon-release.git
       version: 0.1.7-0
     status: unmaintained
+  ixblue_stdbin_decoder:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ixblue/ixblue_stdbin_decoder.git
+      version: master
+    status: developed
   jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_stdbin_decoder` to `0.1.0-1`:

- upstream repository: https://github.com/ixblue/ixblue_stdbin_decoder.git
- release repository: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ixblue_stdbin_decoder

```
* Add package.xml to build with catkin
* Rework cmake installation
* Rename to ixblue_stdbin_decoder in lower case to stay consistent
* Allow the parser to read other header types (Answer and command)
* Use boost::asio::const_buffer instead of boost::asio::mutable_buffer
  Frame data is not modified while parsed.
* Change namespace to ixblue_stdbin_decoder to avoid naming conflict with StdBinDecoder class
  Causes issues in IDEs and adds confusion
* Contributors: Adrien BARRAL, Romain Reignier
```
