### PR TITLE
cyclonedds: 0.7.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -403,7 +403,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.6.0-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -407,7 +407,7 @@ repositories:
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: master
+      version: releases/0.7.x
     status: maintained
   demos:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.7.0-1`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.6.0-1`
