### PR TITLE
Update python-dev for focal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5381,7 +5381,9 @@ pybind11-dev:
 python-dev:
   debian: [python-dev]
   fedora: [python2-devel]
-  ubuntu: [python-dev]
+  ubuntu:
+    '*': [python-dev]
+    'focal': [python-dev-is-python2]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5383,7 +5383,7 @@ python-dev:
   fedora: [python2-devel]
   ubuntu:
     '*': [python-dev]
-    'focal': [python-dev-is-python2]
+    'focal': [python2-dev]
 qhull-bin:
   arch: [qhull]
   debian: [qhull-bin]


### PR DESCRIPTION
I apologize if I'm barking up the wrong tree, so bear with me please.

I'm trying to fix the following build: http://build.ros.org/view/Ndev/job/Ndev__catkin_virtualenv__ubuntu_focal_amd64/4/console

catkin_virtuaelnv allows downstream packages to bundle a python2 or python3 virtualenv, so it needs to add a `python-dev` build_export_depends.

This breaks in focal, even though AFAIK `python-dev` exists as a virtual package for `python-dev-is-python2`. Is there a reason the builder is unable to pull that package in?