### PR TITLE
radial_menu_ros: 0.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8297,7 +8297,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yoshito-n-students/radial_menu_ros-release.git
-      version: 0.3.4-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/radial_menu_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `radial_menu_ros` to `0.4.1-1`:

- upstream repository: https://github.com/yoshito-n-students/radial_menu_ros.git
- release repository: https://github.com/yoshito-n-students/radial_menu_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.4-1`

## radial_menu

```
* No changes
```

## radial_menu_backend

```
* No changes
```

## radial_menu_example

```
* Fix install targets
```

## radial_menu_model

```
* No changes
```

## radial_menu_msgs

```
* No changes
```

## radial_menu_rviz

```
* No changes
```
