### PR TITLE
ueye_cam: 1.0.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11977,6 +11977,15 @@ repositories:
       version: ros1/main
     status: maintained
   ueye_cam:
+    doc:
+      type: git
+      url: https://github.com/anqixu/ueye_cam.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/anqixu/ueye_cam-release.git
+      version: 1.0.17-1
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.17-1`:

- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ueye_cam

```
* Merge pull request #83 <https://github.com/anqixu/ueye_cam/issues/83> from anqixu/use_ros_time
  Do not get timestamp from camera, and use ros::Time::now() instead
* Merge pull request #61 <https://github.com/anqixu/ueye_cam/issues/61> from jackokaiser/master
  Adapted roslaunch for passing camera name as argument
* Changes from https://github.com/anqixu/ueye_cam/issues/82
* Do not link the ueye api to the check api node to avoid conflicts
* Default dynamic_reconfigure parameters now don't overwrite ini file params.
  Fixes #74 <https://github.com/anqixu/ueye_cam/issues/74>
* image dimensions now account for cam_subsampling_rate
* Merge pull request #65 <https://github.com/anqixu/ueye_cam/issues/65> from flynneva/dev
* removed / from frame_ID so that data can be used with new ros tf2 standard
* Removed trailing whitespaces
* Readded camera_conf for backward compatibility
* changed setFlashParams failure into warning
* Adapted roslaunch for passing camera name as argument
* nodelet no longer dies upon setFlashParams fail (since some cameras don't support it)
* Merge pull request #54 <https://github.com/anqixu/ueye_cam/issues/54> from 534o/master
* forget to add check_ueye_api to install list
* Contributors: Anqi Xu, Anup Parikh, Evan Flynn, Jacques KAISER, Tokyo Opensource Robotics Developer 534, loooph
```
