### PR TITLE
ixblue_stdbin_decoder: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4259,11 +4259,15 @@ repositories:
       version: 0.1.7-0
     status: unmaintained
   ixblue_stdbin_decoder:
+    doc:
+      type: git
+      url: https://github.com/ixblue/ixblue_stdbin_decoder.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_stdbin_decoder` to `0.1.1-1`:

- upstream repository: https://github.com/ixblue/ixblue_stdbin_decoder.git
- release repository: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-1`

## ixblue_stdbin_decoder

```
* Reduce minimum required CMake version to allow build on Debian Stretch for ROS Melodic
* Contributors: Romain Reignier
```
