### PR TITLE
ixblue_ins_stdbin_driver: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4258,6 +4258,26 @@ repositories:
       url: https://github.com/ros-gbp/ivcon-release.git
       version: 0.1.7-0
     status: unmaintained
+  ixblue_ins_stdbin_driver:
+    doc:
+      type: git
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
+      version: master
+    release:
+      packages:
+      - ixblue_ins
+      - ixblue_ins_driver
+      - ixblue_ins_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
+      version: master
+    status: developed
   ixblue_stdbin_decoder:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_ins_stdbin_driver` to `0.1.0-1`:

- upstream repository: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
- release repository: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ixblue_ins

```
* Prepare ROS release
* Contributors: Adrien BARRAL, Romain Reignier
```

## ixblue_ins_driver

```
* Prepare ROS release
* Add unit test on ROSPublisher::toNavSatFix()
* Prepare files catkin for release
* Switch stdbin data received log to debug level
* Default packets_replayer port is now the same than driver
  And add missing newline at the end of error message
* ixblue_stdbin_decoder can now be a package within the ROS workspace and
  not only a system library anymore
* Apply ixblue_stdbin_decoder changes on namespace and include dir name
* Build packets_replayer only if PCAP dev package is found
* Initial Commit.
* Contributors: Adrien BARRAL, Romain Reignier
```

## ixblue_ins_msgs

```
* Prepare ROS release
* Initial Commit.
* Contributors: Adrien BARRAL, Romain Reignier
```
