### PR TITLE
navigation: 1.14.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8436,7 +8436,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.7-1
+      version: 1.14.8-1
     source:
       test_commits: false
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.14.8-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.14.7-1`

## amcl

```
* (AMCL) add resample limit cache [Kinetic] (#1013 <https://github.com/ros-planning/navigation/issues/1013>)
* Contributors: Matthijs van der Burgh
```

## base_local_planner

- No changes

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

- No changes

## dwa_local_planner

- No changes

## fake_localization

```
* Fix #796 <https://github.com/ros-planning/navigation/issues/796> (#1017 <https://github.com/ros-planning/navigation/issues/1017>)
  Use ros::Time(0) instead of timestamp in message so as not to fail to lookupTransform.
* Contributors: Ryo KOYAMA
```

## global_planner

- No changes

## map_server

- No changes

## move_base

- No changes

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## robot_pose_ekf

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
