### PR TITLE
navigation: 1.16.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6285,7 +6285,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.16.6-1
+      version: 1.16.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.16.7-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.16.6-1`

## amcl

```
* (AMCL) add resample limit cache [Melodic] (#1012 <https://github.com/ros-planning/navigation/issues/1012>)
* Contributors: Matthijs van der Burgh
```

## base_local_planner

```
* occdist_scale should not be scaled by the costmap resolution as it doesn't multiply a value that includes a distance. (#1000 <https://github.com/ros-planning/navigation/issues/1000>)
* Contributors: wjwagner
```

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

```
* add explicit call to ros::Timer::stop in the destructor (#984 <https://github.com/ros-planning/navigation/issues/984>)
  Co-authored-by: Dima Dorezyuk <mailto:dorezyuk@magazino.eu>
* backport noetic memory fixes (#983 <https://github.com/ros-planning/navigation/issues/983>)
  spent some time with valgrind to fix this test,
  was failing intermittently in melodic, all the
  time in noetic.
* Contributors: Dima Dorezyuk, Michael Ferguson
```

## dwa_local_planner

- No changes

## fake_localization

```
* Fix #796 <https://github.com/ros-planning/navigation/issues/796> (#1017 <https://github.com/ros-planning/navigation/issues/1017>)
  Use ros::Time(0) instead of timestamp in message so as not to fail to lookupTransform.
* fix isolated build, #995 <https://github.com/ros-planning/navigation/issues/995> (#996 <https://github.com/ros-planning/navigation/issues/996>)
* Contributors: Michael Ferguson, Ryo KOYAMA
```

## global_planner

- No changes

## map_server

- No changes

## move_base

```
* move_base: Add options for make_plan service (#981 <https://github.com/ros-planning/navigation/issues/981>)
  Adds the following two parameters for the ~make_plan service:
  1. make_plan_clear_costmap
  Whether or not to clear the global costmap on make_plan service call.
  2. make_plan_add_unreachable_goal
  Whether or not to add the original goal to the path if it is unreachable in the make_plan service call.
* Contributors: nxdefiant
```

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
