### PR TITLE
navigation: 1.17.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2370,7 +2370,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.17.0-1
+      version: 1.17.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation` to `1.17.1-1`:

- upstream repository: https://github.com/ros-planning/navigation.git
- release repository: https://github.com/ros-gbp/navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.17.0-1`

## amcl

```
* (AMCL) add resample limit cache [Noetic] (#1014 <https://github.com/ros-planning/navigation/issues/1014>)
* Contributors: Matthijs van der Burgh
```

## base_local_planner

```
* occdist_scale should not be scaled by the costmap resolution as it doesn't multiply a value that includes a distance. (#1000 <https://github.com/ros-planning/navigation/issues/1000>)
* Contributors: wjwagner
```

## carrot_planner

- No changes

## clear_costmap_recovery

- No changes

## costmap_2d

```
* add explicit call to ros::Timer::stop in the destructor (#984 <https://github.com/ros-planning/navigation/issues/984>)
  Co-authored-by: Dima Dorezyuk <mailto:dorezyuk@magazino.eu>
* Exposing stopped_ variable in costmap2D_ros with the getter function isStopped (#913 <https://github.com/ros-planning/navigation/issues/913>)
* use const for getter methods (#948 <https://github.com/ros-planning/navigation/issues/948>)
* Contributors: Dima Dorezyuk, Marco Bassa, Yuki Furuta
```

## dwa_local_planner

- No changes

## fake_localization

```
* Fix #796 <https://github.com/ros-planning/navigation/issues/796> (#1017 <https://github.com/ros-planning/navigation/issues/1017>)
  Use ros::Time(0) instead of timestamp in message so as not to fail to lookupTransform.
* fix isolated build, #995 <https://github.com/ros-planning/navigation/issues/995> (#997 <https://github.com/ros-planning/navigation/issues/997>)
* Contributors: Michael Ferguson, Ryo KOYAMA
```

## global_planner

- No changes

## map_server

```
* Initial map_server map_mode tests (#1006 <https://github.com/ros-planning/navigation/issues/1006>)
* [noetic] Adding CMake way to find yaml-cpp (#998 <https://github.com/ros-planning/navigation/issues/998>)
* Contributors: David V. Lu!!, Sean Yen
```

## move_base

```
* Fix #933 <https://github.com/ros-planning/navigation/issues/933> (#988 <https://github.com/ros-planning/navigation/issues/988>)
* Contributors: David V. Lu!!
```

## move_slow_and_clear

- No changes

## nav_core

- No changes

## navfn

- No changes

## navigation

- No changes

## rotate_recovery

- No changes

## voxel_grid

- No changes
