### PR TITLE
image_pipeline: 2.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 2.2.0-2
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `2.2.1-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2.2.0-2`

## camera_calibration

```
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* Add pytest.ini to fix warning (#584 <https://github.com/ros-perception/image_pipeline/issues/584>)
  Fixes the following warning:
  Warning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=xunit1' to your pytest.ini file to keep the current format in future versions of pytest and silence this warning.
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
* Contributors: Jacob Perron, Joshua Whitley, Steve Macenski
```

## depth_image_proc

```
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
  * Fixing version and maintainer problems in camera_calibration.
  * Applying ament_auto macros to depth_image_proc.
  * Cleaning up package.xml in image_pipeline.
  * Applying ament_auto macros to image_proc.
  * Applying ament_auto macros to image_publisher.
  * Applying ament_auto macros to image_rotate.
  * Applying ament_auto macros to image_view.
  * Replacing some deprecated headers in image_view.
  * Fixing some build warnings in image_view.
  * Applying ament_auto macros to stereo_image_proc.
  * Adding some linter tests to image_pipeline.
  * Updating package URLs to point to ROS Index.
* Add rclcpp and rclcpp_components dependencies to package.xml. (#569 <https://github.com/ros-perception/image_pipeline/issues/569>) (#570 <https://github.com/ros-perception/image_pipeline/issues/570>)
  I noticed that these are listed in CMakeLists.txt but not in package.xml
  and this is causing a build failure for the binary releases on
  build.ros2.org:
  http://build.ros2.org/view/Dbin_ubhf_uBhf/job/Dbin_uB64__depth_image_proc__ubuntu_bionic_amd64__binary/
  Co-authored-by: Steven! Ragnarök <mailto:nuclearsandwich@users.noreply.github.com>
* Contributors: Joshua Whitley, Steve Macenski
```

## image_pipeline

```
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
* Contributors: Joshua Whitley, Steve Macenski
```

## image_proc

```
* make crop_decimate work (#593 <https://github.com/ros-perception/image_pipeline/issues/593>)
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* Disable "Publish Color!" debug_info (#577 <https://github.com/ros-perception/image_pipeline/issues/577>)
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
* Contributors: Dereck Wonnacott, Joshua Whitley, Michael Ferguson, Steve Macenski
```

## image_publisher

```
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* [Foxy][Image Publisher] Update launch file (#579 <https://github.com/ros-perception/image_pipeline/issues/579>)
  Co-authored-by: louis <mailto:louis.tran@otsaw.com>
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
  * Fixing version and maintainer problems in camera_calibration.
  * Applying ament_auto macros to depth_image_proc.
  * Cleaning up package.xml in image_pipeline.
  * Applying ament_auto macros to image_proc.
  * Applying ament_auto macros to image_publisher.
  * Applying ament_auto macros to image_rotate.
  * Applying ament_auto macros to image_view.
  * Replacing some deprecated headers in image_view.
  * Fixing some build warnings in image_view.
  * Applying ament_auto macros to stereo_image_proc.
  * Adding some linter tests to image_pipeline.
  * Updating package URLs to point to ROS Index.
* Contributors: Joshua Whitley, Steve Macenski, trthanhquang
```

## image_rotate

```
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
* Contributors: Joshua Whitley, Steve Macenski
```

## image_view

```
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
* Contributors: Joshua Whitley, Steve Macenski
```

## stereo_image_proc

```
* remove email blasts from steve macenski (#596 <https://github.com/ros-perception/image_pipeline/issues/596>)
* Refactor stereo_image_proc tests (#588 <https://github.com/ros-perception/image_pipeline/issues/588>)
* [Foxy] Use ament_auto Macros (#573 <https://github.com/ros-perception/image_pipeline/issues/573>)
* Contributors: Jacob Perron, Joshua Whitley, Steve Macenski
```
