### PR TITLE
launch: 0.10.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1155,7 +1155,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.2-1
+      version: 0.10.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.3-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.10.2-1`

## launch

```
* Add new conditions for checking launch configuration values (#453 <https://github.com/ros2/launch/issues/453>) (#457 <https://github.com/ros2/launch/issues/457>)
* Refactor launch service run_async loop to wait on futures and queued events (#449 <https://github.com/ros2/launch/issues/449>) (#455 <https://github.com/ros2/launch/issues/455>)
* Add pytest.ini so local tests don't display warning (#428 <https://github.com/ros2/launch/issues/428>)
* Contributors: Chris Lalancette, Jacob Perron
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Add pytest.ini so local tests don't display warning (#428 <https://github.com/ros2/launch/issues/428>)
* Contributors: Chris Lalancette
```

## launch_yaml

```
* Add pytest.ini so local tests don't display warning (#428 <https://github.com/ros2/launch/issues/428>)
* Contributors: Chris Lalancette
```
