### PR TITLE
transport_drivers: 0.0.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3516,7 +3516,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-drivers-gbp/transport_drivers-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `0.0.6-1`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros-drivers-gbp/transport_drivers-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.5-1`

## serial_driver

```
* Uncrustify fixes.
* Remove lifecycle references (#19 <https://github.com/ros-drivers/transport_drivers/issues/19>)
* Fixing boost dependency. (#18 <https://github.com/ros-drivers/transport_drivers/issues/18>)
* Contributors: Esteve Fernandez, Joshua Whitley
```

## udp_driver

```
* Uncrustify fixes.
* Remove lifecycle references (#19 <https://github.com/ros-drivers/transport_drivers/issues/19>)
* Fixing boost dependency. (#18 <https://github.com/ros-drivers/transport_drivers/issues/18>)
* Contributors: Esteve Fernandez, Joshua Whitley
```
