### PR TITLE
transport_drivers: 0.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3207,6 +3207,24 @@ repositories:
       url: https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis.git
       version: foxy
     status: developed
+  transport_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/transport_drivers.git
+      version: ros2
+    release:
+      packages:
+      - serial_driver
+      - udp_driver
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/transport_drivers-release.git
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/transport_drivers.git
+      version: ros2
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `transport_drivers` to `0.0.6-1`:

- upstream repository: https://github.com/ros-drivers/transport_drivers.git
- release repository: https://github.com/ros-drivers-gbp/transport_drivers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## serial_driver

```
* Uncrustify fixes.
* Remove lifecycle references (#19 <https://github.com/ros-drivers/transport_drivers/issues/19>)
* Fixing boost dependency. (#18 <https://github.com/ros-drivers/transport_drivers/issues/18>)
* Contributors: Esteve Fernandez, Joshua Whitley
```

## udp_driver

```
* Uncrustify fixes.
* Remove lifecycle references (#19 <https://github.com/ros-drivers/transport_drivers/issues/19>)
* Fixing boost dependency. (#18 <https://github.com/ros-drivers/transport_drivers/issues/18>)
* Contributors: Esteve Fernandez, Joshua Whitley
```
