### PR TITLE
Updating branch name for transport_drivers.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3508,7 +3508,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: master
+      version: ros2
     release:
       packages:
       - serial_driver
@@ -3520,7 +3520,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: master
+      version: ros2
     status: developed
   tts:
     doc:


### PR DESCRIPTION
The primary branch for the `transport_drivers` repository has changed from `master` to `ros2`. Once this is fixed, I will release a new version.