### PR TITLE
yp-spur: 1.19.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12957,7 +12957,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.18.2-1
+      version: 1.19.0-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.19.0-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.18.2-1`

## ypspur

```
* Support online device dump (#147 <https://github.com/openspur/yp-spur/issues/147>)
* Update assets to v0.0.9 (#146 <https://github.com/openspur/yp-spur/issues/146>)
* Use snprintf instead of sprintf (#145 <https://github.com/openspur/yp-spur/issues/145>)
* Contributors: Atsushi Watanabe
```
