### PR TITLE
omnibase: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6898,7 +6898,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ERC-BPGC/omnibase-release.git
-      version: 0.0.2-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ERC-BPGC/omnibase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omnibase` to `1.0.1-1`:

- upstream repository: https://github.com/ERC-BPGC/omnibase.git
- release repository: https://github.com/ERC-BPGC/omnibase-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.2-1`

## omnibase_control

```
* version bump
* fixed install issues
* minor fixes
* updated package.xmls
* Contributors: Harshal Deshpande
```

## omnibase_description

```
* version bump
* fixed install issues
* minor fixes
* updated package.xmls
* updated package.xmls
* Contributors: Harshal Deshpande
```

## omnibase_gazebo

```
* version bump
* fixed install issues
* minor fixes
* updated package.xmls
* updated package.xmls
* Contributors: Harshal Deshpande
```
