### PR TITLE
ixblue_stdbin_decoder: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1591,6 +1591,22 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: melodic-devel
     status: unmaintained
+  ixblue_stdbin_decoder:
+    doc:
+      type: git
+      url: https://github.com/ixblue/ixblue_stdbin_decoder.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ixblue/ixblue_stdbin_decoder.git
+      version: master
+    status: developed
   jderobot_assets:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_stdbin_decoder` to `0.1.1-1`:

- upstream repository: https://github.com/ixblue/ixblue_stdbin_decoder.git
- release repository: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## ixblue_stdbin_decoder

```
* Reduce minimum required CMake version to allow build on Debian Stretch for ROS Melodic
* Contributors: Romain Reignier
```
