### PR TITLE
catkin_virtualenv: 0.6.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -304,7 +304,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_virtualenv` to `0.6.1-2`:

- upstream repository: https://github.com/locusrobotics/catkin_virtualenv.git
- release repository: https://github.com/locusrobotics/catkin_virtualenv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.6.1-1`

## catkin_virtualenv

```
* Correct dependencies and autoformat (#72 <https://github.com/locusrobotics/catkin_virtualenv/issues/72>)
  * Remove python-virtualenv dep
  * Add python2-dev
  * Lint
* We're ok with any 44.x version of setuptools (#71 <https://github.com/locusrobotics/catkin_virtualenv/issues/71>)
  But not anything newer.
  Older versions don't appear to work reliably with pip==20.1.
  This helps when running a build of a package depending on catkin_virtualenv on OS which ship with an old version of setuptools (such as Ubuntu Xenial) when USE_SYSTEM_PACKAGES is not set to FALSE. In that situation, only specifying 'setuptools<45` will be true, as setuptools is installed (in the systems site packages), so pip will not upgrade it. Specifying a minimum version like this will force pip to always install an up-to-date version.
* Contributors: G.A. vd. Hoorn, Paul Bovbel
```
