### PR TITLE
hfl_driver: 0.0.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3775,7 +3775,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/flynneva/hfl_driver-release.git
-      version: 0.0.12-1
+      version: 0.0.15-1
     source:
       type: git
       url: https://github.com/continental/hfl_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hfl_driver` to `0.0.15-1`:

- upstream repository: https://github.com/continental/hfl_driver.git
- release repository: https://github.com/flynneva/hfl_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.12-1`

## hfl_driver

```
* open rosrepo pr automatically
* Merge pull request #35 <https://github.com/continental/hfl_driver/issues/35> from continental/release-0.0.14
* 0.0.14
* Update changelog
* Merge pull request #30 <https://github.com/continental/hfl_driver/issues/30> from continental/ros1/main
* fixed release workflow typo
* Merge pull request #28 <https://github.com/continental/hfl_driver/issues/28> from continental/ros1/main
* Contributors: Evan Flynn, flynneva
```
