### PR TITLE
dynamic_reconfigure: 1.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -776,7 +776,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.7.0-1
+      version: 1.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.7.1-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.7.0-1`

## dynamic_reconfigure

```
* narrow down required boost dependencies (#160 <https://github.com/ros/dynamic_reconfigure/issues/160>)
* Make Config object pickle-able in Python 3 (#154 <https://github.com/ros/dynamic_reconfigure/issues/154>)
* Fix python3 issue in a backward compatible way (#157 <https://github.com/ros/dynamic_reconfigure/issues/157>)
* import setup from setuptools instead of distutils-core (#153 <https://github.com/ros/dynamic_reconfigure/issues/153>)
* Contributors: Alejandro Hernández Cordero, Mikael Arguedas, Scott K Logan
```
