### PR TITLE
bond_core: 1.8.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -226,7 +226,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.8.5-1
+      version: 1.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.6-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.8.5-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* narrow down required boost dependencies (#68 <https://github.com/ros/bond_core/issues/68>)
* Contributors: Mikael Arguedas
```

## bondpy

```
* bondpy: Prevent exception in Bond.shutdown() (#62 <https://github.com/ros/bond_core/issues/62>)
* Contributors: Martin Pecka
```

## smclib

- No changes
