### PR TITLE
rmw_fastrtps: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1559,7 +1559,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `2.6.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.5.0-1`

## rmw_fastrtps_cpp

```
* Ensure compliant matched pub/sub count API. (#424 <https://github.com/ros2/rmw_fastrtps/issues/424>)
* Ensure compliant publisher QoS queries. (#425 <https://github.com/ros2/rmw_fastrtps/issues/425>)
* Contributors: Michel Hidalgo
```

## rmw_fastrtps_dynamic_cpp

```
* Ensure compliant matched pub/sub count API. (#424 <https://github.com/ros2/rmw_fastrtps/issues/424>)
* Ensure compliant publisher QoS queries. (#425 <https://github.com/ros2/rmw_fastrtps/issues/425>)
* Contributors: Michel Hidalgo
```

## rmw_fastrtps_shared_cpp

```
* Improve __rmw_create_wait_set() implementation. (#427 <https://github.com/ros2/rmw_fastrtps/issues/427>)
* Ensure compliant matched pub/sub count API. (#424 <https://github.com/ros2/rmw_fastrtps/issues/424>)
* Ensure compliant publisher QoS queries. (#425 <https://github.com/ros2/rmw_fastrtps/issues/425>)
* Fix memory leak that wait_set might be not destoryed in some case. (#423 <https://github.com/ros2/rmw_fastrtps/issues/423>)
* Contributors: Chen Lihui, Michel Hidalgo
```
