### PR TITLE
rmw_cyclonedds: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1523,7 +1523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.14.0-1
+      version: 0.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.15.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.14.0-1`

## rmw_cyclonedds_cpp

```
* Fix context cleanup. (#227 <https://github.com/ros2/rmw_cyclonedds/issues/227>)
* Fix memory leak that type support not deleted. (#225 <https://github.com/ros2/rmw_cyclonedds/issues/225>)
* Ensure compliant matched pub/sub count API. (#223 <https://github.com/ros2/rmw_cyclonedds/issues/223>)
* Fix memory leak that string not deleted. (#224 <https://github.com/ros2/rmw_cyclonedds/issues/224>)
* Change RET_WRONG_IMPLID() to return RMW_RET_INCORRECT_IMPLEMENTATION (#226 <https://github.com/ros2/rmw_cyclonedds/issues/226>)
* Fix bad conditional in rmw_serialize(). (#217 <https://github.com/ros2/rmw_cyclonedds/issues/217>)
* Contributors: Chen Lihui, Michel Hidalgo
```
