### PR TITLE
rcutils: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1429,7 +1429,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 1.1.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.1.0-1`

## rcutils

```
* Add RCUTILS_CAN_SET_ERROR_MSG_AND_RETURN_WITH_ERROR_OF() macro. (#284 <https://github.com/ros2/rcutils/issues/284>)
  To fault inject error messages as well as return codes.
* Change rcutils_fault_injection_set_count to use int64_t (#283 <https://github.com/ros2/rcutils/issues/283>)
* adds QNX support for rcutils_get_executable_name (#282 <https://github.com/ros2/rcutils/issues/282>)
* Add fault injection hooks to default allocator (#277 <https://github.com/ros2/rcutils/issues/277>)
* Fault injection macros and functionality (plus example) (#264 <https://github.com/ros2/rcutils/issues/264>)
* ensure -fPIC is used when building a static lib (#276 <https://github.com/ros2/rcutils/issues/276>)
* Drop vsnprintf mocks entirely. (#275 <https://github.com/ros2/rcutils/issues/275>)
  Binary API is not portable across platforms and compilation config.
* Fix vsnprintf mocks for Release builds. (#274 <https://github.com/ros2/rcutils/issues/274>)
* Improve test coverage mocking system calls (#272 <https://github.com/ros2/rcutils/issues/272>)
* Use mimick/mimick.h header (#273 <https://github.com/ros2/rcutils/issues/273>)
* Add mock test for rcutils/strerror (#265 <https://github.com/ros2/rcutils/issues/265>)
* Add compiler option -Wconversion and add explicit casts for conversions that may alter the value or change the sign (#263 <https://github.com/ros2/rcutils/issues/263>)
  See https://github.com/ros2/rcutils/pull/263#issuecomment-663252537.
* Removed doxygen warnings (#266 <https://github.com/ros2/rcutils/issues/266>) (#268 <https://github.com/ros2/rcutils/issues/268>)
* Removed doxygen warnings (#266 <https://github.com/ros2/rcutils/issues/266>)
* Force _GNU_SOURCE if glibc is used. (#267 <https://github.com/ros2/rcutils/issues/267>)
* Add parenthesis around the argument in time conversion macros defined in time.h (#261 <https://github.com/ros2/rcutils/issues/261>)
* Contributors: Ahmed Sobhy, Alejandro Hernández Cordero, Dirk Thomas, Johannes Meyer, Jorge Perez, Michel Hidalgo, brawner
```
