### PR TITLE
Add python3-protobuf and python3-jinja2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5781,6 +5781,12 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
+python3-jinja2:
+  alpine: [py3-jinja2]
+  debian: [python3-jinja2]
+  fedora: [python3-jinja2]
+  gentoo: [=dev-python/jinja-2*]
+  ubuntu: [python3-jinja2]
 python3-jsonpickle:
   arch: [python-jsonpickle]
   debian: [python3-jsonpickle]
@@ -6028,6 +6034,11 @@ python3-pkg-resources:
 python3-prometheus-client:
   debian: [python3-prometheus-client]
   ubuntu: [python3-prometheus-client]
+python3-protobuf:
+  alpine: [py3-protobuf]
+  debian: [python3-protobuf]
+  gentoo: [dev-python/protobuf-python]
+  ubuntu: [python3-protobuf]
 python3-psutil:
   alpine: [py3-psutil]
   arch: [python-psutil]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6037,6 +6037,7 @@ python3-prometheus-client:
 python3-protobuf:
   alpine: [py3-protobuf]
   debian: [python3-protobuf]
+  fedora: [python3-protobuf]
   gentoo: [dev-python/protobuf-python]
   ubuntu: [python3-protobuf]
 python3-psutil:


### PR DESCRIPTION
Add rosdep key for: 
- `python3-protobuf` in `alpine`, `debian`, `fedora`, `gentoo` and `ubuntu`.
- `python3-jinja2` in `alpine`, `debian`, `fedora`, `gentoo` and `ubuntu`.