### PR TITLE
contracts_lite_vendor: 0.3.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -542,7 +542,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/MaplessAI/external/contracts_lite_vendor-release.git
-      version: 0.2.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://gitlab.com/MaplessAI/external/contracts_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `contracts_lite_vendor` to `0.3.1-1`:

- upstream repository: https://gitlab.com/MaplessAI/external/contracts_lite_vendor
- release repository: https://gitlab.com/MaplessAI/external/contracts_lite_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.2.0-1`

## contracts_lite_vendor

```
* update to 0.3.1: Replace '+' operator for ReturnStatus types with '&&'; add '||' operator
* Contributors: Jeffrey Kane Johnson
```
