### PR TITLE
cookiecutter: add pip-based key for Ubuntu focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1112,11 +1112,20 @@ python-cookiecutter:
   osx:
     pip:
       packages: [cookiecutter]
+  ubuntu: [python-cookiecutter]
+python-cookiecutter-pip:
+  debian:
+    pip:
+      packages: [cookiecutter]
+  fedora:
+    pip:
+      packages: [cookiecutter]
+  osx:
+    pip:
+      packages: [cookiecutter]
   ubuntu:
-    '*': [python-cookiecutter]
-    focal:
-      pip:
-        packages: [cookiecutter]
+    pip:
+      packages: [cookiecutter]
 python-couchdb:
   debian: [python-couchdb]
   fedora: [python-couchdb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1114,7 +1114,7 @@ python-cookiecutter:
       packages: [cookiecutter]
   ubuntu:
     '*': [python-cookiecutter]
-    focal: 
+    focal:
       pip:
         packages: [cookiecutter]
 python-couchdb:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1112,7 +1112,11 @@ python-cookiecutter:
   osx:
     pip:
       packages: [cookiecutter]
-  ubuntu: [python-cookiecutter]
+  ubuntu:
+    '*': [python-cookiecutter]
+    focal: 
+      pip:
+        packages: [cookiecutter]
 python-couchdb:
   debian: [python-couchdb]
   fedora: [python-couchdb]


### PR DESCRIPTION
Package name: cookiecutter
Repo: https://github.com/cookiecutter/cookiecutter

Cookiecutter is already added but the ubuntu apt package hasn't been released for focal (only eoan and earlier)
https://packages.ubuntu.com/search?keywords=cookiecutter

I opened an issue a few days ago but their repo seems inactive lately and they recommend using pip anyway.
https://github.com/cookiecutter/cookiecutter/issues/1446

I updated the python.yaml to use pip for ubuntu focal.