### PR TITLE
kobuki_ftdi: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1126,6 +1126,21 @@ repositories:
       url: https://github.com/stonier/kobuki_firmware-release.git
       version: 1.2.0-1
     status: maintained
+  kobuki_ftdi:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ftdi.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stonier/kobuki_ftdi-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ftdi.git
+      version: release/1.0.x
+    status: maintained
   laser_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_ftdi` to `1.0.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_ftdi.git
- release repository: https://github.com/stonier/kobuki_ftdi-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## kobuki_ftdi

```
* [infra] v1 release
* [read] bugfix to process errors on return from ftdi_read_eeprom
```
