### PR TITLE
kobuki_core: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1102,13 +1102,10 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_core.git
       version: release/1.1.x
     release:
-      packages:
-      - kobuki_dock_drive
-      - kobuki_driver
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/kobuki_core-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1100,7 +1100,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/kobuki-base/kobuki_core.git
-      version: release/1.1.x
+      version: release/1.2.x
     release:
       tags:
         release: release/foxy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.2.0-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/stonier/kobuki_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.1.1-1`

## kobuki_core

```
* [infra] kobuki_dock_drive and kobuki_driver merged into kobuki_core, #31 <https://github.com/kobuki-base/kobuki_core/issues/31>.
* [tools] kobuki_simple_keyop -> kobuki-simple-keyop, #35 <https://github.com/kobuki-base/kobuki_core/issues/35>.
* [tools] kobuki_version_info -> kobuki-version-info, #35 <https://github.com/kobuki-base/kobuki_core/issues/35>.
```
