### PR TITLE
gazebo_video_monitor_plugins: 0.4.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3192,7 +3192,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
-      version: 0.4.1-2
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitor_plugins` to `0.4.2-1`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
- release repository: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.4.1-2`

## gazebo_video_monitor_plugins

```
* Enable C++14
```
