### PR TITLE
gazebo_video_monitor_plugins: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1125,7 +1125,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
-      version: 0.4.1-2
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitor_plugins` to `0.4.2-1`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
- release repository: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.4.1-2`

## gazebo_video_monitor_plugins

```
* Enable C++14
```
