### PR TITLE
ixblue_ins_stdbin_driver: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4271,7 +4271,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_ins_stdbin_driver` to `0.1.2-1`:

- upstream repository: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
- release repository: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.1-1`

## ixblue_ins

- No changes

## ixblue_ins_driver

```
* Fix packets_replayer build by adding CMake package Threads
* Contributors: Romain Reignier
```

## ixblue_ins_msgs

- No changes
