### PR TITLE
pinocchio: 2.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1622,6 +1622,21 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: dashing
     status: maintained
+  pinocchio:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
+      version: 2.5.0-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: master
+    status: developed
   plotjuggler_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pinocchio` to `2.5.0-1`:

- upstream repository: https://github.com/stack-of-tasks/pinocchio.git
- release repository: https://github.com/ipab-slmc/pinocchio_catkin-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
