### PR TITLE
ixblue_stdbin_decoder: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5637,6 +5637,22 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  ixblue_stdbin_decoder:
+    doc:
+      type: git
+      url: https://github.com/ixblue/ixblue_stdbin_decoder.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
+      version: 0.1.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ixblue/ixblue_stdbin_decoder.git
+      version: master
+    status: developed
   jackal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_stdbin_decoder` to `0.1.2-1`:

- upstream repository: https://github.com/ixblue/ixblue_stdbin_decoder.git
- release repository: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ixblue_stdbin_decoder

```
* Fix CMake config file for older CMake
  In order to do a Kinetic release.
* Contributors: Romain Reignier
```
