### PR TITLE
geometric_shapes: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1240,7 +1240,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.7.1-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.7.0-1`

## geometric_shapes

```
* [maint] Declare external includes as SYSTEM includes
* [maint] Migration to reentrant qhull (#149 <https://github.com/ros-planning/geometric_shapes/issues/149>)
* [maint] Use soname version for library (#157 <https://github.com/ros-planning/geometric_shapes/issues/157>)
* Contributors: Jochen Sprickerhof, Robert Haschke, Tyler Weaver
```
