### PR TITLE
Updating URLs for Autoware.AI repositories.

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -809,7 +809,7 @@ repositories:
   autoware_msgs:
     doc:
       type: git
-      url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
+      url: https://github.com/autoware-ai/messages.git
       version: master
     release:
       packages:
@@ -823,11 +823,11 @@ repositories:
       - vector_map_msgs
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/messages-release.git
+      url: https://github.com/autoware-ai/messages-release.git
       version: 1.12.0-1
     source:
       type: git
-      url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
+      url: https://github.com/autoware-ai/messages.git
       version: master
     status: developed
   auv_msgs:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -666,7 +666,7 @@ repositories:
   autoware_msgs:
     doc:
       type: git
-      url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
+      url: https://github.com/autoware-ai/messages.git
       version: master
     release:
       packages:
@@ -681,11 +681,11 @@ repositories:
       - vector_map_msgs
       tags:
         release: release/melodic/{package}/{version}
-      url: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/messages-release.git
+      url: https://github.com/autoware-ai/messages-release.git
       version: 1.13.0-1
     source:
       type: git
-      url: https://gitlab.com/autowarefoundation/autoware.ai/messages.git
+      url: https://github.com/autoware-ai/messages.git
       version: master
     status: developed
   auv_msgs:
@@ -8274,16 +8274,16 @@ repositories:
   qpoases_vendor:
     doc:
       type: git
-      url: https://gitlab.com/autowarefoundation/autoware.ai/qpoases_vendor.git
+      url: https://github.com/autoware-ai/qpoases_vendor.git
       version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://gitlab.com/autowarefoundation/autoware.ai-ros-releases/qpoases_vendor-release.git
+      url: https://github.com/autoware-ai/qpoases_vendor-release.git
       version: 3.2.1-1
     source:
       type: git
-      url: https://gitlab.com/autowarefoundation/autoware.ai/qpoases_vendor.git
+      url: https://github.com/autoware-ai/qpoases_vendor.git
       version: master
     status: maintained
   qt_gui_core:


### PR DESCRIPTION
All Autoware.AI repositories were moved from Gitlab to Github. This updates the relevant repo URLs.