### PR TITLE
rosbag2: 0.3.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2451,7 +2451,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.5-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.4-1`

## ros2bag

```
* Add pytest.ini so local tests don't display warning. (#446 <https://github.com/ros2/rosbag2/issues/446>) (#514 <https://github.com/ros2/rosbag2/issues/514>)
* Contributors: Emerson Knapp
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* resolve memory leak for serialized message (#502 <https://github.com/ros2/rosbag2/issues/502>) (#518 <https://github.com/ros2/rosbag2/issues/518>)
* Use shared logic for importing the rosbag2_transport_py library in Python (#482 <https://github.com/ros2/rosbag2/issues/482>) (#494 <https://github.com/ros2/rosbag2/issues/494>)
* Contributors: Emerson Knapp, Karsten Knese
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
