### PR TITLE
fkie_message_filters: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1036,7 +1036,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/message_filters-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/fkie/message_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_message_filters` to `1.1.1-1`:

- upstream repository: https://github.com/fkie/message_filters.git
- release repository: https://github.com/fkie-release/message_filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.1.0-1`

## fkie_message_filters

```
* Fix compilation bug with RosMessage adapter
* Contributors: Timo Röhling
```
