### PR TITLE
ixblue_stdbin_decoder: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4311,7 +4311,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_stdbin_decoder` to `0.1.2-1`:

- upstream repository: https://github.com/ixblue/ixblue_stdbin_decoder.git
- release repository: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.1-1`

## ixblue_stdbin_decoder

```
* Fix CMake config file for older CMake
  In order to do a Kinetic release.
* Contributors: Romain Reignier
```
