### PR TITLE
system_modes: 0.3.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3134,7 +3134,7 @@ repositories:
       version: 0.3.0-2
     source:
       type: git
-      url: https://github.com/microROS/system_modes.git
+      url: https://github.com/micro-ROS/system_modes.git
       version: eloquent
     status: developed
   teleop_tools:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3120,6 +3120,10 @@ repositories:
       version: dashing-devel
     status: developed
   system_modes:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: eloquent
     release:
       packages:
       - system_modes
@@ -3127,7 +3131,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
     source:
       type: git
       url: https://github.com/microROS/system_modes.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3135,7 +3135,7 @@ repositories:
     source:
       type: git
       url: https://github.com/microROS/system_modes.git
-      version: master
+      version: eloquent
     status: developed
   teleop_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.3.0-2`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.3.0-1`
