### PR TITLE
mrpt_msgs: 0.1.23-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2312,6 +2312,17 @@ repositories:
       url: https://github.com/mrpt/mrpt.git
       version: develop
     status: developed
+  mrpt_msgs:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
+      version: 0.1.23-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: ros1
+    status: developed
   mrt_cmake_modules:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2313,6 +2313,10 @@ repositories:
       version: develop
     status: developed
   mrpt_msgs:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: ros1
     release:
       tags:
         release: release/noetic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.1.23-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## mrpt_msgs

```
* catkin_lint clean
* ROS build farm badges
* Contributors: Jose Luis Blanco-Claraco
```
