### PR TITLE
franka_ros: 0.7.0-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1097,6 +1097,28 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: master
     status: maintained
+  franka_ros:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/franka_ros.git
+      version: noetic-devel
+    release:
+      packages:
+      - franka_control
+      - franka_description
+      - franka_gripper
+      - franka_hw
+      - franka_msgs
+      - franka_visualization
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/frankaemika/franka_ros-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/frankaemika/franka_ros.git
+      version: noetic-devel
+    status: developed
   gazebo_ros_pkgs:
     release:
       packages:


### PR DESCRIPTION
Not releasing 'franka_ros' and 'franka_example_controllers' for now because they are depending on MoveIt, which is not packaged yet.
Cc @davetcoleman, https://github.com/frankaemika/franka_ros/issues/104