### PR TITLE
sick_scan: 1.7.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4530,7 +4530,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan-release.git
-      version: 1.7.7-1
+      version: 1.7.8-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan` to `1.7.8-1`:

- upstream repository: https://github.com/SICKAG/sick_scan.git
- release repository: https://github.com/SICKAG/sick_scan-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.7.7-1`

## sick_scan

```
* fixes #100 <https://github.com/SICKAG/sick_scan/issues/100>
* Update software_pll.md
* software pll information added
* Update angular_compensation.md
* angle compensator
* compensation example plot updated
* angle compensation fixed for NAV2xx
* sizt_t warning reduced, bugfix for result flag by changing ip address
* network comp. to windows
* pcl dependency modified
* Contributors: Michael Lehning
```
