### PR TITLE
nmea_msgs: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1056,6 +1056,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros2
     status: maintained
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    status: maintained
   nodl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros2-gbp/nmea_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## nmea_msgs

```
* Initial release for ROS 2
* Contributors: Andreas Klintberg, Edward Venator
```
