### PR TITLE
webots_ros: 2.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12796,7 +12796,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git


### PR DESCRIPTION
webots_ros (melodic) - 2.1.1-1

The packages in the webots_ros repository were released into the melodic distro by running /usr/bin/bloom-release --rosdistro melodic --track melodic webots_ros --edit on Wed, 02 Sep 2020 16:13:38 -0000

The webots_ros package was released.

Version of package(s) in repository webots_ros:

    upstream repository: https://github.com/cyberbotics/webots_ros.git
    release repository: https://github.com/cyberbotics/webots_ros-release.git
    rosdistro version: 2.1.0-1
    old version: 2.1.0-1
    new version: 2.1.1-1

Versions of tools used:

    bloom version: 0.9.8
    catkin_pkg version: 0.4.22
    rosdep version: 0.19.0
    rosdistro version: 0.8.2
    vcstools version: 0.1.42
