### PR TITLE
rcl: 2.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1296,7 +1296,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 2.1.0-1
+      version: 2.2.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `2.2.0-2`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.1.0-1`

## rcl

```
* Bump rcl arguments' API test coverage (#777 <https://github.com/ros2/rcl/issues/777>)
* Fix rcl arguments' API memory leaks and bugs (#778 <https://github.com/ros2/rcl/issues/778>)
* Add coverage tests wait module (#769 <https://github.com/ros2/rcl/issues/769>)
* Fix wait set allocation cleanup (#770 <https://github.com/ros2/rcl/issues/770>)
* Improve test coverage in rcl (#764 <https://github.com/ros2/rcl/issues/764>)
* Check if rcutils_strdup() outcome immediately (#768 <https://github.com/ros2/rcl/issues/768>)
* Cleanup rcl_get_secure_root() implementation (#762 <https://github.com/ros2/rcl/issues/762>)
* Add fault injection macros to rcl functions (#727 <https://github.com/ros2/rcl/issues/727>)
* Yield rcl_context_fini() error codes (#763 <https://github.com/ros2/rcl/issues/763>)
* Do not invalidate context before successful shutdown (#761 <https://github.com/ros2/rcl/issues/761>)
* Zero initialize guard condition on failed init (#760 <https://github.com/ros2/rcl/issues/760>)
* Adding tests to arguments API (#752 <https://github.com/ros2/rcl/issues/752>)
* Extend rcl_expand_topic_name() API test coverage (#758 <https://github.com/ros2/rcl/issues/758>)
* Add coverage tests 94% to service API (#756 <https://github.com/ros2/rcl/issues/756>)
* Clean up rcl_expand_topic_name() implementation (#757 <https://github.com/ros2/rcl/issues/757>)
* Complete rcl enclave validation API coverage (#751 <https://github.com/ros2/rcl/issues/751>)
* Cope with base function restrictions in mocks (#753 <https://github.com/ros2/rcl/issues/753>)
* Fix allocation when copying arguments (#748 <https://github.com/ros2/rcl/issues/748>)
* Complete rcl package's logging API test coverage (#747 <https://github.com/ros2/rcl/issues/747>)
* Improve coverage to 95% in domain id, init option, rmw implementation id and log level modules (#744 <https://github.com/ros2/rcl/issues/744>)
* Fix rcl package's logging API error code documentation and handling (#746 <https://github.com/ros2/rcl/issues/746>)
* Fix bug error handling in get_param_files (#743 <https://github.com/ros2/rcl/issues/743>)
* Complete subscription API test coverage (#734 <https://github.com/ros2/rcl/issues/734>)
* increase timeouts in test_services fixtures for Connext (#745 <https://github.com/ros2/rcl/issues/745>)
* Tweaks to client.c and subscription.c for cleaner init/fini (#728 <https://github.com/ros2/rcl/issues/728>)
* Improve error checking and handling in subscription APIs (#739 <https://github.com/ros2/rcl/issues/739>)
* Add deallocate calls to free strdup allocated memory (#737 <https://github.com/ros2/rcl/issues/737>)
* Add missing calls to rcl_convert_rmw_ret_to_rcl_ret (#738 <https://github.com/ros2/rcl/issues/738>)
* Add mock tests, publisher 95% coverage (#732 <https://github.com/ros2/rcl/issues/732>)
* Restore env variables set in the test_failing_configuration. (#733 <https://github.com/ros2/rcl/issues/733>)
* Expose qos setting for /rosout (#722 <https://github.com/ros2/rcl/issues/722>)
* Reformat rmw_impl_id_check to call a testable function (#725 <https://github.com/ros2/rcl/issues/725>)
* Add extra check for invalid event implementation (#726 <https://github.com/ros2/rcl/issues/726>)
* Consolidate macro duplication (#653 <https://github.com/ros2/rcl/issues/653>)
* Contributors: Ada-King, Dan Rose, Dirk Thomas, Jorge Perez, Michel Hidalgo, brawner, tomoya
```

## rcl_action

```
* Add fault injection macros and unit tests to rcl_action (#730 <https://github.com/ros2/rcl/issues/730>)
* Change some EXPECT_EQ to ASSERT_EQ in test_action_server. (#759 <https://github.com/ros2/rcl/issues/759>)
* Contributors: Chris Lalancette, brawner
```

## rcl_lifecycle

```
* Add fault injection macros and unit tests to rcl_lifecycle (#731 <https://github.com/ros2/rcl/issues/731>)
* Remove std::cout line from test_rcl_lifecycle.cpp (#773 <https://github.com/ros2/rcl/issues/773>)
* Set transition_map->states/transition size to 0 on fini (#729 <https://github.com/ros2/rcl/issues/729>)
* Contributors: brawner
```

## rcl_yaml_param_parser

```
* Refactor parser.c for better testability (#754 <https://github.com/ros2/rcl/issues/754>)
* Don't overwrite cur_ns pointer if reallocation fails (#780 <https://github.com/ros2/rcl/issues/780>)
* Fix mem leaks in unit test from 776 (#779 <https://github.com/ros2/rcl/issues/779>)
* Fix rcl_parse_yaml_file() error handling. (#776 <https://github.com/ros2/rcl/issues/776>)
* Don't overwrite string_array pointer on reallocation failure (#775 <https://github.com/ros2/rcl/issues/775>)
* Set yaml_variant values to NULL on finalization (#765 <https://github.com/ros2/rcl/issues/765>)
* Remove debugging statements. (#755 <https://github.com/ros2/rcl/issues/755>)
* Contributors: Michel Hidalgo, brawner, tomoya
```
