### PR TITLE
Revert "pinocchio: 2.5.0-1 in 'foxy/distribution.yaml' [bloom]"

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1652,21 +1652,6 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: dashing
     status: maintained
-  pinocchio:
-    doc:
-      type: git
-      url: https://github.com/stack-of-tasks/pinocchio.git
-      version: master
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
-      version: 2.5.0-1
-    source:
-      type: git
-      url: https://github.com/stack-of-tasks/pinocchio.git
-      version: master
-    status: developed
   plotjuggler_msgs:
     release:
       tags:


### PR DESCRIPTION
Reverts ros/rosdistro#26391

Due to memory exhaustion cf. https://github.com/ros-infrastructure/buildfarm_deployment/issues/232

cc: @Rascof 