### PR TITLE
Revert "pinocchio: 2.5.0-1 in 'eloquent/distribution.yaml' [bloom]"

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1624,21 +1624,6 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: dashing
     status: maintained
-  pinocchio:
-    doc:
-      type: git
-      url: https://github.com/stack-of-tasks/pinocchio.git
-      version: master
-    release:
-      tags:
-        release: release/eloquent/{package}/{version}
-      url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
-      version: 2.5.0-1
-    source:
-      type: git
-      url: https://github.com/stack-of-tasks/pinocchio.git
-      version: master
-    status: developed
   plotjuggler_msgs:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#26390

Due to memory exhaustion cf. https://github.com/ros-infrastructure/buildfarm_deployment/issues/232

cc: @Rascof 