### PR TITLE
kinesis_video_streamer: 2.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4809,7 +4809,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/kinesis_video_streamer-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/aws-robotics/kinesisvideo-ros1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinesis_video_streamer` to `2.0.3-1`:

- upstream repository: https://github.com/aws-robotics/kinesisvideo-ros1.git
- release repository: https://github.com/aws-gbp/kinesis_video_streamer-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2.0.2-1`

## kinesis_video_msgs

- No changes

## kinesis_video_streamer

```
* Merge pull request #49 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/49> from aws-robotics/master
  * Ignore test files in coverage calculation
  * Update README.md to install build tool (#40 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/40>)
  * Remove "using namespace std" from headers, even in tests (#47 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/47>)
  Co-authored-by: AAlon <mailto:avishaya@amazon.com>
  Co-authored-by: Abby Xu <mailto:30247381+xabxx@users.noreply.github.com>
* Remove "using namespace std" from headers, even in tests (#47 <https://github.com/aws-robotics/kinesisvideo-ros1/issues/47>)
* Contributors: Emerson Knapp
```
