### PR TITLE
system_metrics_collector: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3117,7 +3117,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-tooling/system_metrics_collector-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/system_metrics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_metrics_collector` to `0.1.1-1`:

- upstream repository: https://github.com/ros-tooling/system_metrics_collector
- release repository: https://github.com/ros-tooling/system_metrics_collector-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-1`

## system_metrics_collector

```
* Fix test_subscriber_topic_statistics being referenced out of scope causing colcon build with flag -DBUILD_TESTING=0 to fail. (#175 <https://github.com/ros-tooling/system_metrics_collector/issues/175>) (#176 <https://github.com/ros-tooling/system_metrics_collector/issues/176>)
* Contributors: Jaison Titus
```
