### PR TITLE
ros_cb: 0.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2390,6 +2390,32 @@ repositories:
       url: https://github.com/ros-industrial/ros_canopen.git
       version: dashing-devel
     status: developed
+  ros_cb:
+    doc:
+      type: git
+      url: https://github.com/jediofgever/ROS_CB-release.git
+      version: master
+    release:
+      packages:
+      - chiconybot
+      - chiconybot_bringup
+      - chiconybot_cartographer
+      - chiconybot_description
+      - chiconybot_gazebo
+      - chiconybot_msgs
+      - chiconybot_navigation2
+      - chiconybot_node
+      - chiconybot_teleop
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/jediofgever/ROS_CB-release.git
+      version: 0.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/jediofgever/ROS_CB.git
+      version: master
+    status: developed
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_cb` to `0.0.0-1`:

- upstream repository: https://github.com/jediofgever/ROS_CB.git
- release repository: https://github.com/jediofgever/ROS_CB-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
