### PR TITLE
ixblue_ins_stdbin_driver: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1613,6 +1613,26 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: melodic-devel
     status: unmaintained
+  ixblue_ins_stdbin_driver:
+    doc:
+      type: git
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
+      version: master
+    release:
+      packages:
+      - ixblue_ins
+      - ixblue_ins_driver
+      - ixblue_ins_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
+      version: 0.1.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
+      version: master
+    status: developed
   ixblue_stdbin_decoder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_ins_stdbin_driver` to `0.1.3-1`:

- upstream repository: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
- release repository: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ixblue_ins

- No changes

## ixblue_ins_driver

```
* Add boost thread as test dependency to fix Debian Stretch build
* Contributors: Romain Reignier
```

## ixblue_ins_msgs

- No changes
