### PR TITLE
adds libnlopt-cxx-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3051,6 +3051,16 @@ libnl-dev:
   fedora: [libnl-devel]
   gentoo: [dev-libs/libnl]
   ubuntu: [libnl-dev]
+libnlopt-cxx-dev:
+  debian:
+    '*': [libnlopt-cxx-dev]
+    stretch: null
+  fedora: [NLopt-devel]
+  gentoo: [sci-libs/nlopt]
+  ubuntu:
+    '*': [libnlopt-cxx-dev]
+    bionic: null
+    xenial: null
 libnlopt-dev:
   debian: [libnlopt-dev]
   fedora: [NLopt-devel]


### PR DESCRIPTION
Starting with `eoan`, `libnlopt-dev` has been split into `libnlopt-dev` (containing the C library) and `libnlopt-cxx-dev` (containing the C++ library) of the `nlopt` package.
The split effects Ubuntu and Debian.

This PR now adds the C++ library (for focal+ / buster+).

Ubuntu: https://packages.ubuntu.com/search?keywords=libnlopt-cxx-dev&searchon=names
Debian: https://packages.debian.org/search?searchon=names&keywords=libnlopt-cxx-dev

For convenience, I added the (unaffected) packages for Fedora and Gentoo, which are the same as for the `libnlopt-dev` package.

I excluded `bionic`, `xenial` and `stretch`, as `libnlopt-cxx-dev` does not exist there. Onwards, I assume it will be released.


This package split is actually a breaking change for current users of the `libnlopt-dev` package,  as the `nlopt.hpp` header which is usually used is not distributed with that package anymore, but with `libnlopt-cxx-dev`.
For reference, here are the Ubuntu file lists:
- [Focal / libnlopt-cxx-dev](https://packages.ubuntu.com/focal/amd64/libnlopt-cxx-dev/filelist)
- [Focal / libnlopt-dev](https://packages.ubuntu.com/focal/amd64/libnlopt-dev/filelist)
- [Bionic / libnlopt-dev](https://packages.ubuntu.com/bionic/amd64/libnlopt-dev/filelist)

Thus, one could also change the `libnlop-dev` rosdep entry to switch use `libnlopt-cxx-dev` starting from `focal` / `buster`. This is under the assumption that as a ROS user you'll usually want the C++ library, and not the C one...

What do you prefer?

