### PR TITLE
ros_type_introspection: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3653,6 +3653,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: noetic-devel
     status: maintained
+  ros_type_introspection:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/facontidavide/ros_type_introspection-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/ros_type_introspection.git
+      version: master
+    status: developed
   rosauth:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_type_introspection` to `2.1.0-1`:

- upstream repository: https://github.com/facontidavide/ros_type_introspection.git
- release repository: https://github.com/facontidavide/ros_type_introspection-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ros_type_introspection

```
* Removed flyweight and fixed potential conversion errors
* Update README.md
* Contributors: Davide Faconti
```
