### PR TITLE
apex_containers: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -173,6 +173,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_containers:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_containers-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: foxy
+    status: developed
   apex_test_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository apex_containers to 0.0.3-1:

* upstream repository: https://gitlab.com/ApexAI/apex_containers.git
* release repository: https://gitlab.com/ApexAI/apex_containers-release.git
* distro file: foxy/distribution.yaml
* bloom version: 0.9.8
* previous version for package: null