### PR TITLE
grbl_ros: 0.0.11-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1046,7 +1046,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/flynneva/grbl_ros-release.git
-      version: 0.0.5-1
+      version: 0.0.11-1
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_ros` to `0.0.11-1`:

- upstream repository: https://github.com/flynneva/grbl_ros.git
- release repository: https://github.com/flynneva/grbl_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.5-1`
