### PR TITLE
grbl_ros: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -930,7 +930,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/flynneva/grbl_ros-release.git
-      version: 0.0.2-4
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -925,7 +925,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: main
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -934,7 +934,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: main
+      version: foxy
     status: developed
   hls_lfcd_lds_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_ros` to `0.2.1-1`:

- upstream repository: https://github.com/flynneva/grbl_ros.git
- release repository: https://github.com/flynneva/grbl_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.2-4`

## grbl_ros

```
* bump version for foxy
* added stream file function
* fixed execution errors
* Merge branch 'devel' into foxy-devel
* moved grbl_device.py to _command.py
* Merge pull request #41 <https://github.com/flynneva/grbl_ros/issues/41> from flynneva/foxy
  Foxy
* Merge pull request #33 <https://github.com/flynneva/grbl_ros/issues/33> from flynneva/restructure
  Restructure
* Contributors: Evan Flynn
```
