### PR TITLE
rt_usb_9axisimu_driver: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10634,6 +10634,22 @@ repositories:
       url: https://github.com/RoverRobotics/rr_openrover_stack.git
       version: melodic-devel
     status: developed
+  rt_usb_9axisimu_driver:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: melodic-devel
+    status: maintained
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `1.0.0-1`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## rt_usb_9axisimu_driver

```
* Contributors: Daisuke Sato, Shota Aoki
```
