### PR TITLE
rt_usb_9axisimu_driver: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14225,6 +14225,11 @@ repositories:
       type: git
       url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/rt-net/rt_usb_9axisimu_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `1.0.0-1`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## rt_usb_9axisimu_driver

```
* Contributors: Daisuke Sato, Shota Aoki
```
