### PR TITLE
rt_usb_9axisimu_driver: 2.0.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3230,6 +3230,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: dashing-devel
     status: maintained
+  rt_usb_9axisimu_driver:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
+      version: 2.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: dashing-devel
+    status: developed
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `2.0.0-2`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## rt_usb_9axisimu_driver

```
* Migrate to ROS 2 Dashing (#26 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/26>)
* Contributors: Shota Aoki
```
