### PR TITLE
plotjuggler: 2.8.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1667,7 +1667,6 @@ repositories:
       url: https://github.com/facontidavide/PlotJuggler.git
       version: foxy
     status: developed
-    status_description: developed
   plotjuggler_msgs:
     release:
       tags:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1652,6 +1652,22 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: dashing
     status: maintained
+  plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/facontidavide/plotjuggler-release.git
+      version: 2.8.4-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: foxy
+    status: developed
+    status_description: developed
   plotjuggler_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `2.8.4-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## plotjuggler

```
* readme updated
* fix issue #318 <https://github.com/facontidavide/PlotJuggler/issues/318>
* fix  #170 <https://github.com/facontidavide/PlotJuggler/issues/170> : problem with ULOG parser in Windows
* build fixes to work on ROS2 eloquent (#314 <https://github.com/facontidavide/PlotJuggler/issues/314>)
* add qtpainterpath.h (#313 <https://github.com/facontidavide/PlotJuggler/issues/313>)
* Update datastream_sample.cpp
* Update contributors.txt
* Fix another sprintf buffer size warning (#303 <https://github.com/facontidavide/PlotJuggler/issues/303>)
* Contributors: Akash Patel, Davide Faconti, Lucas, Mike Purvis
```
