### PR TITLE
geos_cmake_module: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3405,6 +3405,17 @@ repositories:
       url: https://github.com/ros/geometry_tutorials.git
       version: indigo-devel
     status: maintained
+  geos_cmake_module:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/geos_cmake_module-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/geos_cmake_module.git
+      version: master
+    status: maintained
   gl_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geos_cmake_module` to `0.0.2-1`:

- upstream repository: https://github.com/swri-robotics/geos_cmake_module
- release repository: https://github.com/swri-robotics-gbp/geos_cmake_module-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## geos_cmake_module

```
* added license
* Merge branch 'tweak-cmake-extras' into 'master'
  Tweak cmake extras
  See merge request daniel_dsouza/geos_cmake_module!1
* Tweak cmake extras
  This renames the extras.cmake files to be consistent with the package
  name, and it also changes a variable in the installspace file to
  reference the right package.
* works for me
* Contributors: Daniel D'Souza, P. J. Reed
```
