### PR TITLE
Add fonts-noto entry

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -883,6 +883,13 @@ fmt:
   fedora: [fmt-devel]
   gentoo: [dev-libs/libfmt]
   ubuntu: [libfmt-dev]
+fonts-noto:
+  alpine: [font-noto]
+  arch: [noto-fonts]
+  debian: [fonts-noto]
+  fedora: [google-noto-sans-mono-fonts, google-noto-serif-fonts]
+  gentoo: [media-fonts/noto]
+  ubuntu: [fonts-noto]
 fping:
   arch: [fping]
   debian: [fping]


### PR DESCRIPTION
- Add entry to install `fonts-noto` on `alpine`, `arch`, `debian`, `fedora`, `gentoo`, `ubuntu`.
