### PR TITLE
srdfdom: 0.6.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4749,7 +4749,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/srdfdom-release.git
-      version: 0.6.0-1
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `0.6.1-2`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros-gbp/srdfdom-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.6.0-1`

## srdfdom

```
* [bugfix] SRDFWriter: Correctly populate XML document
* [bugfix] SRDFWriter: Use locale independent conversion from double to string (#67 <https://github.com/ros-planning/srdfdom/issues/67>)
* [maint]  Silence cmake warning
* Contributors: Robert Haschke
```
