### PR TITLE
mcl_3dl: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5534,7 +5534,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.3.0-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.2.5-1`

## mcl_3dl

```
* Switch beam model by map label field (#334 <https://github.com/at-wat/mcl_3dl/issues/334>)
* Update test script for latest catkin (#333 <https://github.com/at-wat/mcl_3dl/issues/333>)
* Remove references to sensor_msgs::PointCloud (#332 <https://github.com/at-wat/mcl_3dl/issues/332>)
* Update assets to v0.0.9 (#331 <https://github.com/at-wat/mcl_3dl/issues/331>)
* Improve expansion resetting/global localization test stability (#330 <https://github.com/at-wat/mcl_3dl/issues/330>)
* Fix global localization test parameter (#328 <https://github.com/at-wat/mcl_3dl/issues/328>)
* Avoid rate limit when fetching gh-ph-comment (#329 <https://github.com/at-wat/mcl_3dl/issues/329>)
* Update gh-pr-comment (#327 <https://github.com/at-wat/mcl_3dl/issues/327>)
* Retry codecov script download (#326 <https://github.com/at-wat/mcl_3dl/issues/326>)
* Improve test coverage (#325 <https://github.com/at-wat/mcl_3dl/issues/325>)
* Merge rostest coverage profiles (#324 <https://github.com/at-wat/mcl_3dl/issues/324>)
* Contributors: Atsushi Watanabe, f-fl0
```
