### PR TITLE
pilz_robots: 0.5.19-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7590,7 +7590,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.18-1
+      version: 0.5.19-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.19-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.5.18-1`

## pilz_control

```
* Add tolerance to speed-limit acceptance-test (#436)
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

```
* add pilz_status_indicator_rqt to meta-package (#421)
* Contributors: Pilz GmbH and Co. KG
```

## pilz_status_indicator_rqt

```
* Hide currently unsupported ui elements
* Contributors: Pilz GmbH and Co. KG
```

## pilz_testutils

- No changes

## pilz_utils

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Enhance safety interface launchfiles
* Use arguments of top-level launch file in modbus_client.launch
* Remove unncessary launch arg
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

```
* Move ikfast plugin test to prbt_moveit_config (#450)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_moveit_config

```
* Move ikfast plugin test to prbt_moveit_config (#450)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

```
* Reduce planning context to urdf model in urdf_tests.test (#451)
* Increase acceleration limits. (#442)
* Contributors: Pilz GmbH and Co. KG
```
