### PR TITLE
moveit: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2318,6 +2318,49 @@ repositories:
       url: https://github.com/magazino/move_base_flex.git
       version: noetic
     status: developed
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: noetic-devel
+    release:
+      packages:
+      - chomp_motion_planner
+      - moveit
+      - moveit_chomp_optimizer_adapter
+      - moveit_commander
+      - moveit_core
+      - moveit_fake_controller_manager
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_chomp
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_manipulation
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_servo
+      - moveit_setup_assistant
+      - moveit_simple_controller_manager
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit.git
+      version: noetic-devel
+    status: maintained
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.0-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## chomp_motion_planner

```
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [feature] Unified Collision Environment Integration (#1584 <https://github.com/ros-planning/moveit/issues/1584>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [fix] Fix calculation of potential (#1651 <https://github.com/ros-planning/moveit/issues/1651>)
* [fix] Fix Chomp planning adapter (#1525 <https://github.com/ros-planning/moveit/issues/1525>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Ayush Garg, Bence Magyar, Dave Coleman, Jens P, Jonathan Binney, Markus Vieth, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan
```

## moveit

```
* [maint] Use standard cmake text for metapackages (#1620 <https://github.com/ros-planning/moveit/issues/1620>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Jonathan Binney, Robert Haschke, Sean Yen
```

## moveit_chomp_optimizer_adapter

```
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [feature] Allow ROS namespaces for planning request adapters (#1530 <https://github.com/ros-planning/moveit/issues/1530>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [fix] Fix Chomp planning adapter (#1525 <https://github.com/ros-planning/moveit/issues/1525>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Henning Kayser, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan
```

## moveit_commander

```
* [feature] Add missing variants of place from list of PlaceLocations and Poses in the python interface (#2231 <https://github.com/ros-planning/moveit/issues/2231>)
* [fix]     Add default velocity/acceleration scaling factors (#1890 <https://github.com/ros-planning/moveit/issues/1890>)
* [fix]     Handle the updated plan() function of MoveGroupCommander (#1640 <https://github.com/ros-planning/moveit/issues/1640>)
* [fix]     Fix failing tutorial <https://github.com/ros-planning/moveit_tutorials/issues/301> (#1459 <https://github.com/ros-planning/moveit/issues/1459>)
* [maint]   Update dependencies for python3 in noetic (#2131 <https://github.com/ros-planning/moveit/issues/2131>)
* [maint]   Better align MoveGroupInterface.plan() with C++ MoveGroup::plan() (#790 <https://github.com/ros-planning/moveit/issues/790>)
* Contributors: Bence Magyar, Bjar Ne, Dave Coleman, Felix von Drigalski, Gerard Canal, Jafar Abdi, Masaki Murooka, Michael Ferguson, Michael Görner, Pavel-P, Raphael Druon, Robert Haschke, Ryodo Tanaka, Ryosuke Tajima, Sean Yen, v4hn
```

## moveit_core

```
* [feature] Add a utility to print collision pairs (#2275 <https://github.com/ros-planning/moveit/issues/2275>)
* [feature] Fix subframes disappearing when object is detached/scaled/renamed (#1866 <https://github.com/ros-planning/moveit/issues/1866>)
* [feature] Use Eigen::Transform::linear() instead of rotation() (#1964 <https://github.com/ros-planning/moveit/issues/1964>)
* [feature] Utilize new geometric_shapes functions to improve performance (#2038 <https://github.com/ros-planning/moveit/issues/2038>)
* [feature] move_group pick place test (#2031 <https://github.com/ros-planning/moveit/issues/2031>)
* [feature] Split collision proximity threshold (#2008 <https://github.com/ros-planning/moveit/issues/2008>)
* [feature] Integration test to defend subframe tutorial (#1757 <https://github.com/ros-planning/moveit/issues/1757>)
* [feature] List missing joints in group states (#1935 <https://github.com/ros-planning/moveit/issues/1935>)
* [feature] Improve documentation for setJointPositions() (#1921 <https://github.com/ros-planning/moveit/issues/1921>)
* [feature] Installs an empty plugin description xml file if bullet is not found (#1898 <https://github.com/ros-planning/moveit/issues/1898>)
* [feature] Bullet collision detection (#1839 <https://github.com/ros-planning/moveit/issues/1839>)
* [feature] Improve RobotState documentation (#1846 <https://github.com/ros-planning/moveit/issues/1846>)
* [feature] Adapt cmake for Bullet (#1744 <https://github.com/ros-planning/moveit/issues/1744>)
* [feature] Unified Collision Environment Bullet (#1572 <https://github.com/ros-planning/moveit/issues/1572>)
* [feature] Adding continuous collision detection to Bullet (#1551 <https://github.com/ros-planning/moveit/issues/1551>)
* [feature] Bullet Collision Detection (#1504 <https://github.com/ros-planning/moveit/issues/1504>)
* [feature] Generic collision detection test suite (#1543 <https://github.com/ros-planning/moveit/issues/1543>)
* [feature] Empty collision checker template for usage with tesseract and bullet (#1499 <https://github.com/ros-planning/moveit/issues/1499>)
* [feature] Add deepcopy option for RobotTrajectory's copy constructor (#1760 <https://github.com/ros-planning/moveit/issues/1760>)
* [feature] Enable code-coverage test (#1776 <https://github.com/ros-planning/moveit/issues/1776>)
* [feature] Provide UniquePtr macros (#1771 <https://github.com/ros-planning/moveit/issues/1771>)
* [feature] Improve variable name in RobotModel (#1752 <https://github.com/ros-planning/moveit/issues/1752>)
* [feature] Adding documentation to collision detection (#1645 <https://github.com/ros-planning/moveit/issues/1645>)
* [feature] Unified Collision Environment Integration (#1584 <https://github.com/ros-planning/moveit/issues/1584>)
* [feature] Document discretization behavior in KinematicsBase (#1602 <https://github.com/ros-planning/moveit/issues/1602>)
* [feature] Rename lm to link_model (#1592 <https://github.com/ros-planning/moveit/issues/1592>)
* [feature] Allow ROS namespaces for planning request adapters (#1530 <https://github.com/ros-planning/moveit/issues/1530>)
* [feature] Add named frames to CollisionObjects (#1439 <https://github.com/ros-planning/moveit/issues/1439>)
* [feature] More verbose "id" argument in PlanningScene, RobotState & CollisionWorld functions (#1450 <https://github.com/ros-planning/moveit/issues/1450>)
* [feature] Separate source file for CartesianInterpolator (#1149 <https://github.com/ros-planning/moveit/issues/1149>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Change FloatingJointModel::getStateSpaceDimension return value to 7
* [fix] collision world: check for empty shapes vector before access (#2026 <https://github.com/ros-planning/moveit/issues/2026>)
* [fix] Fix Condition for Adding current DistanceResultData to DistanceMap for DistanceRequestType::SINGLE (#1963 <https://github.com/ros-planning/moveit/issues/1963>)
* [fix] Do not override empty URDF link collision geometry (#1952 <https://github.com/ros-planning/moveit/issues/1952>)
* [fix] Fix issue in unpadded collision checking (#1899 <https://github.com/ros-planning/moveit/issues/1899>)
* [fix] Remove object from collision world only once (#1900 <https://github.com/ros-planning/moveit/issues/1900>)
* [fix] Initialize zero dynamics in CurrentStateMonitor (#1883 <https://github.com/ros-planning/moveit/issues/1883>)
* [fix] getFrameInfo(): Avoid double search for link name (#1853 <https://github.com/ros-planning/moveit/issues/1853>)
* [fix] Fix RobotTrajectory's copy constructor (#1834 <https://github.com/ros-planning/moveit/issues/1834>)
* [fix] Fix flaky moveit_cpp test (#1781 <https://github.com/ros-planning/moveit/issues/1781>)
* [fix] Fix doc string OrientationConstraint (#1793 <https://github.com/ros-planning/moveit/issues/1793>)
* [fix] Move ASSERT() into test setup (#1657 <https://github.com/ros-planning/moveit/issues/1657>)
* [fix] Add missing dependencies to library (#1746 <https://github.com/ros-planning/moveit/issues/1746>)
* [fix] Fix clang-tidy for unified collision environment (#1638 <https://github.com/ros-planning/moveit/issues/1638>)
* [fix] PlanningRequestAdapter::initialize() = 0 (#1621 <https://github.com/ros-planning/moveit/issues/1621>)
* [fix] Fix World::getTransform (#1553 <https://github.com/ros-planning/moveit/issues/1553>)
* [fix] Link moveit_robot_model from moveit_test_utils (#1534 <https://github.com/ros-planning/moveit/issues/1534>)
* [maint] Move constraint representation dox to moveit_tutorials (#2147 <https://github.com/ros-planning/moveit/issues/2147>)
* [maint] Update dependencies for python3 in noetic (#2131 <https://github.com/ros-planning/moveit/issues/2131>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #2004 <https://github.com/ros-planning/moveit/issues/2004>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Rename PR2-related collision test files (#1856 <https://github.com/ros-planning/moveit/issues/1856>)
* [maint] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] Add missing licenses (#1716 <https://github.com/ros-planning/moveit/issues/1716>) (#1720 <https://github.com/ros-planning/moveit/issues/1720>)
* [maint] Move isEmpty() test functions to moveit_core/utils (#1627 <https://github.com/ros-planning/moveit/issues/1627>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: AndyZe, Aris Synodinos, Ayush Garg, Bryce Willey, Dale Koenig, Dave Coleman, Felix von Drigalski, Henning Kayser, Jafar Abdi, Jens P, Jere Liukkonen, Jeroen, John Stechschulte, Jonas Wittmann, Jonathan Binney, Markus Vieth, Martin Pecka, Michael Ferguson, Michael Görner, Mike Lautman, Niklas Fiedler, Patrick Beeson, Robert Haschke, Sean Yen, Shivang Patel, Tyler Weaver, Wolfgang Merkt, Yu, Yan, tsijs, v4hn
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* [feature] Implementation of parameter TranslationXY2D IKFast (#1949 <https://github.com/ros-planning/moveit/issues/1949>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Delete IKCache copy constructor (#1750 <https://github.com/ros-planning/moveit/issues/1750>)
* [maint] Move NOLINT instructions to intended positions (#2058 <https://github.com/ros-planning/moveit/issues/2058>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>) (#2004 <https://github.com/ros-planning/moveit/issues/2004>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Fix various build issues on Windows (#1880 <https://github.com/ros-planning/moveit/issues/1880>)
* [maint] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* [maint] Relax dependencies of moveit_kinematics (#1529 <https://github.com/ros-planning/moveit/issues/1529>)
* Contributors: Ayush Garg, Christian Henkel, Dave Coleman, Henning Kayser, Immanuel Martini, Jonathan Binney, Markus Vieth, Martin Günther, Michael Ferguson, Michael Görner, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan, edetleon, jschleicher, v4hn
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* [feature] Replace $(find xacro)/xacro -> xacro (#2282 <https://github.com/ros-planning/moveit/issues/2282>)
* [feature] Start new joint_state_publisher_gui on param use_gui (#2257 <https://github.com/ros-planning/moveit/issues/2257>)
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [feature] Change API of ChompPlanner::solve() to not use message
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [fix] Small fixes to chomp planner (#1407 <https://github.com/ros-planning/moveit/issues/1407>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Add Missing License (#1779 <https://github.com/ros-planning/moveit/issues/1779>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Ayush Garg, Chittaranjan Srinivas Swaminathan, Dave Coleman, Jonathan Binney, Markus Vieth, Robert Haschke, Sean Yen, Tyler Weaver, Yoan Mollard
```

## moveit_planners_ompl

- No changes

## moveit_plugins

```
* [feature] Use standard cmake text for metapackages (#1620 <https://github.com/ros-planning/moveit/issues/1620>)
* [feature] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Jonathan Binney, Robert Haschke, Sean Yen, Tyler Weaver
```

## moveit_ros

```
* [maint] Use standard cmake text for metapackages (#1620 <https://github.com/ros-planning/moveit/issues/1620>)
* [maint] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Jonathan Binney, Robert Haschke, Sean Yen
```

## moveit_ros_benchmarks

```
* [feature] Benchmark combinations of predefined poses (#1548 <https://github.com/ros-planning/moveit/issues/1548>)
* [feature] Support benchmarking of full planning pipelines (#1531 <https://github.com/ros-planning/moveit/issues/1531>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix plot details, correcting xlabels positions and cleaning the graph (#1658 <https://github.com/ros-planning/moveit/issues/1658>) (#1668 <https://github.com/ros-planning/moveit/issues/1668>)
* [maint] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #2004 <https://github.com/ros-planning/moveit/issues/2004>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Fix usage of panda_moveit_config (#1904 <https://github.com/ros-planning/moveit/issues/1904>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] Do not install helper scripts in global bin destination (#1704 <https://github.com/ros-planning/moveit/issues/1704>)
* [maint] Cleanup launch + config files (#1631 <https://github.com/ros-planning/moveit/issues/1631>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Ayush Garg, Dave Coleman, Henning Kayser, Jonathan Binney, Mahmoud Ahmed Selim, Markus Vieth, Michael Görner, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan
```

## moveit_ros_control_interface

```
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [feature] Remove support for Indigo's ros_control (#2128 <https://github.com/ros-planning/moveit/issues/2128>)
* [feature] Add support for pos_vel_controllers and pos_vel_acc_controllers (#1806 <https://github.com/ros-planning/moveit/issues/1806>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] clang-tidy-fix modernize-loop-convert to entire code base (#1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Henning Kayser, Jonathan Binney, Robert Haschke, Sandro Magalhães, Sean Yen, Tyler Weaver, Yu, Yan
```

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

```
* [feature] Start new joint_state_publisher_gui on param use_gui (#2257 <https://github.com/ros-planning/moveit/issues/2257>)
* [feature] TfPublisher: fixup and add attached collsion objects (#1792 <https://github.com/ros-planning/moveit/issues/1792>)
* [feature] move_group capability for publishing planning scene frames to the tf system (#1761 <https://github.com/ros-planning/moveit/issues/1761>)
* [feature] get_planning_scene_service: return full scene when nothing was requested (#1424 <https://github.com/ros-planning/moveit/issues/1424>)
* [feature] Separate source file for CartesianInterpolator (#1149 <https://github.com/ros-planning/moveit/issues/1149>)
* [fix]   Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix]   Fix TfPublisher subframe publishing (#2002 <https://github.com/ros-planning/moveit/issues/2002>)
* [maint] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>) (#2004 <https://github.com/ros-planning/moveit/issues/2004>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Move isEmpty() test functions to moveit_core/utils (#1627 <https://github.com/ros-planning/moveit/issues/1627>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Mike Lautman, Robert Haschke, Felix von Drigalski, Jens P, Jonathan Binney, JonasTietz, Michael Görner, Tyler Weaver, Yoan Mollard, Yu, Yan, v4hn
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* [feature] Utilize new geometric_shapes functions to improve performance (#2038 <https://github.com/ros-planning/moveit/issues/2038>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix getTransform() (#2113 <https://github.com/ros-planning/moveit/issues/2113>)
* [fix] depth_image_octomap_updater: correctly set properties of debug images (#1653 <https://github.com/ros-planning/moveit/issues/1653>)
* [maint] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #2004 <https://github.com/ros-planning/moveit/issues/2004>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] NAMED logging for moveit_ros_perception (#1897 <https://github.com/ros-planning/moveit/issues/1897>)
* [maint] Fix various build issues on Windows (#1880 <https://github.com/ros-planning/moveit/issues/1880>)
* [maint] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Ayush Garg, Bjar Ne, Dale Koenig, Dave Coleman, Henning Kayser, Jonathan Binney, Mahmoud Ahmed Selim, Markus Vieth, Martin Pecka, Matthias Nieuwenhuisen, Michael Görner, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan, jschleicher
```

## moveit_ros_planning

```
* [feature] Use Eigen::Transform::linear() instead of rotation() (#1964 <https://github.com/ros-planning/moveit/issues/1964>)
* [feature] Bullet collision detection (#1839 <https://github.com/ros-planning/moveit/issues/1839>) (#1504 <https://github.com/ros-planning/moveit/issues/1504>)
* [feature] Allow different controllers for execution (#1832 <https://github.com/ros-planning/moveit/issues/1832>)
* [feature] Adding continuous collision detection to Bullet (#1551 <https://github.com/ros-planning/moveit/issues/1551>)
* [feature] plan_execution: refine logging for invalid paths (#1705 <https://github.com/ros-planning/moveit/issues/1705>)
* [feature] Unified Collision Environment Integration (#1584 <https://github.com/ros-planning/moveit/issues/1584>)
* [feature] Allow ROS namespaces for planning request adapters (#1530 <https://github.com/ros-planning/moveit/issues/1530>)
* [feature] Add named frames to CollisionObjects (#1439 <https://github.com/ros-planning/moveit/issues/1439>)
* [feature] get_planning_scene_service: return full scene when nothing was requested (#1424 <https://github.com/ros-planning/moveit/issues/1424>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Initialize zero dynamics in CurrentStateMonitor (#1883 <https://github.com/ros-planning/moveit/issues/1883>)
* [fix] memory leak (#1526 <https://github.com/ros-planning/moveit/issues/1526>)
* [maint] Adapt repository for splitted moveit_resources layout (#2199 <https://github.com/ros-planning/moveit/issues/2199>)
* [maint] partially transition unused test bin to rostest (#2158 <https://github.com/ros-planning/moveit/issues/2158>)
* [maint] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #2004 <https://github.com/ros-planning/moveit/issues/2004>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Fix usage of panda_moveit_config (#1904 <https://github.com/ros-planning/moveit/issues/1904>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Adapt cmake for Bullet (#1744 <https://github.com/ros-planning/moveit/issues/1744>)
* [maint] Readme for speed benchmark (#1648 <https://github.com/ros-planning/moveit/issues/1648>)
* [maint] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] Improve variable naming in RobotModelLoader (#1759 <https://github.com/ros-planning/moveit/issues/1759>)
* [maint] Move isEmpty() test functions to moveit_core/utils (#1627 <https://github.com/ros-planning/moveit/issues/1627>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Ayush Garg, Bianca Homberg, Dave Coleman, Felix von Drigalski, Henning Kayser, Jens P, Jonathan Binney, Markus Vieth, Martin Pecka, Max Krichenbauer, Michael Görner, Robert Haschke, Sean Yen, Simon Schmeisser, Tyler Weaver, Yu, Yan, jschleicher, livanov93, llach
```

## moveit_ros_planning_interface

```
* [feature] Use Eigen::Transform::linear() instead of rotation() (#1964 <https://github.com/ros-planning/moveit/issues/1964>)
* [feature] move_group pick place test (#2031 <https://github.com/ros-planning/moveit/issues/2031>)
* [feature] Check for grasp service - general cleanup MGI (#2077 <https://github.com/ros-planning/moveit/issues/2077>)
* [feature] Integration test to defend subframe tutorial (#1757 <https://github.com/ros-planning/moveit/issues/1757>)
* [feature] Release Python GIL for C++ calls (#1947 <https://github.com/ros-planning/moveit/issues/1947>)
* [feature] Add default velocity/acceleration scaling factors (#1890 <https://github.com/ros-planning/moveit/issues/1890>)
* [feature] Improve move_group_interface's const correctness (#1715 <https://github.com/ros-planning/moveit/issues/1715>)
* [feature] Add get_jacobian_matrix to moveit_commander (#1501 <https://github.com/ros-planning/moveit/issues/1501>)
* [feature] Add named frames to CollisionObjects (#1439 <https://github.com/ros-planning/moveit/issues/1439>)
* [feature] Added GILRelease to pick and place (#2272 <https://github.com/ros-planning/moveit/issues/2272>)
* [feature] Add missing variants of place from list of PlaceLocations and Poses in the python interface (#2231 <https://github.com/ros-planning/moveit/issues/2231>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Resolve PSI lock-up in RViz display (#1951 <https://github.com/ros-planning/moveit/issues/1951>)
* [fix] Fix flaky moveit_cpp test (#1781 <https://github.com/ros-planning/moveit/issues/1781>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] Fix a parameter mix-up in moveit_cpp loading (#2187 <https://github.com/ros-planning/moveit/issues/2187>)
* [maint] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [maint] update dependencies for python3 in noetic (#2131 <https://github.com/ros-planning/moveit/issues/2131>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #1586 <https://github.com/ros-planning/moveit/issues/1586>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Fix some clang tidy issues (#2004 <https://github.com/ros-planning/moveit/issues/2004>)
* [maint] export  moveit_py_bindings_tools library (#1970 <https://github.com/ros-planning/moveit/issues/1970>)
* [maint] Fix usage of panda_moveit_config (#1904 <https://github.com/ros-planning/moveit/issues/1904>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Fix typo in cmake file (#1857 <https://github.com/ros-planning/moveit/issues/1857>)
* [maint] Reduce console output warnings (#1845 <https://github.com/ros-planning/moveit/issues/1845>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* [maint] improve [get|set]JointValueTarget in python wrapper (#858 <https://github.com/ros-planning/moveit/issues/858>)
* [maint] moveit_commander.MoveGroupInterface.plan() to better align with C++ MoveGroup::plan() (#790 <https://github.com/ros-planning/moveit/issues/790>)
* Contributors: AndyZe, Ayush Garg, Bence Magyar, Bjar Ne, Dave Coleman, Felix von Drigalski, Gerard Canal, Guilhem Saurel, Henning Kayser, Jafar Abdi, JafarAbdi, Jere Liukkonen, Jonathan Binney, Kunal Tyagi, Luca Rinelli, Mahmoud Ahmed Selim, Markus Vieth, Martin Pecka, Masaki Murooka, Michael Ferguson, Michael Görner, Niklas Fiedler, Robert Haschke, Ryosuke Tajima, Sean Yen, Tyler Weaver, Yeshwanth, Yu, Yan, mvieth, v4hn
```

## moveit_ros_robot_interaction

```
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [fix] Various fixes for upcoming Noetic release #2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Ayush Garg, Dave Coleman, Henning Kayser, Jonathan Binney, Markus Vieth, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan
```

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

```
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Ayush Garg, Dave Coleman, Henning Kayser, Jonathan Binney, Max Krichenbauer, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan
```

## moveit_runtime

```
* [feature] Use standard cmake text for metapackages (#1620 <https://github.com/ros-planning/moveit/issues/1620>)
* [feature] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Jonathan Binney, Robert Haschke, Sean Yen, Tyler Weaver
```

## moveit_servo

```
* [feature] Update last_sent_command_ at ServoCalcs start (#2249 <https://github.com/ros-planning/moveit/issues/2249>)
* [feature] Add a utility to print collision pairs (#2275 <https://github.com/ros-planning/moveit/issues/2275>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [maint] add soname version to moveit_servo (#2266 <https://github.com/ros-planning/moveit/issues/2266>)
* [maint] delete python integration tests (#2186 <https://github.com/ros-planning/moveit/issues/2186>)
* Contributors: AdamPettinger, AndyZe, Robert Haschke, Ruofan Xu, Tyler Weaver, v4hn
```

## moveit_setup_assistant

```
* [feature] Start new joint_state_publisher_gui on param use_gui (#2257 <https://github.com/ros-planning/moveit/issues/2257>)
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [feature] Add default velocity/acceleration scaling factors (#1890 <https://github.com/ros-planning/moveit/issues/1890>)
* [feature] MSA: use matching group/state name for default controller state (#1936 <https://github.com/ros-planning/moveit/issues/1936>)
* [feature] MSA: Restore display of current directory (#1932 <https://github.com/ros-planning/moveit/issues/1932>)
* [feature] Cleanup: use range-based for-loop (#1830 <https://github.com/ros-planning/moveit/issues/1830>)
* [feature] Add delete process to the doneEditing() function in end_effectors_widgets (#1829 <https://github.com/ros-planning/moveit/issues/1829>)
* [feature] Fix Rviz argument in demo_gazebo.launch (#1797 <https://github.com/ros-planning/moveit/issues/1797>)
* [feature] Allow user to specify planner termination condition. (#1695 <https://github.com/ros-planning/moveit/issues/1695>)
* [feature] Add OMPL planner 'AnytimePathShortening' (#1686 <https://github.com/ros-planning/moveit/issues/1686>)
* [feature] MVP TrajOpt Planner Plugin (#1593 <https://github.com/ros-planning/moveit/issues/1593>)
* [feature] Use QDir::currentPath() rather than getenv("PWD") (#1618 <https://github.com/ros-planning/moveit/issues/1618>)
* [feature] Add named frames to CollisionObjects (#1439 <https://github.com/ros-planning/moveit/issues/1439>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix ordering of request adapters (#2053 <https://github.com/ros-planning/moveit/issues/2053>)
* [fix] Fix some clang tidy issues (#2004 <https://github.com/ros-planning/moveit/issues/2004>)
* [fix] Fix usage of panda_moveit_config (#1904 <https://github.com/ros-planning/moveit/issues/1904>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [fix] Use portable string() on filesystem::path. (#1571 <https://github.com/ros-planning/moveit/issues/1571>)
* [fix] Fix test utilities in moveit core (#1409 <https://github.com/ros-planning/moveit/issues/1409>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Replace namespaces robot_state and robot_model with moveit::core (#1924 <https://github.com/ros-planning/moveit/issues/1924>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* [maint] remove obsolete moveit_resources/config.h (#1412 <https://github.com/ros-planning/moveit/issues/1412>)
* Contributors: AndyZe, Ayush Garg, Daniel Wang, Dave Coleman, Felix von Drigalski, Henning Kayser, Jafar Abdi, Jonathan Binney, Mark Moll, Max Krichenbauer, Michael Görner, Mike Lautman, Mohmmad Ayman, Omid Heidari, Robert Haschke, Sandro Magalhães, Sean Yen, Simon Schmeisser, Tejas Kumar Shastha, Tyler Weaver, Yoan Mollard, Yu, Yan, jschleicher, tnaka, v4hn
```

## moveit_simple_controller_manager

```
* [feature] Optional cpp version setting (#2166 <https://github.com/ros-planning/moveit/issues/2166>)
* [feature] Allow different controllers for execution #1832 <https://github.com/ros-planning/moveit/issues/1832>)
* [feature] ControllerManager: wait for done-callback (#1783 <https://github.com/ros-planning/moveit/issues/1783>)
* [feature] Use CMAKE_CXX_STANDARD to enforce c++14 for portability (#1607 <https://github.com/ros-planning/moveit/issues/1607>)
* [fix] Various fixes for upcoming Noetic release (#2180 <https://github.com/ros-planning/moveit/issues/2180>)
* [fix] Fix errors: catkin_lint 1.6.7 (#1987 <https://github.com/ros-planning/moveit/issues/1987>)
* [fix] Fix compiler warnings (#1773 <https://github.com/ros-planning/moveit/issues/1773>)
* [fix] Fix binary artifact install locations. (#1575 <https://github.com/ros-planning/moveit/issues/1575>)
* [fix] add missing space to log (#1477 <https://github.com/ros-planning/moveit/issues/1477>)
* [maint] clang-tidy fixes (#2050 <https://github.com/ros-planning/moveit/issues/2050>, #1419 <https://github.com/ros-planning/moveit/issues/1419>)
* [maint] Switch from include guards to pragma once (#1615 <https://github.com/ros-planning/moveit/issues/1615>)
* [maint] Remove ! from MoveIt name (#1590 <https://github.com/ros-planning/moveit/issues/1590>)
* Contributors: Dave Coleman, Henning Kayser, Jonathan Binney, Leroy Rügemer, Robert Haschke, Sean Yen, Tyler Weaver, Yu, Yan, llach
```
