### PR TITLE
rospilot: 1.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4004,6 +4004,17 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/rosparam_shortcuts.git
       version: noetic-devel
+  rospilot:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/rospilot/rospilot-release.git
+      version: 1.6.0-1
+    source:
+      type: git
+      url: https://github.com/rospilot/rospilot.git
+      version: noetic
+    status: maintained
   rospy_message_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.6.0-1`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## rospilot

```
* Add support for Noetic
* Update to Python3
* Upgrade jquery to fix CVE
* Contributors: Christopher Berner
```
