### PR TITLE
ros_cb: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2439,7 +2439,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/jediofgever/ROS_CB-release.git
-      version: 0.0.0-2
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_cb` to `0.0.2-1`:

- upstream repository: https://github.com/jediofgever/ROS_CB.git
- release repository: https://github.com/jediofgever/ROS_CB-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.0-2`
