### PR TITLE
diagnostics: 1.10.2-3 in noetic/distribution.yaml

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -698,7 +698,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.10.2-1
+      version: 1.10.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Due to a wrongly set up computer, the previous bloom-release command failed to create the _buster tags.
With this release, the issue has been solved and the jobs on the buildfarm should go back to a green state.
Sorry for the double pr!