### PR TITLE
ros1_bridge: 0.9.3-6 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2275,7 +2275,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.9.3-2
+      version: 0.9.3-6
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.9.3-6`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.9.3-2`

## ros1_bridge

```
* Fix multiple definition if message with same name as service exists (#272 <https://github.com/ros2/ros1_bridge/issues/272>)
* Contributors: Dirk Thomas
```
