### PR TITLE
Fix postgresql-postgis for Debian buster

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5294,7 +5294,7 @@ postgresql-client:
   ubuntu: [postgresql-client]
 postgresql-postgis:
   debian:
-    buster: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
+    buster: [postgresql-11-postgis-2.5, postgresql-contrib, postgresql-server-dev-all]
     jessie: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
     stretch: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
   fedora: [postgis]


### PR DESCRIPTION
postgresql-9.6-postgis-2.3 only exists for stretch
(https://packages.debian.org/search?keywords=postgresql-9.6-postgis-2.3)

Buster uses postgres 11: https://packages.debian.org/buster/postgresql-11-postgis-2.5