### PR TITLE
Add pip version of the `typing` python module

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4950,6 +4950,13 @@ python-typing:
     '*': [python-typing]
     trusty: null
     xenial: null
+python-typing-pip:
+  debian:
+    pip:
+      packages: [typing]
+  ubuntu:
+    pip:
+      packages: [typing]
 python-tz:
   arch: [python2-pytz]
   debian: [python-tz]


### PR DESCRIPTION
For use on Ubuntu 16.04 xenial

This installs https://pypi.org/project/typing/ . On newer versions of Ubuntu, there is an debian package, so I think it's best to leave the choice to the users instead of automatically switching between the pip or debian package version