### PR TITLE
rosdep install - support for additional python dependencies (Ubuntu Focal)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -882,7 +882,7 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
-    focal: [python-catkin-pkg]
+    focal: [python3-catkin-pkg]
     lucid: [python-catkin-pkg]
     maverick: [python-catkin-pkg]
     natty: [python-catkin-pkg]
@@ -1650,7 +1650,7 @@ python-future:
   ubuntu:
     artful: [python-future]
     bionic: [python-future]
-    focal: [python-future]
+    focal: [python3-future]
     trusty:
       pip:
         packages: [future]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -882,6 +882,7 @@ python-catkin-pkg:
   ubuntu:
     artful: [python-catkin-pkg]
     bionic: [python-catkin-pkg]
+    focal: [python-catkin-pkg]
     lucid: [python-catkin-pkg]
     maverick: [python-catkin-pkg]
     natty: [python-catkin-pkg]
@@ -1649,6 +1650,7 @@ python-future:
   ubuntu:
     artful: [python-future]
     bionic: [python-future]
+    focal: [python-future]
     trusty:
       pip:
         packages: [future]
@@ -2475,6 +2477,7 @@ python-mock:
   ubuntu:
     artful: [python-mock]
     bionic: [python-mock]
+    focal: [python-mock]
     lucid: [python-mock]
     maverick: [python-mock]
     natty: [python-mock]
@@ -3192,6 +3195,7 @@ python-psutil:
   ubuntu:
     artful: [python-psutil]
     bionic: [python-psutil]
+    focal: [python-psutil]
     lucid: [python-psutil]
     maverick: [python-psutil]
     natty: [python-psutil]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3848,6 +3848,7 @@ python-requests:
       packages: [requests]
   ubuntu:
     '*': [python-requests]
+    focal_python3: [python3-requests]
     trusty_python3: [python3-requests]
     utopic_python3: [python3-requests]
     vivid_python3: [python3-requests]


### PR DESCRIPTION
While developing with _noetic_ I had difficulties installing some _python_ dependencies with _rosdep_.
Added support for those dependencies.