### PR TITLE
rosserial: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4055,7 +4055,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.9.1-1`:

- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.9.0-1`

## rosserial

- No changes

## rosserial_arduino

- No changes

## rosserial_chibios

- No changes

## rosserial_client

- No changes

## rosserial_embeddedlinux

- No changes

## rosserial_mbed

- No changes

## rosserial_msgs

- No changes

## rosserial_python

```
* rosserial_python py3 fix (#514 <https://github.com/ros-drivers/rosserial/issues/514>)
* Contributors: BriceRenaudeau
```

## rosserial_server

```
* Add boost::thread dependency to rosserial_server (#513 <https://github.com/ros-drivers/rosserial/issues/513>)
* Contributors: Mike Purvis
```

## rosserial_tivac

- No changes

## rosserial_vex_cortex

- No changes

## rosserial_vex_v5

- No changes

## rosserial_windows

- No changes

## rosserial_xbee

- No changes
