### PR TITLE
cyclonedds: 0.7.0-2 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -443,7 +443,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-      version: releases/0.5.x
+      version: releases/0.7.x
     status: developed
   demos:
     doc:

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -437,7 +437,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.5.1-2
+      version: 0.7.0-2
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `cyclonedds` to `0.7.0-2`:

- upstream repository: https://github.com/eclipse-cyclonedds/cyclonedds.git
- release repository: https://github.com/ros2-gbp/cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.5.1-2`
