### PR TITLE
behaviortree_cpp_v3: 3.5.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -253,7 +253,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
-      version: 3.5.2-1
+      version: 3.5.3-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v3` to `3.5.3-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `3.5.2-1`

## behaviortree_cpp_v3

```
* fix issue #228 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/228> . Retry and Repeat node need to halt the child
* better tutorial
* Contributors: Davide Faconti
```
