### PR TITLE
mavlink: 2020.9.10-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1335,7 +1335,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2020.8.8-1
+      version: 2020.9.10-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2020.9.10-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/mavlink/mavlink-gbp-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2020.8.8-1`
