### PR TITLE
ros1_bridge: 0.9.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2279,7 +2279,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.9.3-7
+      version: 0.9.4-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.9.4-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.9.3-7`

## ros1_bridge

```
* use hardcoded QoS (keep all, transient local) for /tf_static topic in dynamic_bridge (#282 <https://github.com/ros2/ros1_bridge/issues/282>)
* document explicitly passing the topic type to 'ros2 topic echo' (#279 <https://github.com/ros2/ros1_bridge/issues/279>)
```
