### PR TITLE
contracts_lite_vendor: 0.3.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -541,7 +541,7 @@ repositories:
     release:
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/ros-safety/contracts_lite_vendor.git
+      url: https://github.com/ros-safety/contracts_lite_vendor-release.git
       version: 0.3.2-1
     source:
       type: git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -536,12 +536,12 @@ repositories:
   contracts_lite_vendor:
     doc:
       type: git
-      url: https://github.com/ros-safety/contracts_lite.git
+      url: https://github.com/ros-safety/contracts_lite_vendor.git
       version: master
     release:
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/ros-safety/contracts_lite_vendor-release
+      url: https://github.com/ros-safety/contracts_lite_vendor.git
       version: 0.3.2-1
     source:
       type: git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -536,7 +536,7 @@ repositories:
   contracts_lite_vendor:
     doc:
       type: git
-      url: https://gitlab.com/MaplessAI/external/contracts_lite.git
+      url: https://github.com/ros-safety/contracts_lite.git
       version: master
     release:
       tags:
@@ -545,7 +545,7 @@ repositories:
       version: 0.3.2-1
     source:
       type: git
-      url: https://gitlab.com/MaplessAI/external/contracts_lite.git
+      url: https://github.com/ros-safety/contracts_lite_vendor.git
       version: master
     status: developed
   control_msgs:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -541,8 +541,8 @@ repositories:
     release:
       tags:
         release: release/dashing/{package}/{version}
-      url: https://gitlab.com/MaplessAI/external/contracts_lite_vendor-release.git
-      version: 0.3.1-1
+      url: https://github.com/ros-safety/contracts_lite_vendor-release
+      version: 0.3.2-1
     source:
       type: git
       url: https://gitlab.com/MaplessAI/external/contracts_lite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `contracts_lite_vendor` to `0.3.2-1`:

- upstream repository: https://github.com/ros-safety/contracts_lite_vendor.git
- release repository: https://github.com/ros-safety/contracts_lite_vendor-release
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.3.1-1`

## contracts_lite_vendor

```
* Delete .gitlab-ci.yml (#3 <https://github.com/ros-safety/contracts_lite_vendor/issues/3>)
* point to github repo, bump version
* Add link to original contracts_lite project in readme (#2 <https://github.com/ros-safety/contracts_lite_vendor/issues/2>)
* Contributors: Jeffrey Kane Johnson
```
