### PR TITLE
rosdep definition for the Glasgow Haskell Compiler

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1087,6 +1087,12 @@ gfortran:
   fedora: [gcc-gfortran]
   gentoo: ['sys-devel/gcc[fortran]']
   ubuntu: [gfortran]
+ghc:
+  arch: [ghc]
+  debian: [ghc]
+  fedora: [ghc]
+  gentoo: ['dev-lang/ghc']
+  ubuntu: [ghc]
 gifsicle:
   arch: [gifsicle]
   debian: [gifsicle]


### PR DESCRIPTION
Adds a rosdep definition for ghc, the Glasgow Haskell Compiler.

We're using some Haskell code for file generation during build time, so we would like to install the compiler automatically through `build_depend`.

Package links:
Ubuntu: https://packages.ubuntu.com/focal/ghc
Debian: https://packages.debian.org/en/buster/ghc
Arch: https://www.archlinux.org/packages/community/x86_64/ghc/
Fedora: https://fedora.pkgs.org/30/fedora-x86_64/ghc-8.4.4-74.fc30.x86_64.rpm.html
Gentoo: https://packages.gentoo.org/packages/dev-lang/ghc