### PR TITLE
Add ur_client_library

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12157,16 +12157,16 @@ repositories:
       version: master
     status: maintained
   ur_client_library:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: boost
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
       version: 0.1.0-1
     source:
-      type: git
-      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
-      version: boost
-    doc:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
       version: boost

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12165,7 +12165,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12156,6 +12156,17 @@ repositories:
       url: https://github.com/uos/uos_tools.git
       version: master
     status: maintained
+  ur_client_library:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: boost
+    status: developed
   ur_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12166,6 +12166,10 @@ repositories:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
       version: boost
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: boost
     status: developed
   ur_msgs:
     doc:


### PR DESCRIPTION
We are currently in the process of splitting the client library from the [ur_robot_driver](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver) itself. The client library shall be released first so that users can install it using rosdep instead of having to build their workspace in isolation because the library isn't a catkin package.