### PR TITLE
mavros: 1.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2144,7 +2144,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.4.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.3.0-1`

## libmavconn

```
* Dispatch GCS IP address
* Contributors: Morten Fyhn Amundsen
```

## mavros

```
* mavros: use mavlink::minimal:: after incompatible changes in mavlink package
  Incompatible change: https://github.com/mavlink/mavlink/pull/1463
  Fix: #1483 <https://github.com/mavlink/mavros/issues/1483>, https://github.com/mavlink/mavlink/issues/1474
* fixes based on vooon's review
* fix issue what we couldn't set real parameters to 0.0 in mavros
* Add error message
* Fixed compilation error: publish std_msgs::String, not std::string for gcs_ip
* Dispatch GCS IP address
* Contributors: Artem Batalov, Marcelino, Morten Fyhn Amundsen, Vladimir Ermakov, Øystein Skotheim
```

## mavros_extras

```
* mavros: use mavlink::minimal:: after incompatible changes in mavlink package
  Incompatible change: https://github.com/mavlink/mavlink/pull/1463
  Fix: #1483 <https://github.com/mavlink/mavros/issues/1483>, https://github.com/mavlink/mavlink/issues/1474
* play_tune: Assign tune format directly
* play_tune: Uncrustify
* play_tune: Use msg_set_target and set_string_z
* play_tune: Write new plugin
* Contributors: Morten Fyhn Amundsen, Vladimir Ermakov
```

## mavros_msgs

```
* play_tune: Assign tune format directly
* play_tune: Write new plugin
* Contributors: Morten Fyhn Amundsen
```

## test_mavros

- No changes
