### PR TITLE
contracts_lite_vendor: 0.3.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -385,6 +385,21 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: foxy
     status: maintained
+  contracts_lite_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-safety/contracts_lite.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-safety/contracts_lite_vendor-release.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/ros-safety/contracts_lite.git
+      version: master
+    status: developed
   control_box_rst:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `contracts_lite_vendor` to `0.3.2-1`:

- upstream repository: https://github.com/ros-safety/contracts_lite_vendor.git
- release repository: https://github.com/ros-safety/contracts_lite_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## contracts_lite_vendor

```
* Delete .gitlab-ci.yml (#3 <https://github.com/ros-safety/contracts_lite_vendor/issues/3>)
* point to github repo, bump version
* Add link to original contracts_lite project in readme (#2 <https://github.com/ros-safety/contracts_lite_vendor/issues/2>)
* Contributors: Jeffrey Kane Johnson
```
