### PR TITLE
rpyutils: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2776,7 +2776,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rpyutils` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/rpyutils.git
- release repository: https://github.com/ros2-gbp/rpyutils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-1`

## rpyutils

```
* Create a shared function for importing c libraries (#4 <https://github.com/ros2/rpyutils/issues/4>)
* Add pytest.ini so local tests don't display warning (#3 <https://github.com/ros2/rpyutils/issues/3>)
* Contributors: Chris Lalancette, Emerson Knapp
```
