### PR TITLE
hfl_driver: 0.0.17-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4801,7 +4801,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/flynneva/hfl_driver-release.git
-      version: 0.0.17-1
+      version: 0.0.17-2
     source:
       type: git
       url: https://github.com/continental/hfl_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hfl_driver` to `0.0.17-2`:

- upstream repository: https://github.com/continental/hfl_driver.git
- release repository: https://github.com/flynneva/hfl_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.17-1`

## hfl_driver

```
* Merge pull request #42 <https://github.com/continental/hfl_driver/issues/42> from continental/ros1/main
* fixed build export depend typo
* add dynamic_reconfigure to build depend
* Contributors: Evan Flynn
```
