### PR TITLE
ecl_core: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -585,7 +585,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stonier/ecl_core.git
-      version: release/1.1.x
+      version: release/1.2.x
     release:
       packages:
       - ecl_command_line

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -616,7 +616,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ecl_core` to `1.2.0-1`:

- upstream repository: https://github.com/stonier/ecl_core.git
- release repository: https://github.com/yujinrobot-release/ecl_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.1.0-1`
