### PR TITLE
audio_common: 0.3.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -638,7 +638,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.7-1
+      version: 0.3.8-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.8-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.7-1`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

```
* Merge pull request #151 <https://github.com/ros-drivers/audio_common/issues/151> from knorth55/do-timestamp-false
  [audio_play] set do_timestamp false
* set do_timestamp false
* Contributors: Shingo Kitagawa
```

## sound_play

```
* Merge pull request #155 <https://github.com/ros-drivers/audio_common/issues/155> from garaemon/use-myargv
  Use rospy.myargv() instead of sys.argv to support remapping
* Use rospy.myargv() instead of sys.argv to support remapping
* Merge pull request #154 <https://github.com/ros-drivers/audio_common/issues/154> from mikaelarguedas/fix_say_python3
* update to support no iso-8859-15 language (#1 <https://github.com/ros-drivers/audio_common/issues/1>)
  * support non iso-8859-15 language
  * encode only for python2
* convert items to an iterator
* make cleanup compatible with Python 3
* catch AttributeError to handle python3 strings
* Contributors: Mikael Arguedas, Ryohei Ueda, Shingo Kitagawa
```
