### PR TITLE
rplidar_ros: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2760,7 +2760,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/allenh1/rplidar_ros-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_ros` to `2.0.1-1`:

- upstream repository: https://github.com/allenh1/rplidar_ros
- release repository: https://github.com/allenh1/rplidar_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2.0.0-1`

## rplidar_ros

```
* Remove old driver (#21 <https://github.com/allenh1/rplidar_ros/issues/21>)
  * Remove old rplidar driver in favor of the component version
  * Lint the source
* Fix incompatibilities with slam_toolbox (#20 <https://github.com/allenh1/rplidar_ros/issues/20>)
  * Fix incompatibilities with slam_toolbox:
  - Fix angle compensate mode to publish angle compensated values
  - Fix angle_increment calculation
  - Add optional flip_x_axis option to deal with issue discussed here: https://github.com/SteveMacenski/slam_toolbox/issues/198.  Flip x-axis can be used when laser is mounted with motor behind it as rotated TF laser frame doesn't seem to work with slam_toolbox.
  * Fix whitespace
* Fix node count for component implementation (#19 <https://github.com/allenh1/rplidar_ros/issues/19>)
* Slam Toolbox compatibility (#18 <https://github.com/allenh1/rplidar_ros/issues/18>)
  (cherry picked from commit f21079fea8eca8946b5b4ae72f50b8d9f1ac46a2)
* Fix building with GCC 10 (#17 <https://github.com/allenh1/rplidar_ros/issues/17>)
* Contributors: Christen Lofland, Hunter L. Allen, justinIRBT
```
