### PR TITLE
add xmlplain package to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5268,7 +5268,6 @@ python-xmltodict:
     xenial: [python-xmltodict]
     yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
-
 python-yamale-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5258,6 +5258,16 @@ python-xmltodict:
     xenial: [python-xmltodict]
     yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
+python-xmlplain:
+  debian:
+    pip:
+      packages: [xmlplain]
+  fedora:
+    pip:
+      packages: [xmlplain]
+  ubuntu:
+    pip:
+      packages: [xmlplain]
 python-yamale-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5245,6 +5245,16 @@ python-xlrd:
   debian: [python-xlrd]
   fedora: [python-xlrd]
   ubuntu: [python-xlrd]
+python-xmlplain-pip:
+  debian:
+    pip:
+      packages: [xmlplain]
+  fedora:
+    pip:
+      packages: [xmlplain]
+  ubuntu:
+    pip:
+      packages: [xmlplain]
 python-xmltodict:
   debian:
     buster: [python-xmltodict]
@@ -5258,16 +5268,7 @@ python-xmltodict:
     xenial: [python-xmltodict]
     yakkety: [python-xmltodict]
     zesty: [python-xmltodict]
-python-xmlplain:
-  debian:
-    pip:
-      packages: [xmlplain]
-  fedora:
-    pip:
-      packages: [xmlplain]
-  ubuntu:
-    pip:
-      packages: [xmlplain]
+
 python-yamale-pip:
   debian:
     pip:


### PR DESCRIPTION
### BreafExplanation

This module is a set of utility functions for parsing self-contained XML input into plain list/dict/string types and emitting to/reading from XML or YAML formats.


### Compatibility
The module is compatible with python 2.6/2.7 and python 3.x.


https://pypi.org/project/xmlplain/