### PR TITLE
kobuki_core: 0.7.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6268,7 +6268,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.7.8-1
+      version: 0.7.10-1
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.7.10-1`:

- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.7.8-1`

## kobuki_driver

```
* [firmware] recommended version checking for 1.1.4 and 1.2.0
```
