### PR TITLE
teleop_twist_joy: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4922,6 +4922,21 @@ repositories:
       url: https://github.com/ros-teleop/teleop_tools.git
       version: kinetic-devel
     status: maintained
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_joy.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/teleop_twist_joy-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_twist_joy.git
+      version: indigo-devel
+    status: unmaintained
   teleop_twist_keyboard:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `0.1.3-1`:

- upstream repository: https://github.com/ros-teleop/teleop_twist_joy.git
- release repository: https://github.com/ros-gbp/teleop_twist_joy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## teleop_twist_joy

```
* Use industrial ci
* Don't crash with invalid axes.
* Make sure to not crash when the Joy message buttons is too small.
* Don't get the axis twice.
* Add ROS Wiki link (#26 <https://github.com/ros-teleop/teleop_twist_joy/issues/26>)
* Contributors: Chris Lalancette, Julian Gaal, Rousseau Vincent, vincentrou
```
