### PR TITLE
moose_simulator: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5823,6 +5823,24 @@ repositories:
       url: https://github.com/moose-cpr/moose.git
       version: master
     status: maintained
+  moose_simulator:
+    doc:
+      type: git
+      url: https://github.com/moose-cpr/moose_simulator.git
+      version: master
+    release:
+      packages:
+      - moose_gazebo
+      - moose_simulator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/moose_simulator-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/moose-cpr/moose_simulator.git
+      version: master
+    status: maintained
   move_base_flex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_simulator` to `0.1.3-1`:

- upstream repository: https://github.com/moose-cpr/moose_simulator.git
- release repository: https://github.com/clearpath-gbp/moose_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## moose_gazebo

```
* Add the yaw argument to spawn_moose
* Rename spawn launch (#5 <https://github.com/moose-cpr/moose_simulator/issues/5>)
  * Add the scripts folder to the install target too
  * Rename moose_sim to spawn_moose to stay consistent with the recent changes for the new sim environments
  * Remove the duplicate scripts from the install paths
* [moose_gazebo] Minor clean-up.
  - Removed env_run since it wasn't used
  - Dropped .py
  - Updated install in CMakeLists.txt
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## moose_simulator

- No changes
