### PR TITLE
lanelet2: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1857,7 +1857,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lanelet2` to `1.1.1-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.1.0-2`

## lanelet2

```
* Add missing dependency to ros_environment
* Contributors: Fabian Poggenhans
```

## lanelet2_core

- No changes

## lanelet2_examples

- No changes

## lanelet2_io

- No changes

## lanelet2_maps

- No changes

## lanelet2_projection

- No changes

## lanelet2_python

- No changes

## lanelet2_routing

- No changes

## lanelet2_traffic_rules

- No changes

## lanelet2_validation

- No changes
