### PR TITLE
dingo: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2089,7 +2089,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.1-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-1`

## dingo_control

```
* Improve joy device configurability (#4 <https://github.com/dingo-cpr/dingo/issues/4>)
  * Remove the joy device from the yaml file, but keep it as the default in the launch file. Add support for a DINGO_JOY_DEV environment variable to override the default joy device.
  * Add the ASCII art diagram of the controller from Husky to make it easier to interpret the button mappings, should anyone want to remap them.
  * Expose the yaml file as an additional argument to the teleop launch file, allow overriding it with DINGO_JOY_CONFIG
* [dingo_control] Added limits for y motion omni platform.
* [dingo_control] Updated max velocity and acceleration limits.
* [dingo_control] Updated robot_localization config.
* [dingo_control] Moved control extras to botton of launch file.
* Contributors: Chris I-B, Tony Baltovski
```

## dingo_description

```
* Disable gravity on the L515 links; they were causing the odom frame to drift in gazebo
* Nav improvements (#5 <https://github.com/dingo-cpr/dingo/issues/5>)
  * Expose the scan_topic argument in the gmapping_demo and amcl_demo launch files
  * Add placeholder support for the RS L515 and D455 so that the gazebo plugins work; the meshes for these sensors don't exist yet, but we can at least get the plugin configured & add the appropriate links for now
  * Refactor the RealSense macro to put the mesh + gazebo plugin in one place. Create a more-accurate L515 mesh out of cylinders until Intel releases an official mesh for the sensor
* Fix missing quotes around the lidar models
* Model Update (#3 <https://github.com/dingo-cpr/dingo/issues/3>)
  * Make the yellow of the chassis more yellow and less orange
  * Fix the spawn position of the Hokuyo lidar & its focal point. Add the STLs for the LMS-1xx & Hokuyo lidars.  Add lms1xx as a dependency so that the lidar macro is available.
  * Add additional mounting points for accessories, fix the position of the existing front_mount
  * Start adding support for the Intel RealSense cameras as out-of-the-box accessories
  * Update the dependencies
  * Remove the hector gazebo plugin dependency; it's included in dingo_gazebo, and isn't strictly needed in the description package
  * Refactor the lidar accessory variables, add clarifying comments to make it easier to find supported values for the sensor models
  * Fix the measurements.  Keep the front/rear mounts 5cm back from the bumpers, move the bumper mounts to the center of the bumper
  * Remove the rear_bumper_mount since that's where the HMI is, which would prevent anything from being reasonably mounted there
* [dingo_description] Switched to find over dirname since it was causing errors in tests.
* Fix the spawn position of the Hokuyo lidar & its focal point. Add the STLs for the LMS-1xx & Hokuyo lidars.  Add lms1xx as a dependency so that the lidar macro is available.
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## dingo_msgs

- No changes

## dingo_navigation

```
* Nav improvements (#5 <https://github.com/dingo-cpr/dingo/issues/5>)
  * Expose the scan_topic argument in the gmapping_demo and amcl_demo launch files
  * Add placeholder support for the RS L515 and D455 so that the gazebo plugins work; the meshes for these sensors don't exist yet, but we can at least get the plugin configured & add the appropriate links for now
  * Refactor the RealSense macro to put the mesh + gazebo plugin in one place. Create a more-accurate L515 mesh out of cylinders until Intel releases an official mesh for the sensor
* Contributors: Chris I-B
```
