### PR TITLE
rqt_tf_tree: 0.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4518,7 +4518,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_tf_tree-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `0.6.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros-gbp/rqt_tf_tree-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.6.1-1`

## rqt_tf_tree

```
* fix shebang line for Python 3 (#21 <https://github.com/ros-visualization/rqt_tf_tree/issues/21>)
```
