### PR TITLE
rmw_cyclonedds: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1538,7 +1538,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.15.0-1
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.15.0-1`

## rmw_cyclonedds_cpp

```
* Fix that not to delete some objects after destroying functions (#236 <https://github.com/ros2/rmw_cyclonedds/issues/236>)
* Update rmw_publish_serialized_message() error returns (#240 <https://github.com/ros2/rmw_cyclonedds/issues/240>)
* Update rmw_publish() error returns (#239 <https://github.com/ros2/rmw_cyclonedds/issues/239>)
* Remove public declarations (#230 <https://github.com/ros2/rmw_cyclonedds/issues/230>)
* Use quotes for non-system includes (#231 <https://github.com/ros2/rmw_cyclonedds/issues/231>)
* Use correct functions to resize and get an item, avoiding memory leaks in typesupport code (#228 <https://github.com/ros2/rmw_cyclonedds/issues/228>)
* Contributors: Chen Lihui, Dan Rose, Lobotuerk
```
