### PR TITLE
kobuki_core: 1.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1135,7 +1135,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/stonier/kobuki_core-release.git
-      version: 1.2.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1130,7 +1130,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/kobuki-base/kobuki_core.git
-      version: release/1.2.x
+      version: release/1.3.x
     release:
       tags:
         release: release/foxy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.3.1-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/stonier/kobuki_core-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.2.0-1`

## kobuki_core

```
* [keyop] protect command variables with a mutex, #41 <https://github.com/kobuki-base/kobuki_core/issues/41>
* [core] ros_ prefixes dropped, custom_logging & raw_data_stream demos, #40 <https://github.com/kobuki-base/kobuki_core/issues/40>
* [infra] recommended firmware versions 1.1.4, 1.2.0, #37 <https://github.com/kobuki-base/kobuki_core/issues/37>
```
