### PR TITLE
hfl_driver: 0.0.20-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3810,7 +3810,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/flynneva/hfl_driver-release.git
-      version: 0.0.19-1
+      version: 0.0.20-1
     source:
       type: git
       url: https://github.com/continental/hfl_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hfl_driver` to `0.0.20-1`:

- upstream repository: https://github.com/continental/hfl_driver.git
- release repository: https://github.com/flynneva/hfl_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.19-1`

## hfl_driver

```
* fixed package.xml for rosdep install
* Merge pull request #58 <https://github.com/continental/hfl_driver/issues/58> from continental/release-0.0.19
* Contributors: Evan Flynn
```
