### PR TITLE
kobuki_core: 0.7.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4862,7 +4862,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.7.10-1
+      version: 0.7.12-1
     source:
       type: git
       url: https://github.com/yujinrobot/kobuki_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.7.12-1`:

- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.7.10-1`
