### PR TITLE
kobuki_core: 0.7.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1822,6 +1822,26 @@ repositories:
       url: https://github.com/utexas-bwi/knowledge_representation.git
       version: master
     status: developed
+  kobuki_core:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_core.git
+      version: noetic
+    release:
+      packages:
+      - kobuki_core
+      - kobuki_dock_drive
+      - kobuki_driver
+      - kobuki_ftdi
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/yujinrobot-release/kobuki_core-release.git
+      version: 0.7.12-1
+    source:
+      type: git
+      url: https://github.com/yujinrobot/kobuki_core.git
+      version: noetic
+    status: maintained
   kobuki_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `0.7.12-1`:

- upstream repository: https://github.com/yujinrobot/kobuki_core.git
- release repository: https://github.com/yujinrobot-release/kobuki_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
