### PR TITLE
Add python3-distro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5588,6 +5588,11 @@ python3-dev:
   openembedded: [python3@openembedded-core]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
+python3-distro:
+  debian: [python3-distro]
+  fedora: [python3-distro]
+  gentoo: [dev-python/distro]
+  ubuntu: [python3-distro]
 python3-distutils:
   debian:
     '*': [python3-distutils]


### PR DESCRIPTION
* https://pkgs.org/download/python3-distro
* https://pypi.org/project/distro/

> It is the recommended replacement for Python's original platform.linux_distribution function (which will be removed in Python 3.8). It also provides much more functionality which isn't necessarily Python bound, like a command-line interface.