### PR TITLE
Add rb1_base_sim package manually into melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8553,6 +8553,28 @@ repositories:
       url: https://github.com/rt-net/raspimouse_sim.git
       version: melodic-devel
     status: developed
+  rb1_base_common:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/rb1_base_common.git
+      version: melodic-devel
+    release:
+      packages:
+      - rb1_base_common
+      - rb1_base_control
+      - rb1_base_description
+      - rb1_base_localization
+      - rb1_base_navigation
+      - rb1_base_pad
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rb1_base_common-release.git
+      version: 1.12.0-1
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/rb1_base_common.git
+      version: melodic-devel
+    status: maintained
   rb1_base_sim:
     doc:
       type: git
@@ -8568,7 +8590,6 @@ repositories:
       url: https://github.com/RobotnikAutomation/rb1_base_sim-release.git
       version: 1.12.0-2
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/RobotnikAutomation/rb1_base_sim.git
       version: melodic-devel

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9168,6 +9168,36 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
       version: melodic-devel
     status: developed
+  robotnik_msgs:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/robotnik_msgs-release.git
+      version: 1.12.0-1
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_msgs.git
+      version: melodic-devel
+    status: maintained
+  robotnik_sensors:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_sensors.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/robotnik_sensors-release.git
+      version: 1.12.0-1
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_sensors.git
+      version: melodic-devel
+    status: maintained
   rocon_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8538,6 +8538,26 @@ repositories:
       url: https://github.com/rt-net/raspimouse_sim.git
       version: melodic-devel
     status: developed
+  rb1_base_sim:
+    doc:
+      type: git
+      url: https://github.com/RobotnikAutomation/rb1_base_sim.git
+      version: melodic-devel
+    release:
+      packages:
+      - rb1_base_gazebo
+      - rb1_base_sim
+      - rb1_base_sim_bringup
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RobotnikAutomation/rb1_base_sim-release.git
+      version: 1.12.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotnikAutomation/rb1_base_sim.git
+      version: melodic-devel
+    status: maintained
   rc_cloud_accumulator:
     doc:
       type: git


### PR DESCRIPTION
Opening a PR manually after `bloom-release` in order to add the rb1_base_sim package into the rosdisto