### PR TITLE
librealsense2: 2.38.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1238,6 +1238,22 @@ repositories:
       url: https://github.com/ros2-gbp/libg2o-release.git
       version: 2019.11.23-4
     status: maintained
+  librealsense2:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/IntelRealSense/librealsense2-release.git
+      version: 2.38.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    status: developed
   libyaml_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.38.1-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
