### PR TITLE
realsense2_camera: 3.0.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2072,6 +2072,26 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: eloquent
     status: maintained
+  realsense2_camera:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: eloquent
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_node
+      - realsense_camera_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/IntelRealSense/realsense-ros-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: eloquent
+    status: developed
   realtime_support:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `3.0.0-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## realsense2_camera

```
* Update README.md
* Enable recovery from reconnect event.
* Add an example config file: d435i.yaml.
* fix launch file installation. Allow running the following command: 'ros2 launch realsense2_camera rs.launch.py'
* enable set_auto_exposure_roi options.
* enable sensors and filters dynamic parameters.
* clean
* RealSenseNodeFactory inherits from rclcpp::Node
* Add project: realsense2_node
* Add support for D455
* README.md: update installation process.
```

## realsense2_node

- No changes
