### PR TITLE
added rosdep rule for fastnumbers pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5768,7 +5768,7 @@ python3-gql-pip:
 python3-grpc-tools:
   debian:
     '*': [python3-grpc-tools]
-    stretch:
+    stretch: null
   ubuntu:
     '*': [python3-grpc-tools]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -207,7 +207,7 @@ jupyter-nbconvert:
   gentoo: [dev-python/nbconvert]
   ubuntu:
     '*': [jupyter-nbconvert]
-    xenial: null
+    xenial:
 jupyter-notebook:
   debian:
     '*': [jupyter-notebook]
@@ -731,7 +731,7 @@ python-boto3:
   opensuse: [python-boto3]
   ubuntu:
     '*': [python-boto3]
-    trusty: null
+    trusty:
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
@@ -1513,6 +1513,22 @@ python-fastdtw-pip:
   ubuntu:
     pip:
       packages: [python-fastdtw]
+python-fastnumbers-pip:
+  arch:
+    pip:
+      packages: [fastnumbers]
+  debian:
+    pip:
+      packages: [fastnumbers]
+  fedora:
+    pip:
+      packages: [fastnumbers]
+  osx:
+    pip:
+      packages: [fastnumbers]
+  ubuntu:
+    pip:
+      packages: [fastnumbers]
 python-fcl-pip:
   debian:
     pip:
@@ -2098,7 +2114,7 @@ python-imaging:
   arch: [python2-pillow]
   debian:
     '*': [python-pil]
-    jessie:  [python-imaging]
+    jessie: [python-imaging]
     stretch: [python-imaging]
   fedora: [python-pillow, python-pillow-qt]
   freebsd: [py27-pillow]
@@ -4535,12 +4551,12 @@ python-statsd:
 python-subprocess32:
   debian:
     '*': [python-subprocess32]
-    jessie: null
+    jessie:
   fedora: [python-subprocess32]
   gentoo: [dev-python/subprocess32]
   ubuntu:
     '*': [python-subprocess32]
-    trusty: null
+    trusty:
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -4948,8 +4964,8 @@ python-typing:
   gentoo: [dev-python/typing]
   ubuntu:
     '*': [python-typing]
-    trusty: null
-    xenial: null
+    trusty:
+    xenial:
 python-typing-pip:
   debian:
     pip:
@@ -5384,7 +5400,7 @@ python3-autobahn:
   gentoo: [dev-python/autobahn]
   rhel:
     '*': ['python%{python3_pkgversion}-autobahn']
-    '7': null
+    '7':
   ubuntu: [python3-autobahn]
 python3-babeltrace:
   alpine: [py3-babeltrace]
@@ -5452,7 +5468,7 @@ python3-boto3:
   opensuse: [python3-boto3]
   rhel:
     '*': ['python%{python3_pkgversion}-boto3']
-    '7': null
+    '7':
   ubuntu: [python3-boto3]
 python3-bson:
   debian: [python3-bson]
@@ -5479,18 +5495,18 @@ python3-can:
   fedora: [python3-can]
   ubuntu:
     '*': [python3-can]
-    xenial: null
+    xenial:
 python3-catkin-lint:
   debian:
     '*': [python3-catkin-lint]
-    buster: null
-    jessie: null
-    stretch: null
+    buster:
+    jessie:
+    stretch:
   fedora: [python3-catkin_lint]
   ubuntu:
     '*': [python3-catkin-lint]
-    bionic: null
-    xenial: null
+    bionic:
+    xenial:
 python3-catkin-pkg:
   alpine: [py3-catkin-pkg]
   debian: [python3-catkin-pkg]
@@ -5525,13 +5541,13 @@ python3-click:
 python3-collada:
   debian:
     '*': [python3-collada]
-    buster: null
-    stretch: null
+    buster:
+    stretch:
   fedora: [python3-collada]
   ubuntu:
     '*': [python3-collada]
-    bionic: null
-    xenial: null
+    bionic:
+    xenial:
 python3-collada-pip:
   debian:
     pip:
@@ -5591,12 +5607,12 @@ python3-dev:
 python3-distutils:
   debian:
     '*': [python3-distutils]
-    stretch: null
+    stretch:
   fedora: [python3]
   gentoo: [dev-lang/python]
   ubuntu:
     '*': [python3-distutils]
-    xenial: null
+    xenial:
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]
@@ -5676,7 +5692,7 @@ python3-flake8:
       packages: [flake8]
   rhel:
     '*': ['python%{python3_pkgversion}-flake8']
-    '7': null
+    '7':
   ubuntu: [python3-flake8]
 python3-future:
   debian: [python3-future]
@@ -5752,19 +5768,19 @@ python3-gql-pip:
 python3-grpc-tools:
   debian:
     '*': [python3-grpc-tools]
-    stretch: null
+    stretch:
   ubuntu:
     '*': [python3-grpc-tools]
-    bionic: null
-    xenial: null
+    bionic:
+    xenial:
 python3-grpcio:
   debian:
     '*': [python3-grpcio]
-    stretch: null
+    stretch:
   ubuntu:
     '*': [python3-grpcio]
-    bionic: null
-    xenial: null
+    bionic:
+    xenial:
 python3-httplib2:
   debian: [python3-httplib2]
   fedora: [python3-httplib2]
@@ -5803,7 +5819,7 @@ python3-importlib-metadata:
   gentoo: [dev-python/importlib_metadata]
   rhel:
     '*': ['python%{python3_pkgversion}-importlib-metadata']
-    '7': null
+    '7':
   ubuntu:
     '*': [python3-importlib-metadata]
     bionic:
@@ -5843,7 +5859,7 @@ python3-kitchen:
       packages: [kitchen]
   ubuntu:
     '*': [python3-kitchen]
-    xenial: null
+    xenial:
 python3-lark-parser:
   alpine: [py3-lark-parser]
   debian:
@@ -5862,8 +5878,8 @@ python3-lttng:
   debian: [python3-lttng]
   fedora:
     '*': [python3-lttng]
-    '30': null
-    '31': null
+    '30':
+    '31':
   ubuntu: [python3-lttng]
 python3-lxml:
   alpine: [py3-lxml]
@@ -5909,7 +5925,7 @@ python3-matplotlib:
       packages: [matplotlib]
   rhel:
     '*': ['python%{python3_pkgversion}-matplotlib']
-    '7': null
+    '7':
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mock:
@@ -5923,7 +5939,7 @@ python3-mock:
 python3-msgpack:
   debian:
     '*': [python3-msgpack]
-    stretch: null
+    stretch:
   ubuntu: [python3-msgpack]
 python3-mypy:
   alpine: [py3-mypy]
@@ -6108,11 +6124,11 @@ python3-psutil:
 python3-pyassimp:
   debian:
     '*': [python3-pyassimp]
-    stretch: null
+    stretch:
   fedora: [python3-assimp]
   ubuntu:
     '*': [python3-pyassimp]
-    xenial: null
+    xenial:
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]
@@ -6150,7 +6166,7 @@ python3-pydot:
   openembedded: [python3-pydot@meta-ros]
   rhel:
     '*': ['python%{python3_pkgversion}-pydot']
-    '7': null
+    '7':
   ubuntu: [python3-pydot]
 python3-pygame:
   debian:
@@ -6183,16 +6199,16 @@ python3-pygraphviz:
 python3-pykdl:
   debian:
     '*': [python3-pykdl]
-    'bionic': null
-    'xenial': null
+    bionic:
+    xenial:
   fedora:
     '*': [python3-pykdl]
-    '30': null
-    '31': null
+    '30':
+    '31':
   ubuntu:
     '*': [python3-pykdl]
-    'bionic': null
-    'xenial': null
+    bionic:
+    xenial:
 python3-pymesh2-pip:
   debian:
     pip:
@@ -6206,11 +6222,11 @@ python3-pymesh2-pip:
 python3-pymodbus:
   debian:
     '*': [python3-pymodbus]
-    stretch: null
+    stretch:
   fedora: [python3-pymodbus]
   ubuntu:
     '*': [python3-pymodbus]
-    xenial: null
+    xenial:
 python3-pyosmium:
   debian: [python3-pyosmium]
   fedora: [python3-osmium]
@@ -6229,7 +6245,7 @@ python3-pyproj:
   gentoo: [dev-python/pyproj]
   rhel:
     '*': ['python%{python3_pkgversion}-pyproj']
-    '7': null
+    '7':
   ubuntu: [python3-pyproj]
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
@@ -6278,7 +6294,7 @@ python3-pytest-mock:
   gentoo: [dev-python/pytest-mock]
   rhel:
     '*': ['python%{python3_pkgversion}-pytest-mock']
-    '7': null
+    '7':
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:
   debian: [python3-pytest-timeout]
@@ -6618,7 +6634,7 @@ python3-tqdm:
       packages: [tqdm]
   ubuntu:
     '*': [python3-tqdm]
-    xenial: null
+    xenial:
 python3-triangle-pip:
   debian:
     pip:
@@ -6649,7 +6665,7 @@ python3-twisted:
   gentoo: [dev-python/twisted]
   rhel:
     '*': ['python%{python3_pkgversion}-twisted']
-    '7': null
+    '7':
   ubuntu: [python3-twisted]
 python3-urllib3:
   debian: [python3-urllib3]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2114,7 +2114,7 @@ python-imaging:
   arch: [python2-pillow]
   debian:
     '*': [python-pil]
-    jessie: [python-imaging]
+    jessie:  [python-imaging]
     stretch: [python-imaging]
   fedora: [python-pillow, python-pillow-qt]
   freebsd: [py27-pillow]
@@ -6199,16 +6199,16 @@ python3-pygraphviz:
 python3-pykdl:
   debian:
     '*': [python3-pykdl]
-    bionic: null
-    xenial: null
+    'bionic': null
+    'xenial': null
   fedora:
     '*': [python3-pykdl]
     '30': null
     '31': null
   ubuntu:
     '*': [python3-pykdl]
-    bionic: null
-    xenial: null
+    'bionic': null
+    'xenial': null
 python3-pymesh2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1513,6 +1513,22 @@ python-fastdtw-pip:
   ubuntu:
     pip:
       packages: [python-fastdtw]
+python-fastnumbers-pip:
+  arch:
+    pip:
+      packages: [fastnumbers]
+  debian:
+    pip:
+      packages: [fastnumbers]
+  fedora:
+    pip:
+      packages: [fastnumbers]
+  osx:
+    pip:
+      packages: [fastnumbers]
+  ubuntu:
+    pip:
+      packages: [fastnumbers]
 python-fcl-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1513,7 +1513,7 @@ python-fastdtw-pip:
   ubuntu:
     pip:
       packages: [python-fastdtw]
-python-fastnumbers-pip:
+python3-fastnumbers-pip:
   arch:
     pip:
       packages: [fastnumbers]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -207,7 +207,7 @@ jupyter-nbconvert:
   gentoo: [dev-python/nbconvert]
   ubuntu:
     '*': [jupyter-nbconvert]
-    xenial:
+    xenial: null
 jupyter-notebook:
   debian:
     '*': [jupyter-notebook]
@@ -731,7 +731,7 @@ python-boto3:
   opensuse: [python-boto3]
   ubuntu:
     '*': [python-boto3]
-    trusty:
+    trusty: null
 python-bottle:
   debian: [python-bottle]
   fedora: [python-bottle]
@@ -4551,12 +4551,12 @@ python-statsd:
 python-subprocess32:
   debian:
     '*': [python-subprocess32]
-    jessie:
+    jessie: null
   fedora: [python-subprocess32]
   gentoo: [dev-python/subprocess32]
   ubuntu:
     '*': [python-subprocess32]
-    trusty:
+    trusty: null
 python-support:
   debian: [python-support]
   fedora: [python]
@@ -4964,8 +4964,8 @@ python-typing:
   gentoo: [dev-python/typing]
   ubuntu:
     '*': [python-typing]
-    trusty:
-    xenial:
+    trusty: null
+    xenial: null
 python-typing-pip:
   debian:
     pip:
@@ -5400,7 +5400,7 @@ python3-autobahn:
   gentoo: [dev-python/autobahn]
   rhel:
     '*': ['python%{python3_pkgversion}-autobahn']
-    '7':
+    '7': null
   ubuntu: [python3-autobahn]
 python3-babeltrace:
   alpine: [py3-babeltrace]
@@ -5468,7 +5468,7 @@ python3-boto3:
   opensuse: [python3-boto3]
   rhel:
     '*': ['python%{python3_pkgversion}-boto3']
-    '7':
+    '7': null
   ubuntu: [python3-boto3]
 python3-bson:
   debian: [python3-bson]
@@ -5495,18 +5495,18 @@ python3-can:
   fedora: [python3-can]
   ubuntu:
     '*': [python3-can]
-    xenial:
+    xenial: null
 python3-catkin-lint:
   debian:
     '*': [python3-catkin-lint]
-    buster:
-    jessie:
-    stretch:
+    buster: null
+    jessie: null
+    stretch: null
   fedora: [python3-catkin_lint]
   ubuntu:
     '*': [python3-catkin-lint]
-    bionic:
-    xenial:
+    bionic: null
+    xenial: null
 python3-catkin-pkg:
   alpine: [py3-catkin-pkg]
   debian: [python3-catkin-pkg]
@@ -5541,13 +5541,13 @@ python3-click:
 python3-collada:
   debian:
     '*': [python3-collada]
-    buster:
-    stretch:
+    buster: null
+    stretch: null
   fedora: [python3-collada]
   ubuntu:
     '*': [python3-collada]
-    bionic:
-    xenial:
+    bionic: null
+    xenial: null
 python3-collada-pip:
   debian:
     pip:
@@ -5607,12 +5607,12 @@ python3-dev:
 python3-distutils:
   debian:
     '*': [python3-distutils]
-    stretch:
+    stretch: null
   fedora: [python3]
   gentoo: [dev-lang/python]
   ubuntu:
     '*': [python3-distutils]
-    xenial:
+    xenial: null
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]
@@ -5771,16 +5771,16 @@ python3-grpc-tools:
     stretch:
   ubuntu:
     '*': [python3-grpc-tools]
-    bionic:
-    xenial:
+    bionic: null
+    xenial: null
 python3-grpcio:
   debian:
     '*': [python3-grpcio]
-    stretch:
+    stretch: null
   ubuntu:
     '*': [python3-grpcio]
-    bionic:
-    xenial:
+    bionic: null
+    xenial: null
 python3-httplib2:
   debian: [python3-httplib2]
   fedora: [python3-httplib2]
@@ -5819,7 +5819,7 @@ python3-importlib-metadata:
   gentoo: [dev-python/importlib_metadata]
   rhel:
     '*': ['python%{python3_pkgversion}-importlib-metadata']
-    '7':
+    '7': null
   ubuntu:
     '*': [python3-importlib-metadata]
     bionic:
@@ -5859,7 +5859,7 @@ python3-kitchen:
       packages: [kitchen]
   ubuntu:
     '*': [python3-kitchen]
-    xenial:
+    xenial: null
 python3-lark-parser:
   alpine: [py3-lark-parser]
   debian:
@@ -5878,8 +5878,8 @@ python3-lttng:
   debian: [python3-lttng]
   fedora:
     '*': [python3-lttng]
-    '30':
-    '31':
+    '30': null
+    '31': null
   ubuntu: [python3-lttng]
 python3-lxml:
   alpine: [py3-lxml]
@@ -5925,7 +5925,7 @@ python3-matplotlib:
       packages: [matplotlib]
   rhel:
     '*': ['python%{python3_pkgversion}-matplotlib']
-    '7':
+    '7': null
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mock:
@@ -5939,7 +5939,7 @@ python3-mock:
 python3-msgpack:
   debian:
     '*': [python3-msgpack]
-    stretch:
+    stretch: null
   ubuntu: [python3-msgpack]
 python3-mypy:
   alpine: [py3-mypy]
@@ -6124,11 +6124,11 @@ python3-psutil:
 python3-pyassimp:
   debian:
     '*': [python3-pyassimp]
-    stretch:
+    stretch: null
   fedora: [python3-assimp]
   ubuntu:
     '*': [python3-pyassimp]
-    xenial:
+    xenial: null
 python3-pyaudio:
   arch: [python-pyaudio]
   debian: [python3-pyaudio]
@@ -6166,7 +6166,7 @@ python3-pydot:
   openembedded: [python3-pydot@meta-ros]
   rhel:
     '*': ['python%{python3_pkgversion}-pydot']
-    '7':
+    '7': null
   ubuntu: [python3-pydot]
 python3-pygame:
   debian:
@@ -6199,16 +6199,16 @@ python3-pygraphviz:
 python3-pykdl:
   debian:
     '*': [python3-pykdl]
-    bionic:
-    xenial:
+    bionic: null
+    xenial: null
   fedora:
     '*': [python3-pykdl]
-    '30':
-    '31':
+    '30': null
+    '31': null
   ubuntu:
     '*': [python3-pykdl]
-    bionic:
-    xenial:
+    bionic: null
+    xenial: null
 python3-pymesh2-pip:
   debian:
     pip:
@@ -6222,11 +6222,11 @@ python3-pymesh2-pip:
 python3-pymodbus:
   debian:
     '*': [python3-pymodbus]
-    stretch:
+    stretch: null
   fedora: [python3-pymodbus]
   ubuntu:
     '*': [python3-pymodbus]
-    xenial:
+    xenial: null
 python3-pyosmium:
   debian: [python3-pyosmium]
   fedora: [python3-osmium]
@@ -6245,7 +6245,7 @@ python3-pyproj:
   gentoo: [dev-python/pyproj]
   rhel:
     '*': ['python%{python3_pkgversion}-pyproj']
-    '7':
+    '7': null
   ubuntu: [python3-pyproj]
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
@@ -6294,7 +6294,7 @@ python3-pytest-mock:
   gentoo: [dev-python/pytest-mock]
   rhel:
     '*': ['python%{python3_pkgversion}-pytest-mock']
-    '7':
+    '7': null
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:
   debian: [python3-pytest-timeout]
@@ -6634,7 +6634,7 @@ python3-tqdm:
       packages: [tqdm]
   ubuntu:
     '*': [python3-tqdm]
-    xenial:
+    xenial: null
 python3-triangle-pip:
   debian:
     pip:
@@ -6665,7 +6665,7 @@ python3-twisted:
   gentoo: [dev-python/twisted]
   rhel:
     '*': ['python%{python3_pkgversion}-twisted']
-    '7':
+    '7': null
   ubuntu: [python3-twisted]
 python3-urllib3:
   debian: [python3-urllib3]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1513,22 +1513,6 @@ python-fastdtw-pip:
   ubuntu:
     pip:
       packages: [python-fastdtw]
-python3-fastnumbers-pip:
-  arch:
-    pip:
-      packages: [fastnumbers]
-  debian:
-    pip:
-      packages: [fastnumbers]
-  fedora:
-    pip:
-      packages: [fastnumbers]
-  osx:
-    pip:
-      packages: [fastnumbers]
-  ubuntu:
-    pip:
-      packages: [fastnumbers]
 python-fcl-pip:
   debian:
     pip:
@@ -5665,6 +5649,22 @@ python3-events-pip:
   ubuntu:
     pip:
       packages: [Events]
+python3-fastnumbers-pip:
+  arch:
+    pip:
+      packages: [fastnumbers]
+  debian:
+    pip:
+      packages: [fastnumbers]
+  fedora:
+    pip:
+      packages: [fastnumbers]
+  osx:
+    pip:
+      packages: [fastnumbers]
+  ubuntu:
+    pip:
+      packages: [fastnumbers]
 python3-filterpy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5692,7 +5692,7 @@ python3-flake8:
       packages: [flake8]
   rhel:
     '*': ['python%{python3_pkgversion}-flake8']
-    '7':
+    '7': null
   ubuntu: [python3-flake8]
 python3-future:
   debian: [python3-future]


### PR DESCRIPTION
Added rosdep rule "python-fastnumbers-pip" for Arch, Debian, Fedora, OSX and Ubuntu. Passes all unit tests on my machine. Additionally ran "scripts/clean_rosdep_yaml.py" for as suggested by the tests.