### PR TITLE
contracts_lite_vendor: 0.3.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -542,7 +542,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-safety/contracts_lite_vendor-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/ros-safety/contracts_lite_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `contracts_lite_vendor` to `0.3.3-1`:

- upstream repository: https://github.com/ros-safety/contracts_lite_vendor.git
- release repository: https://github.com/ros-safety/contracts_lite_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.3.2-1`

## contracts_lite_vendor

```
* Library update: Make includes more consistent, use the gcc_7x to_string function (#4 <https://github.com/ros-safety/contracts_lite/pull/4>)
* Contributors: Jeffrey Kane Johnson
```
