### PR TITLE
[melodic] Add source git for common_tutorials

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1688,6 +1688,10 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/common_tutorials-release.git
       version: 0.1.11-0
+    source:
+      type: git
+      url: https://github.com/ros/common_tutorials.git
+      version: indigo-devel
     status: maintained
   control_box_rst:
     doc:


### PR DESCRIPTION
Adding the source Git location for `common_tutorials`. The will be useful for generating the repos file by `rosinstall_generator --upstream`.