### PR TITLE
aruco_ros: 2.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -254,6 +254,16 @@ repositories:
       url: https://github.com/asherikov/ariles-release.git
       version: 1.3.2-1
     status: developed
+  aruco_ros:
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: 2.1.1-1
   asr_aruco_marker_recognition:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `2.1.1-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.1`
- previous version for package: `null`

## aruco

- No changes

## aruco_msgs

- No changes

## aruco_ros

```
* Use time stamps from image messages
* Contributors: Markus Vieth
```
