### PR TITLE
warthog_desktop: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12794,7 +12794,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog_desktop-release.git
-      version: 0.0.1-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog_desktop` to `0.1.0-1`:

- upstream repository: https://github.com/warthog-cpr/warthog_desktop.git
- release repository: https://github.com/clearpath-gbp/warthog_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.1-1`

## warthog_desktop

- No changes

## warthog_viz

```
* [warthog_viz] Removed joint_state_publisher since joint_state_publisher_gui is generating the same data.
* Fix a deprecation warning with the joint state publisher gui
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```
