### PR TITLE
warthog: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17321,7 +17321,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/warthog-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/warthog-cpr/warthog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warthog` to `0.1.2-1`:

- upstream repository: https://github.com/warthog-cpr/warthog.git
- release repository: https://github.com/clearpath-gbp/warthog-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.1-1`

## warthog_control

```
* Remove unused arg and set joysticks to use joy topic. (#11 <https://github.com/warthog-cpr/warthog/issues/11>)
* Disable ekf option (#9 <https://github.com/warthog-cpr/warthog/issues/9>)
  * added env var and if-statement to disable robot ekf
  * changed if to unless
  * clearer wording
  * chenged default to true
* [warthog_control] Removed rosserial_server as run dependency.
* Contributors: Michael Hosmar, Tony Baltovski, jmastrangelo-cpr
```

## warthog_description

```
* Add the legacy namespace mode attribute to the ros control plugin. This suppresses a warning in gazebo
* Contributors: Chris I-B
```

## warthog_msgs

- No changes
