### PR TITLE
heron: 0.3.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3801,6 +3801,25 @@ repositories:
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
       version: debian
     status: maintained
+  heron:
+    doc:
+      type: git
+      url: https://github.com/heron/heron.git
+      version: kinetic-devel
+    release:
+      packages:
+      - heron_control
+      - heron_description
+      - heron_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron-release.git
+      version: 0.3.3-1
+    source:
+      type: git
+      url: https://github.com/heron/heron.git
+      version: kinetic-devel
+    status: maintained
   hfl_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron` to `0.3.3-1`:

- upstream repository: https://github.com/heron/heron
- release repository: https://github.com/clearpath-gbp/heron-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## heron_control

- No changes

## heron_description

```
* Update ROS deps to remove/rename third-party packages that are not available on Melodic
* Related to https://github.com/heron/heron_simulator/pull/6.  Change the topic that the mag data is published to so we can translate it to the new message standard to work-around a bug with the imu filter.
* Contributors: Chris Iverach-Brereton
```

## heron_msgs

- No changes
