### PR TITLE
performance_test_fixture: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1172,7 +1172,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.0.4-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.3-1`

## performance_test_fixture

```
* Expose a function for resetting the heap counters (#6 <https://github.com/ros2/performance_test_fixture/issues/6>)
* Stop recording memory operations sooner (#5 <https://github.com/ros2/performance_test_fixture/issues/5>)
* Suppress memory tools warning if tests will be skipped (#4 <https://github.com/ros2/performance_test_fixture/issues/4>)
* Contributors: Scott K Logan
```
