### PR TITLE
Melodic: Update apriltag to 3.1.2 to fix libdir issue

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -186,7 +186,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/AprilRobotics/apriltag-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/aprilrobotics/apriltag.git


### PR DESCRIPTION
Melodic was missing a patch for `GNUInstallDirs` and multi-architecture support. The new release includes this patch.