### PR TITLE
webots_ros2: 1.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3556,7 +3556,7 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: eloquent
     status: maintained
-  webots_ros2_desktop:
+  webots_ros2:
     doc:
       type: git
       url: https://github.com/cyberbotics/webots_ros2.git
@@ -3567,7 +3567,6 @@ repositories:
       - webots_ros2_abb
       - webots_ros2_core
       - webots_ros2_demos
-      - webots_ros2_desktop
       - webots_ros2_epuck
       - webots_ros2_examples
       - webots_ros2_importer
@@ -3578,7 +3577,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros2-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
## webots_ros2 (eloquent) - 1.0.1-1

The packages in the `webots_ros2` repository were released into the `eloquent` distro by running `/usr/bin/bloom-release --rosdistro eloquent --track eloquent webots_ros2 --edit` on `Fri, 18 Sep 2020 12:41:36 -0000`

These packages were released:
- `webots_ros2`
- `webots_ros2_abb`
- `webots_ros2_core`
- `webots_ros2_demos`
- `webots_ros2_epuck`
- `webots_ros2_examples`
- `webots_ros2_importer`
- `webots_ros2_msgs`
- `webots_ros2_tiago`
- `webots_ros2_universal_robot`
- `webots_ros2_ur_e_description`

Version of package(s) in repository `webots_ros2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: unknown
- rosdistro version: `null`
- old version: `1.0.0-1`
- new version: `1.0.1-1`

Versions of tools used:

- bloom version: `0.9.8`
- catkin_pkg version: `0.4.22`
- rosdep version: `0.19.0`
- rosdistro version: `0.8.2`
- vcstools version: `0.1.42`