### PR TITLE
wu_ros_tools: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5331,6 +5331,28 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros.git
       version: master
     status: maintained
+  wu_ros_tools:
+    doc:
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: noetic
+    release:
+      packages:
+      - easy_markers
+      - joy_listener
+      - kalman_filter
+      - rosbaglive
+      - wu_ros_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wu-robotics/wu_ros_tools.git
+      version: 0.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/wu_ros_tools.git
+      version: noetic
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wu_ros_tools` to `0.3.0-1`:

- upstream repository: https://github.com/DLu/wu_ros_tools
- release repository: https://github.com/wu-robotics/wu_ros_tools.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
