### PR TITLE
rqt_graph: 1.0.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2746,7 +2746,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.0.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.0.4-1`

## rqt_graph

```
* install executable rqt_graph (#49 <https://github.com/ros-visualization/rqt_graph/issues/49>)
* add setup.cfg with script install directories (#42 <https://github.com/ros-visualization/rqt_graph/issues/42>)
* add pytest.ini so local tests don't display warning (#48 <https://github.com/ros-visualization/rqt_graph/issues/48>)
```
