### PR TITLE
rmw_fastrtps: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1574,7 +1574,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 2.6.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.6.0-1`

## rmw_fastrtps_cpp

```
* Call Domain::removePublisher while failure occurs in create_publisher (#434 <https://github.com/ros2/rmw_fastrtps/issues/434>)
* Contributors: Barry Xu
```

## rmw_fastrtps_dynamic_cpp

```
* Call Domain::removePublisher while failure occurs in create_publisher (#434 <https://github.com/ros2/rmw_fastrtps/issues/434>)
* Avoid memory leaks and undefined behavior in rmw_fastrtps_dynamic_cpp typesupport code (#429 <https://github.com/ros2/rmw_fastrtps/issues/429>)
* Contributors: Barry Xu, Miguel Company
```

## rmw_fastrtps_shared_cpp

```
* Update rmw_take_serialized() and rmw_take_with_message_info() error returns  (#435 <https://github.com/ros2/rmw_fastrtps/issues/435>)
* Update rmw_take() error returns (#432 <https://github.com/ros2/rmw_fastrtps/issues/432>)
* Update rmw_publish() error returns (#430 <https://github.com/ros2/rmw_fastrtps/issues/430>)
* Update rmw_publish_serialized_message() error returns (#431 <https://github.com/ros2/rmw_fastrtps/issues/431>)
* Contributors: Jose Tomas Lorente, Lobotuerk
```
