### PR TITLE
mimick_vendor: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1031,7 +1031,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.2.2-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.2.1-1`

## mimick_vendor

```
* Suppress cppcheck for MMK_MANGLE_ (#8 <https://github.com/ros2/mimick_vendor/issues/8>)
* Change Mimick tagged version. (#7 <https://github.com/ros2/mimick_vendor/issues/7>)
* Contributors: Michel Hidalgo, brawner
```
