### PR TITLE
rclcpp: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1397,7 +1397,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 4.0.0-1
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `5.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `4.0.0-1`

## rclcpp

```
* Make node_graph::count_graph_users() const (#1320 <https://github.com/ros2/rclcpp/issues/1320>)
* Add coverage for wait_set_policies (#1316 <https://github.com/ros2/rclcpp/issues/1316>)
* Only exchange intra_process waitable if nonnull (#1317 <https://github.com/ros2/rclcpp/issues/1317>)
* Check waitable for nullptr during constructor (#1315 <https://github.com/ros2/rclcpp/issues/1315>)
* Call vector.erase with end iterator overload (#1314 <https://github.com/ros2/rclcpp/issues/1314>)
* Use best effort, keep last, history depth 1 QoS Profile for '/clock' subscriptions (#1312 <https://github.com/ros2/rclcpp/issues/1312>)
* Add tests type_support module (#1308 <https://github.com/ros2/rclcpp/issues/1308>)
* Replace std_msgs with test_msgs in executors test (#1310 <https://github.com/ros2/rclcpp/issues/1310>)
* Add set_level for rclcpp::Logger (#1284 <https://github.com/ros2/rclcpp/issues/1284>)
* Remove unused private function (rclcpp::Node and rclcpp_lifecycle::Node) (#1294 <https://github.com/ros2/rclcpp/issues/1294>)
* Adding tests basic getters (#1291 <https://github.com/ros2/rclcpp/issues/1291>)
* Adding callback groups in executor (#1218 <https://github.com/ros2/rclcpp/issues/1218>)
* Refactor Subscription Topic Statistics Tests (#1281 <https://github.com/ros2/rclcpp/issues/1281>)
* Add operator!= for duration (#1236 <https://github.com/ros2/rclcpp/issues/1236>)
* Fix clock thread issue (#1266 <https://github.com/ros2/rclcpp/issues/1266>) (#1267 <https://github.com/ros2/rclcpp/issues/1267>)
* Fix topic stats test, wait for more messages, only check the ones with samples (#1274 <https://github.com/ros2/rclcpp/issues/1274>)
* Add get_domain_id method to rclcpp::Context (#1271 <https://github.com/ros2/rclcpp/issues/1271>)
* Fixes for unit tests that fail under cyclonedds (#1270 <https://github.com/ros2/rclcpp/issues/1270>)
* initialize_logging_ should be copied (#1272 <https://github.com/ros2/rclcpp/issues/1272>)
* Use static_cast instead of C-style cast for instrumentation (#1263 <https://github.com/ros2/rclcpp/issues/1263>)
* Make parameter clients use template constructors (#1249 <https://github.com/ros2/rclcpp/issues/1249>)
* Ability to configure domain_id via InitOptions. (#1165 <https://github.com/ros2/rclcpp/issues/1165>)
* Simplify and fix allocator memory strategy unit test for connext (#1252 <https://github.com/ros2/rclcpp/issues/1252>)
* Use global namespace for parameter events subscription topic (#1257 <https://github.com/ros2/rclcpp/issues/1257>)
* Increase timeouts for connext for long tests (#1253 <https://github.com/ros2/rclcpp/issues/1253>)
* Adjust test_static_executor_entities_collector for rmw_connext_cpp (#1251 <https://github.com/ros2/rclcpp/issues/1251>)
* Fix failing test with Connext since it doesn't wait for discovery (#1246 <https://github.com/ros2/rclcpp/issues/1246>)
* Fix node graph test with Connext and CycloneDDS returning actual data (#1245 <https://github.com/ros2/rclcpp/issues/1245>)
* Warn about unused result of add_on_set_parameters_callback (#1238 <https://github.com/ros2/rclcpp/issues/1238>)
* Unittests for memory strategy files, except allocator_memory_strategy (#1189 <https://github.com/ros2/rclcpp/issues/1189>)
* EXPECT_THROW_EQ and ASSERT_THROW_EQ macros for unittests (#1232 <https://github.com/ros2/rclcpp/issues/1232>)
* Add unit test for static_executor_entities_collector (#1221 <https://github.com/ros2/rclcpp/issues/1221>)
* Parameterize test executors for all executor types (#1222 <https://github.com/ros2/rclcpp/issues/1222>)
* Unit tests for allocator_memory_strategy.cpp part 2 (#1198 <https://github.com/ros2/rclcpp/issues/1198>)
* Unit tests for allocator_memory_strategy.hpp (#1197 <https://github.com/ros2/rclcpp/issues/1197>)
* Derive and throw exception in spin_some spin_all for StaticSingleThreadedExecutor (#1220 <https://github.com/ros2/rclcpp/issues/1220>)
* Make ring buffer thread-safe (#1213 <https://github.com/ros2/rclcpp/issues/1213>)
* Add missing RCLCPP_PUBLIC to ~StaticExecutorEntitiesCollector (#1227 <https://github.com/ros2/rclcpp/issues/1227>)
* Document graph functions don't apply remap rules (#1225 <https://github.com/ros2/rclcpp/issues/1225>)
* Remove recreation of entities_collector (#1217 <https://github.com/ros2/rclcpp/issues/1217>)
* Contributors: Audrow Nash, Chen Lihui, Christophe Bedard, Daisuke Sato, Devin Bonnie, Dirk Thomas, Ivan Santiago Paunovic, Jacob Perron, Jannik Abbenseth, Jorge Perez, Pedro Pena, Shane Loretz, Stephen Brawner, Tomoya Fujita
```

## rclcpp_action

```
* Pass goal handle to goal response callback instead of a future (#1311 <https://github.com/ros2/rclcpp/issues/1311>)
* Remove deprecated client goal handle method for getting result (#1309 <https://github.com/ros2/rclcpp/issues/1309>)
* Increase test timeout necessary for Connext (#1256 <https://github.com/ros2/rclcpp/issues/1256>)
* Contributors: Dirk Thomas, Jacob Perron
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Increase test coverage of rclcpp_lifecycle to 96% (#1298 <https://github.com/ros2/rclcpp/issues/1298>)
* Log error instead of throwing exception in Transition and State reset(), mark no except (#1297 <https://github.com/ros2/rclcpp/issues/1297>)
* Remove unused private function (rclcpp::Node and rclcpp_lifecycle::Node) (#1294 <https://github.com/ros2/rclcpp/issues/1294>)
* Remove rmw-dependent unit-test checks (#1293 <https://github.com/ros2/rclcpp/issues/1293>)
* Added missing tests for rclcpp lifecycle (#1240 <https://github.com/ros2/rclcpp/issues/1240>)
* Warn about unused result of add_on_set_parameters_callback (#1238 <https://github.com/ros2/rclcpp/issues/1238>)
* Contributors: Alejandro Hernández Cordero, Jacob Perron, Stephen Brawner
```
