### PR TITLE
xpp: 1.0.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5347,6 +5347,30 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: noetic-devel
     status: maintained
+  xpp:
+    doc:
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    release:
+      packages:
+      - xpp
+      - xpp_examples
+      - xpp_hyq
+      - xpp_msgs
+      - xpp_quadrotor
+      - xpp_states
+      - xpp_vis
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/leggedrobotics/xpp-release.git
+      version: 1.0.10-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/leggedrobotics/xpp.git
+      version: master
+    status: maintained
   xv_11_laser_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xpp` to `1.0.10-1`:

- upstream repository: https://github.com/leggedrobotics/xpp.git
- release repository: https://github.com/leggedrobotics/xpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## xpp

```
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_examples

```
* Update README.txt
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_hyq

```
* add xacro dependency
* Contributors: Alexander Winkler
```

## xpp_msgs

```
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_quadrotor

```
* add xacro dependency to xpp_hyq and xpp_quadrotor
* Contributors: Alexander Winkler
```

## xpp_states

```
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler
```

## xpp_vis

```
* checking sum of the contact forces was hiding negative forces. Use norm instead (#10 <https://github.com/leggedrobotics/xpp/issues/10>)
* Improve docs (#8 <https://github.com/leggedrobotics/xpp/issues/8>)
* Contributors: Alexander Winkler, Ruben Grandia
```
