### PR TITLE
pr2_calibration: 1.0.11-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7800,6 +7800,28 @@ repositories:
       url: https://github.com/pr2-gbp/pr2_apps-release.git
       version: 0.6.1-0
     status: unmaintained
+  pr2_calibration:
+    doc:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration.git
+      version: kinetic-devel
+    release:
+      packages:
+      - dense_laser_assembler
+      - laser_joint_processor
+      - laser_joint_projector
+      - pr2_calibration
+      - pr2_calibration_launch
+      - pr2_dense_laser_snapshotter
+      - pr2_se_calibration_launch
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration-release.git
+      version: 1.0.11-3
+    source:
+      type: git
+      url: https://github.com/UNR-RoboticsResearchLab/pr2_calibration.git
+      version: kinetic-devel
   pr2_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_calibration` to `1.0.11-3`:

- upstream repository: https://github.com/UNR-RoboticsResearchLab/pr2_calibration.git
- release repository: https://github.com/UNR-RoboticsResearchLab/pr2_calibration-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## dense_laser_assembler

```
* updated CMakeLists to address warnings
* Contributors: David Feil-Seifer
```

## laser_joint_processor

- No changes

## laser_joint_projector

```
* updated CMakeLists to address warnings
* Contributors: David Feil-Seifer
```

## pr2_calibration

- No changes

## pr2_calibration_launch

- No changes

## pr2_dense_laser_snapshotter

- No changes

## pr2_se_calibration_launch

- No changes
