### PR TITLE
python3-catkin-lint is valid for debian buster

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5483,7 +5483,6 @@ python3-can:
 python3-catkin-lint:
   debian:
     '*': [python3-catkin-lint]
-    buster: null
     jessie: null
     stretch: null
   fedora: [python3-catkin_lint]


### PR DESCRIPTION
Looks like the package exists in debian buster:
https://packages.debian.org/buster/python3-catkin-lint

Didn't see anything specific about why it was entered as null initially in June: https://github.com/ros/rosdistro/pull/25055; probably we just didn't look further back than bullseye?