### PR TITLE
adding jlb_pid: 0.1.2 to 'foxy/distribution.yaml'

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1120,7 +1120,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/Juulbl/ros2-pid
-      version: 0.1.2
+      version: ros2
     status: maintained
   joint_state_publisher:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1733,7 +1733,7 @@ repositories:
       type: git
       url: https://gitlab.com/Juulbl/ros2-pid
       version: 0.1.0
-      status: developed
+      status: maintained
   plotjuggler:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1116,6 +1116,12 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: foxy
     status: maintained
+  jlb_pid:
+    doc:
+      type: git
+      url: https://gitlab.com/Juulbl/ros2-pid
+      version: 0.1.2
+    status: maintained
   joint_state_publisher:
     doc:
       type: git
@@ -1727,12 +1733,6 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: dashing
-    status: maintained
-  pid:
-    doc:
-      type: git
-      url: https://gitlab.com/Juulbl/ros2-pid
-      version: 0.1.0
     status: maintained
   plotjuggler:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1733,7 +1733,7 @@ repositories:
       type: git
       url: https://gitlab.com/Juulbl/ros2-pid
       version: 0.1.0
-      status: maintained
+    status: maintained
   plotjuggler:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1728,6 +1728,12 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: dashing
     status: maintained
+  pid:
+    doc:
+      type: git
+      url: https://gitlab.com/Juulbl/ros2-pid
+      version: 0.1.0
+      status: developed
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Added a PID control node to `foxy/distribution.yaml`
- repository: <https://gitlab.com/Juulbl/ros2-pid>
- distro file: foxy/distribution.yaml