### PR TITLE
sick_safetyscanners: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4676,7 +4676,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners-release.git
-      version: 1.0.5-2
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners` to `1.0.6-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners.git
- release repository: https://github.com/SICKAG/sick_safetyscanners-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.0.5-2`

## sick_safetyscanners

```
* checking if number beams is correct
* checking if if all data is present after parsing the header
* fix for seg fault in measurementdata
* Remove rqt_reconfigure dep
* Contributors: Lennart Puck, Rein Appeldoorn
```
