### PR TITLE
Add eiquadprog to melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2520,22 +2520,22 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: master
     status: developed
- eiquadprog:
-   doc:
-     type: git
-     url: https://github.com/stack-of-tasks/eiquadprog.git
-     version: devel
-   release:
-     tags:
-       release: release/melodic/{package}/{version}
-     url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
-     version: 1.2.2-1
-   source:
-     test_pull_requests: true
-     type: git
-     url: https://github.com/stack-of-tasks/eiquadprog.git
-     version: devel
-   status: maintained
+  eiquadprog:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
+      version: 1.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    status: maintained
   eml:
     release:
       tags:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2520,6 +2520,22 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: master
     status: developed
+ eiquadprog:
+   doc:
+     type: git
+     url: https://github.com/stack-of-tasks/eiquadprog.git
+     version: devel
+   release:
+     tags:
+       release: release/melodic/{package}/{version}
+     url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
+     version: 1.2.2-1
+   source:
+     test_pull_requests: true
+     type: git
+     url: https://github.com/stack-of-tasks/eiquadprog.git
+     version: devel
+   status: maintained
   eml:
     release:
       tags:


### PR DESCRIPTION
Release eiquadprog a third-party package from SoT on melodic
First package I released from the SoT : #25488 for reference