### PR TITLE
mrp2_common: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6062,6 +6062,27 @@ repositories:
       url: https://github.com/groove-x/mqtt_bridge.git
       version: master
     status: maintained
+  mrp2_common:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_common.git
+      version: melodic-devel
+    release:
+      packages:
+      - mrp2_common
+      - mrp2_description
+      - mrp2_navigation
+      - mrp2_slam
+      - mrp2_teleop
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_common-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_common.git
+      version: melodic-devel
+    status: maintained
   mrpt1:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_common` to `1.0.1-1`:

- upstream repository: https://github.com/milvusrobotics/mrp2_common.git
- release repository: https://github.com/milvusrobotics/mrp2_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## mrp2_slam

```
* version bump to 1.0.0
* package maintainers updated
* refactor: mrp2_slam --> mrp2_mapping
* Contributors: OnurDz
```
