### PR TITLE
Add eiquadprog to Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -930,22 +930,22 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: master
     status: developed
- eiquadprog:
-   doc:
-     type: git
-     url: https://github.com/stack-of-tasks/eiquadprog.git
-     version: devel
-   release:
-     tags:
-       release: release/melodic/{package}/{version}
-     url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
-     version: 1.2.2-1
-   source:
-     test_pull_requests: true
-     type: git
-     url: https://github.com/stack-of-tasks/eiquadprog.git
-     version: devel
-   status: maintained
+  eiquadprog:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
+      version: 1.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    status: maintained
   executive_smach:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -930,6 +930,22 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: master
     status: developed
+ eiquadprog:
+   doc:
+     type: git
+     url: https://github.com/stack-of-tasks/eiquadprog.git
+     version: devel
+   release:
+     tags:
+       release: release/melodic/{package}/{version}
+     url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
+     version: 1.2.2-1
+   source:
+     test_pull_requests: true
+     type: git
+     url: https://github.com/stack-of-tasks/eiquadprog.git
+     version: devel
+   status: maintained
   executive_smach:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -937,7 +937,7 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/melodic/{package}/{version}
+        release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
       version: 1.2.2-1
     source:


### PR DESCRIPTION
Release eiquadprog a third-party package from SoT on noetic
First package I released from the SoT : #25488 for reference