### PR TITLE
ros2_tracing: 1.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2414,7 +2414,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 1.0.2-1
+      version: 1.0.4-1
     source:
       test_abi: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `1.0.4-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.0.2-1`

## tracetools

```
* Allow disabling tracetools status app
* Contributors: Christophe Bedard, Ingo Lütkebohle, José Antonio Moral
```
