### PR TITLE
Add eiquadprog on foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -759,6 +759,22 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: master
     status: developed
+  eiquadprog:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
+      version: 1.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    status: maintained
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Release eiquadprog a third-party package from SoT on foxy
First package I released from the SoT : #25488 for reference