### PR TITLE
dnn_detect: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -705,6 +705,17 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: noetic-devel
     status: maintained
+  dnn_detect:
+    doc:
+      type: git
+      url: https://github.com/UbiquityRobotics/dnn_detect.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
+      version: 0.1.0-1
+    status: maintained
   dual_quaternions:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dnn_detect` to `0.1.0-1`:

- upstream repository: https://github.com/UbiquityRobotics/dnn_detect.git
- release repository: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## dnn_detect

```
* dnn_images_test.cpp - support opencv version 4
* Noetic support
* Contributors: Jim Vaughan, Rohan Agrawal, Tim
```
