### PR TITLE
dnn_detect: 0.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2647,7 +2647,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
-      version: 0.0.3-0
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/UbiquityRobotics/dnn_detect.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dnn_detect` to `0.1.0-1`:

- upstream repository: https://github.com/UbiquityRobotics/dnn_detect.git
- release repository: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.3-0`

## dnn_detect

```
* dnn_images_test.cpp - support opencv version 4
* Noetic support
* Contributors: Jim Vaughan, Rohan Agrawal, Tim
```
