### PR TITLE
people: 1.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2952,6 +2952,26 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: noetic-devel
     status: maintained
+  people:
+    doc:
+      type: git
+      url: https://github.com/wg-perception/people.git
+      version: noetic
+    release:
+      packages:
+      - people
+      - people_msgs
+      - people_velocity_tracker
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/OSUrobotics/people-release.git
+      version: 1.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/wg-perception/people.git
+      version: noetic
+    status: maintained
   perception_pcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.2.2-1`:

- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
