### PR TITLE
moose_desktop: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7667,7 +7667,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/moose_desktop-release.git
-      version: 0.1.0-3
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/moose-cpr/moose_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/moose-cpr/moose_desktop.git
- release repository: https://github.com/clearpath-gbp/moose_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-3`

## moose_desktop

- No changes

## moose_viz

```
* [moose_viz] Updated robot_state_publisher to robot_state_publisher_gui.
* Contributors: Tony Baltovski
```
