### PR TITLE
Implement fix to nlohmann-json-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5004,10 +5004,17 @@ nkf:
   rhel: [nkf]
   ubuntu: [nkf]
 nlohmann-json-dev:
-  debian: [nlohmann-json-dev]
+  debian: 
+    jessie: null
+    stretch: [nlohmann-json-dev]
+    buster: [nlohmann-json3-dev]
+    bullseye: [nlohmann-json3-dev]
+    sid: nlohmann-json3-dev
   gentoo: [dev-cpp/nlohmann_json]
   ubuntu:
-    '*': [nlohmann-json-dev]
+    bionic: [nlohmann-json-dev]
+    focal: [nlohmann-json3-dev]
+    groovy: [nlohmann-json3-dev]
     xenial: null
 nmap:
   archlinux: [nmap]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5004,12 +5004,12 @@ nkf:
   rhel: [nkf]
   ubuntu: [nkf]
 nlohmann-json-dev:
-  debian: 
-    jessie: null
-    stretch: [nlohmann-json-dev]
-    buster: [nlohmann-json3-dev]
+  debian:
     bullseye: [nlohmann-json3-dev]
-    sid: nlohmann-json3-dev
+    buster: [nlohmann-json3-dev]
+    jessie: null
+    sid: [nlohmann-json3-dev]
+    stretch: [nlohmann-json-dev]
   gentoo: [dev-cpp/nlohmann_json]
   ubuntu:
     bionic: [nlohmann-json-dev]


### PR DESCRIPTION
As proposed in issues #26454, change the newer Ubuntu variants to use `nlohmann-json3-dev`.

* Ubuntu [Focal, Groovy]: https://packages.ubuntu.com/search?keywords=nlohmann-json3-dev
* Ubuntu [Bionic]: https://packages.ubuntu.com/search?keywords=nlohmann-json-dev
* Debian [Stretch]: https://packages.debian.org/search?keywords=nlohmann-json&searchon=names&suite=all&section=all
* Debian [ Buster, Bullseye, Sid]: https://packages.debian.org/search?keywords=nlohmann-json3&searchon=names&suite=all&section=all

Closes #26454.

Co-Authored-By: Daniel Seifert
Signed-off-by: Michael Carroll <michael@openrobotics.org>