### PR TITLE
moose_desktop: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5862,6 +5862,24 @@ repositories:
       url: https://github.com/moose-cpr/moose.git
       version: master
     status: maintained
+  moose_desktop:
+    doc:
+      type: git
+      url: https://github.com/moose-cpr/moose_desktop.git
+      version: kinetic-devel
+    release:
+      packages:
+      - moose_desktop
+      - moose_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/moose_desktop-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/moose-cpr/moose_desktop.git
+      version: kinetic-devel
+    status: maintained
   moose_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose_desktop` to `0.1.1-1`:

- upstream repository: https://github.com/moose-cpr/moose_desktop.git
- release repository: https://github.com/clearpath-gbp/moose_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## moose_desktop

- No changes

## moose_viz

```
* [moose_viz] Updated robot_state_publisher to robot_state_publisher_gui.
* Contributors: Tony Baltovski
```
