### PR TITLE
ros1_bridge: 0.9.4-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1645,7 +1645,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.9.4-1
+      version: 0.9.4-2
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.9.4-2`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.9.4-1`

## ros1_bridge

```
* use hardcoded QoS (keep all, transient local) for /tf_static topic in dynamic_bridge (#282 <https://github.com/ros2/ros1_bridge/issues/282>)
* document explicitly passing the topic type to 'ros2 topic echo' (#279 <https://github.com/ros2/ros1_bridge/issues/279>)
```
