### PR TITLE
mrp2_simulator: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6176,6 +6176,20 @@ repositories:
       url: https://github.com/milvusrobotics/mrp2_common.git
       version: melodic-devel
     status: maintained
+  mrp2_simulator:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_simulator.git
+      version: melodic-devel
+    release:
+      packages:
+      - mrp2_gazebo
+      - mrp2_simulator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_simulator-release.git
+      version: 1.0.1-1
+    status: maintained
   mrpt1:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_simulator` to `1.0.1-1`:

- upstream repository: https://github.com/milvusrobotics/mrp2_simulator.git
- release repository: https://github.com/milvusrobotics/mrp2_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## mrp2_gazebo

```
* version bump to 1.0.0
* package maintainers updated
* remove controls
* default gazebo gui=false to save resources in development
* removed cartographer launch from gazebo launch
* added entry for launching cartographer node with simulation
* cmake install directories
* properly removed dependency: mrp2_hardware_gazebo package
* refactor: mrp2_control to mrp2_teleop
* removed: mrp2_hardware_gazebo package, dependency to mrp2_analyzer
* Contributors: Emir Cem Gezer, OnurDz
```

## mrp2_simulator

```
* version bump to 1.0.0
* package maintainers updated
* removed dependency: mrp2_hardware_gazebo package
* Contributors: OnurDz
```
