### PR TITLE
Revert "Adding heifu to documentation index for distro melodic"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3791,30 +3791,6 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
       version: melodic-devel
     status: maintained
-  heifu:
-    doc:
-      type: git
-      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
-      version: debian
-    release:
-      packages:
-      - heifu_bringup
-      - heifu_description
-      - heifu_diagnostic
-      - heifu_mavros
-      - heifu_msgs
-      - heifu_safety
-      - heifu_simple_waypoint
-      - heifu_tools
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/amferreiraBEV/heifu-release.git
-      version: 0.7.1-2
-    source:
-      type: git
-      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
-      version: debian
-    status: maintained
   heron:
     doc:
       type: git


### PR DESCRIPTION
ros/rosdistro#26336 introduced packages that do not build and have private, unreleased dependencies.

Signed-off-by: Michael Carroll <michael@openrobotics.org>