### PR TITLE
contracts_lite_vendor: 0.4.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -542,7 +542,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-safety/contracts_lite_vendor-release.git
-      version: 0.3.3-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-safety/contracts_lite_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `contracts_lite_vendor` to `0.4.0-1`:

- upstream repository: https://github.com/ros-safety/contracts_lite_vendor.git
- release repository: https://github.com/ros-safety/contracts_lite_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.3.3-1`

## contracts_lite_vendor

```
* Library update: (#5 <https://github.com/ros-safety/contracts_lite/pull/5>)
  
    * Move-optimize comment string handling
    * Make string serializer for contract violation objects static
    * Move-optimize return status object in enforcement macro
    * Add CONTRACT_COMMENT macro and update readme
  
```
