### PR TITLE
computer_status_msgs: 2.0.0 in {kinetic, melodic, noetic}/distribution.yaml [non-bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2078,6 +2078,22 @@ repositories:
       url: https://github.com/ros/common_tutorials.git
       version: indigo-devel
     status: maintained
+  computer_status_msgs:
+    doc:
+      type: git
+      url: https://github.com/plusone-robotics/computer_status_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/130s/computer_status_msgs-release.git
+      version: 2.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/plusone-robotics/computer_status_msgs.git
+      version: master
+    status: maintained
   control_msgs:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1689,6 +1689,22 @@ repositories:
       url: https://github.com/ros-gbp/common_tutorials-release.git
       version: 0.1.11-0
     status: maintained
+  computer_status_msgs:
+    doc:
+      type: git
+      url: https://github.com/plusone-robotics/computer_status_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/130s/computer_status_msgs-release.git
+      version: 2.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/plusone-robotics/computer_status_msgs.git
+      version: master
+    status: maintained
   control_box_rst:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -462,6 +462,22 @@ repositories:
       url: https://github.com/ros/common_tutorials.git
       version: noetic-devel
     status: maintained
+  computer_status_msgs:
+    doc:
+      type: git
+      url: https://github.com/plusone-robotics/computer_status_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/130s/computer_status_msgs-release.git
+      version: 2.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/plusone-robotics/computer_status_msgs.git
+      version: master
+    status: maintained
   control_box_rst:
     doc:
       type: git


### PR DESCRIPTION
Initial release of package(s) in repository `computer_status_msgs` to `2.0.0-2`:
- upstream repository: https://github.com/plusone-robotics/computer_status_msgs.git
- release repository: https://github.com/130s/computer_status_msgs-release.git
- distro file: `{kinetic, melodic, noetic}/distribution.yaml`
- bloom version: `0.9.8`  (bloom failed to open a pull request to rosdistro)
- previous version for package: None


Related discussion https://github.com/PR2/pr2_common/issues/286#issuecomment-695975839