### PR TITLE
fetch_tools: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1023,6 +1023,17 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
       version: 0.6.1-1
+  fetch_tools:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_tools.git
+      version: ros1
+    status: maintained
   filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.3.1-1`:

- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## fetch_tools

```
* Update dependencies from py2 to py3
* Contributors: Eric Relson
```
