### PR TITLE
realsense2_camera: 3.1.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2127,7 +2127,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `3.1.1-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `3.1.0-1`

## realsense2_camera

```
* fix bug: Conversion from milliseconds to nanoseconds.
  enable use of parameter: use_sim_time.
* various fixes for canonical ROS2
* Contributors: AustinDeric, doronhi
```

## realsense2_node

```
* remove uneeded realsense_camera_msgs from package.xml
* various fixes for canonical ROS2
* Contributors: AustinDeric
```

## realsense_camera_msgs

- No changes
