### PR TITLE
filters: 1.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1032,7 +1032,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.9.0-1
+      version: 1.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.9.1-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.9.0-1`

## filters

```
* make FilterBase::getName() const
* Making FilterBase::getParam const
* narrow down required boost dependencies (#40 <https://github.com/ros/filters/issues/40>)
* [noetic] deprecate h for hpp (#34 <https://github.com/ros/filters/issues/34>)
* [noetic] Delete unused code (#33 <https://github.com/ros/filters/issues/33>)
* Bump CMake version to avoid CMP0048
* Contributors: Alejandro Hernández Cordero, Mikael Arguedas, Shane Loretz, Tully Foote
```
