### PR TITLE
foxy: drop ros_cb

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2481,32 +2481,6 @@ repositories:
       url: https://github.com/ros-industrial/ros_canopen.git
       version: dashing-devel
     status: developed
-  ros_cb:
-    doc:
-      type: git
-      url: https://github.com/jediofgever/ROS_CB.git
-      version: master
-    release:
-      packages:
-      - chiconybot
-      - chiconybot_bringup
-      - chiconybot_cartographer
-      - chiconybot_description
-      - chiconybot_gazebo
-      - chiconybot_msgs
-      - chiconybot_navigation2
-      - chiconybot_node
-      - chiconybot_teleop
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/jediofgever/ROS_CB-release.git
-      version: 0.0.2-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/jediofgever/ROS_CB.git
-      version: master
-    status: developed
   ros_environment:
     doc:
       type: git


### PR DESCRIPTION
* https://github.com/jediofgever/ROS_CB-release.git isn't available causing rosdistro_build_cache
  to fail on many chiconybot* components
* https://github.com/ros/rosdistro/commit/f0193fb9a26b4260fb853e355198f50e3c2d2a4d

Signed-off-by: Martin Jansa <martin.jansa@lge.com>