### PR TITLE
rc_genicam_api: 2.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8751,7 +8751,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.3.4-1
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.4.1-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2.3.4-1`

## rc_genicam_api

```
* Enabled building for ROS focal on gitlab
```
