### PR TITLE
rmw_fastrtps: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1576,7 +1576,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.0.0-1`

## rmw_fastrtps_cpp

```
* Add tests for native entity getters. (#439 <https://github.com/ros2/rmw_fastrtps/issues/439>)
* Avoid deadlock if graph update fails. (#438 <https://github.com/ros2/rmw_fastrtps/issues/438>)
* Contributors: Michel Hidalgo
```

## rmw_fastrtps_dynamic_cpp

```
* Add tests for native entity getters. (#439 <https://github.com/ros2/rmw_fastrtps/issues/439>)
* Avoid deadlock if graph update fails. (#438 <https://github.com/ros2/rmw_fastrtps/issues/438>)
* Contributors: Michel Hidalgo
```

## rmw_fastrtps_shared_cpp

```
* Inject faults on __rmw_publish() and run_listener_thread() call. (#441 <https://github.com/ros2/rmw_fastrtps/issues/441>)
* Update gid API return codes. (#440 <https://github.com/ros2/rmw_fastrtps/issues/440>)
* Update graph API return codes. (#436 <https://github.com/ros2/rmw_fastrtps/issues/436>)
* Contributors: Michel Hidalgo
```
