### PR TITLE
sdhlibrary_cpp: 0.2.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4751,6 +4751,21 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.3.1-3
+  sdhlibrary_cpp:
+    doc:
+      type: git
+      url: https://github.com/ipab-slmc/SDHLibrary-CPP.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipab-slmc/SDHLibrary-CPP-release.git
+      version: 0.2.10-1
+    source:
+      type: git
+      url: https://github.com/ipab-slmc/SDHLibrary-CPP.git
+      version: master
+    status: maintained
   sensehat_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdhlibrary_cpp` to `0.2.10-1`:

- upstream repository: https://github.com/ipab-slmc/SDHLibrary-CPP.git
- release repository: https://github.com/ipab-slmc/SDHLibrary-CPP-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## sdhlibrary_cpp

```
* Create LICENSE
* change license to Apache 2.0
* export library
* comment unused parameters
* remove extra semicolon
* fix arguments for formatted printing (-Wformat=)
* demo executables
* fix CAN handler casting
* deactivate undefined 'NTCAN_ERROR_NO_BAUDRATE' and 'NTCAN_ERROR_LOM'
* CMake support
* remove deprecated dynamic exception specifications (-Wdeprecated)
* fix ostream comparison
* SDHLibrary-CPP 0.0.2.10
* Contributors: Christian Rauch
```
