### PR TITLE
rmw_connext: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1522,7 +1522,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `3.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.3.0-1`

## rmw_connext_cpp

```
* Updated returns on rmw_take_serialized_with_info(). (#462 <https://github.com/ros2/rmw_connext/issues/462>)
* Update gid API return codes. (#461 <https://github.com/ros2/rmw_connext/issues/461>)
* Contributors: Jose Tomas Lorente, Michel Hidalgo
```

## rmw_connext_shared_cpp

```
* Update graph API return codes. (#459 <https://github.com/ros2/rmw_connext/issues/459>)
* Contributors: Michel Hidalgo
```
