### PR TITLE
leo_description: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5134,7 +5134,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_description-release.git
-      version: 0.3.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_description` to `1.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_description.git
- release repository: https://github.com/fictionlab-gbp/leo_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.3.0-1`

## leo_description

```
* Added gazebo references
* Added camera_optical_frame link which uses camera coordinate convention
* Added launch files for publishing robot state
* Added low-poly outline models for collision geometry
* Added physical properties for all links and revolute joints
* Added joints for rockers and antenna
* Replaced meshes with more optimized ones
```
