### PR TITLE
rmw_cyclonedds: 0.18.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1540,7 +1540,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.17.0-3
+      version: 0.18.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.18.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.17.0-3`

## rmw_cyclonedds_cpp

```
* Update gid API return codes. (#244 <https://github.com/ros2/rmw_cyclonedds/issues/244>)
* Update graph API return codes. (#243 <https://github.com/ros2/rmw_cyclonedds/issues/243>)
* Check for message_info on take where appropriate. (#245 <https://github.com/ros2/rmw_cyclonedds/issues/245>)
  Fix for regression introduced in #241 <https://github.com/ros2/rmw_cyclonedds/issues/241>.
* Contributors: Michel Hidalgo
```
