### PR TITLE
add key for python-twilio-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4915,6 +4915,16 @@ python-trimesh-pip:
   ubuntu:
     pip:
       packages: [trimesh]
+python-twilio-pip:
+  debian:
+    pip:
+      packages: [twilio]
+  fedora:
+    pip:
+      packages: [twilio]
+  ubuntu:
+    pip:
+      packages: [twilio]
 python-twisted-bin:
   arch: [python2-twisted]
   debian: [python-twisted-bin]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4915,16 +4915,24 @@ python-trimesh-pip:
   ubuntu:
     pip:
       packages: [trimesh]
-python-twilio-pip:
+python-twilio:
   debian:
-    pip:
-      packages: [twilio]
-  fedora:
-    pip:
-      packages: [twilio]
+    buster: [python-twilio]
+    jessie:
+      pip:
+        packages: [twilio]
+    stretch:
+      pip:
+        packages: [twilio]
+  fedora: [python3-twilio]
   ubuntu:
-    pip:
-      packages: [twilio]
+    '*': [python3-twilio]
+    trusty:
+      pip:
+        packages: [twilio]
+    xenial:
+      pip:
+        packages: [twilio]
 python-twisted-bin:
   arch: [python2-twisted]
   debian: [python-twisted-bin]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4915,10 +4915,6 @@ python-trimesh-pip:
   ubuntu:
     pip:
       packages: [trimesh]
-python3-twilio:
-  debian: [python3-twilio]
-  fedora: [python3-twilio]
-  ubuntu: [python3-twilio]
 python-twilio-pip:
   debian:
     pip:
@@ -6670,6 +6666,10 @@ python3-trimesh-pip:
   ubuntu:
     pip:
       packages: [trimesh]
+python3-twilio:
+  debian: [python3-twilio]
+  fedora: [python3-twilio]
+  ubuntu: [python3-twilio]
 python3-twisted:
   arch: [python-twisted]
   debian: [python3-twisted]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4915,24 +4915,20 @@ python-trimesh-pip:
   ubuntu:
     pip:
       packages: [trimesh]
-python-twilio:
-  debian:
-    buster: [python-twilio]
-    jessie:
-      pip:
-        packages: [twilio]
-    stretch:
-      pip:
-        packages: [twilio]
+python3-twilio:
+  debian: [python3-twilio]
   fedora: [python3-twilio]
+  ubuntu: [python3-twilio]
+python-twilio-pip:
+  debian:
+    pip:
+      packages: [twilio]
+  fedora:
+    pip:
+      packages: [twilio]
   ubuntu:
-    '*': [python3-twilio]
-    trusty:
-      pip:
-        packages: [twilio]
-    xenial:
-      pip:
-        packages: [twilio]
+    pip:
+      packages: [twilio]
 python-twisted-bin:
   arch: [python2-twisted]
   debian: [python-twisted-bin]


### PR DESCRIPTION
adding `rosdep` key for `twilio` 
:point_right: https://pypi.org/project/twilio/