### PR TITLE
mrp2_desktop: 0.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6184,6 +6184,20 @@ repositories:
       url: https://github.com/milvusrobotics/mrp2_common.git
       version: melodic-devel
     status: maintained
+  mrp2_desktop:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_desktop.git
+      version: melodic-devel
+    release:
+      packages:
+      - mrp2_desktop
+      - mrp2_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_desktop-release.git
+      version: 0.2.2-1
+    status: maintained
   mrp2_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_desktop` to `0.2.2-1`:

- upstream repository: https://github.com/milvusrobotics/mrp2_desktop.git
- release repository: https://github.com/milvusrobotics/mrp2_desktop-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## mrp2_desktop

```
* Updated package informations
* Contributors: Akif
```

## mrp2_viz

```
* Updated package informations
* Contributors: Akif
```
