### PR TITLE
leo_gazebo: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5140,6 +5140,21 @@ repositories:
       url: https://github.com/LeoRover/leo_description.git
       version: master
     status: maintained
+  leo_gazebo:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_gazebo.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_gazebo-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_gazebo.git
+      version: master
+    status: maintained
   leo_viz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_gazebo` to `0.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_gazebo.git
- release repository: https://github.com/fictionlab-gbp/leo_gazebo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## leo_gazebo

```
* Added marsyard world and marsyard terrain model
* Initial package version
```
