### PR TITLE
rosidl: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1863,7 +1863,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 1.1.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.1.0-1`

## rosidl_adapter

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Fix the declared language for a few packages (#530 <https://github.com/ros2/rosidl/issues/530>)
* Contributors: Scott K Logan
```

## rosidl_generator_cpp

```
* Add to_yaml() function for C++ messages (#527 <https://github.com/ros2/rosidl/issues/527>)
* Contributors: Devin Bonnie, Dirk Thomas
```

## rosidl_parser

- No changes

## rosidl_runtime_c

```
* Fix the declared language for a few packages (#530 <https://github.com/ros2/rosidl/issues/530>)
* Add fault injection macros and test (#509 <https://github.com/ros2/rosidl/issues/509>)
* Contributors: Scott K Logan, brawner
```

## rosidl_runtime_cpp

```
* Add to_yaml() function for C++ messages (#527 <https://github.com/ros2/rosidl/issues/527>)
* Contributors: Devin Bonnie, Dirk Thomas
```

## rosidl_typesupport_interface

```
* Update Quality Declaration to QL 1 for rosidl_typesupport_interface (#519 <https://github.com/ros2/rosidl/issues/519>)
* Contributors: brawner
```

## rosidl_typesupport_introspection_c

```
* Fix get_function and get_const_function semantics for arrays (#531 <https://github.com/ros2/rosidl/issues/531>)
* Fix the declared language for a few packages (#530 <https://github.com/ros2/rosidl/issues/530>)
* Contributors: Ivan Santiago Paunovic, Scott K Logan
```

## rosidl_typesupport_introspection_cpp

- No changes
