### PR TITLE
rmw_cyclonedds: 0.18.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1540,7 +1540,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.18.0-1
+      version: 0.18.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.18.1-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.18.0-1`

## rmw_cyclonedds_cpp

```
* Fix array get_function semantics (#248 <https://github.com/ros2/rmw_cyclonedds/issues/248>)
* Update service/client construction/destruction API return codes. (#247 <https://github.com/ros2/rmw_cyclonedds/issues/247>)
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo
```
