### PR TITLE
rmw_fastrtps: 3.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1576,7 +1576,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `3.1.1-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `3.1.0-1`

## rmw_fastrtps_cpp

```
* Make service/client construction/destruction implementation compliant (#445 <https://github.com/ros2/rmw_fastrtps/issues/445>)
* Make sure type can be unregistered successfully (#437 <https://github.com/ros2/rmw_fastrtps/issues/437>)
* Contributors: Barry Xu, Michel Hidalgo
```

## rmw_fastrtps_dynamic_cpp

```
* Fix array get_function semantics (#448 <https://github.com/ros2/rmw_fastrtps/issues/448>)
* Make service/client construction/destruction implementation compliant (#445 <https://github.com/ros2/rmw_fastrtps/issues/445>)
* Make sure type can be unregistered successfully (#437 <https://github.com/ros2/rmw_fastrtps/issues/437>)
* Contributors: Barry Xu, Ivan Santiago Paunovic, Michel Hidalgo
```

## rmw_fastrtps_shared_cpp

```
* Add tests for RMW QoS to DDS attribute conversion. (#449 <https://github.com/ros2/rmw_fastrtps/issues/449>)
* Make service/client construction/destruction implementation compliant (#445 <https://github.com/ros2/rmw_fastrtps/issues/445>)
* Contributors: Michel Hidalgo
```
