### PR TITLE
leo_gazebo: 0.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5149,7 +5149,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_gazebo-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_gazebo` to `0.1.1-1`:

- upstream repository: https://github.com/LeoRover/leo_gazebo.git
- release repository: https://github.com/fictionlab-gbp/leo_gazebo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-1`

## leo_gazebo

```
* Fixed binary release build
* Added gazebo to dependencies
```
