### PR TITLE
Adding rosaic to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9726,6 +9726,12 @@ repositories:
       url: https://github.com/facontidavide/ros_type_introspection.git
       version: master
     status: developed
+  rosaic:
+    doc:
+      type: git
+      url: https://github.com/septentrio-gnss/rosaic
+      version: master
+    status: maintained
   rosauth:
     doc:
       type: git


### PR DESCRIPTION
Would be great if rosaic could be indexed and documented on ros.org.