### PR TITLE
[dep] Add AWS CLI

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -225,6 +225,12 @@ avrdude:
   fedora: [avrdude]
   gentoo: [dev-embedded/avrdude]
   ubuntu: [avrdude]
+awscli:
+  arch: [aws-cli]
+  debian: [awscli]
+  fedora: [awscli]
+  gentoo: [dev-python/awscli]
+  ubuntu: [awscli]
 babeltrace:
   debian: [babeltrace]
   fedora: [babeltrace]


### PR DESCRIPTION
Rationale
- arch https://www.archlinux.org/packages/community/any/aws-cli/
- debian https://packages.debian.org/jessie/awscli
- fedora https://src.fedoraproject.org/rpms/awscli
- gentoo https://packages.gentoo.org/packages/dev-python/awscli
- Ubuntu xenial onward https://packages.ubuntu.com/xenial/admin/awscli