### PR TITLE
cloudwatch_common: 1.1.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -457,7 +457,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.1.3-1
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.1.4-1`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.1.3-1`

## cloudwatch_logs_common

```
* Correct seconds to milliseconds (#59 <https://github.com/aws-robotics/cloudwatch-common/issues/59>)
* Add AWS logging to batch tests (#58 <https://github.com/aws-robotics/cloudwatch-common/issues/58>)
* Allow user to automatically delete CloudWatch logs in batch that are > 14 days old (#56 <https://github.com/aws-robotics/cloudwatch-common/issues/56>)
  * move docstring and don't break loop
  * call fileUploadComplete
  * modify struct and add tests
  * add tests and change 2 week wording to old
  * Add lock to discard stale data container
  * extend stale data protection
  * remove setter
  * Reduce lock_guard scope
* add error for invalid log batch (#52 <https://github.com/aws-robotics/cloudwatch-common/issues/52>)
  * add error for invalid log batch
  * modify logic
  * change to long instead of time
  * fix syntax
  * separate to function
  * change function order
  * add unit test
  * Add file manager test to CMakeList
  * file manager unit test
  * typo
  * add test log file manager class
  * modify filetest class and add unit test
  * add test publisher
  * debug
  * add validate batch function:
  * organize tuple
  * for loop to add valid data
  * pair
  * new priority queue
  * back to tuple
  * add outdated check
  * modify logic
  * modify test and pq
  * modify tests
  * add readbatch mock
  * add headers
  * remove data token
  * separate to new log_batch test file
  * add log comparison function
  * update test
  * fix typos
  * update batch test
  * remove outdated, fix timestamp
  * add > 24 hour log
  * remove utility
  * fix typo
  * changes based on review
  * modify macro
  * modify test
  * modify log_data
  * typo
  * add testfilemanagerstrategy
  * change logfile to datamanager & more
  * mock read function
  * update read and write functions
  * modify tests based on review
  * add batch_data validation
  * remove unnecessary headers
  * add test fixture
  * update test fixtures
  * updates based on review
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Jesse Ikawa, Miaofei Mei, Nick Burek, Ragha Prasad
```

## cloudwatch_metrics_common

```
* Allow user to automatically delete CloudWatch logs in batch that are > 14 days old (#56 <https://github.com/aws-robotics/cloudwatch-common/issues/56>)
  * move docstring and don't break loop
  * call fileUploadComplete
  * modify struct and add tests
  * add tests and change 2 week wording to old
  * Add lock to discard stale data container
  * extend stale data protection
  * remove setter
  * Reduce lock_guard scope
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Add support for Cloudwatch MetricDatum StatisticSet (#48 <https://github.com/aws-robotics/cloudwatch-common/issues/48>)
  * add support for cloudwatch metrics' StatisticSet
  * add test for metricObjectToDatum()
  * address PR comments
  * take into consideration that MetricDatum's Value and StatisticValues are mutually exclusive
  * add docstring to MetricObject constructors
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Jesse Ikawa, Miaofei Mei, Nick Burek, Ragha Prasad
```

## dataflow_lite

```
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Contributors: Miaofei Mei, Nick Burek, Ragha Prasad
```

## file_management

```
* Add AWS logging to batch tests (#58 <https://github.com/aws-robotics/cloudwatch-common/issues/58>)
* Allow user to automatically delete CloudWatch logs in batch that are > 14 days old (#56 <https://github.com/aws-robotics/cloudwatch-common/issues/56>)
  * move docstring and don't break loop
  * call fileUploadComplete
  * modify struct and add tests
  * add tests and change 2 week wording to old
  * Add lock to discard stale data container
  * extend stale data protection
  * remove setter
  * Reduce lock_guard scope
* Bumping version to match bloom release (#51 <https://github.com/aws-robotics/cloudwatch-common/issues/51>)
  Bumping version to 1.1.3
* Fix linting issues found by clang-tidy 6.0 (#50 <https://github.com/aws-robotics/cloudwatch-common/issues/50>)
  * clang-tidy fixes
  * revert explicit constructor declarations to maintain API compatbility
  * clang-tidy linting issues fixed manually
  * fix unit tests build break
* Increase package version numbers to 1.1.2 (#44 <https://github.com/aws-robotics/cloudwatch-common/issues/44>)
* Fixes a bug where we did not null check the result of getting the HOM… (#43 <https://github.com/aws-robotics/cloudwatch-common/issues/43>)
  Fixes a bug where we did not null check the result of getting the HOME env variable and also switches to create_directories instead of create_directory so that it doesn't SIGABRT when asked to create multiple levels of a directory.
* Contributors: Jesse Ikawa, Miaofei Mei, Nick Burek, Ragha Prasad
```
