### PR TITLE
[dep] Add wireshark

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6301,6 +6301,10 @@ wireshark:
   fedora: [wireshark]
   gentoo: [net-analyzer/wireshark]
   ubuntu: [wireshark]
+wireshark-common:
+  debian: [wireshark-common]
+  fedora: [wireshark-cli]
+  ubuntu: [wireshark-common]
 wkhtmltopdf:
   arch: [wkhtmltopdf]
   debian: [wkhtmltopdf]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6296,6 +6296,11 @@ wireless-tools:
   fedora: [wireless-tools]
   gentoo: [net-wireless/wireless-tools]
   ubuntu: [wireless-tools]
+wireshark:
+  debian: [wireshark]
+  fedora: [wireshark]
+  gentoo: [net-analyzer/wireshark]
+  ubuntu: [wireshark]
 wkhtmltopdf:
   arch: [wkhtmltopdf]
   debian: [wkhtmltopdf]


### PR DESCRIPTION
wireshark 
- arch https://wiki.archlinux.org/index.php/Wireshark says qt and cli are separate package, while those in other distros likely bundle both gui and cli. So I'm not sure what to do with arch, hence not added.
- debian jessie https://packages.debian.org/jessie/wireshark
- fedora https://src.fedoraproject.org/rpms/wireshark
- gentoo https://packages.gentoo.org/packages/net-analyzer/wireshark
- Ubuntu xenial https://packages.ubuntu.com/search?keywords=wireshark

wireshark common module
- fedora https://fedora.pkgs.org/30/fedora-x86_64/wireshark-cli-3.0.1-1.fc30.x86_64.rpm.html  (Couldn't find any on fedoraproject.org)
- debian.org/jessie https://packages.debian.org/jessie/wireshark-common
- Ubuntu https://packages.ubuntu.com/xenial/net/wireshark-common