### PR TITLE
rmw_fastrtps: 3.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1576,7 +1576,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `3.1.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.1.1-1`

## rmw_fastrtps_cpp

```
* Updated publisher/subscription allocation and wait set API return codes (#443 <https://github.com/ros2/rmw_fastrtps/issues/443>)
* Added rmw_logging tests (#442 <https://github.com/ros2/rmw_fastrtps/issues/442>)
* Contributors: Alejandro Hernández Cordero
```

## rmw_fastrtps_dynamic_cpp

```
* Updated publisher/subscription allocation and wait set API return codes (#443 <https://github.com/ros2/rmw_fastrtps/issues/443>)
* Added rmw_logging tests (#442 <https://github.com/ros2/rmw_fastrtps/issues/442>)
* Contributors: Alejandro Hernández Cordero
```

## rmw_fastrtps_shared_cpp

```
* Updated publisher/subscription allocation and wait set API return codes (#443 <https://github.com/ros2/rmw_fastrtps/issues/443>)
* Added rmw_logging tests (#442 <https://github.com/ros2/rmw_fastrtps/issues/442>)
* Contributors: Alejandro Hernández Cordero
```
