### PR TITLE
remote_rosbag_record: 0.0.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11622,7 +11622,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/remote_rosbag_record.git


### PR DESCRIPTION
Increasing version of package(s) in repository `remote_rosbag_record` to `0.0.3-1`:

- upstream repository: https://github.com/yoshito-n-students/remote_rosbag_record.git
- release repository: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.2-1`

## remote_rosbag_record

```
* Avoid an exception from class_loader when record node finishes
```
