### PR TITLE
fcl: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1033,6 +1033,17 @@ repositories:
       url: https://github.com/iron-ox/fadecandy_ros.git
       version: master
     status: developed
+  fcl:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/fcl-release.git
+      version: 0.6.1-1
+    source:
+      type: git
+      url: https://github.com/flexible-collision-library/fcl.git
+      version: master
+    status: maintained
   fcl_catkin:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.6.1-1`:

- upstream repository: https://github.com/flexible-collision-library/fcl.git
- release repository: https://github.com/ros-gbp/fcl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
