### PR TITLE
remote_rosbag_record: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3464,7 +3464,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
-      version: 0.0.2-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/yoshito-n-students/remote_rosbag_record.git


### PR DESCRIPTION
Increasing version of package(s) in repository `remote_rosbag_record` to `0.0.4-1`:

- upstream repository: https://github.com/yoshito-n-students/remote_rosbag_record.git
- release repository: https://github.com/yoshito-n-students/remote_rosbag_record-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.2-1`

## remote_rosbag_record

```
* Install joy_listener
* Change cmake minimum version from 2.8.3 to 3.0.2 to suppress CMP0048 warning
```
