### PR TITLE
euslime: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2618,7 +2618,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/jsk-ros-pkg/euslime-release.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/euslime.git


### PR DESCRIPTION
Increasing version of package(s) in repository `euslime` to `1.1.0-1`:

- upstream repository: https://github.com/jsk-ros-pkg/euslime.git
- release repository: https://github.com/jsk-ros-pkg/euslime-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.0.2-1`

## euslime

```
* Major updates in python and toplevel
* Better support for packages
* Better TAGS functionality
* Major updates to test suite
* Bugfix
* Contributors: Guilherme Affonso
```
