### PR TITLE
v4l2_camera: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3598,7 +3598,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
-      version: 0.2.1-3
+      version: 0.3.0-1
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.3.0-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.2.1-3`

## v4l2_camera

```
* Publishing is done on private topics to enable remapping of the namespace (!22)
* CameraInfo is published in intra-process communication mode (!24)
* Added parameter descriptions (!25)
* Contributors: Christian Rauch, Marcus M. Scheunemann, Sander G. van Dijk
```
