### PR TITLE
cob_common: 0.7.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1657,7 +1657,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.3-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.7.2-1`

## cob_actions

```
* Merge pull request #288 <https://github.com/ipa320/cob_common/issues/288> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_common

```
* Merge pull request #288 <https://github.com/ipa320/cob_common/issues/288> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_description

```
* Merge pull request #288 <https://github.com/ipa320/cob_common/issues/288> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #287 <https://github.com/ipa320/cob_common/issues/287> from fmessmer/fix/include_common_xacro
  add missing common xacro includes
* more missing common.xacro for intertial macros
* missing common.xacro for default intertia
* Merge pull request #279 <https://github.com/ipa320/cob_common/issues/279> from fmessmer/fix_xacro_test
  [travis] xacro test
* add ROS_DISTRO condition for --inorder
* Merge pull request #284 <https://github.com/ipa320/cob_common/issues/284> from fmessmer/left_right_heads
  support various available head variants
* correct property values for head_cad version
* prepare structure
* use property_blocks for joint origins
* Contributors: Felix Messmer, fmessmer, ipa-mjp
```

## cob_msgs

```
* Merge pull request #288 <https://github.com/ipa320/cob_common/issues/288> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_srvs

```
* Merge pull request #288 <https://github.com/ipa320/cob_common/issues/288> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## raw_description

```
* Merge pull request #288 <https://github.com/ipa320/cob_common/issues/288> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #287 <https://github.com/ipa320/cob_common/issues/287> from fmessmer/fix/include_common_xacro
  add missing common xacro includes
* more missing common.xacro for intertial macros
* Merge pull request #279 <https://github.com/ipa320/cob_common/issues/279> from fmessmer/fix_xacro_test
  [travis] xacro test
* comment ur_description bits
* Contributors: Felix Messmer, fmessmer
```
