### PR TITLE
cob_gazebo_plugins: 0.7.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1795,7 +1795,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_gazebo_plugins-release.git
-      version: 0.7.4-1
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_gazebo_plugins` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_gazebo_plugins.git
- release repository: https://github.com/ipa320/cob_gazebo_plugins-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.7.4-1`

## cob_gazebo_plugins

```
* Merge pull request #47 <https://github.com/ipa320/cob_gazebo_plugins/issues/47> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_ros_control

```
* Merge pull request #47 <https://github.com/ipa320/cob_gazebo_plugins/issues/47> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #44 <https://github.com/ipa320/cob_gazebo_plugins/issues/44> from MatthiasNieuwenhuisen/fix_joint_filtering_segfault
  Fix wrong array index occuring if using joint filtering
* Fix wrong array index occuring if using joint filtering
* Contributors: Felix Messmer, Matthias Nieuwenhuisen, fmessmer
```
