### PR TITLE
nmea_navsat_driver: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2768,6 +2768,22 @@ repositories:
       url: https://github.com/ros-drivers/nmea_msgs.git
       version: master
     status: maintained
+  nmea_navsat_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
+      version: 0.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: master
+    status: maintained
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `0.6.0-1`:

- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## nmea_navsat_driver

```
* Update to Python3 for ROS Noetic (#113 <https://github.com/ros-drivers/nmea_navsat_driver/issues/113>)
* Fix valid_fix check (#111 <https://github.com/ros-drivers/nmea_navsat_driver/issues/111>) (#112 <https://github.com/ros-drivers/nmea_navsat_driver/issues/112>)
* Add Sphinx and rosdoc configuration (#93 <https://github.com/ros-drivers/nmea_navsat_driver/issues/93>)
* Add missing dependency on tf (#102 <https://github.com/ros-drivers/nmea_navsat_driver/issues/102>)
* Trim whitespace in nmea_topic_driver (#98 <https://github.com/ros-drivers/nmea_navsat_driver/issues/98>)
* Use a regex to split tokens in parser (#87 <https://github.com/ros-drivers/nmea_navsat_driver/issues/87>)
* Fix PEP8 Violations (#68 <https://github.com/ros-drivers/nmea_navsat_driver/issues/68>)
* Remove automatic prefixing of forward slash to frame_id. (#33 <https://github.com/ros-drivers/nmea_navsat_driver/issues/33>/#57 <https://github.com/ros-drivers/nmea_navsat_driver/issues/57>)
* Add support for IMU aided GPS systems (#30 <https://github.com/ros-drivers/nmea_navsat_driver/issues/30>/#58 <https://github.com/ros-drivers/nmea_navsat_driver/issues/58>)
* Publish heading (#25 <https://github.com/ros-drivers/nmea_navsat_driver/issues/25>)
* Improve Covariance Estimation (#46 <https://github.com/ros-drivers/nmea_navsat_driver/issues/46>)
* Remove Mean Sea Level compensation (#36 <https://github.com/ros-drivers/nmea_navsat_driver/issues/36>)
* Contributors: Ed Venator, Maximilian von Unwerth
```
