### PR TITLE
dynamixel-workbench: 2.2.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -2828,13 +2828,11 @@ repositories:
       - dynamixel_workbench
       - dynamixel_workbench_controllers
       - dynamixel_workbench_operators
-      - dynamixel_workbench_single_manager
-      - dynamixel_workbench_single_manager_gui
       - dynamixel_workbench_toolbox
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
-      version: 2.0.0-0
+      version: 2.2.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench` to `2.2.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.0.0-0`

## dynamixel_workbench

```
* Added XW540
* Bugs fixed, typos revised
* Contributors: Ryan Shim, Yutaka Kondo, T-Kitajima, Nico Zevallos, Madhur Deep Jain, Will Son, YongHo Na
```

## dynamixel_workbench_controllers

```
* Added XW540
* Bugs fixed, typos revised
* Contributors: Ryan Shim, Yutaka Kondo, T-Kitajima, Nico Zevallos, Madhur Deep Jain, Will Son, YongHo Na
```

## dynamixel_workbench_operators

```
* Added XW540
* Bugs, typos fixed
* Contributors: Ryan Shim, Yutaka Kondo, T-Kitajima, Nico Zevallos, Madhur Deep Jain, Will Son, YongHo Na
```

## dynamixel_workbench_toolbox

```
* Added XW540
* Bugs fixed, typos revised
* Contributors: Ryan Shim, Yutaka Kondo, T-Kitajima, Nico Zevallos, Madhur Deep Jain, Will Son, YongHo Na
```
