### PR TITLE
dynamixel-workbench-msgs: 2.0.1-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2345,7 +2345,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
-      version: 2.0.0-0
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel-workbench-msgs` to `2.0.1-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `2.0.0-0`

## dynamixel_workbench_msgs

```
* Updated the package info only
* Contributors: Will Son
```
