### PR TITLE
robotis_manipulator: 1.1.0-0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12116,7 +12116,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_manipulator` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.0-0`

## robotis_manipulator

```
* supports Doxygen
* added getTrajectory function
* added torque coefficient
* change return type of funtions from void to bool
* added dynamics solving options
* fixed several bugs
* Contributors: Hye-Jong KIM, Yong-Ho Na, Tomoya Yamanokuchi
```
