### PR TITLE
robotis_manipulator: 1.1.0-0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9315,7 +9315,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/robotis_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotis_manipulator` to `1.1.0-0`:

- upstream repository: https://github.com/ROBOTIS-GIT/robotis_manipulator.git
- release repository: https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.1`
- previous version for package: `1.0.0-0`

## robotis_manipulator

```
* supports Doxygen
* added getTrajectory function
* added torque coefficient
* change return type of funtions from void to bool
* added dynamics solving options
* fixed several bugs
* Contributors: Hye-Jong KIM, Yong-Ho Na, Tomoya Yamanokuchi
```
