### PR TITLE
tsid: 1.4.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11904,6 +11904,22 @@ repositories:
       url: https://github.com/boschresearch/ros1_tracetools.git
       version: devel
     status: developed
+  tsid:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/tsid.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stack-of-tasks/tsid-ros-release.git
+      version: 1.4.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/tsid.git
+      version: devel
+    status: maintained
   tts:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tsid` to `1.4.1-3`:

- upstream repository: https://github.com/stack-of-tasks/tsid.git
- release repository: https://github.com/stack-of-tasks/tsid-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
