### PR TITLE
robot_state_publisher: 2.4.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2377,7 +2377,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.4.1-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2.4.0-1`

## robot_state_publisher

```
* fix types in range loops to avoid copy due to different type (#143 <https://github.com/ros/robot_state_publisher/issues/143>)
* Make sure not to crash on an invalid URDF. (#141 <https://github.com/ros/robot_state_publisher/issues/141>)
* Contributors: Chris Lalancette, Dirk Thomas
```
