### PR TITLE
rmw_connext: 3.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1522,7 +1522,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 3.4.0-1
+      version: 3.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `3.4.1-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `3.4.0-1`

## rmw_connext_cpp

```
* Updated publisher/subscription allocation and wait set API return codes. (#463 <https://github.com/ros2/rmw_connext/issues/463>)
* Update service/client construction/destruction API return codes. (#464 <https://github.com/ros2/rmw_connext/issues/464>)
* Contributors: Alejandro Hernández Cordero, Michel Hidalgo
```

## rmw_connext_shared_cpp

```
* Updated publisher/subscription allocation and wait set API return codes. (#463 <https://github.com/ros2/rmw_connext/issues/463>)
* Contributors: Alejandro Hernández Cordero
```
