### PR TITLE
sr_hand_detector: 0.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11435,6 +11435,12 @@ repositories:
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
       version: melodic-devel
     status: maintained
+  sr_hand_detector:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/shadow-robot/sr_hand_detector-release.git
+      version: 0.0.1-2
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_hand_detector` to `0.0.1-2`:

- upstream repository: https://github.com/shadow-robot/sr_hand_detector.git
- release repository: https://github.com/shadow-robot/sr_hand_detector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## sr_hand_detector

```
* Set license to GNU v2 as is our standard (#3 <https://github.com/shadow-robot/sr_hand_detector/issues/3>)
  * Delete LICENSE
  * Create LICENSE
* Rename aws.yaml to aws.yml
* Adding code (#2 <https://github.com/shadow-robot/sr_hand_detector/issues/2>)
  * Adding code
  * adding postinst
  * adding aws file
* Create LICENSE (#1 <https://github.com/shadow-robot/sr_hand_detector/issues/1>)
* Initial commit
* Contributors: ToivoS, mikramarc
```
