### PR TITLE
cob_supported_robots: 0.6.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1964,7 +1964,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_supported_robots-release.git
-      version: 0.6.14-1
+      version: 0.6.15-1
     source:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.15-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.6.14-1`

## cob_supported_robots

```
* Merge pull request #28 <https://github.com/ipa320/cob_supported_robots/issues/28> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* add noetic jobs
* Contributors: Felix Messmer, fmessmer
```
