### PR TITLE
cob_supported_robots: 0.6.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -423,6 +423,21 @@ repositories:
       url: https://github.com/ipa320/cob_gazebo_plugins.git
       version: kinetic_dev
     status: maintained
+  cob_supported_robots:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_supported_robots.git
+      version: indigo_release_candidate
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_supported_robots-release.git
+      version: 0.6.15-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_supported_robots.git
+      version: indigo_dev
+    status: maintained
   code_coverage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_supported_robots` to `0.6.15-1`:

- upstream repository: https://github.com/ipa320/cob_supported_robots.git
- release repository: https://github.com/ipa320/cob_supported_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## cob_supported_robots

```
* Merge pull request #28 <https://github.com/ipa320/cob_supported_robots/issues/28> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* add noetic jobs
* Contributors: Felix Messmer, fmessmer
```
