### PR TITLE
ros_environment: 1.2.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9600,7 +9600,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_environment-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros/ros_environment.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `1.2.3-1`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros-gbp/ros_environment-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.2.2-1`
