### PR TITLE
rosidl: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1863,7 +1863,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.0.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2.0.0-1`

## rosidl_adapter

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_parser

- No changes

## rosidl_runtime_c

```
* Add rcutils dependency. (#534 <https://github.com/ros2/rosidl/issues/534>)
* QD: Add links to hosted API docs (#533 <https://github.com/ros2/rosidl/issues/533>)
* Updated Quality Level to 1 (#532 <https://github.com/ros2/rosidl/issues/532>)
* Add benchmarks for rosidl_runtime_* packages (#521 <https://github.com/ros2/rosidl/issues/521>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Louise Poubel, Scott K Logan
```

## rosidl_runtime_cpp

```
* QD: Add links to hosted API docs (#533 <https://github.com/ros2/rosidl/issues/533>)
* Updated Quality Level to 1 (#532 <https://github.com/ros2/rosidl/issues/532>)
* Add benchmarks for rosidl_runtime_* packages (#521 <https://github.com/ros2/rosidl/issues/521>)
* Contributors: Alejandro Hernández Cordero, Louise Poubel, Scott K Logan
```

## rosidl_typesupport_interface

```
* QD: Add links to hosted API docs (#533 <https://github.com/ros2/rosidl/issues/533>)
* Contributors: Louise Poubel
```

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
