### PR TITLE
ros: 1.15.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3693,7 +3693,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.6-1
+      version: 1.15.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.7-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.15.6-1`

## mk

- No changes

## rosbash

```
* add trailing := to roslaunch args:=value completion (#259 <https://github.com/ros/ros/issues/259>)
* add quoting to prevent unwanted globbing and word splitting in rosbash (#269 <https://github.com/ros/ros/issues/269>)
* fix ros_location_find with Python 3 (#270 <https://github.com/ros/ros/issues/270>)
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

- No changes

## rosmake

- No changes

## rosunit

- No changes
