### PR TITLE
rmw_fastrtps: 3.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1576,7 +1576,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 3.1.2-1
+      version: 3.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `3.1.3-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `3.1.2-1`

## rmw_fastrtps_cpp

```
* Return RMW_RET_UNSUPPORTED in rmw_get_serialized_message_size (#452 <https://github.com/ros2/rmw_fastrtps/issues/452>)
* Contributors: Alejandro Hernández Cordero
```

## rmw_fastrtps_dynamic_cpp

```
* Return RMW_RET_UNSUPPORTED in rmw_get_serialized_message_size (#452 <https://github.com/ros2/rmw_fastrtps/issues/452>)
* Contributors: Alejandro Hernández Cordero
```

## rmw_fastrtps_shared_cpp

```
* checked client implementation and return RMW_RET_INCORRECT_RMW_IMPLEMENTATION (#451 <https://github.com/ros2/rmw_fastrtps/issues/451>)
* Update service/client request/response API error returns (#450 <https://github.com/ros2/rmw_fastrtps/issues/450>)
* Contributors: Alejandro Hernández Cordero, Jose Tomas Lorente
```
