### PR TITLE
rmw_cyclonedds: 0.18.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1540,7 +1540,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.18.2-1
+      version: 0.18.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.18.3-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.18.2-1`

## rmw_cyclonedds_cpp

```
* Return RMW_RET_UNSUPPORTED in rmw_get_serialized_message_size (#250 <https://github.com/ros2/rmw_cyclonedds/issues/250>)
* Update service/client request/response API error returns (#249 <https://github.com/ros2/rmw_cyclonedds/issues/249>)
* Contributors: Alejandro Hernández Cordero, Jose Tomas Lorente
```
