### PR TITLE
rmw_connext: 3.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1522,7 +1522,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `3.4.2-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `3.4.1-1`

## rmw_connext_cpp

```
* Return RMW_RET_UNSUPPORTED in rmw_get_serialized_message_size (#467 <https://github.com/ros2/rmw_connext/issues/467>)
* Returned RMW_RET_INCORRECT_RMW_IMPLEMENTATION in rmw_service_server_is_available (#466 <https://github.com/ros2/rmw_connext/issues/466>)
* Update service/client request/response API error returns (#465 <https://github.com/ros2/rmw_connext/issues/465>)
* Contributors: Alejandro Hernández Cordero, Jose Tomas Lorente
```

## rmw_connext_shared_cpp

- No changes
