### PR TITLE
dingo: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2119,7 +2119,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.3-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## dingo_control

```
* Remove the 0/1 DINGO_CONTROL_EXTRAS + DINGO_CONTROL_EXTRAS_PATH, simplify to just DINGO_CONFIG_EXTRAS, like Husky & Warthog. (#6 <https://github.com/dingo-cpr/dingo/issues/6>)
* [dingo_control] Reduced linear acceleration limits.
* Contributors: Chris I-B, Tony Baltovski
```

## dingo_description

- No changes

## dingo_msgs

- No changes

## dingo_navigation

```
* Make the default scan topic for gmapping + amcl use the env vars (#7 <https://github.com/dingo-cpr/dingo/issues/7>)
  Load the DINGO_LASER_TOPIC env var as the default scan topic for nav demos
* Contributors: Chris I-B
```
