### PR TITLE
apex_test_tools: 0.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -200,7 +200,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/ApexAI/apex_test_tools-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/apex_test_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apex_test_tools` to `0.0.2-1`:

- upstream repository: https://gitlab.com/ApexAI/apex_test_tools.git
- release repository: https://gitlab.com/ApexAI/apex_test_tools-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.0.1-1`
