### PR TITLE
jackal: 0.7.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4407,7 +4407,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.7.2-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.1-1`

## jackal_control

```
* Load the control extras last (#75 <https://github.com/jackal/jackal/issues/75>)
* Remove the PS4 device from the yaml file, always apply the parameter from the joy_dev argument instead (#73 <https://github.com/jackal/jackal/issues/73>)
* Contributors: Chris I-B
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

```
* Use the JACKAL_LASER_TOPIC env var as the default for the scan topic in amcl + gmapping demos (#74 <https://github.com/jackal/jackal/issues/74>)
* Contributors: Chris I-B
```
