### PR TITLE
mrt_cmake_modules: 1.0.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1438,7 +1438,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
-      version: 1.0.5-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.7-1`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.0.5-1`

## mrt_cmake_modules

```
* Fix versioning of sofiles
* Ensure unittests use the right gtest include dir
* Contributors: Fabian Poggenhans
```
