### PR TITLE
mrt_cmake_modules: 1.0.8-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1529,6 +1529,21 @@ repositories:
       url: https://github.com/astuff/ml_classifiers.git
       version: master
     status: maintained
+  mrt_cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
+      version: 1.0.8-1
+    source:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    status: maintained
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.8-1`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## mrt_cmake_modules

```
* Fix finding boost python on versions with old cmake but new boost
* Contributors: Fabian Poggenhans
```
