### PR TITLE
mrp2_robot: 0.2.5-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6197,6 +6197,26 @@ repositories:
       url: https://github.com/milvusrobotics/mrp2_common.git
       version: melodic-devel
     status: maintained
+  mrp2_robot:
+    doc:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_robot.git
+      version: melodic-devel
+    release:
+      packages:
+      - mrp2_bringup
+      - mrp2_display
+      - mrp2_hardware
+      - mrp2_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/milvusrobotics/mrp2_robot-release.git
+      version: 0.2.5-2
+    source:
+      type: git
+      url: https://github.com/milvusrobotics/mrp2_robot.git
+      version: melodic-devel
+    status: maintained
   mrp2_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_robot` to `0.2.5-2`:

- upstream repository: https://github.com/milvusrobotics/mrp2_robot.git
- release repository: https://github.com/milvusrobotics/mrp2_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## mrp2_bringup

```
* Minor fixes
* Fixed bringup
* Implemented motor controller
* Solved hw problems. Updated parameters.
* Contributors: Akif
```

## mrp2_display

```
* Fixed bringup
* Fixed topic name
* Fixed voltage and added estop button led controller
* Minor fixes
* Solved hw problems. Updated parameters.
* Contributors: Bolkar Altuntas, Akif
```

## mrp2_hardware

```
* Removed redundant topics
* Fixed bringup
* Implemented motor controller
* Minor fixes
* Solved hw problems. Updated parameters.
* Contributors: Akif
```

## mrp2_robot

- No changes
