### PR TITLE
jsk_recognition: 1.2.11-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4736,6 +4736,7 @@ repositories:
       version: master
     release:
       packages:
+      - audio_to_spectrogram
       - checkerboard_detector
       - imagesift
       - jsk_pcl_ros
@@ -4748,7 +4749,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.10-0
+      version: 1.2.11-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.11-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.10-0`

## audio_to_spectrogram

```
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * upgrade package.xml to format=3, migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
  
* [audio_to_spectrogram] Enable multi channel input by retrieving single channel data (#2514 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2514>)
* [audio_to_spectrogram] Add README for usage and scripts interface (#2498 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2498>)
  
    * [audio_to_spectrogram] Add README for usage and scripts interface
    * [audio_to_spectrogram] add args to audio_to_spectrogram.launch
    * [audio_to_spectrogram] Add arg to run audio_capture
  
* Convert audio data to spectrogram (#2478 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2478>)
  
    * Make audio_to_spectrogram as ROS package
  
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa
```

## checkerboard_detector

```
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * fix for python3, use 2to3 -f print, 2to3 -f except
    * support opencv4 to checkerboard_detector
  
* set chainer version less than 7.0.0 (#2485 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2485>)
  
    * relax test conditions
  
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* Add sample, test and doc (#2440 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2440>)
  
    * Add test for objectdetection_tf_publisher
    * Add sample for objectdetection_tf_publisher
    * Add test for objectdetection_transform_echo
    * Add sample for objectdetection_transform_echo
    * Fix namespace for including from upper layer
    * Publish PoseStamped in objectdetection_transform_echo
    * Add sample for checkerboard_calibration
    * Install sample/ and test/ to 'share' space
    * Add test for checkerboard_detector
    * Add sample for checkerboard_detector
    * Publish debug_image even when param display == 0
    * Publish debug_image as well in checkerboard_detector
  
* Contributors: Kei Okada, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi
```

## imagesift

```
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * imagesift/src/imagesift.cpp fix for opencv4
    * upgrade package.xml to format=3, migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
  
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* Contributors: Kei Okada, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi
```

## jsk_pcl_ros

```
* [color_filter] publish color space for debugging(#2477 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2477>)
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * support -std=c++14, include image_transport/kdl_parser to library, disable moveit_ros_perception if not possible, support python3
    * fix for python3, use 2to3 -f print, 2to3 -f except
    * upgrade package.xml to format=3, migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
  
* fix publishDebugCloud (#2488 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2488>)
* set chainer version less than 7.0.0 (#2485 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2485>)
  
    * add time-limit to jsk_pcl_ros/test/test_linemod_trainer.test, jsk_perception/test/bing.test
    * set time-limit=25 for timeout:30 tests
  
* [jsk_pcl_ros] Add nearest plane index label to cluster_point_indices_decomposer (#2472 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2472>)
  
    * [jsk_pcl_ros/cluster_point_indices_decomposer] Renamed bba -> boxes
    * [jsk_pcl_ros/cluster_point_indices_decomposer] Add parameter fill_bba_label_with_nearest_plane_index
    * [jsk_pcl_ros/cluster_point_indices] Modified output bounding box indicating nearest plane index
  
* [jsk_pcl_ros] Add multi euclidean clustering (#2463 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2463>)
  * [jsk_pcl_ros/multi_euclidean_clustering_sample] Fixed parameter cluster_tolerance to tolerance
  * Moved bagfile for multi object detection:  Fixed path of play_rosbag xml[jsk_pcl_ros_utils/install_sample_data.py] Make it multiprocess downloadable
  
    * [jsk_pcl_eus/multi_euclidean_clustering] Add test
    * [jsk_pcl_ros/euclidean_clustering] Update install data for data compression
      [jsk_pcl_ros/euclidean_clustering] Update sample bag file player for data compression
    * [jsk_pcl_ros/euclidean_clustering] Use capital for arguments
    * [jsk_pcl_ros/euclidean_clustering] Fixed typo (multi -> ~multi)
      [jsk_pcl_ros/euclidean_clustering] Fixed typo (synchornizes -> synchronizes)
      [jsk_pcl_ros/euclidean_clustering] Fixed typo (approximate_sync_ -> approximate_sync)
      [jsk_pcl_ros/euclidean_clustering] Fixed size of maximum cluster size
      [jsk_pcl_ros/euclidean_clustering] Delete duplicated value downsample_enable
      [jsk_pcl_ros/euclidean_clustering] Fixed indent
      [jsk_pcl_ros/euclidean_clustering/cfg] Fixed indent
    * add downsample_cloud method
    * [jsk_pcl_ros/multi_euclidean_clustering] Support cluster_filter type
    * [jsk_pcl_ros/multi_euclidean_clustering] Modified input indices's name to ~input/cluster_indices'
    * [jsk_pcl_ros/multi_euclidean_clustering] Modified default queue_size for sync
    * [jsk_pcl_ros] Add test of multi euclidean clustering
    * [jsk_pcl_ros] Add sample of multi euclidean clustering
    * [jsk_pcl_ros/euclidean_clustering] Enable multi euclideanclustering
  
* add the on-off function of using use_pca in dynamic reconfigure (#2461 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2461>)
  
    * removed pnh_->param(use_pca, use_pca_, false); in src/cluster_point_indices_decomposer_nodelet.cpp.
    * add the on-off function of using use_pca in dynamic reconfigure
  
* [jsk_pcl_ros/cluster_point_indices] Enable use_pca in case of align_boxes is false (#2462 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2462>)
  
    * [jsk_pcl_ros/sample_cluster_point_indices] Add PoseArray of results
    * [jsk_pcl_ros/cluster_point_indices_decomposer] Fixed principal component axis
    * [jsk_pcl_ros/cluster_point_indices_decomposer] Fixed comment
    * [jsk_pcl_ros/cluster_point_indices_decomposer] Add use_pca is true case of example
    * set center pose orientation
    * fix centroid position
    * [jsk_pcl_ros/cluster_point_indices] Enable use_pca in case of align_boxes is false
  
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* Add sample, test and doc (#2440 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2440>)
  
    * Re-enable tests which failed due to wrong timeout of waitForTransform in PlaneSupportedCuboidEstimator
    * Show message when tf2::TransformException is catched and just return
    * Set timeout of waitForTransform: 0.0 -> 1.0 sec
    * Do not query in sample for faster success of test
    * Call rospy.spin() to correctly publish topics in depth_error_calibration.py
    * Add ~organize_cloud parameter
    * Show message when tf2::TransformException is catched and just return
    * Set timeout of waitForTransform: 0.0 -> 1.0 sec
    * Check NaN value to correctly set is_dense field
    * Publish organized pointcloud
    * Fix substitution to each element of output pointcloud
    * Disable some test in jsk_pcl_ros
    * Fix condition of publishing ~output/pose_array in ExtractCuboidParticlesTopN
    * Disable loading URDF in default in play_rosbag_pr2_sink.xml to reduce test time
    * Fix ~timeout param in test_linemod_trainer.py
    * Wait a moment until /clock is published in test_linemod_trainer.py
    * Add test for in_hand_recognition_manager.py
    * Add sample for in_hand_recognition_manager.py
    * Remove unused publisher and set queue_size to publisher
    * Fix logging in in_hand_recognition_manager.py
    * Update test for pointcloud_screenpoint.l
    * Add new sample for pointcloud_screenpoint.l
    * Add sample for store-pointcloud.l
    * Fix shebang in store-pointcloud.l
    * Add test for publish_clicked_point_bbox.py
    * Add sample for publish_clicked_point_bbox.py
    * Add queue_size to publisher in publish_clicked_point_bbox.py
    * Add test for depth_error_calibration.py
    * Add sample for depth_error_calibration.py
    * Publish error plot image as well in depth_error_calibration.py
    * Add test for display-bounding-box-array.l
    * Add sample for display-bounding-box-array.l
    * Fix shebang in display-bounding-box-array.l
    * Add test for marker_appender.py
    * Add sample for marker_appender.py
    * Set queue_size to 1 in publisher in marker_appender.py
    * Add test for tracking_info.py and tracker_status_info.py
    * Add sample for tracking_info.py and tracker_status_info.py
    * Do not duplicate dynamic_reconfigure server in one node
    * Add test for renew_tracking.py and ParticleFilterTracking
    * Add sample for renew_tracking.py
    * Fix missing service argument in renew_tracking.py
    * Add test for LINEMODDetector
    * Add sample for LINEMODDetector
    * Add test for LINEMODTrainer
    * Add sample for LINEMODTrainer
    * Fix mask image shape in LINEMODDetector
    * Fix for working correctly with yaml-cpp>=0.5.0 in LINEMODDetector
    * Add param for viewpoint sampling number in LINEMODTrainer
    * Add test for IntermittentImageAnnotator
    * Add sample for IntermittentImageAnnotator
    * Fix index of polygon vertices to use because it's rectangle
    * Just return from callback when snapshot_buffer is empty in IntermittentImageAnnotator
    * Add test for CaptureStereoSynchronizer
    * Add sample for CaptureStereoSynchronizer
    * Add test for FeatureRegistration
    * Add sample for FeatureRegistration
    * Add ~transformation_epsilon paramter to enable converging in registration in FeatureRegistration
    * Add test for TargetAdaptiveTracking
    * Add sample for TargetAdaptiveTracking
    * Fix dynamic_reconfigure::Server namespace in TargetAdaptiveTracking
    * Support getting paramters for parent_frame and child_frame in TargetAdaptiveTracking
    * Add test for Snapit
    * Add sample for Snapit
    * Remove totally malformed sample for Snapit
    * Add test for CollisionDetector
    * Add sample for CollisionDetector
    * Add test for IncrementalModelRegistration
    * Add sample for IncrementalModelRegistration
    * Add test for TorusFinder
    * Add sample for TorusFinder
    * Suppress huge amount of error message in ParticleFilterTracking
    * Add test for TiltLaserListener
    * Add sample for TiltLaserListener
    * Add test for ParticleFilterTracking
    * Add sample for ParticleFilterTracking
    * Update test for PointcloudDatabaseServer
    * Update sample for PointcloudDatabaseServer
    * Add test for ParallelEdgeFinder
    * Add sample for ParallelEdgeFinder
    * Add test for PointCloudLocalization
    * Add sample for PointCloudLocalization
    * Fix test for ICPRegistration
    * Fix sample for ICPRegistration
    * Add missing '~correspondence_randomness' param in ICPRegistration
    * Add test for PlaneSupportedCuboidEstimator
    * Add test for LineSegmentCollector
    * Add sample for LineSegmentCollector
    * Remove unused parameter error to successfully finish onInit in LineSegmentCollector
    * Update test for LineSegmentDetector
    * Update sample for LineSegmentDetector
    * Add test for HintedStickFinder
    * Add sample for HintedStickFinder
    * Add test for HintedHandleEstimator
    * Add sample for HintedHandleEstimator
    * Add test for HintedPlaneDetector
    * Add sample for HintedPlaneDetector
    * Fix conditional branching to use correct parameter in HintedPlaneDetector
    * Add test for HeightmapTimeAccumulation
    * Add sample for HeightmapTimeAccumulation
    * Show error message when lookupTransform failed in HeightmapTimeAccumulation
    * Add test for HeightmapToPointCloud
    * Add sample for HeightmapToPointCloud
    * Add test for HeightmapMorphologicalFiltering
    * Add sample for HeightmapMorphologicalFiltering
    * Add test for HeightmapConverter
    * Add sample for HeightmapConverter
    * Fix transform in HeightmapConveter
    * Add test for ExtractCuboidParticlesTopN
    * Add sample for ExtractCuboidParticlesTopN
    * Add test for RegionGrowingSegmentation
    * Add sample for RegionGrowingSegmentation
    * Add test for RegionGrowingMultiplePlaneSegmentation
    * Add sample for RegionGrowingMultiplePlaneSegmentation
    * Run test_organized_edge_detector.test only when PCL>1.7.2
    * Add test for MultiPlaneExtraction
    * Add sample for MultiPlaneExtraction
    * Add test for OctreeChangePublisher
    * Add sample for OctreeChangePublisher
    * fix include order
    * Add test for OrganizedPassThrough
    * Add sample for OrganizedPassThrough
    * Add test for OrganizedEdgeDetector
    * Add sample for OrganizedEdgeDetector
    * Add test for OrganizedMultiPlaneSegmentation
    * Add sample for OrganizedMultiPlaneSegmentation
    * Add test for MaskImageClusterFilter
    * Add sample for MaskImageClusterFilter
    * Add test for KeypointsPublisher
    * Add sample for KeypointsPublisher
    * Add test for MovingLeastSquareSmoothing
    * Add sample for MovingLeastSquareSmoothing
    * Add test for NormalEstimationIntegralImage
    * Add sample for NormalEstimationIntegralImage
    * Add test for NormalDirectionFilter
    * Add sample for NormalDirectionFilter
    * Add test for NormalEstimationOMP
    * Add sample for NormalEstimationOMP
    * Add test for VoxelGridLargeScale
    * Add sample for VoxelGridLargeScale
    * Add test for SupervoxelSegmentation
    * Add sample for SupervoxelSegmentation
    * Add test for ROIClipper
    * Add sample for ROIClipper
    * Remove duplicated test_mask_image_filter.test
    * Add test for ResizePointsPublisher
    * Add sample for ResizePointsPublisher
    * Add test for FuseRGBImages
    * Add test for FuseDepthImages
    * Add test for RGBColorFilter
    * Fix sample for RGBColorFilter not to require real camera
    * Add test for GridSampler
    * Add sample for GridSampler
    * Add test for FisheyeSpherePublisher
    * Add sample for FisheyeSpherePublisher
    * Add test for MaskImageFilter
    * Add sample for MaskImageFilter
    * Add test for DepthCalibration
    * Add sample for DepthCalibration
    * Add test for BoundingBoxOcclusionRejector
    * Fix sample for BoundingBoxOcclusionRejector so that users don't have to move interactive marker
    * Add test for BorderEstimator
    * Add sample for BorderEstimator
    * Add test for extract_top_polygon_likelihood.py
    * Add sample for extract_top_polygon_likelihood.py
    * Add test for plane_time_ensync_for_recognition.py
    * Add sample for plane_time_ensync_for_recognition.py
    * Add test for dump_depth_error.py
    * Add sample for dump_depth_error.py
    * Support specifying output csv path as rosparam in dump_depth_error.py
    * Add test for calculate_polygon_from_imu.py
    * Add sample for calculate_polygon_from_imu.py
    * Fix condition to use np.abs(acc) in calculate_polygon_from_imu.py
    * Fix initialize arguments of PolygonArray in calculate_polygon_from_imu.py
    * Move sample for PlanarPointCloudSimulator to jsk_pcl_ros_utils and do not use deprecated node
  
* kinfu supports BGR8 encoding input (#2432 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2432>)
* add volume_size for kinfu parameter (#2449 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2449>)
* Publish organized pointcloud in DepthImageCreator (#2446 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2446>)
* [jsk_pcl_ros/DepthImageCreator] Add ~fill_value to specify initial value of depth image (#2445 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2445>)
  
    * Add ~fill_value parameter (default is nan) to specify initial value of depth image.
  
* [jsk_pcl_ros/DepthImageCreator] Fix SEGV when pointcloud is not available yet in asynchronous mode (#2444 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2444>)
* [jsk_pcl_ros/pointcloud_moveit_filter] build support moveit > 1.0.0 (#2443 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2443>)
* add keep_organized param to heightmap_to_pointcloud (#2434 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2434>)
* add negative rosparam in mask_image_filter (#2431 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2431>)
  
    * add color_histogram_matcher test
    * modified member variable is_dense true to false, to compute3DCentroid
    * modified rosbag file, rviz config and document
    * add keep_organized param to heightmap_to_pointcloud
    * mofify test of mask_image_filter
    * rename test file name from .launch to .test & modify CMakeLists for test of mask_image_filter
    * add test for mask_image_filter
    * add sample for maks_image_filter
  
* [jsk_pcl_ros] Add sample_color_histogram_matcher.launch (#2429 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2429>)
  
    * add color_histogram_publisher node
    * add rosbag file and rviz config file
    * add sample_color_histogram_matcher.launch
    * add negative param in mask_image_filter
  
* Modify pcl version check for building with pcl-1.9 (#2426 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2426>)
* ClusterPointIndicesDecomposer: suppress error if contains zero indices (#2408 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2408>)
  
    * add wawrning on clustering zero size cloud
    * suppress error if contains zero indices
  
* Contributors: Akihiro Miki, Kei Okada, Ryohei Ueda, Shingo Kitagawa, Takayuki Murooka, Tomoya Ishii, Yuki Furuta, Yuki Omori, Yuto Uchimi, Iory Yanokura, Taichi Higashide
```

## jsk_pcl_ros_utils

```
* [jsk_pcl_ros] Add multi euclidean clustering (#2463 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2463>)
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * upgrade package.xml to format=3, migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
  
* set time-limit and increase retry for jsk_pcl_ros_utils/test/tf_transform_bounding_box_array.test (#2495 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2495>)
  
    * set time-limit=25 for timeout:30 tests
  
* set chainer version less than 7.0.0 (#2485 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2485>)
  
    * Moved bagfile for multi object detection Fixed path of play_rosbag xml [jsk_pcl_ros_utils/install_sample_data.py] Make it multiprocess downloadable
  
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* MaskImageToDepthConsideredMaskImage: support approximate sync (#2410 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2410>)
* Add sample, test and doc (#2440 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2440>)
  
    * Add test for DepthImageError
    * Add sample for DepthImageError
    * Add test for PointCloudToSTL
    * Add sample for PointCloudToSTL
    * Fix mesh_resource in output marker msg in PointCloudToSTL
    * Add test for ColorizeDistanceFromPlane
    * Add sample for ColorizeDistanceFromPlane
    * Add test for PoseWithCovarianceStampedToGaussianPointCloud
    * Add sample for PoseWithCovarianceStampedToGaussianPointCloud
    * Add test for PolygonPointsSampler
    * Add sample for PolygonPointsSampler
    * Add test for PolygonFlipper
    * Add sample for PolygonFlipper
    * Add test for PolygonArrayWrapper
    * Add sample for PolygonArrayWrapper
    * Add sample for PolygonArrayUnwrapper
    * Add test for PolygonArrayTransformer
    * Add sample for PolygonArrayTransformer
    * Add test for PlaneConcatenator
    * Add sample for PlaneConcatenator
    * Add test for MarkerArrayVoxelToPointCloud
    * Add sample for MarkerArrayVoxelToPointCloud
    * Add test for PointCloudToClusterPointIndices
    * Add sample for PointCloudToClusterPointIndices
    * Support skip_nan in PointCloudToClusterPointIndices
    * Add test for LabelToClusterPointIndices
    * Add sample for LabelToClusterPointIndices
    * Add test for SphericalPointCloudSimulator
    * Add sample for SphericalPointCloudSimulator
    * Add test for PlanarPointCloudSimulator
    * Move sample for PlanarPointCloudSimulator to jsk_pcl_ros_utils and do not use deprecated node
    * Add test for PointCloudRelativeFromPoseStamped
    * Add sample for PointCloudRelativeFromPoseStamped
    * Support approximate_sync in PointCloudRelativeFromPoseStamped
    * Add test for NormalFlipToFrame
    * Add sample for NormalFlipToFrame
    * Add test for PCDReaderWithPose
    * Add sample for PCDReaderWithPose
    * Add test for TfTransformCloud
    * Add sample for TfTransformCloud
    * Add test for TfTransformBoundingBoxArray
    * Add sample for TfTransformboundingBoxArray
    * Add test for TfTransformBoundingBox
    * Add sample for TfTransformBoundingBox
    * Add test for PolygonArrayFootAngleLikelihood
    * Add sample for PolygonArrayFootAngleLikelihood
    * Add test for PolygonArrayDistanceLikelihood
    * Add sample for PolygonArrayDistanceLikelihood
    * Add test for PolygonArrayAreaLikelihood
    * Add sample for PolygonArrayAreaLikelihood
    * Add test for PolygonArrayAngleLikelihood
    * Add sample for PolygonArrayAngleLikelihood
    * Add test for DelayPointCloud
    * Add sample for DelayPointCloud
    * Add test for ColorizeHeight2DMapping
    * Add sample for ColorizeHeight2DMapping
    * Increase publishing rate of pcd_to_pointcloud in sample_pointcloud_xyz_to_xyzrgb.launch
    * Add missing test for PointCloudXYZToXYZRGB
    * Add test for PointCloudXYZRGBToXYZ
    * Add sample for PointCloudXYZRGBToXYZ
    * Explicitly depend on jsk_rviz_plugins in jsk_pcl_ros_utils/package.xml
    * Add test for cloud_on_plane_info.py
    * Add test for CloudOnPlane
    * Add sample for CloudOnPlane and cloud_on_plane_info.py
    * Support approximate_sync in CloudOnPlane
    * Add test for MaskImageToDepthConsideredMaskImage
    * MaskImageToDepthConsideredMaskImage: support approximate sync
  
* MaskImageToPointIndices: support multi channel mask image (#2409 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2409>)
  
    * Enable all test for MaskImageToPointIndices
    * Increase threshold to support JPEG compression as much as possible
    * Use NODELET_ERROR instead of ROS_ERROR
    * Fix access to each element of image
    * Partially disable mask_image_to_point_indices.test
    * Add sample for MaskImageToPointIndices
    * Publish to another topic if ~use_multi_channels is true and ~target_channel == -1
    * Merge branch 'master' into subtract-mask-image
    * MaskImageToPointIndices: support multi channel mask image
  
* Contributors: Kei Okada, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi, Iory Yanokura
```

## jsk_perception

```
* Add FCN8sDepthPredictionConcatFirst model to fcn_depth_prediction.py (#2481 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2481>)
  
    * Update output file names
    * Read dataset directory from argument
    * Fix directory name of dataset extracted from tar ball
    * Flatten images for network input
    * Remove wrong transform of dataset from train_fcn_depth_prediction.py
    * Add training script of FCNDepthPredictionConcatFirst model
    * Move FCN8sDepthPrediction chainer models to jsk_recognition_utils
    * Add install script of mirror dataset
    * Fix typo of model path
    * Use cv2 version of colormap JET
    * Add trained model of FCN8sDepthPredictionConcatFirst
    * Add FCN8sDepthPredictionConcatFirst model to fcn_depth_prediction.py
  
* refactor sample launches in jsk_perception (#2376 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2376>)
* Add nose mask publisher (#2347 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2347>)
* [jsk_perception/people_pose_estimation_2d.py][jsk_perception/people_mask_publisher.py] Fix edge case bug (#2465 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2465>)
* Publish ClusterPointIndices in ssd_object_detector.py (#2467 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2467>)
  
    * add predict profilling message above cluster indices computation
  
* fix travis - skip noetic test into two jobs, using BUILD_PKGS - skip catkin_python_setup for indigo (#2522 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2522>)
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * jsk_perception/scripts: respect ROS_PYTHON_VERSION
    * support for opencv4 : jsk_perception
    * remove signals from find_package(Boost)
    * jsk_perception depends on roseus, but it sometimes hard to keep dependency
    * fix for python3, use 2to3 -f print, 2to3 -f except
    * upgrade package.xml to format=3, migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
  
* more fix for #2500 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2500> (#2502 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2502>)
  
    * fix print '' -> print('')
  
* fix print syntax in train_ssd.py (#2500 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2500>)
  
    * fix print '' -> print('')
  
* [jsk_perception] support image with alpha in image_publisher (#2479 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2479>)
  
    * fix image_publisher for loading grayscale image
    * use cv2 default type
    * add test for image with alpha channel
    * add sample for alpha image
    * fix for depth image
    * support image with alpha in image_publisher
  
* [jsk_perception] add program for training ssd with box annotation (#2483 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2483>)
* show what should we do, if we have error on 'import chainer' (#2491 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2491>)
  
    * use --clock for sample_image_cluster_indices_decomposer.launch, add --clock to sample_bounding_box_to_rect.launch does not work...
    * print how to intall cupy
  if you do not have cupy, it raises error
  ```
  [INFO] [1588763738.839739]: Read the image file: /home/k-okada/ws_recognition/src/jsk_recognition/jsk_perception/sample/object_detection_example_2.jpg
  [INFO] [1588763739.625133]: Loaded 43 labels
  Traceback (most recent call last):
  File "/home/k-okada/ws_recognition/src/jsk_recognition/jsk_perception/node_scripts/ssd_object_detector.py", line 207, in <module>
  ssd = SSDObjectDetector()
  File "/opt/ros/melodic/lib/python2.7/dist-packages/jsk_topic_tools/transport.py", line 26, in __call\_\_
  obj = type.__call_\_(cls, *args, **kwargs)
  File "/home/k-okada/ws_recognition/src/jsk_recognition/jsk_perception/node_scripts/ssd_object_detector.py", line 71, in __init\_\_
  chainer.cuda.get_device_from_id(self.gpu).use()
  File "/usr/local/lib/python2.7/dist-packages/chainer/backends/cuda.py", line 275, in get_device_from_id
  check_cuda_available()
  File "/usr/local/lib/python2.7/dist-packages/chainer/backends/cuda.py", line 138, in check_cuda_available
  raise RuntimeError(msg)
  RuntimeError: CUDA environment is not correctly set up
  (see https://github.com/chainer/chainer#installation).No module named cupy
  ``
  * show what should we do, if we have error on 'import chainer'
  ```
  Traceback (most recent call last):
  File "/home/k-okada/ws_recognition/src/jsk_recognition/jsk_perception/node_scripts/ssd_object_detector.py", line 26, in <module>
  import chainer
  File "/usr/local/lib/python2.7/dist-packages/chainer/__init__.py", line 10, in <module>
  from chainer import backends  # NOQA
  File "/usr/local/lib/python2.7/dist-packages/chainer/backends/__init__.py", line 1, in <module>
  from chainer.backends import cuda  # NOQA
  File "/usr/local/lib/python2.7/dist-packages/chainer/backends/cuda.py", line 77
  def shape(self) -> types.Shape:
  ^
  SyntaxError: invalid syntax
  ```
  c.f. https://github.com/jsk-ros-pkg/jsk_recognition/pull/2485
* add more arg INPUT_IMAGE (#2492 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2492>)
  
    * arg name='INPUT_IMAGE' need to use default, instead of value, so that we can cheange the input name as ros args. 'value' is constant value and 'default' is default value, see http://wiki.ros.org/roslaunch/XML/arg
  
* jsk_perception/train_ssd.py fix error when out_dir is set (#2493 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2493>)
* set chainer version less than 7.0.0 (#2485 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2485>)
  
    * split test_bing to test_bing_output and test_bing_objectness
    * add time-limit to jsk_pcl_ros/test/test_linemod_trainer.test, jsk_perception/test/bing.test
    * jsk_perception/package.xml: node_scripts/pointit.py imports tf2_geometry_msgs
    * set time-limit=25 for timeout:30 tests
    * relax test conditions
    * set chainer version less than 7.0.0
    * jsjk_perception/train_ssd.py fix error when out_dir is set
  
* Fix test for consensus_tracking (#2475 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2475> from YutoUchimi/fix_consensus_tracking
* Parameterize frames, transformation and interpolation in virtual_camera_mono (#2470 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2470>)
  
    * Change logger level of TransformException to WARN
    * Add test for virtual_camera_mono
    * Add sample for virtual_camera_mono
    * Parameterize virtual_camera_mono
  
* Convert audio data to spectrogram (#2478 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2478>)
  
    * add unit to axis
    * remove unused files
    * add node to visualize spectrum
    * fix size of spectrogram
    * fix typo in launch
    * divide program into audio_to_spectrum and spectrum_to_spectrogram
    * fix comment
    * add test
    * use rosbag with /audio of 300Hz
    * use timer callback to publish spectrogram constantly
    * update comments and name of parameter
    * add sample program to convert audio message  to spectrogram
  
* Add train script and sample for SSD (#2471 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2471>)
  
    * [jsk_perception] add program for training ssd with box annotation
    * use cv2 for cv_resize_backend
    * add classnames for ssd
    * add trained model in install_trained_data.py
  
* Add queue_size and slop param to TileImages (#2453 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2453>)
* Fix label_id division by 256 -> 255 (#2455 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2455>)
  
    * Fix label_id division by 256 -> 255
      Since len(colormap) is 255, % 256 is wrong since it can return 255
      which raises IndexError.
  
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* Publish human skelton msgs in OpenPose node (#2437 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2437>)
  
    * add lines considering shoulder when predicting face region
    * add LIMB_PART param
    * enable to create nose mask image
    * [jsk_perception/node_scripts/people_pose_estimation_2d.py] fix edge case
    * [jsk_perception/node_scripts/people_mask_publisher.py] fix edge case
  
* Fix tile_image.py for Python3 (#2452 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2452>)
* Fix label_image_decomposer.py for Python3 (#2454 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2454>)
* Update to slic d77d6e8 (#2450 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2450>)
* mask_rcnn_instance_segmentation: support loading yaml from file (#2413 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2413>)
* pointit: add option '~use_arm' to select arm for pointing (#2415 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2415>)
* Add sample, test and doc (#2440 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2440>)
  
    * Fix condition of fatal message
    * Keep backward compatibility for ~dist_threshold
    * Add test for kalman-filtered-objectdetection-marker.l
    * Add sample for kalman-filtered-objectdetection-marker.l
    * Change permission of kalman-filtered-objectdetection-marker.l: 644->755
    * Update sample for RobotToMaskImage
    * Add sample for CollisionDetector
    * Merge branch 'master' into kinfu-fix
    * updae people_pose_estimation_2d.test
    * add visualization link in commentout
    * Add test for RobotToMaskImage
    * Add minimal sample for RobotToMaskImage, which is only for testing
    * Add test for SlidingWindowObjectDetector
    * Add sample for SlidingWindowObjectDetector
    * Support overriding parameters in manifest file
    * Add sample for sliding_window_object_detector_trainer_node
    * Add params for fg/bg training dataset image topics and output manifest file
    * Add test for ColorHistogramLabelMatch
    * Add sample for ColorHistogramLabelMatch
    * Add test SingleChannelHistogram
    * Add sample for SingleChannelHistogram
    * Explicitly depend of topic_tools because sample_polygon_array_color_histogram.launch uses this
    * Add test for PolygonArrayColorLikelihood
    * Add sample for PolygonArrayColorLikelihood
    * Suppress very long log of downloading pretrained weight in sample_deep_sort_tracker.launch
    * Add test for PolygonArrayColorHistogram
    * Add sample for PolygonArrayColorHistogram
    * Support selecting histogram index by rosparam in unwrap_histogram_with_range_array.py
    * Build SnakeSegmentation only when OpenCV<3
    * Add test for UnapplyMaskImage
    * Add sample for UnapplyMaskImage
    * Add test for TabletopColorDifferenceLikelihood
    * Add sample for TabletopColorDifferenceLikelihood
    * Add test for SnakeSegmentation
    * Add sample for SnakeSegmentation
    * Add test for Skeletonization
    * Add sample for Skeletonization
    * Add test for SaliencyMapGenerator
    * Add sample for SaliencyMapGenerator
    * Add test for ROIToRect
    * Add sample for ROIToRect
    * Fix output polygon vertices for ROIToRect
    * Add test for ROIToMaskImage
    * Add sample for ROIToMaskImage
    * Add test for RectToROI
    * Add sample for RectToROI
    * Add test for RectToMaskImage
    * Fix ROSTimeMoveBackward before publishing output in sample_rect_to_mask_image.launch
    * Fix point index for bottom right point of rectangle in rect_to_mask_image.cpp
    * Add test for ProjectImagePoint
    * Add sample for ProjectImagePoint
    * Add test for PolygonToMaskImage
    * Add sample for PolygonToMaskImage
    * Add test for PolygonArrayToLabelImage
    * Add sample for PolygonArrayToLabelImage
    * Add test for MaskImageToROI
    * Add sample for MaskImageToROI
    * Add test for GrabCut
    * Add sample for GrabCut
    * Disable fast_rcnn.test
    * Add test for FisheyeToPanorama
    * Add sample for FisheyeToPanorama
    * Add test for GaussianBlur
    * Add sample for GaussianBlur
    * Add test for YCCDecomposer
    * Add sample for YCCDecomposer
    * Add test for LabDecomposer
    * Add sample for LabDecomposer
    * Add test for RGBDecomposer
    * Add sample for RGBDecomposer
    * Add test for HSVDecomposer
    * Add sample for HSVDecomposer
    * Add test for morphological operators
    * Add sample for morphlogical operators such as ErodeMaskImage, Opening, MorphlogicalGradient, TopHat
    * Add test for pointit.py
    * Add sample for pointit.py
    * Remove unused import in pointit.py
    * Remove unused computation in get_marker func in pointit.py
    * Fix tf2 listener
    * Fix return value in find_pose func in pointit.py
    * Add test for unwrap_histogram_with_range_array.py
    * Add sample for unwrap_histogram_with_range_array.py
    * Add test for solidity_rag_merge.py
    * Add sample for solidity_rag_merge.py
    * Support networkX>=2 and scikit-image>=0.13 in solidity_rag_merge.py
    * Add test for non_maximum_suppression.py
    * Add sample for non_maximum_suppression.py
    * Add ROS topic API for non_maximum_suppression.py
    * pointit: add option '~use_arm' to select arm for pointing
    * mask_rcnn_instance_segmentation: support loading yaml from file
    * add jsk_perception/SubtractMaskImage
    * fix typo in sample_face_pose_estimation.launch
    * GPU -> gpu in face_pose_estimation.launch
    * use args in sample launch: GPU -> gpu
    * remove test_mode from sample_face_pose_estimation.launch
    * remove test_mode in sample_ssd_object_detector.launch
    * Do not use deprecated param in sample_pointit.launch
    * Fix use of deprecated param ~dist_threshold
  
* fixes scope bug on point_pose_extraction (#2414 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2414>)
* [jsk_perception] Add trained maskrcnn model for 73b2 kitchen (#2423 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2423>)
  
    * update kitchen pretrained model (#9 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/9>)
    * [jsk_perception] Add trained maskrcnn model for 73b2 kitchen
    * add sample launch file using 73b2 kitchen model
    * update kitchen pretrained model
    * add sample launch for kitchen dataset
  
* update to use jsk_travis 0.5.0 (#2439 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2439>)
  * skip deep_sort_tracker.test on indigo
  https://travis-ci.org/jsk-ros-pkg/jsk_recognition/jobs/549216064#L8697-L8733
  downloading SSD data(ssd300_voc0712_converted_2017_06_06.npz) failes with
  ```
  IOError: [Errno socket error] [Errno 1] _ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure'
  ```
  do we need to update Python to 2.7.9? for indidgo ????
  https://stackoverflow.com/questions/54413685/insecureplatform-warning
  
    * Do not mix tab and space for indentation
    * Add test for mask_rcnn_instance_segmentaion.py, but comment out testing because GPU required
    * Add test for image_time_diff.py
    * Add sample for image_time_diff.py
    * Avoid crashing when ROS time moved backward in image_time_diff.py
    * Fix AttributeError in image_time_diff.py
    * Add test for fcn_depth_prediction, but do not run because unstable
    * Add test for fast_rcnn.py
    * Add test for binpack_rect_array.py
    * Add sample for binpack_rect_array.py
    * Add test for apply_context_to_label_probability
    * Add gpu arg to sample_apply_context_to_label_probability.launch
    * fix typo: skelton -> skeleton
    * publish skelton in people_pose_estimation_2d
  
* Add Mask R-CNN model trained with COCO dataset (~80 classes) (already included VOC model only detects ~20 classes) (#2427 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2427>)
* MaskImageToPointIndices: support multi channel mask image (#2409 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2409>)
  
    * fix mask rcnn 73b2 model classname typo (#8 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/8>)
  
* point_pose_extractor: fix bug on scope
* point_pose_extractor: fill reliability
* Add sample for MaskImageToPointIndices
* add jsk_perception/SubtractMaskImage (#2411 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2411>)
  
    * Fix typo of main node name
  
* Re-enable bing.test (#2418 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2418>)
  
    * Fix target name of bing for testing
  
* Contributors: Fuki Furuta, Kei Okada, Kentaro Wada, Naoya Yamaguchi, Shingo Kitagawa, Yoshiki Obinata, Yuki Furuta, Yuto Uchimi, Iory Yanokura, Hideaki Ito, Taichi Higashide
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

```
* Convert audio data to spectrogram (#2478 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2478>)
  
    * divide program into audio_to_spectrum and spectrum_to_spectrogram
  
* set chainer version less than 7.0.0 (#2485 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2485>)
  
    * relax test conditions
  
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* Publish human skelton msgs in OpenPose node (#2437 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2437>)
  
    * fix typo: skelton -> skeleton
    * add human skelton msgs
  
* Add sample, test and doc (#2440 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2440>)
  
    * Wait at most ~timeout [sec] in plot_data_to_csv.test
    * Merge branch 'master' into pointit
    * Add test for save_mesh_server.py
    * Add test for plot_data_to_csv.py
    * Add sample for plot_data_to_csv.py
    * Run mkdir if output directory does not exist
    * Add test for people_pose_array_to_pose_array.py
    * Add sample for people_pose_array_to_pose_array.py
    * Add symbolic link to doc in jsk_recognition_msgs
    * Add test for object_array_publisher.py
    * Update sample for object_array_publisher.py not to depend on jsk_arc2017_common
  
* Contributors: Kei Okada, Naoya Yamaguchi, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi
```

## jsk_recognition_utils

```
* Add ssd to bounding box sample (#2513 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2513>)
  
    * rename launch and rvizconfig
    * rename to sample_table_rects_to_bounding_box.launch
    * update rviz config
    * refactor launch files
    * add ssd output arg
    * enabe to put out the bounding box
    * try to make ssd to bbox sample
  
* Include cython3 when searching (#2531 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2531>)
* [jsk_recognition_utils] add rect_array_to_cluster_point_indices.py (#2511 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2511>)
* [jsk_recognition_utils] remove unnecessary dynamic_reconfigure in rect_array_to_polygon_array.py (#2510 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2510>)
  
    * fix typo in rect_array_to_cluster_point_indices.py
    * add test and sample for rect_array_to_cluster_point_indices
    * add rect_array_to_cluster_point_indices.py
    * remove unused dynamic_reconfigure in rect_array_to_polygon_array.py
  
* Add FCN8sDepthPredictionConcatFirst model to fcn_depth_prediction.py (#2481 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2481>)
  
    * Remove unused import in depth_prediction dataset
    * Rewrite data augmentation to remove dependency on imgaug
    * Read dataset directory from argument
    * Add loss computation
    * Add weight initialization from VGG16
    * Flatten images for network input
    * Rewrite mvtk-dependent code
    * Remove redundant visualization of DepthPredictionDataset
    * Rosdep install imgaug
    * Fix default root_dir of DepthPredictionDataset
    * Move FCN8sDepthPrediction chainer models to jsk_recognition_utils
    * Add DepthPredictionDataset
  
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * jsk_recognition_utils/cv_utils.h fix for opencv4
    * upgrade package.xml to format=3, migrate to noetic with ROS_PYTHON_VERSION=2/3, use multiple ROS distro strategy http://wiki.ros.org/noetic/Migration
  
* [jsk_perception] add program for training ssd with box annotation (#2483 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2483>)
* set chainer version less than 7.0.0 (#2485 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2485>)
* [jsk_recognition_utils] Fix ear clipping triangulation to support concave polygon (#2447 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2447>)
  
    * Handle parallel line segments as well
    * Check if line segment 'uw' completely lies inside the polygon for correcting isEar function
    * Rename func: triangulate -> triangulateClockwiseVertices
    * Add space in 'if' line for readable code
    * Fix ear clipping to support concave polygon
  
* Add train script and sample for SSD (#2471 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2471>)
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* Add sample, test and doc (#2440 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2440>)
  
    * Add dependency on image_view in jsk_recognition_utils/package.xml
    * Add test for image_16uc1_to_32fc1.py
    * Add sample for image_16uc1_to_32fc1.py
    * Add test for rect_array_to_polygon_array.py
    * Add sample for rect_array_to_polygon_array.py
    * Fix output polygon vertices in rect_array_to_polygon_array.py
    * Add test for add_cluster_indices.py
    * Add sample for add_cluster_indices.py
    * Add test for static_virtual_camera.py
    * Add test for pose_array_to_pose.py
    * Add sample for pose_array_to_pose.py
    * Add test for polygon_array_to_polygon
    * Add sample for polygon_array_to_polygon
    * Add test for polygon_array_publisher
    * Fix rviz config for sample_polygon_array_publisher.launch
    * add label to bounding_box_publisher.py
  
* [jsk_recognition_utils] Add label to bounding_box_publisher.py (#2430 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2430>)
* Contributors: Naoaki Kanazawa, Kei Okada, Peter Mitrano, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi, Taichi Higashide
```

## resized_image_transport

```
* Fix for  noetic / 20.04 (#2507 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2507>)
  
    * resized_image_transport/src/log_polar_nodelet.cpp fix for opencv4
  
* fix generate_readme.py and update readme (#2442 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2442>)
* Add sample, test and doc (#2440 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2440>)
  
    * Remove unnecessary dependency duplication and comments in package.xml
    * Add test for LogPolar
    * Add sample for LogPolar
  
* Contributors: Kei Okada, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi
```
