### PR TITLE
sot-core: 4.10.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11403,6 +11403,22 @@ repositories:
       url: https://github.com/yujinrobot-release/sophus-release.git
       version: 1.0.1-1
     status: maintained
+  sot-core:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/sot-core.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stack-of-tasks/sot-core-ros-release.git
+      version: 4.10.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/sot-core.git
+      version: devel
+    status: maintained
   sparse_bundle_adjustment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-core` to `4.10.1-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-core.git
- release repository: https://github.com/stack-of-tasks/sot-core-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
