### PR TITLE
sot-core: 4.10.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5019,6 +5019,22 @@ repositories:
       url: https://github.com/stonier/sophus.git
       version: release/1.1.x
     status: maintained
+  sot-core:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/sot-core.git
+      version: devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stack-of-tasks/sot-core-ros-release.git
+      version: 4.10.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/sot-core.git
+      version: devel
+    status: maintained
   sparse_bundle_adjustment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-core` to `4.10.1-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-core.git
- release repository: https://github.com/stack-of-tasks/sot-core-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
