### PR TITLE
add python3-docopt

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5636,6 +5636,9 @@ python3-docker:
   rhel:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
+python3-docopt:
+  debian: [python3-docopt]
+  ubuntu: [python3-docopt]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5637,7 +5637,10 @@ python3-docker:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
 python3-docopt:
+  arch: [python-docopt]
   debian: [python3-docopt]
+  fedora: [python3-docopt]
+  gentoo: [dev-python/docopt]
   ubuntu: [python3-docopt]
 python3-docutils:
   arch: [python-docutils]


### PR DESCRIPTION
argument parser available as system package at least on debian and ubuntu