### PR TITLE
wireless: 0.1.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5618,6 +5618,24 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros.git
       version: master
     status: maintained
+  wireless:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: master
+    release:
+      packages:
+      - wireless_msgs
+      - wireless_watcher
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/wireless-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: master
+    status: maintained
   wu_ros_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `0.1.1-2`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## wireless_msgs

- No changes

## wireless_watcher

```
* Improve connected detection logic so topic doesn't stop when interface is down
* Contributors: Nikesh Bernardshaw
```
