### PR TITLE
husky: 0.3.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5120,7 +5120,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/husky-release.git
-      version: 0.3.7-1
+      version: 0.3.8-1
     source:
       type: git
       url: https://github.com/husky/husky.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husky` to `0.3.8-1`:

- upstream repository: https://github.com/husky/husky.git
- release repository: https://github.com/clearpath-gbp/husky-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.3.7-1`

## husky_base

- No changes

## husky_bringup

```
* Fix a bug where the UM7 and UM6 launch files don't work when installed to /etc/ros/*/ros.d; they fail to find the mag config files.
* Contributors: Chris Iverach-Brereton
```

## husky_control

```
* Remove the Kinect 360 support; the deprecation warning is being treated as an error, and it's about time to remove it anyway
* Contributors: Chris Iverach-Brereton
```

## husky_description

```
* Remove the Kinect 360 support; the deprecation warning is being treated as an error, and it's about time to remove it anyway
* Contributors: Chris Iverach-Brereton
```

## husky_desktop

- No changes

## husky_gazebo

```
* Remove an extra < that we missed when removing the kinect stuff
* Remove the Kinect 360 support; the deprecation warning is being treated as an error, and it's about time to remove it anyway
* Contributors: Chris Iverach-Brereton
```

## husky_msgs

- No changes

## husky_navigation

- No changes

## husky_robot

- No changes

## husky_simulator

- No changes

## husky_viz

```
* Remove the Kinect 360 support; the deprecation warning is being treated as an error, and it's about time to remove it anyway
* Contributors: Chris Iverach-Brereton
```
