### PR TITLE
slam_gmapping: 1.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4954,6 +4954,24 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: noetic
     status: developed
+  slam_gmapping:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: melodic-devel
+    release:
+      packages:
+      - gmapping
+      - slam_gmapping
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/slam_gmapping-release.git
+      version: 1.4.2-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/slam_gmapping.git
+      version: melodic-devel
+    status: unmaintained
   slam_karto:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_gmapping` to `1.4.2-1`:

- upstream repository: https://github.com/ros-perception/slam_gmapping
- release repository: https://github.com/ros-gbp/slam_gmapping-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## gmapping

```
* change find_package(Boost REQUIRED signales) to find_package(Boost REQUIRED) for noteic (#84 <https://github.com/ros-perception/slam_gmapping/issues/84>)
* Contributors: Kei Okada
```

## slam_gmapping

- No changes
