### PR TITLE
lanelet2: 1.1.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1269,6 +1269,32 @@ repositories:
       url: https://github.com/aws-robotics/kinesisvideo-ros2.git
       version: master
     status: developed
+  lanelet2:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    release:
+      packages:
+      - lanelet2
+      - lanelet2_core
+      - lanelet2_examples
+      - lanelet2_io
+      - lanelet2_maps
+      - lanelet2_projection
+      - lanelet2_python
+      - lanelet2_routing
+      - lanelet2_traffic_rules
+      - lanelet2_validation
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    status: maintained
   laser_geometry:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `lanelet2` to `1.1.1-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
- release repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## lanelet2

```
* Add missing dependency to ros_environment
* Contributors: Fabian Poggenhans
```

## lanelet2_core

- No changes

## lanelet2_examples

- No changes

## lanelet2_io

- No changes

## lanelet2_maps

- No changes

## lanelet2_projection

- No changes

## lanelet2_python

- No changes

## lanelet2_routing

- No changes

## lanelet2_traffic_rules

- No changes

## lanelet2_validation

- No changes
