### PR TITLE
ros_numpy: 0.0.4-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3924,6 +3924,21 @@ repositories:
       url: https://github.com/ignitionrobotics/ros_ign.git
       version: noetic
     status: developed
+  ros_numpy:
+    doc:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/eric-wieser/ros_numpy-release.git
+      version: 0.0.4-4
+    source:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    status: maintained
   ros_pytest:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_numpy` to `0.0.4-4`:

- upstream repository: https://github.com/eric-wieser/ros_numpy.git
- release repository: https://github.com/eric-wieser/ros_numpy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
