### PR TITLE
rcutils: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1446,7 +1446,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `2.0.0-1`

## rcutils

```
* Add RCUTILS_NO_FAULT_INJECTION() macro. (#295 <https://github.com/ros2/rcutils/issues/295>)
* Inject faults on rcutils_get_env() and rcutils_set_env() call. (#292 <https://github.com/ros2/rcutils/issues/292>)
* env.h and get_env.h docblock fixes (#291 <https://github.com/ros2/rcutils/issues/291>)
* Introduce rcutils_strcasecmp, case insensitive string compare. (#280 <https://github.com/ros2/rcutils/issues/280>)
* Stop using fprintf to avoid using file handles by changing as few lines of code as possible. (#289 <https://github.com/ros2/rcutils/issues/289>)
* Defines QNX implementation for rcutils_get_platform_library_name (#287 <https://github.com/ros2/rcutils/issues/287>)
* Contributors: Ahmed Sobhy, Ivan Santiago Paunovic, Michel Hidalgo, tomoya
```
