### PR TITLE
Change src/doc branches for multiple repos

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11894,7 +11894,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/locusrobotics/robot_navigation.git
-      version: master
+      version: kinetic
     release:
       packages:
       - costmap_queue
@@ -11924,7 +11924,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/locusrobotics/robot_navigation.git
-      version: master
+      version: kinetic
     status: developed
   robot_pose_publisher:
     doc:
@@ -13131,7 +13131,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/DLu/roscompile.git
-      version: master
+      version: main
     release:
       packages:
       - ros_introspection
@@ -13144,7 +13144,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/DLu/roscompile.git
-      version: master
+      version: main
     status: developed
   rosconsole_bridge:
     doc:
@@ -15215,7 +15215,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/DLu/static_tf.git
-      version: master
+      version: main
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -15224,7 +15224,7 @@ repositories:
     source:
       type: git
       url: https://github.com/DLu/static_tf.git
-      version: master
+      version: main
     status: maintained
   static_transform_mux:
     doc:
@@ -16780,7 +16780,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_tutorial.git
-      version: master
+      version: ros1
     release:
       packages:
       - urdf_sim_tutorial
@@ -16792,7 +16792,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/urdf_tutorial.git
-      version: master
+      version: ros1
     status: maintained
   urdfdom_py:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9188,7 +9188,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/locusrobotics/robot_navigation.git
-      version: tf2
+      version: melodic
     release:
       packages:
       - costmap_queue
@@ -9218,7 +9218,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/locusrobotics/robot_navigation.git
-      version: tf2
+      version: melodic
     status: developed
   robot_one:
     release:
@@ -9878,7 +9878,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/DLu/roscompile.git
-      version: master
+      version: main
     release:
       packages:
       - ros_introspection
@@ -9890,7 +9890,7 @@ repositories:
     source:
       type: git
       url: https://github.com/DLu/roscompile.git
-      version: master
+      version: main
     status: developed
   rosconsole:
     doc:
@@ -11495,7 +11495,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/DLu/static_tf.git
-      version: master
+      version: main
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -11504,7 +11504,7 @@ repositories:
     source:
       type: git
       url: https://github.com/DLu/static_tf.git
-      version: master
+      version: main
     status: maintained
   static_transform_mux:
     doc:
@@ -12474,7 +12474,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_sim_tutorial.git
-      version: master
+      version: ros1
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -12483,7 +12483,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/urdf_sim_tutorial.git
-      version: master
+      version: ros1
     status: maintained
   urdf_test:
     release:
@@ -12495,7 +12495,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_tutorial.git
-      version: master
+      version: ros1
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -12504,7 +12504,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/urdf_tutorial.git
-      version: master
+      version: ros1
     status: maintained
   urdfdom_py:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5352,7 +5352,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_sim_tutorial.git
-      version: master
+      version: ros1
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -5362,7 +5362,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/urdf_sim_tutorial.git
-      version: master
+      version: ros1
     status: maintained
   urdf_tutorial:
     doc:


### PR DESCRIPTION
This is a non-standard `rosdistro` PR that changes the src/doc branches for a number of repos I maintain based on [this thread](https://discourse.ros.org/t/consider-renaming-default-branches/15385)