### PR TITLE
jsk_recognition: 1.2.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4749,7 +4749,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.11-1
+      version: 1.2.12-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.12-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.11-1`

## audio_to_spectrogram

- No changes

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

- No changes

## jsk_pcl_ros_utils

- No changes

## jsk_perception

```
* check if chainer is found before check version (#2533 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2533>)
  
    * fixes http://build.ros.org/job/Nbin_uF64__jsk_perception__ubuntu_focal_amd64__binary/1/console and http://build.ros.org/job/Mbin_uB64__jsk_perception__ubuntu_bionic_amd64__binary/91/console
  
* Contributors: Kei Okada
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

- No changes

## resized_image_transport

- No changes
