### PR TITLE
google_benchmark_vendor: 0.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1007,6 +1007,18 @@ repositories:
       url: https://github.com/ros2/geometry2.git
       version: foxy
     status: maintained
+  google_benchmark_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
+      version: 0.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/google_benchmark_vendor.git
+      version: main
+    status: maintained
   googletest:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `google_benchmark_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/ament/google_benchmark_vendor.git
- release repository: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`
