### PR TITLE
mimick_vendor: 0.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1512,6 +1512,21 @@ repositories:
       url: https://github.com/ros2/message_filters.git
       version: foxy
     status: maintained
+  mimick_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/mimick_vendor-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: master
+    status: maintained
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.2.2-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## mimick_vendor

```
* Suppress cppcheck for MMK_MANGLE_ (#8 <https://github.com/ros2/mimick_vendor/issues/8>)
* Change Mimick tagged version. (#7 <https://github.com/ros2/mimick_vendor/issues/7>)
* Contributors: Michel Hidalgo, brawner
```
