### PR TITLE
urdfdom: 2.3.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2619,7 +2619,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 2.3.2-2
+      version: 2.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `2.3.3-1`:

- upstream repository: https://github.com/ros2/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.3.2-2`
