### PR TITLE
rcpputils: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1431,7 +1431,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros2/rcpputils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.0.1-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.0-1`

## rcpputils

```
* Make sure that an existing path is a directory for create_directories (#98 <https://github.com/ros2/rcpputils/issues/98>)
* Transfer ownership to Open Robotics (#100 <https://github.com/ros2/rcpputils/issues/100>)
* Ensure -fPIC is used when building a static lib (#93 <https://github.com/ros2/rcpputils/issues/93>)
* Contributors: Christophe Bedard, Dirk Thomas, Louise Poubel, William Woodall
```
