### PR TITLE
urdf: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2582,10 +2582,13 @@ repositories:
       url: https://github.com/ros2/urdf.git
       version: ros2
     release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.4.0-2
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.5.0-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.4.0-2`

## urdf

```
* Enable -Wall -Wextra -Wpedantic (#20 <https://github.com/ros2/urdf/issues/20>)
* Add dependency on TinyXML2 (#19 <https://github.com/ros2/urdf/issues/19>)
* Remove TinyXML dependency from urdf. (#17 <https://github.com/ros2/urdf/issues/17>)
* Make urdf plugable and revive urdf_parser_plugin (#13 <https://github.com/ros2/urdf/issues/13>)
* Contributors: Audrow Nash, Chris Lalancette, Shane Loretz
```

## urdf_parser_plugin

```
* Make urdf plugable and revive urdf_parser_plugin (#13 <https://github.com/ros2/urdf/issues/13>)
* Contributors: Shane Loretz
```
