### PR TITLE
base: add libtiff-dev for focal

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4089,6 +4089,7 @@ libtiff-dev:
   ubuntu:
     artful: [libtiff5-dev]
     bionic: [libtiff5-dev]
+    focal: [libtiff-dev]
     lucid: [libtiff4-dev]
     maverick: [libtiff4-dev]
     natty: [libtiff4-dev]


### PR DESCRIPTION
It seems the focal release was missing for libtiff-dev.

Relevant package can be found here:
https://ubuntu.pkgs.org/20.04/ubuntu-main-amd64/libtiff-dev_4.1.0+git191117-2build1_amd64.deb.html