### PR TITLE
fetch_tools: 0.2.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2944,7 +2944,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
-      version: 0.2.1-0
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.2.2-1`:

- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.2.1-0`

## fetch_tools

```
* Several 18.04 fixes/additions to debug_snapshot tool (#14 <https://github.com/fetchrobotics/fetch_tools/issues/14>)
* Contributors: Alex Moriarty, Eric Relson, Nick Walker, Russell Toris
```
