### PR TITLE
mrp2_robot: 0.2.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6230,7 +6230,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/milvusrobotics/mrp2_robot-release.git
-      version: 0.2.5-2
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/milvusrobotics/mrp2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrp2_robot` to `0.2.6-1`:

- upstream repository: https://github.com/milvusrobotics/mrp2_robot.git
- release repository: https://github.com/milvusrobotics/mrp2_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.5-2`

## mrp2_bringup

```
* updated changelogs
* updated changelogs
* updated changelogs
* Contributors: OnurDz
* updated changelogs
* updated changelogs
* Contributors: OnurDz
* updated changelogs
* Contributors: OnurDz
```

## mrp2_display

```
* fix version for release
* updated changelogs
* updated changelogs
* version bump
* fix: missing dependency
* updated changelogs
* Contributors: OnurDz
* updated changelogs
* version bump
* fix: missing dependency
* updated changelogs
* Contributors: OnurDz
* fix: missing dependency
* updated changelogs
* Contributors: OnurDz
```

## mrp2_hardware

```
* updated changelogs
* updated changelogs
* updated changelogs
* Contributors: OnurDz
* updated changelogs
* updated changelogs
* Contributors: OnurDz
* updated changelogs
* Contributors: OnurDz
```

## mrp2_robot

```
* updated changelogs
* version bump
* updated changelogs
* updated changelogs
* Contributors: OnurDz
* version bump
* updated changelogs
* updated changelogs
* Contributors: OnurDz
* updated changelogs
* Contributors: OnurDz
```
