### PR TITLE
webots_ros2: 1.0.1-4 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3669,7 +3669,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros2-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     source:
       test_pull_requests: true
       type: git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3669,7 +3669,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros2-release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
The packages in the `webots_ros2` repository were released into the `eloquent` distro by running `/home/lukic/.local/bin/bloom-release --rosdistro eloquent --track eloquent webots_ros2 --edit` on `Wed, 07 Oct 2020 07:07:00 -0000`

These packages were released:
- `webots_ros2`
- `webots_ros2_abb`
- `webots_ros2_core`
- `webots_ros2_demos`
- `webots_ros2_epuck`
- `webots_ros2_examples`
- `webots_ros2_importer`
- `webots_ros2_msgs`
- `webots_ros2_tiago`
- `webots_ros2_universal_robot`
- `webots_ros2_ur_e_description`

Version of package(s) in repository `webots_ros2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/cyberbotics/webots_ros2-release.git
- rosdistro version: `1.0.1-1`
- old version: `1.0.1-3`
- new version: `1.0.1-4`

Versions of tools used:

- bloom version: `0.10.0`
- catkin_pkg version: `0.4.20`
- rosdep version: `0.19.0`
- rosdistro version: `0.8.2`
- vcstools version: `0.1.42`