### PR TITLE
fkie_potree_rviz_plugin: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3022,7 +3022,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fkie-release/potree_rviz_plugin-release.git
-      version: 1.0.0-0
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/fkie/potree_rviz_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_potree_rviz_plugin` to `1.0.1-1`:

- upstream repository: https://github.com/fkie/potree_rviz_plugin.git
- release repository: https://github.com/fkie-release/potree_rviz_plugin-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-0`

## fkie_potree_rviz_plugin

```
* Improve cone rendering
```
