### PR TITLE
fkie_potree_rviz_plugin: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1191,6 +1191,17 @@ repositories:
       url: https://github.com/fkie/multimaster_fkie.git
       version: noetic-devel
     status: maintained
+  fkie_potree_rviz_plugin:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fkie-release/potree_rviz_plugin-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/fkie/potree_rviz_plugin.git
+      version: master
+    status: maintained
   fmi_adapter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_potree_rviz_plugin` to `1.0.1-1`:

- upstream repository: https://github.com/fkie/potree_rviz_plugin.git
- release repository: https://github.com/fkie-release/potree_rviz_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## fkie_potree_rviz_plugin

```
* Improve cone rendering
```
