### PR TITLE
qt_gui_core: 1.1.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1292,7 +1292,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 1.1.2-1
+      version: 1.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `1.1.2-2`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.2-1`

## qt_dotgraph

```
* add API to set edge tooltip (#237 <https://github.com/ros-visualization/qt_gui_core/issues/237>)
```

## qt_gui

```
* allow hide title in standalone (#235 <https://github.com/ros-visualization/qt_gui_core/issues/235>)
```

## qt_gui_app

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
