### PR TITLE
urdf: 2.4.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3608,7 +3608,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.4.0-1
+      version: 2.4.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.4.0-2`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.4.0-1`

## urdf

```
* Deprecate methods that require tinyxml (#12 <https://github.com/ros2/urdf/issues/12>)
* Contributors: Dan Rose
```
