### PR TITLE
rc_common_msgs: 0.5.3-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2064,6 +2064,22 @@ repositories:
       url: https://github.com/rt-net/raspimouse2.git
       version: dashing-devel
     status: developed
+  rc_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_common_msgs_ros2-release.git
+      version: 0.5.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    status: developed
   rc_dynamics_api:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_common_msgs` to `0.5.3-1`:

- upstream repository: https://github.com/roboception/rc_common_msgs_ros2.git
- release repository: https://github.com/roboception-gbp/rc_common_msgs_ros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rc_common_msgs

```
* CI changes only: also build for focal/foxy
```
