### PR TITLE
play_motion: 0.4.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7849,6 +7849,15 @@ repositories:
       url: https://github.com/SeaosRobotics/pipeline_planner_open.git
       version: master
     status: maintained
+  play_motion:
+    release:
+      packages:
+      - play_motion
+      - play_motion_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-gbp/play_motion-release2.git
+      version: 0.4.8-1
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion` to `0.4.8-1`:

- upstream repository: https://github.com/pal-robotics/play_motion.git
- release repository: https://github.com/pal-gbp/play_motion-release2.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## play_motion

```
* Fixes for shadowed variables
* Contributors: Jordan Palacios
```

## play_motion_msgs

- No changes
