### PR TITLE
Revert jsk recognition

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4736,7 +4736,6 @@ repositories:
       version: master
     release:
       packages:
-      - audio_to_spectrogram
       - checkerboard_detector
       - imagesift
       - jsk_pcl_ros
@@ -4749,7 +4748,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.11-1
+      version: 1.2.10-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4749,7 +4749,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.12-1
+      version: 1.2.11-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
The latest versions aren't building on the buildfarm: see http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__jsk_perception__ubuntu_bionic_amd64__binary/ for one example.  This reverts it back to the last version that built, 1.2.10.  @k-okada FYI.