### PR TITLE
ament_cmake: 0.9.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -39,6 +39,7 @@ repositories:
       - ament_cmake_export_link_flags
       - ament_cmake_export_targets
       - ament_cmake_gmock
+      - ament_cmake_google_benchmark
       - ament_cmake_gtest
       - ament_cmake_include_directories
       - ament_cmake_libraries
@@ -51,7 +52,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.9.6-1
+      version: 0.9.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `0.9.7-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.6-1`
