### PR TITLE
Add boost_sml source entry to Melodic distribution

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -892,6 +892,12 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
     status: maintained
+  boost_sml:
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/boost_sml.git
+      version: master
+    status: maintained
   brics_actuator:
     doc:
       type: git


### PR DESCRIPTION
`boost_sml` is a convience ros package wrapper of the [boost].SML library with a few logging niceties.