### PR TITLE
Add leo_desktop to melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5139,6 +5139,24 @@ repositories:
       url: https://github.com/LeoRover/leo_description.git
       version: master
     status: maintained
+  leo_desktop:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop.git
+      version: master
+    release:
+      packages:
+      - leo_desktop
+      - leo_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_desktop-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop.git
+      version: master
+    status: maintained
   leo_gazebo:
     doc:
       type: git
@@ -5152,21 +5170,6 @@ repositories:
     source:
       type: git
       url: https://github.com/LeoRover/leo_gazebo.git
-      version: master
-    status: maintained
-  leo_viz:
-    doc:
-      type: git
-      url: https://github.com/LeoRover/leo_viz.git
-      version: master
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/fictionlab-gbp/leo_viz-release.git
-      version: 0.2.0-1
-    source:
-      type: git
-      url: https://github.com/LeoRover/leo_viz.git
       version: master
     status: maintained
   leuze_ros_drivers:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5124,19 +5124,22 @@ repositories:
       version: hydro
     status: developed
     status_description: Slow development
-  leo_description:
+  leo_common:
     doc:
       type: git
-      url: https://github.com/LeoRover/leo_description.git
+      url: https://github.com/LeoRover/leo_common.git
       version: master
     release:
+      packages:
+      - leo
+      - leo_description
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/fictionlab-gbp/leo_description-release.git
-      version: 1.0.0-1
+      url: https://github.com/fictionlab-gbp/leo_common-release.git
+      version: 1.0.1-1
     source:
       type: git
-      url: https://github.com/LeoRover/leo_description.git
+      url: https://github.com/LeoRover/leo_common.git
       version: master
     status: maintained
   leo_desktop:


### PR DESCRIPTION
I had to manually make changes and open Pull Request, because the `leo_viz` package has been moved to `leo_desktop` repository.