### PR TITLE
performance_test_fixture: 0.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1817,6 +1817,18 @@ repositories:
       url: https://github.com/ros-perception/perception_pcl.git
       version: foxy-devel
     status: maintained
+  performance_test_fixture:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test_fixture-release.git
+      version: 0.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/performance_test_fixture.git
+      version: main
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.0.4-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## performance_test_fixture

```
* Expose a function for resetting the heap counters (#6 <https://github.com/ros2/performance_test_fixture/issues/6>)
* Stop recording memory operations sooner (#5 <https://github.com/ros2/performance_test_fixture/issues/5>)
* Suppress memory tools warning if tests will be skipped (#4 <https://github.com/ros2/performance_test_fixture/issues/4>)
* Contributors: Scott K Logan
```
