### PR TITLE
novatel_gps_driver: 4.1.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1552,7 +1552,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 4.0.3-1
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `4.0.3-1`

## novatel_gps_driver

```
* Add param to disable invalid GPSFixes, replace GPRMC with BESTVEL (ROS2) (#94 <https://github.com/swri-robotics/novatel_gps_driver/issues/94>)
* Use rclcpp::WallRate to sleep instead of boost (ROS2) (#86 <https://github.com/swri-robotics/novatel_gps_driver/issues/86>)
* Refactor GPSFix generation (ROS2) (#73 <https://github.com/swri-robotics/novatel_gps_driver/issues/73>)
* Contributors: P. J. Reed
```

## novatel_gps_msgs

```
* Refactor GPSFix generation (ROS2) (#73 <https://github.com/swri-robotics/novatel_gps_driver/issues/73>)
* Contributors: P. J. Reed
```
