### PR TITLE
novatel_gps_driver: 4.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1684,6 +1684,25 @@ repositories:
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
       version: foxy-devel
     status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
+      version: 4.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: dashing-devel
+    status: developed
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## novatel_gps_driver

```
* Add param to disable invalid GPSFixes, replace GPRMC with BESTVEL (ROS2) (#94 <https://github.com/swri-robotics/novatel_gps_driver/issues/94>)
* Use rclcpp::WallRate to sleep instead of boost (ROS2) (#86 <https://github.com/swri-robotics/novatel_gps_driver/issues/86>)
* Refactor GPSFix generation (ROS2) (#73 <https://github.com/swri-robotics/novatel_gps_driver/issues/73>)
* Contributors: P. J. Reed
```

## novatel_gps_msgs

```
* Refactor GPSFix generation (ROS2) (#73 <https://github.com/swri-robotics/novatel_gps_driver/issues/73>)
* Contributors: P. J. Reed
```
