### PR TITLE
rmw_fastrtps: 1.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2440,7 +2440,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.2.1-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.0-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Fix memory leak that wait_set might be not destoryed in some case (#423 <https://github.com/ros2/rmw_fastrtps/issues/423>) (#426 <https://github.com/ros2/rmw_fastrtps/issues/426>)
* Use package path to TypeSupport.hpp headers in ServiceTypeSupport and MessageTypeSupport (#415 <https://github.com/ros2/rmw_fastrtps/issues/415>) (#420 <https://github.com/ros2/rmw_fastrtps/issues/420>)
* Fix trying to get topic data that was already removed (#421 <https://github.com/ros2/rmw_fastrtps/issues/421>)
* Contributors: Chen Lihui, Dirk Thomas, Jose Luis Rivero
```
