### PR TITLE
rosidl_typesupport_connext: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2914,7 +2914,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-1`

## connext_cmake_module

- No changes

## rosidl_typesupport_connext_c

- No changes

## rosidl_typesupport_connext_cpp

```
* Check allocation of requester and replier (#60 <https://github.com/ros2/rosidl_typesupport_connext/issues/60>)
* Contributors: brawner
```
