### PR TITLE
rmw_cyclonedds: 0.7.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2402,7 +2402,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.7.4-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.3-1`

## rmw_cyclonedds_cpp

```
* rmw_destroy_node must remove node from graph cache (#252 <https://github.com/ros2/rmw_cyclonedds/issues/252>)
* Contributors: Erik Boasson
```
