### PR TITLE
rcl: 1.1.8-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2153,7 +2153,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.7-1
+      version: 1.1.8-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.8-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.7-1`

## rcl

```
* Tweaks to client.c and subscription.c for cleaner init/fini (#728 <https://github.com/ros2/rcl/issues/728>) (#822 <https://github.com/ros2/rcl/issues/822>)
* Contributors: Stephen Brawner
```

## rcl_action

```
* Fix action client test failure on Windows by zero initializing pointers and freeing memory (#717 <https://github.com/ros2/rcl/issues/717>) (#820 <https://github.com/ros2/rcl/issues/820>)
* Use valid clock in case of issue in rcl_timer_init (#795 <https://github.com/ros2/rcl/issues/795>) Store reference to rcl_clock_t instead of copy (#797 <https://github.com/ros2/rcl/issues/797>) (#805 <https://github.com/ros2/rcl/issues/805>)
* Contributors: Shane Loretz, Stephen Brawner
```

## rcl_lifecycle

```
* Set transition_map->states/transition size to 0 on fini (#729 <https://github.com/ros2/rcl/issues/729>) (#821 <https://github.com/ros2/rcl/issues/821>)
* Topic fix rcl lifecycle test issue (#715 <https://github.com/ros2/rcl/issues/715>) (#796 <https://github.com/ros2/rcl/issues/796>)
* Remove std::cout line from test_rcl_lifecycle.cpp (#773 <https://github.com/ros2/rcl/issues/773>) (#774 <https://github.com/ros2/rcl/issues/774>)
* Contributors: Shane Loretz, Stephen Brawner
```

## rcl_yaml_param_parser

```
* Fix yaml parser error when meets .nan (refactor on #754 <https://github.com/ros2/rcl/issues/754>) (#781 <https://github.com/ros2/rcl/issues/781>) (#785 <https://github.com/ros2/rcl/issues/785>)
* Refactor parser.c for better testability (#754 <https://github.com/ros2/rcl/issues/754>) (#784 <https://github.com/ros2/rcl/issues/784>)
* Don't overwrite cur_ns pointer if reallocation fails (#780 <https://github.com/ros2/rcl/issues/780>) (#783 <https://github.com/ros2/rcl/issues/783>)
* Set yaml_variant values to NULL on finalization (#765 <https://github.com/ros2/rcl/issues/765>) (#782 <https://github.com/ros2/rcl/issues/782>)
* Fix rcl_parse_yaml_file() error handling (#776 <https://github.com/ros2/rcl/issues/776>) (#786 <https://github.com/ros2/rcl/issues/786>)
* Contributors: Michel Hidalgo, Stephen Brawner
```
