### PR TITLE
rclcpp: 2.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2241,7 +2241,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.1.0-1`

## rclcpp

```
* Fix implementation of NodeOptions::use_global_arguments() (#1176 <https://github.com/ros2/rclcpp/issues/1176>) (#1372 <https://github.com/ros2/rclcpp/issues/1372>)
* Fix conversion of negative durations to messages (#1188 <https://github.com/ros2/rclcpp/issues/1188>) (#1371 <https://github.com/ros2/rclcpp/issues/1371>)
* Call vector.erase with end iterator overload (#1314 <https://github.com/ros2/rclcpp/issues/1314>) (#1380 <https://github.com/ros2/rclcpp/issues/1380>)
* Check waitable for nullptr during constructor (#1315 <https://github.com/ros2/rclcpp/issues/1315>) (#1379 <https://github.com/ros2/rclcpp/issues/1379>)
* Fix pub/sub count API tests. (#1203 <https://github.com/ros2/rclcpp/issues/1203>) (#1319 <https://github.com/ros2/rclcpp/issues/1319>)
* Reorganize test directory and split CMakeLists.txt (#1173 <https://github.com/ros2/rclcpp/issues/1173>) (#1262 <https://github.com/ros2/rclcpp/issues/1262>)
* Add operator!= for duration (#1236 <https://github.com/ros2/rclcpp/issues/1236>) (#1278 <https://github.com/ros2/rclcpp/issues/1278>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron, Jannik Abbenseth, Johannes Meyer, Michel Hidalgo, Stephen Brawner
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Include original exception in ComponentManagerException (#1157 <https://github.com/ros2/rclcpp/issues/1157>) (#1223 <https://github.com/ros2/rclcpp/issues/1223>)
* Contributors: Dereck Wonnacott
```

## rclcpp_lifecycle

```
* Log error instead of throwing exception in Transition and State reset() mark no except (#1297 <https://github.com/ros2/rclcpp/issues/1297>) (#1378 <https://github.com/ros2/rclcpp/issues/1378>)
* Remove rmw-dependent unit-test checks (#1293 <https://github.com/ros2/rclcpp/issues/1293>) (#1377 <https://github.com/ros2/rclcpp/issues/1377>)
* Contributors: Stephen Brawner
```
