### PR TITLE
udp_msgs: 0.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3400,6 +3400,17 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: eloquent-devel
     status: maintained
+  udp_msgs:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/flynneva/udp_msgs-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: devel
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_msgs` to `0.0.1-1`:

- upstream repository: https://github.com/flynneva/udp_msgs.git
- release repository: https://github.com/flynneva/udp_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
