### PR TITLE
turtlebot3: 1.2.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12051,7 +12051,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 1.2.2-1
+      version: 1.2.4-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `1.2.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.2.2-1`

## turtlebot3

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_bringup

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_description

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_example

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_navigation

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_slam

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_teleop

```
* Package info updated
* Contributors: Will Son
```
