### PR TITLE
turtlebot3: 1.2.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5295,6 +5295,29 @@ repositories:
       url: https://github.com/stack-of-tasks/tsid.git
       version: devel
     status: maintained
+  turtlebot3:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: noetic-devel
+    release:
+      packages:
+      - turtlebot3
+      - turtlebot3_bringup
+      - turtlebot3_description
+      - turtlebot3_example
+      - turtlebot3_navigation
+      - turtlebot3_slam
+      - turtlebot3_teleop
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
+      version: 1.2.4-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: noetic-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `1.2.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## turtlebot3

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_bringup

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_description

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_example

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_navigation

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_slam

```
* Package info updated
* Contributors: Will Son
```

## turtlebot3_teleop

```
* Package info updated
* Contributors: Will Son
```
