### PR TITLE
ddynamic_reconfigure: 0.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2039,7 +2039,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-gbp/ddynamic_reconfigure.git
-      version: 0.2.0-0
+      version: 0.3.1-1
   ddynamic_reconfigure_python:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure` to `0.3.1-1`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.0-0`

## ddynamic_reconfigure

```
* Merge pull request #18 from clearpathrobotics/issue_17
  Reverse the order of creation of the topic publisher and rosservice
* Reverse the order of creation of the topic publisher and rosservice to prevent startup race conditions leading to crash.
  issue: #17
* Contributors: Guillaume Autran, Victor Lopez
```
