### PR TITLE
sot-core: 4.10.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5098,7 +5098,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/sot-core-ros-release.git
-      version: 4.10.1-1
+      version: 4.10.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-core` to `4.10.1-3`:

- upstream repository: https://github.com/stack-of-tasks/sot-core.git
- release repository: https://github.com/stack-of-tasks/sot-core-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `4.10.1-1`
