### PR TITLE
Revert "jsk_recognition: 1.2.13-1 in 'melodic/distribution.yaml' [blo…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4742,7 +4742,6 @@ repositories:
       version: master
     release:
       packages:
-      - audio_to_spectrogram
       - checkerboard_detector
       - imagesift
       - jsk_pcl_ros
@@ -4755,7 +4754,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.13-1
+      version: 1.2.10-0
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
…om] (#26861)"

This reverts commit 87bb64ca1e6a2d0a8cc155323797867f6246d54f.