### PR TITLE
mcl_3dl: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5642,7 +5642,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.4.0-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.0-1`

## mcl_3dl

```
* Fix typos of license (#340 <https://github.com/at-wat/mcl_3dl/issues/340>)
* Add PointCloudSamplerWithNormal (#339 <https://github.com/at-wat/mcl_3dl/issues/339>)
* Contributors: Naotaka Hatao
```
