### PR TITLE
mcl_3dl: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2365,7 +2365,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.4.0-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.0-1`

## mcl_3dl

```
* Fix typos of license (#340 <https://github.com/at-wat/mcl_3dl/issues/340>)
* Add PointCloudSamplerWithNormal (#339 <https://github.com/at-wat/mcl_3dl/issues/339>)
* Contributors: Naotaka Hatao
```
