### PR TITLE
roverrobotics_ros2: 0.1.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2976,7 +2976,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/RoverRobotics-release/roverrobotics_ros2-release.git
-      version: 0.1.0-4
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/RoverRobotics/roverrobotics_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roverrobotics_ros2` to `0.1.1-2`:

- upstream repository: https://github.com/RoverRobotics/roverrobotics_ros2.git
- release repository: https://github.com/RoverRobotics-release/roverrobotics_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-4`

## rover_bringup

```
* correct package dependency to allow for ros buildfarm passage
```

## rover_description

```
* correct package dependency to allow for ros buildfarm passage
```

## rover_driver

```
* Add pi contoller timeout to prevent run away
* correct package dependency to allow for ros buildfarm passage
```

## rover_msgs

- No changes

## rover_navigation

- No changes

## rover_simulation

```
* formatting launch.py files and adding env-hooks
```

## rover_teleop

- No changes

## roverrobotics_ros2

```
* Add pi contoller timeout to prevent run away
* formatting launch.py files and adding env-hooks
* correct package dependency to allow for ros buildfarm passage
```
