### PR TITLE
leo_common: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5138,10 +5138,11 @@ repositories:
       packages:
       - leo
       - leo_description
+      - leo_teleop
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-1`

## leo

```
* Add leo_teleop package
```

## leo_description

```
* Bump minimum cmake version to 3.0.2
* Update package manifest
```

## leo_teleop

```
* Add leo_teleop package
```
