### PR TITLE
moveit_visual_tools: 3.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2602,6 +2602,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_resources.git
       version: master
     status: maintained
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/moveit_visual_tools-release.git
+      version: 3.6.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: noetic-devel
+    status: developed
   mpc_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `3.6.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/ros-gbp/moveit_visual_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## moveit_visual_tools

```
* [feature] Unified collision environment used (#54 <https://github.com/ros-planning/moveit_visual_tools/issues/54>)
* [feature] publish cuboids with size (#59 <https://github.com/ros-planning/moveit_visual_tools/issues/59>)
* [feature] hideRobot(): use new .hide member of DisplayRobotState msg (#56 <https://github.com/ros-planning/moveit_visual_tools/issues/56>)
* [feature] Use first trajectory point as start state for visualization (#49 <https://github.com/ros-planning/moveit_visual_tools/issues/49>)
* [feature] exposing the publishers to the user (#48 <https://github.com/ros-planning/moveit_visual_tools/issues/48>)
* [feature] Highlight selected links in publishRobotState() + improved collision visualization (#45 <https://github.com/ros-planning/moveit_visual_tools/issues/45>)
* [fix] Update to Noetic and fix various warnings (#79 <https://github.com/ros-planning/moveit_visual_tools/issues/79>)
* [fix] Fix Eigen alignment (#63 <https://github.com/ros-planning/moveit_visual_tools/issues/63>)
* [fix] missing end effector markers because clear (#51 <https://github.com/ros-planning/moveit_visual_tools/issues/51>)
* [fix] Remove #attempts from setFromIK (#43 <https://github.com/ros-planning/moveit_visual_tools/issues/43>)
* [documentation] Update README.md (#69 <https://github.com/ros-planning/moveit_visual_tools/issues/69>)
* [documentation] update doc of hideRobot() (#64 <https://github.com/ros-planning/moveit_visual_tools/issues/64>)
* [maint] add soname version (#74 <https://github.com/ros-planning/moveit_visual_tools/issues/74>)
* [maint] Replace tf_conversions with tf2's toMsg / fromMsg (#66 <https://github.com/ros-planning/moveit_visual_tools/issues/66>)
* [maint] fix clang-tidy issue (#68 <https://github.com/ros-planning/moveit_visual_tools/issues/68>)
* [maint] Cleanup (#65 <https://github.com/ros-planning/moveit_visual_tools/issues/65>)
  * Replace robot_model and robot_state namespaces by moveit::core
  * Fix clang-tidy issues
  * Remove deprecated function
* [maint] Bump required cmake version (#62 <https://github.com/ros-planning/moveit_visual_tools/issues/62>)
* [maint] moveit.rosinstall: use master branch for all deps (#57 <https://github.com/ros-planning/moveit_visual_tools/issues/57>)
* [maint] drop melodic + kinetic support for master branch (#58 <https://github.com/ros-planning/moveit_visual_tools/issues/58>)
* [maint] Fix Travis config + issues (#47 <https://github.com/ros-planning/moveit_visual_tools/issues/47>)
* [maint] Change 'MoveIt!' to MoveIt
* Contributors: Bjar Ne, Dave Coleman, Henning Kayser, Jafar Abdi, Jens P, Mark Moll, Michael Görner, Mike Lautman, Robert Haschke, Tyler Weaver
```
