### PR TITLE
rviz_visual_tools: 3.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4881,7 +4881,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
-      version: 3.9.0-1
+      version: 3.9.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_visual_tools` to `3.9.1-1`:

- upstream repository: https://github.com/PickNikRobotics/rviz_visual_tools.git
- release repository: https://github.com/PickNikRobotics/rviz_visual_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.9.0-1`

## rviz_visual_tools

```
* [maint] add soname versions to libraries (#166 <https://github.com/tylerjw/rviz_visual_tools/issues/166>)
* [maint] Apply clang-format-10 (#173 <https://github.com/tylerjw/rviz_visual_tools/issues/173>)
* Contributors: Tyler Weaver
```
