### PR TITLE
warehouse_ros_mongo: 0.10.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5674,6 +5674,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: kinetic-devel
     status: maintained
+  warehouse_ros_mongo:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/warehouse_ros_mongo-release.git
+      version: 0.10.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: noetic-devel
+    status: maintained
   webkit_dependency:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `0.10.0-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/ros-gbp/warehouse_ros_mongo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## warehouse_ros_mongo

```
* clang-format-10
* Python3 compatibility layer for roslaunch in CMake (#35 <https://github.com/ros-planning/warehouse_ros_mongo/issues/35>)
* Contributors: Robert Haschke, Tyler Weaver
```
