### PR TITLE
rcpputils: 1.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2274,7 +2274,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_abi: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `1.3.1-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.3.0-1`

## rcpputils

```
* Add scope_exit helper. (#78 <https://github.com/ros2/rcpputils//issues/78>) (#103 <https://github.com/ros2/rcpputils//issues/103>)
* Contributors: Alejandro Hernández Cordero, Michel Hidalgo
```
