### PR TITLE
jsk_recognition: 1.2.15-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6067,7 +6067,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.14-1
+      version: 1.2.15-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.15-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.14-1`

## audio_to_spectrogram

- No changes

## checkerboard_detector

- No changes

## imagesift

- No changes

## jsk_pcl_ros

- No changes

## jsk_pcl_ros_utils

- No changes

## jsk_perception

```
* check if template/ direcotry exists, because this is auto-generated directory (#2537 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2537>)
  
    * install within roseus_FOUND
    * check if template/ direcotry exists, because this is auto-generated directory
  
* Contributors: Kei Okada
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

- No changes

## jsk_recognition_utils

- No changes

## resized_image_transport

- No changes
