### PR TITLE
grbl_msgs: 0.0.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -951,6 +951,17 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: dashing-devel
     status: developed
+  grbl_msgs:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/flynneva/grbl_msgs-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
+    status: maintained
   grbl_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_msgs` to `0.0.1-1`:

- upstream repository: https://github.com/flynneva/grbl_msgs.git
- release repository: https://github.com/flynneva/grbl_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
