### PR TITLE
ros_controllers: 0.18.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3923,7 +3923,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.17.0-1
+      version: 0.18.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.18.0-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.17.0-1`

## ackermann_steering_controller

```
* Fix dependency on Boost
* Clean dependencies of diff_drive_controller package
* Remove (unneeded?) dependencies on rosunit and gtest
* Format package.xml and CMakeLists.txt according to ros_control pkgs
* Clean dependencies of ackermann_steering_controller pkg
* Contributors: Mateus Amarante
```

## diff_drive_controller

```
* Fix dependency on Boost
* Apply consistent format to CMakeLists.txt
* Update package.xml to format 3
* Clean dependencies of diff_drive_controller package
* Apply waitForController method to all diff_drive_controller tests
* Move odom_pub setup to the end to allow consistent isControllerAlive check
* Contributors: Mateus Amarante
```

## effort_controllers

```
* Update effort_controllers' package.xml file to format 3
* Apply consistent format to effort_controllers' CMakeLists.txt file
* Clean effort_controllers' dependencies
* [effort_controllers] JointGroupPositionController: Change to initRT
* [effort_controllers] JointGroupPositionController: Set to current position in starting
  Currently, the target position upon starting is all zeros. This is not
  great if a command is not issued immediately. To be safer, set the goal
  position to the current sensed position and also reset the PID internal
  state upon starting.
* Remove unused transmission in effort_controllers test
* Add missing test dependency on joint_state_controller in effort_controllers
* [effort_controllers] JointGroupPositionController: Load URDF from namespace
  Mimics #245 <https://github.com/ros-controls/ros_controllers/issues/245>
* Contributors: Mateus Amarante, Wolfgang Merkt
```

## force_torque_sensor_controller

- No changes

## forward_command_controller

```
* Apply consistent format to forward_command_controller's CMakeLists.txt file
* Update package.xml of forward_ccommand_controller pkg to format 3
* Fix dependencies of forward_command_controller pkg
* Contributors: Mateus Amarante
```

## four_wheel_steering_controller

```
* Add missing test dependency on xacro in four_wheel_steering_controller
* Contributors: Mateus Amarante
```

## gripper_action_controller

- No changes

## imu_sensor_controller

- No changes

## joint_state_controller

```
* Move .yaml and .launch files to config/ and launch/ folders
* Update joint_state_controller's package.xml file to format 3
* Apply consistent format to joint_state_controller's CMakeLists.txt file
* Clean joint_state_controller's dependencies
* Move pluginlib/clast_list_macros.hpp include to cpp file
* Contributors: Mateus Amarante
```

## joint_trajectory_controller

```
* Increase joint0 smoothing to force goal tolerance violation
* Add pathToleranceViolationSingleJoint and goalToleranceViolationSingleJoint tests
* Allow setting 'smoothing' to each joint of rrbot
* Only update state_joint_error_  values in loop where used
* JointTrajectoryController: Fix tolerance checking to use state error from the correct joints
* Fix missing virtual destructor
* Contributors: Bence Magyar, Doug Morrison, Mateus Amarante, Tyler Weaver
```

## position_controllers

- No changes

## ros_controllers

- No changes

## rqt_joint_trajectory_controller

```
* Use Python3 explicitly
* fix shebang line for python3
* Contributors: Bence Magyar, Mikael Arguedas
```

## velocity_controllers

- No changes
