### PR TITLE
ros_control: 0.19.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3878,7 +3878,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.19.2-1
+      version: 0.19.3-2
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.19.3-2`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.19.2-1`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

```
* Update mainpage.dox
  - Explain JointStateInterface and PositionJointInterface
  - Explain how to use potential software transmissions
  - Link to transmission_interface examples
* Update doc of robot_hw.h
  - Use JointStateHandle in case of read-only operations
* doc: add README.md for hardware_interface
* doc: add mainpage.dox including examples
* doc: update robot_hw.h docstrings
  update docstring of class and init method.
* Contributors: Franz Pucher, Bence Magyar
```

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Fix jnt-to-act command propagation check in transmission_interface_loader_test (#473 <https://github.com/ros-controls/ros_control/issues/473>)
  * Fix jnt-to-act command propagation check
  * Fix jnt-to-act command propagation check of bidirectional transmissions
* Remove ParseStatus enum (#470 <https://github.com/ros-controls/ros_control/issues/470>)
* Remove irrelevant test case (resolve #460 <https://github.com/ros-controls/ros_control/issues/460>) (#472 <https://github.com/ros-controls/ros_control/issues/472>)
* Contributors: Mateus Amarante, Jordan Lack
```
