### PR TITLE
rosaic: 1.0.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9791,6 +9791,16 @@ repositories:
       type: git
       url: https://github.com/septentrio-gnss/rosaic.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/septentrio-gnss/rosaic-release.git
+      version: 1.0.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/septentrio-gnss/rosaic.git
+      version: master
     status: maintained
   rosauth:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosaic` to `1.0.5-1`:

- upstream repository: https://github.com/septentrio-gnss/rosaic.git
- release repository: https://github.com/septentrio-gnss/rosaic-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rosaic

```
* Merge pull request #21 <https://github.com/septentrio-gnss/rosaic/issues/21> from septentrio-gnss/local_tibor
  Added rosdoc.yaml file
* Merge pull request #20 <https://github.com/septentrio-gnss/rosaic/issues/20> from septentrio-gnss/local_tibor
  Improved doxygen annotations
* Merge pull request #19 <https://github.com/septentrio-gnss/rosaic/issues/19> from septentrio-gnss/local_tibor
  Improved doxygen annotations
* Update README.md
* Merge pull request #18 <https://github.com/septentrio-gnss/rosaic/issues/18> from septentrio-gnss/local_tibor
  Adopted ROS and C++ conventions, added ROS diagnostics msg,
* Update README.md
* Update README.md
* Update README.md
* Contributors: septentrio-users
```
