### PR TITLE
rcpputils activated test_pull_request: Foxy and Rolling

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2277,6 +2277,7 @@ repositories:
       version: 1.3.0-1
     source:
       test_abi: true
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcpputils.git
       version: foxy

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1433,6 +1433,7 @@ repositories:
       url: https://github.com/ros2-gbp/rcpputils-release.git
       version: 2.0.1-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcpputils.git
       version: master


### PR DESCRIPTION
As discussed in this PR https://github.com/ros2/rcpputils/pull/104, the idea of this PR is to deactivate the Github Actions in favour of the CI offered by the ROS buildfarm in the rcpputils package.

Signed-off-by: ahcorde <ahcorde@gmail.com>