### PR TITLE
Adding shadow robot repos to documentation index for distro kinetic

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15150,6 +15150,76 @@ repositories:
       url: https://github.com/neufieldrobotics/spinnaker_sdk_camera_driver.git
       version: master
     status: maintained
+  sr_common:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_common.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_common.git
+      version: kinetic-devel
+    status: developed
+  sr_config:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-config.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-config.git
+      version: kinetic-devel
+    status: developed
+  sr_core:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_core.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_core.git
+      version: kinetic-devel
+    status: developed
+  sr_ethercat:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: kinetic-devel
+    status: developed
+  sr_interface:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_interface.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface.git
+      version: kinetic-devel
+    status: developed
+  sr_tools:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_tools.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_tools.git
+      version: kinetic-devel
+    status: developed
+  sr_visualisation:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-visualization.git
+      version: kinetic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-visualization.git
+      version: kinetic-devel
+    status: developed
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
I'm like the shadow robot repos to be indexed and documented on ros.org.