### PR TITLE
Adding shadow robot repos to documentation index for distro melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11524,6 +11524,46 @@ repositories:
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
       version: melodic-devel
     status: maintained
+  sr_common:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_common.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_common.git
+      version: melodic-devel
+    status: maintained
+  sr_config:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-config.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-config.git
+      version: melodic-devel
+    status: maintained
+  sr_core:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_core.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_core.git
+      version: melodic-devel
+    status: maintained
+  sr_ethercat:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
+      version: melodic-devel
+    status: maintained
   sr_hand_detector:
     release:
       tags:
@@ -11534,6 +11574,36 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/sr_hand_detector.git
       version: melodic-devel
+  sr_interface:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_interface.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_interface.git
+      version: melodic-devel
+    status: maintained
+  sr_tools:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr_tools.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr_tools.git
+      version: melodic-devel
+    status: maintained
+  sr_visualisation:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/sr-visualization.git
+      version: melodic-devel
+    source:
+      type: git
+      url: https://github.com/shadow-robot/sr-visualization.git
+      version: melodic-devel
+    status: maintained
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
I'd like shadow robot repos to be indexed and documented on ros.org.