### PR TITLE
Add ainstein_radar to documentation index for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -44,6 +44,12 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: noetic-devel
     status: maintained
+  ainstein_radar:
+    source:
+      type: git
+      url: https://github.com/AinsteinAI/ainstein_radar.git
+      version: master
+    status: maintained
   angles:
     doc:
       type: git


### PR DESCRIPTION
I'd like ainstein_radar to be indexed and documented on ros.org.