### PR TITLE
joystick_drivers: 1.15.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1860,7 +1860,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/joystick_drivers-release.git
-      version: 1.14.0-1
+      version: 1.15.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `1.15.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros-gbp/joystick_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.14.0-1`

## joy

```
* Added autodetection for force-feedback devices. (#169 <https://github.com/ros-drivers/joystick_drivers/issues/169>)
  * Added autodetection for force-feedback devices.
  * RAII for closedir
* joy: Little fixes for force feedback. (#167 <https://github.com/ros-drivers/joystick_drivers/issues/167>)
  This commit increases the maximum magnitude of the FF effects to double the previous maximum.
* Print out joystick name on initialization. (#168 <https://github.com/ros-drivers/joystick_drivers/issues/168>)
  This helps figuring out what string to give to the dev_name parameter.
* Contributors: Martin Pecka
```

## joystick_drivers

- No changes

## ps3joy

- No changes

## spacenav_node

```
* Remove spacenavd from the requirements for Noetic (#186 <https://github.com/ros-drivers/joystick_drivers/issues/186>)
* Contributors: Tyler Weaver
```

## wiimote

- No changes
