### PR TITLE
udp_msgs: 0.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3405,7 +3405,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/flynneva/udp_msgs-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/flynneva/udp_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/flynneva/udp_msgs.git
- release repository: https://github.com/flynneva/udp_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.1-1`

## udp_msgs

```
* add release gh action
* fix std_msgs dependency
* add changelog
* Contributors: Evan Flynn
```
