### PR TITLE
udp_msgs: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2550,6 +2550,21 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: galactic-devel
     status: maintained
+  udp_msgs:
+    doc:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/flynneva/udp_msgs-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: main
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `udp_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/flynneva/udp_msgs.git
- release repository: https://github.com/flynneva/udp_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## udp_msgs

```
* add release gh action
* fix std_msgs dependency
* add changelog
* Contributors: Evan Flynn
```
