### PR TITLE
ur_msgs: 1.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12514,7 +12514,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-industrial-release/ur_msgs-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `1.3.2-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros-industrial-release/ur_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.3.1-1`

## ur_msgs

```
* Fix domain constants in ``Analog.msg`` (#8 <https://github.com/ros-industrial/ur_msgs/issues/8>)
* Contributors: Gaël Écorchard
```
