### PR TITLE
view_controller_msgs: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5679,6 +5679,21 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
       version: master
     status: maintained
+  view_controller_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/view_controller_msgs.git
+      version: lunar-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/view_controller_msgs-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/view_controller_msgs.git
+      version: lunar-devel
+    status: unmaintained
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `view_controller_msgs` to `0.1.3-1`:

- upstream repository: https://github.com/ros-visualization/view_controller_msgs.git
- release repository: https://github.com/ros-gbp/view_controller_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## view_controller_msgs

```
* Merge pull request #5 <https://github.com/ros-visualization/view_controller_msgs/issues/5> from k-okada/lunar-devel
  change maintainer to ROS Orphaned Package Maintainers
* change maintainer to ROS Orphaned Package Maintainers
* Merge pull request #4 <https://github.com/ros-visualization/view_controller_msgs/issues/4> from k-okada/add_travis
  update travis.yml
* update travis.yml
* Contributors: Kei Okada
```
