### PR TITLE
rospy_message_converter: 0.5.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13454,7 +13454,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/rospy_message_converter-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.4-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.3-1`

## rospy_message_converter

```
* Avoid numpy dependency
* Contributors: Martin Günther, betaboon
```
