### PR TITLE
ros2_tracing: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1688,7 +1688,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
-      version: 1.0.3-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `2.0.0-1`:

- upstream repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing.git
- release repository: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.3-1`

## tracetools

```
* Add lifecycle node state transition instrumentation
* Do not export tracetools if empty
* Allow disabling tracetools status app
* Contributors: Christophe Bedard, Ingo Lütkebohle, José Antonio Moral
```

## tracetools_test

```
* Add lifecycle node state transition instrumentation test
* Contributors: Christophe Bedard, Ingo Lütkebohle
```

## tracetools_trace

```
* Add lifecycle node state transition instrumentation
* Contributors: Christophe Bedard, Ingo Lütkebohle
```
