### PR TITLE
dbw_polaris_ros: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -792,6 +792,27 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git
       version: master
     status: developed
+  dbw_polaris_ros:
+    doc:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git
+      version: master
+    release:
+      packages:
+      - dbw_polaris
+      - dbw_polaris_can
+      - dbw_polaris_description
+      - dbw_polaris_joystick_demo
+      - dbw_polaris_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git
+      version: master
+    status: developed
   ddynamic_reconfigure:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_polaris_ros` to `0.0.4-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## dbw_polaris

- No changes

## dbw_polaris_can

```
* Add Accel and Gyro reports
* Contributors: Sun Hwang
```

## dbw_polaris_description

- No changes

## dbw_polaris_joystick_demo

- No changes

## dbw_polaris_msgs

- No changes
