### PR TITLE
boost_sml: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -239,6 +239,21 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
     status: maintained
+  boost_sml:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/boost_sml.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PickNikRobotics/boost_sml-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/boost_sml.git
+      version: master
+    status: developed
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_sml` to `0.1.0-1`:

- upstream repository: https://github.com/PickNikRobotics/boost_sml.git
- release repository: https://github.com/PickNikRobotics/boost_sml-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## boost_sml

```
* [feature] Generate SML diagrams using boost.Graph (#4 <https://github.com/PickNikRobotics/boost_sml/issues/4>)
* [feature] example source to enable catkin to build package that can be depended on (#2 <https://github.com/PickNikRobotics/boost_sml/issues/2>)
* [fix] undefined reference error (#6 <https://github.com/PickNikRobotics/boost_sml/issues/6>)
  * Change static constexpr into const to avoid compiler errors when building in debug mode doesn't inline variables.
* [fix] compilation errors when setting overriding CMAKE_CXX_STANDARD in catkin config. (#5 <https://github.com/PickNikRobotics/boost_sml/issues/5>)
* [maint] move all headers into one directory (#3 <https://github.com/PickNikRobotics/boost_sml/issues/3>)
* Contributors: JafarAbdi, Jere Liukkonen, Mark Moll, Tyler Weaver, picknik-jliukkonen
```
