### PR TITLE
rqt_launch: 0.4.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4529,7 +4529,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_launch-release.git
-      version: 0.4.8-1
+      version: 0.4.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_launch` to `0.4.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_launch.git
- release repository: https://github.com/ros-gbp/rqt_launch-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.8-1`

## rqt_launch

```
* fix shebang line for Python 3 (#24 <https://github.com/ros-visualization/rqt_launch/issues/24>)
* refactor get spawn count text (#23 <https://github.com/ros-visualization/rqt_launch/issues/23>)
* bump CMake minimum version to avoid CMP0048 warning
* autopep8 (#19 <https://github.com/ros-visualization/rqt_launch/issues/19>)
* add Ryan Sinnet co-maintainer, update the current maintainer contact info
```
