### PR TITLE
Add netcdf4 to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2623,6 +2623,14 @@ python-netaddr:
     xenial: [python-netaddr]
     yakkety: [python-netaddr]
     zesty: [python-netaddr]
+python-netcdf4:
+  arch: [python-netcdf4]
+  debian: [python-netcdf4]
+  fedora: [netcdf4-python]
+  freebsd: [py27-netCDF4]
+  gentoo: [dev-python/netcdf4-python]
+  macports: [py27-netcdf4]
+  ubuntu: [python-netcdf4]
 python-netifaces:
   alpine: [py-netifaces]
   arch: [python2-netifaces]
@@ -5993,6 +6001,14 @@ python3-nclib-pip:
   ubuntu:
     pip:
       packages: [nclib]
+python3-netcdf4:
+  arch: [python-netcdf4]
+  debian: [python3-netcdf4]
+  fedora: [python3-netcdf4]
+  freebsd: [py37-netCDF4]
+  gentoo: [dev-python/netcdf4-python]
+  macports: [py37-netcdf4]
+  ubuntu: [python3-netcdf4]
 python3-netifaces:
   alpine: [py3-netifaces]
   debian: [python3-netifaces]


### PR DESCRIPTION
Python interface for accessing large scientific data files. The initial use case is to gather ocean currents data for use in underwater vehicle simulations using Gazebo (uuv_simulator and DAVE). I tested the rosdep keys for Ubuntu and Debian entries (it's not clear which `version` to use with the other operating systems).

arch: https://www.archlinux.org/packages/community/x86_64/python-netcdf4/
debian: https://packages.debian.org/search?keywords=netcdf4&searchon=names&suite=stable&section=all
fedora: https://pkgs.org/search/?q=netcdf4
freebsd: https://www.freebsd.org/cgi/ports.cgi?query=netcdf4&stype=all
gentoo: https://packages.gentoo.org/packages/search?q=netcdf4
macports: https://ports.macports.org/?search=netcdf4&search_by=name
ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=netcdf&searchon=names