### PR TITLE
ublox: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3615,6 +3615,27 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: foxy-devel
     status: maintained
+  ublox:
+    doc:
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: foxy-devel
+    release:
+      packages:
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/KumarRobotics/ublox-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: foxy-devel
+    status: maintained
   udp_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox` to `2.0.0-1`:

- upstream repository: https://github.com/KumarRobotics/ublox.git
- release repository: https://github.com/KumarRobotics/ublox-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## ublox

```
* Initial ROS 2 port to Dashing
* Port the ublox package to ROS 2.
* Start ROS 2 port by COLCON_IGNORE everything.
* Contributors: Chao Qu, Chris Lalancette
```

## ublox_gps

```
* Initial ROS 2 port to Dashing
* Create publishers based on ROS parameters (#1 <https://github.com/KumarRobotics/ublox/issues/1>)
* Make sure to reset for survey-in mode.
* Make sure to depend on tf2 properly.
* Make sure to have package.xml depend on ament_cmake_ros
* Fix getting RTCM ids and rates.
* Increase the timeout for NavPVT messages during Survey-In config.
* Configure the base more accurately.
* Update rover configuration.
* Create ROS 2 launch files.
* Finish porting configs to ROS 2.
* Fix heading output to comply with REP-103
* Make ublox_gps composable.
* Fixes pointed out by clang-tidy.
* Rename rawDataStreamPa member variable to raw_data_stream_pa
* Fix a bug for reads of zero size.
* Re-enable logging in the AsyncWorker.
* Switch a couple more catch blocks to const.
* Remove -ggdb3 flag from CMakeLists.txt.
* Fix a few bugs pointed out by valgrind.
* Pass the logger down to the Gps level.
* Minor cleanup in the gps code.
* More fixes for declaring parameters.
* Declare more parameters.
* Declare more parameters correctly.
* More fixes so that we get the correct rates.
* More fixes around the codebase.
* Mark constants as such.
* Remove declareRosBoolean.
* Update configuration files for ROS 2.
* Port ublox_gps to ROS 2.
* Start ROS 2 port by COLCON_IGNORE everything.
* Split the main out into its own file.
* Move spinning out of the constructor.
* Cleanup includes in node.{hpp,cpp}.
* Move HpPosRecProduct class to its own files.
* Move HpgRefProduct class to its own files.
* Move UbloxFirmware9 class to its own files.
* Move UbloxFirmware8 class to its own files.
* Move UbloxFirmware7 to its own files.
* Move UbloxFirmware7Plus class to its own header file.
* Move UbloxFirmware6 class to its own files.
* Move UbloxFirmware class to its own files.
* Move RawDataProduct class into its own files.
* Move HpgRovProduct class to its own files.
* Move AdrUdrProduct class into its own files.
* Move TimProduct class into its own file.
* Make the node handle a member variable of UbloxNode.
* Remove the last uses of the global variable.
* Pass the nodehandle into more methods.
* Start passing the node into functions.
* Declare a few more booleans.
* Declare a lot more parameters.
* Finish removing the "enable" map.
* Move some more boolean parameters to declarations.
* Declare more parameters.
* Convert a few more parameters over to being declared.
* Declare the config_on_startup flag.
* Make dat/set a declared parameter.
* Make sure to declare the sbas parameter.
* Add in ROS2-like declare and get parameters.
* Replace templated publish call with lambdas.
* Make fix_status_service a member variable of UbloxFirmware.
* Move fixFromString and modelFromString into node.cpp
* Make gps a member variable of UbloxNode.
* Add namespaces to component_interface and fts_product.hpp
* Minor code improvements.
* Move FixDiagnostic class to its own file.
* Move UbloxTopicDiagnostic to its own file.
* Make gnss a member variable of UbloxNode.
* Move kNavSvInfoSubscribeRate into the base class that uses it.
* Remove kSubscribeRate.
* Move the kDefaultMeasRate to the class that needs it.
* Remove kROSQueueSize constant.
* Make rtcms a member variable of UbloxNode.
* Switch to a structure for RTCMs.
* Make freq_diag a member variable of UbloxNode.
* Make updater a member variable of UbloxNode.
* Make frame_id a member variable.
* Make config_on_startup_flag a member variable.
* Make meas_rate a member variable.
* Make nav_rate a class variable.
* Lots of small code updates throughout the GPS module.
* Get rid of global 'debug' variable.
* Move serialization into the ublox_serialization module.
* More rearrangement of header files to make a more sane structure.
* Move FTSProduct class into its own file.
* UbloxNode is not a component.
* Move ComponentInterface to its own file.
* Remove the one static ros::Subscriber.
* Remove last static advertiser.
* Switch to const references for std::string where possible.
* Switch to more idiomatic publisher initialization.
* Switch the one use of tf to tf2.
* Remove 'using namespace' uses.
* Switch to non-boost asio.
* Remove uses of 'new' throughout the codebase.
* Remove the last of boost from node.cpp
* Remove most of boost from node.cpp/.hpp.
* Remove a bunch of boost from node.cpp
* Remove more boost.
* Remove boost from worker.hpp
* Remove some uses of boost from async_worker.hpp
* Fully de-boostify callback.hpp
* Rearrange messages.
* Switch out boost time and mutex for std
* Remove trailing whitespace in all files.
* Rename header files to have .hpp extension.
* Contributors: Chao Qu, Chris Lalancette, Mabel Zhang
```

## ublox_msgs

```
* Fixes to compile on Foxy.
* Fix heading output to comply with REP-103
* Fixes pointed out by clang-tidy.
* Small style fixups.
* Port ublox_msgs to ROS 2.
* Start ROS 2 port by COLCON_IGNORE everything.
* Move serialization into the ublox_serialization module.
* More rearrangement of header files to make a more sane structure.
* Move the directory structure around just a bit.
* Rearrange messages.
* Remove boost from ublox_msgs.hpp serialization.
* Remove trailing whitespace in all files.
* Rename header files to have .hpp extension.
* Contributors: Chao Qu, Chris Lalancette
```

## ublox_serialization

```
* Initial ROS 2 port to Dashing
* Fixes pointed out by clang-tidy.
* Make sure to initialize checksum properly.
* Port of ublox_serialization to ROS 2.
* Start ROS 2 port by COLCON_IGNORE everything.
* Remove unused vector serialization.
* Move serialization into the ublox_serialization module.
* Move the directory structure around just a bit.
* Remove boost from serialization.
* Remove trailing whitespace in all files.
* Rename header files to have .hpp extension.
* Contributors: Chao Qu, Chris Lalancette
```
