### PR TITLE
Add siphon to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6575,6 +6575,22 @@ python3-sip:
   fedora: [python3-sip]
   gentoo: [dev-python/sip]
   ubuntu: [python3-sip-dev]
+python3-siphon-pip:
+  debian:
+    pip:
+      packages: [siphon]
+  fedora:
+    pip:
+      packages: [siphon]
+  gentoo:
+    pip:
+      packages: [siphon]
+  osx:
+    pip:
+      packages: [siphon]
+  ubuntu:
+    pip:
+      packages: [siphon]
 python3-skimage:
   debian: [python3-skimage]
   fedora: [python3-scikit-image]


### PR DESCRIPTION
Utilities for downloading scientific data files. The initial use case is to gather ocean currents data for use in underwater vehicle simulations using Gazebo (uuv_simulator and DAVE). I tested the rosdep keys for Ubuntu and Debian entries. There are no packages available on the main OS package managers, so a rule has been added for PyPI.

https://pkgs.org/search/?q=siphon
https://pypi.org/project/siphon/

Some of the datasets that can be downloaded with Siphon include

[Global Ocean Currents Database](https://www.ncei.noaa.gov/access/data/global-ocean-currents-database/)
[Ocean Surface Current Analyses Real-time](https://www.esr.org/research/oscar/)