### PR TITLE
xacro: 1.14.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5898,7 +5898,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.4-1
+      version: 1.14.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.5-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.14.4-1`

## xacro

```
* [fix]     yaml loading: recursively wrap lists and dicts for dotted dict access (#258 <https://github.com/ros/xacro/issues/258>)
* [feature] Provide support for yaml constructors !degrees and !radians (#252 <https://github.com/ros/xacro/issues/252>)
* Contributors: Robert Haschke, G.A. vd. Hoorn
```
