### PR TITLE
ros2-lgsvl-bridge: 0.2.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2516,7 +2516,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/lgsvl/ros2-lgsvl-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2-lgsvl-bridge` to `0.2.0-1`:

- upstream repository: https://github.com/lgsvl/ros2-lgsvl-bridge.git
- release repository: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.1-1`

## lgsvl_bridge

```
* Include exec depends for needed message types
  Published by lgsvl simulator
* Contributors: Ruffin
```
