### PR TITLE
ros2-lgsvl-bridge: 0.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2549,7 +2549,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
-      version: 0.1.3-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/lgsvl/ros2-lgsvl-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2-lgsvl-bridge` to `0.2.1-1`:

- upstream repository: https://github.com/lgsvl/ros2-lgsvl-bridge.git
- release repository: https://github.com/lgsvl/ros2-lgsvl-bridge-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.3-1`

## lgsvl_bridge

```
* Include exec depends for needed message types
  Published by lgsvl simulator
* Use two buffers to handle message larger than 65536 bytes.
* Contributors: Guodong Rong, Ruffin
```
