### PR TITLE
grbl_msgs: 0.0.2-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1056,11 +1056,15 @@ repositories:
       version: dashing-devel
     status: developed
   grbl_msgs:
+    doc:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/flynneva/grbl_msgs-release.git
-      version: 0.0.1-1
+      version: 0.0.2-2
     source:
       type: git
       url: https://github.com/flynneva/grbl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_msgs` to `0.0.2-2`:

- upstream repository: https://github.com/flynneva/grbl_msgs.git
- release repository: https://github.com/flynneva/grbl_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.1-1`

## grbl_msgs

```
* Merge pull request #6 <https://github.com/flynneva/grbl_msgs/issues/6> from flynneva/main
* add release gh action
* removed exec depend
* missing std_msgs dependency
* Contributors: Evan Flynn
```
