### PR TITLE
grbl_msgs: 0.0.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -951,6 +951,21 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: dashing-devel
     status: developed
+  grbl_msgs:
+    doc:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/flynneva/grbl_msgs-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
+    status: maintained
   grbl_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/flynneva/grbl_msgs.git
- release repository: https://github.com/flynneva/grbl_msgs-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## grbl_msgs

```
* Merge pull request #6 <https://github.com/flynneva/grbl_msgs/issues/6> from flynneva/main
* add release gh action
* removed exec depend
* missing std_msgs dependency
* Contributors: Evan Flynn
```
