### PR TITLE
Add gpac to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1191,6 +1191,14 @@ google-mock:
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
   ubuntu: [google-mock]
+gpac:
+  debian: [gpac]
+  fedora: [gpac]
+  gentoo: [media-video/gpac]
+  osx:
+    homebrew:
+      packages: [gpac]
+  ubuntu: [gpac]
 gperf:
   debian: [gperf]
   fedora: [gperf]


### PR DESCRIPTION
This PR adds a package `gpac` to `rosdep/base.yaml`.
`gpac` contains programs for spliting/joining mp4 video files.