### PR TITLE
cob_perception_common: 0.6.17-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1880,11 +1880,12 @@ repositories:
       - cob_object_detection_visualizer
       - cob_perception_common
       - cob_perception_msgs
+      - cob_vision_utils
       - ipa_3d_fov_visualization
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_perception_common-release.git
-      version: 0.6.16-1
+      version: 0.6.17-1
     source:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_perception_common` to `0.6.17-1`:

- upstream repository: https://github.com/ipa320/cob_perception_common.git
- release repository: https://github.com/ipa320/cob_perception_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.6.16-1`

## cob_3d_mapping_msgs

- No changes

## cob_cam3d_throttle

- No changes

## cob_image_flip

- No changes

## cob_object_detection_msgs

- No changes

## cob_object_detection_visualizer

- No changes

## cob_perception_common

```
* Merge pull request #102 <https://github.com/ipa320/cob_perception_common/issues/102> from fmessmer/minimal_cob_vision_utils
  minimal cob_vision_utils
* Revert "remove cob_vision_utils"
  This reverts commit ce1a4f9a397abd11f4d038c5ea4c769324bf53af.
* Contributors: Felix Messmer, fmessmer
```

## cob_perception_msgs

- No changes

## cob_vision_utils

```
* fix package version
* Merge pull request #102 <https://github.com/ipa320/cob_perception_common/issues/102> from fmessmer/minimal_cob_vision_utils
  minimal cob_vision_utils
* use cv_bridge
* remove problematic functions
* reduce cob_vision_utils to bare minimum
* Revert "remove cob_vision_utils"
  This reverts commit ce1a4f9a397abd11f4d038c5ea4c769324bf53af.
* Contributors: Felix Messmer, fmessmer
```

## ipa_3d_fov_visualization

- No changes
