### PR TITLE
openrtm_aist_python: 1.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7438,7 +7438,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist_python-release.git
-      version: 1.1.0-0
+      version: 1.1.0-2
     status: maintained
   openslam_gmapping:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7433,7 +7433,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tork-a/openrtm_aist_python-release.git
-      version: release/hydro/openrtm_aist_python
+      version: release/melodic/openrtm_aist_python
     release:
       tags:
         release: release/melodic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_python` to `1.1.0-2`:

- upstream repository: https://github.com/OpenRTM/OpenRTM-aist-Python.git
- release repository: https://github.com/tork-a/openrtm_aist_python-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.1.0-0`
