### PR TITLE
cob_driver: 0.7.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -386,6 +386,42 @@ repositories:
       url: https://github.com/ipa320/cob_common.git
       version: kinetic_dev
     status: maintained
+  cob_driver:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_base_drive_chain
+      - cob_bms_driver
+      - cob_canopen_motor
+      - cob_driver
+      - cob_elmo_homing
+      - cob_generic_can
+      - cob_light
+      - cob_mimic
+      - cob_phidget_em_state
+      - cob_phidget_power_state
+      - cob_phidgets
+      - cob_relayboard
+      - cob_scan_unifier
+      - cob_sick_lms1xx
+      - cob_sick_s300
+      - cob_sound
+      - cob_undercarriage_ctrl
+      - cob_utilities
+      - cob_voltage_control
+      - laser_scan_densifier
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_driver-release.git
+      version: 0.7.4-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_driver.git
+      version: kinetic_dev
+    status: maintained
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.4-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## cob_base_drive_chain

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_bms_driver

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_canopen_motor

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_driver

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* remove cob_camera_sensors
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_elmo_homing

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_generic_can

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_light

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_mimic

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_phidget_em_state

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_phidget_power_state

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_phidgets

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_relayboard

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_scan_unifier

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_sick_lms1xx

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_sick_s300

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #414 <https://github.com/ipa320/cob_driver/issues/414> from nlamprian/nlamprian/fix-frame-ids
  Remove leading slashes from frame ids
* Remove leading slashes from frame ids
* Contributors: Felix Messmer, Nick Lamprianidis, fmessmer
```

## cob_sound

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_undercarriage_ctrl

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #414 <https://github.com/ipa320/cob_driver/issues/414> from nlamprian/nlamprian/fix-frame-ids
  Remove leading slashes from frame ids
* Remove leading slashes from frame ids
* Contributors: Felix Messmer, Nick Lamprianidis, fmessmer
```

## cob_utilities

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_voltage_control

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* ROS_PYTHON_VERSION conditional dependency for matplotlib
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## laser_scan_densifier

```
* Merge pull request #417 <https://github.com/ipa320/cob_driver/issues/417> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
