### PR TITLE
catkin: 0.8.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -309,7 +309,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.8-1
+      version: 0.8.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.9-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.8-1`

## catkin

```
* set CATKIN_PACKAGE_LIBEXEC_DESTINATION which was documented but not set (#1122 <https://github.com/ros/catkin/issues/1122>)
* count 'skipped' tests as skipped (#1121 <https://github.com/ros/catkin/issues/1121>)
* check PYTHON_INSTALL_DIR before making directory (#1120 <https://github.com/ros/catkin/issues/1120>)
* execute the output of _setup_util.py in place (#1116 <https://github.com/ros/catkin/issues/1116>)
* use raw string literal (#1117 <https://github.com/ros/catkin/issues/1117>)
* [Windows] offload source spaces into order_paths.py (#1113 <https://github.com/ros/catkin/issues/1113>)
```
