### PR TITLE
catkin: 0.7.29-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1390,7 +1390,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.20-1
+      version: 0.7.29-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.7.29-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.20-1`

## catkin

```
* set CATKIN_PACKAGE_LIBEXEC_DESTINATION which was documented but not set (#1122 <https://github.com/ros/catkin/issues/1122>)
* count 'skipped' tests as skipped (#1121 <https://github.com/ros/catkin/issues/1121>)
* check PYTHON_INSTALL_DIR before making directory (#1120 <https://github.com/ros/catkin/issues/1120>)
* execute the output of _setup_util.py in place (#1116 <https://github.com/ros/catkin/issues/1116>)
* use raw string literal (#1117 <https://github.com/ros/catkin/issues/1117>)
* [Windows] offload source spaces into order_paths.py (#1113 <https://github.com/ros/catkin/issues/1113>)
```
