### PR TITLE
open_manipulator_p_simulations: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -9290,6 +9290,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
       version: kinetic-devel
     status: developed
+  open_manipulator_p_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_p_simulations.git
+      version: kinetic-devel
+    release:
+      packages:
+      - open_manipulator_p_gazebo
+      - open_manipulator_p_simulations
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: kinetic-devel
+      version: kinetic-devel
+    status: developed
   open_manipulator_perceptions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_p_simulations` to `1.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_p_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## open_manipulator_p_gazebo

```
* First release of the open_manipulator_p_simulations stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```

## open_manipulator_p_simulations

```
* First release of the open_manipulator_p_simulations stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```
