### PR TITLE
open_manipulator_p_simulations: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7271,6 +7271,24 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
       version: melodic-devel
     status: developed
+  open_manipulator_p_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_p_simulations.git
+      version: melodic-devel
+    release:
+      packages:
+      - open_manipulator_p_gazebo
+      - open_manipulator_p_simulations
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release.git
+      version: melodic-devel
+    status: developed
   open_manipulator_simulations:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_p_simulations` to `1.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_p_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## open_manipulator_p_gazebo

```
* First release of the open_manipulator_p_simulations stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```

## open_manipulator_p_simulations

```
* First release of the open_manipulator_p_simulations stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```
