### PR TITLE
turtlebot3: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3604,6 +3604,30 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: ros2
     status: developed
+  turtlebot3:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: foxy-devel
+    release:
+      packages:
+      - turtlebot3
+      - turtlebot3_bringup
+      - turtlebot3_cartographer
+      - turtlebot3_description
+      - turtlebot3_example
+      - turtlebot3_navigation2
+      - turtlebot3_node
+      - turtlebot3_teleop
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/robotis-ros2-release/turtlebot3-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: foxy-devel
+    status: developed
   turtlebot3_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `2.1.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## turtlebot3

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Enable Windows port
* Contributors: Ryan, Ashe, Sean Yen
```

## turtlebot3_bringup

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Contributors: Ryan, Ashe
```

## turtlebot3_cartographer

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Contributors: Ryan, Ashe
```

## turtlebot3_description

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Contributors: Ryan, Ashe
```

## turtlebot3_example

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Contributors: Ryan, Ashe
```

## turtlebot3_navigation2

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Contributors: Ryan, Ashe
```

## turtlebot3_node

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Contributors: Ryan, Ashe
```

## turtlebot3_teleop

```
* ROS 2 Foxy Fitzroy supported
* ROS 2 Eloquent Elusor supported
* Enable Windows teleop keyboard
* Contributors: Ryan, Ashe, Sean Yen
```
