### PR TITLE
cloudwatch_common: 1.1.5-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1513,7 +1513,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_common-release.git
-      version: 1.1.4-1
+      version: 1.1.5-2
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatch-common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudwatch_common` to `1.1.5-2`:

- upstream repository: https://github.com/aws-robotics/cloudwatch-common.git
- release repository: https://github.com/aws-gbp/cloudwatch_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.4-1`

## cloudwatch_logs_common

```
* Limit the rate of cloudwatch log uploading to match API service limits (#61 <https://github.com/aws-robotics/cloudwatch-common/issues/61>)
  * Limit the rate of publishing to PutLogEvents by delaying calls inside the CloudWathLogsFacade
* Contributors: Emerson Knapp
```

## cloudwatch_metrics_common

```
No changes.
```

## dataflow_lite

```
No changes.
```

## file_management

```
No changes.
```
