### PR TITLE
open_manipulator_p: 1.0.0-5 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7271,6 +7271,28 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_msgs.git
       version: melodic-devel
     status: developed
+  open_manipulator_p:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_p.git
+      version: melodic-devel
+    release:
+      packages:
+      - open_manipulator_p
+      - open_manipulator_p_control_gui
+      - open_manipulator_p_controller
+      - open_manipulator_p_description
+      - open_manipulator_p_libs
+      - open_manipulator_p_teleop
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/open_manipulator_p-release.git
+      version: 1.0.0-5
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator_p.git
+      version: melodic-devel
+    status: developed
   open_manipulator_simulations:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator_p` to `1.0.0-5`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator_p.git
- release repository: https://github.com/ROBOTIS-GIT-release/open_manipulator_p-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## open_manipulator_p

```
* First release of the open_manipulator_p stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```

## open_manipulator_p_control_gui

```
* First release of the open_manipulator_p stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```

## open_manipulator_p_controller

```
* First release of the open_manipulator_p stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```

## open_manipulator_p_description

```
* First release of the open_manipulator_p stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```

## open_manipulator_p_libs

```
* First release of the open_manipulator_p stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```

## open_manipulator_p_teleop

```
* First release of the open_manipulator_p stack
* Contributors: Ryan Shim, YongHo-Na, HyeJong KIM
```
