### PR TITLE
mcl_3dl: 0.5.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7326,7 +7326,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.5.0-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.0-1`

## mcl_3dl

```
* Fix crushing when new map is received (#347 <https://github.com/at-wat/mcl_3dl/issues/347>)
* Ease condition for test of PointCloudSamplerWithNormal (#344 <https://github.com/at-wat/mcl_3dl/issues/344>)
* Add faster raycast algorithm using DDA (#343 <https://github.com/at-wat/mcl_3dl/issues/343>)
* Contributors: Naotaka Hatao
```
