### PR TITLE
ros_motion_builder: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9741,6 +9741,25 @@ repositories:
       url: https://github.com/aws-robotics/monitoringmessages-ros1.git
       version: master
     status: maintained
+  ros_motion_builder:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/ros_motion_builder.git
+      version: master
+    release:
+      packages:
+      - ros_motion_builder
+      - ros_motion_builder_msgs
+      - rqt_motion_builder
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-robotics/ros_motion_builder-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/ros_motion_builder.git
+      version: master
+    status: maintained
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_motion_builder` to `1.0.0-1`:

- upstream repository: https://github.com/pal-robotics/ros_motion_builder.git
- release repository: https://github.com/pal-robotics/ros_motion_builder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ros_motion_builder

```
* Documentation
* Initial commit
* Contributors: davidfernandez
```

## ros_motion_builder_msgs

```
* Documentation
* Initial commit
* Contributors: davidfernandez
```

## rqt_motion_builder

```
* Fix dependencies and CMakeFile
* Add missing build dependencies
* Fix dependencies for RQT-plugin
* Initial commit
* Contributors: davidfernandez
```
