### PR TITLE
septentrio_gnss_driver: 1.0.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11322,6 +11322,16 @@ repositories:
       type: git
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
+      version: 1.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: master
     status: maintained
   serial:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.0.6-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## septentrio_gnss_driver

- No changes
