### PR TITLE
septentrio_gnss_driver: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5100,6 +5100,16 @@ repositories:
       type: git
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
+      version: 1.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: master
     status: maintained
   sick_ldmrs_laser:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.0.6-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## septentrio_gnss_driver

- No changes
