### PR TITLE
leo_robot: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5196,6 +5196,25 @@ repositories:
       url: https://github.com/LeoRover/leo_desktop.git
       version: master
     status: maintained
+  leo_robot:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_robot.git
+      version: master
+    release:
+      packages:
+      - leo_bringup
+      - leo_fw
+      - leo_robot
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_robot-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_robot.git
+      version: master
+    status: maintained
   leo_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## leo_bringup

```
* Update package description
* Increase cmake minimum version
* Change CMakeLists formatting
* Add xacro to dependencies, remove raspicam_node from dependencies
```

## leo_fw

```
* Add leo_fw package
```

## leo_robot

```
* Add leo_robot metapackage
```
