### PR TITLE
leo_common: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2271,6 +2271,25 @@ repositories:
       url: https://github.com/ros-perception/laser_proc.git
       version: melodic-devel
     status: maintained
+  leo_common:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_common.git
+      version: master
+    release:
+      packages:
+      - leo
+      - leo_description
+      - leo_teleop
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_common-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_common.git
+      version: master
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## leo

```
* Add leo_teleop package
```

## leo_description

```
* Bump minimum cmake version to 3.0.2
* Update package manifest
```

## leo_teleop

```
* Add leo_teleop package
```
