### PR TITLE
node_interface_test: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6923,7 +6923,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/tecnalia-advancedmanufacturing-robotics/node_interface_test.git
-      version: 0.1.0
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -6932,7 +6932,7 @@ repositories:
     source:
       type: git
       url: https://github.com/tecnalia-advancedmanufacturing-robotics/node_interface_test.git
-      version: 0.1.0
+      version: melodic-devel
     status: maintained
   nodelet_core:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6919,6 +6919,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/nmea_to_geopose.git
       version: master
     status: developed
+  node_interface_test:
+    doc:
+      type: git
+      url: https://github.com/tecnalia-advancedmanufacturing-robotics/node_interface_test.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tecnalia-advancedmanufacturing-robotics/node_interface_test-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/tecnalia-advancedmanufacturing-robotics/node_interface_test.git
+      version: 0.1.0
+    status: maintained
   nodelet_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `node_interface_test` to `0.1.0-1`:

- upstream repository: https://github.com/tecnalia-advancedmanufacturing-robotics/node_interface_test.git
- release repository: https://github.com/tecnalia-advancedmanufacturing-robotics/node_interface_test-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## node_interface_test

```
* change package name
* Contributors: Anthony Remazeilles
```
