### PR TITLE
Move urdfdom back to the 'ros' organization.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2689,7 +2689,7 @@ repositories:
   urdfdom:
     doc:
       type: git
-      url: https://github.com/ros2/urdfdom.git
+      url: https://github.com/ros/urdfdom.git
       version: ros2
     release:
       tags:
@@ -2699,7 +2699,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/urdfdom.git
+      url: https://github.com/ros/urdfdom.git
       version: ros2
     status: maintained
   urdfdom_headers:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>