### PR TITLE
ros_comm: 1.15.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3970,7 +3970,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.8-1
+      version: 1.15.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.9-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.15.8-1`

## message_filters

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix compatibility issue with boost 1.73 and above (#2023 <https://github.com/ros/ros_comm/issues/2023>)
* Contributors: Sean Yen, Shane Loretz
```

## ros_comm

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Contributors: Shane Loretz
```

## rosbag

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Gracefully stop recording upon SIGTERM and SIGINT (#2038 <https://github.com/ros/ros_comm/issues/2038>)
* Fix compatibility issue with boost 1.73 and above (#2023 <https://github.com/ros/ros_comm/issues/2023>)
* Use heapq.merge instead of custom merge sort code (#2017 <https://github.com/ros/ros_comm/issues/2017>)
* Contributors: Devin Bonnie, Florian Friesdorf, Sean Yen, Shane Loretz, tomoya
```

## rosbag_storage

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix compatibility issue with boost 1.73 and above (#2023 <https://github.com/ros/ros_comm/issues/2023>)
* Contributors: Sean Yen, Shane Loretz
```

## roscpp

```
* Fix deadlock when service connection is dropped (#2074 <https://github.com/ros/ros_comm/issues/2074>)
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix case where accessing cached parameters shuts down another node (#2068 <https://github.com/ros/ros_comm/issues/2068>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Fix Lost Wake Bug in ROSOutAppender (#2033 <https://github.com/ros/ros_comm/issues/2033>)
* Fix compatibility issue with boost 1.73 and above (#2023 <https://github.com/ros/ros_comm/issues/2023>)
* Contributors: Adel Fakih, Chen Lihui, Sean Yen, Shane Loretz, tomoya
```

## rosgraph

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Contributors: Shane Loretz, tomoya
```

## roslaunch

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix handling of single quotes in command arguments on Windows (#2051 <https://github.com/ros/ros_comm/issues/2051>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Clearer error message (#2035 <https://github.com/ros/ros_comm/issues/2035>)
* Ignore underscores when parsing literal numeric values for Python 3 compatibility (#2022 <https://github.com/ros/ros_comm/issues/2022>)
* Contributors: Andreas Vinter-Hviid, Jochen Sprickerhof, Sean Yen, Shane Loretz, tomoya
```

## roslz4

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Contributors: Shane Loretz, tomoya
```

## rosmaster

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix case where accessing cached parameters shuts down another node (#2068 <https://github.com/ros/ros_comm/issues/2068>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Contributors: Shane Loretz, tomoya
```

## rosmsg

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Contributors: Shane Loretz, tomoya
```

## rosnode

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Clear cached URI for a node that has gone offline (#2010 <https://github.com/ros/ros_comm/issues/2010>)
* Add skip_cache parameter to rosnode_ping() (#2009 <https://github.com/ros/ros_comm/issues/2009>)
* Contributors: Shane Loretz, mabaue, tomoya
```

## rosout

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Contributors: Shane Loretz, tomoya
```

## rosparam

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Contributors: Shane Loretz
```

## rospy

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Fix error handling with Python 3 (#2050 <https://github.com/ros/ros_comm/issues/2050>)
* Contributors: Markus Grimm, Sean Yen, Shane Loretz, larslue, salihmarangoz, tomoya
```

## rosservice

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Contributors: Shane Loretz
```

## rostest

```
* Fix incorrect test expecation (#2054 <https://github.com/ros/ros_comm/issues/2054>)
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Install advertisetest (#2046 <https://github.com/ros/ros_comm/issues/2046>)
* Contributors: Levko Ivanchuk, Shane Loretz, beetleskin, tomoya
```

## rostopic

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Use range instead of xrange for Python 3 compatibility (#2013 <https://github.com/ros/ros_comm/issues/2013>)
* Contributors: Dirk Thomas, Shane Loretz
```

## roswtf

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Contributors: Shane Loretz, tomoya
```

## topic_tools

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix compatibility issue with boost 1.73 and above (#2023 <https://github.com/ros/ros_comm/issues/2023>)
* Contributors: Sean Yen, Shane Loretz
```

## xmlrpcpp

```
* Update maintainers (#2075 <https://github.com/ros/ros_comm/issues/2075>)
* Fix to address CVE-2020-16124 (#2065 <https://github.com/ros/ros_comm/issues/2065>)
* Fix spelling (#2066 <https://github.com/ros/ros_comm/issues/2066>)
* Fix XmlRpcValue::_doubleFormat being unused (#2003 <https://github.com/ros/ros_comm/issues/2003>)
* Contributors: Shane Loretz, Sid Faber, tomoya
```
