### PR TITLE
cob_command_tools: 0.6.17-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1296,7 +1296,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.16-1
+      version: 0.6.17-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.17-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.16-1`

## cob_command_gui

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_command_tools

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_dashboard

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_helper_tools

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_interactive_teleop

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_monitoring

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* ROS_PYTHON_VERSION conditional dependency for paramiko
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_script_server

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #282 <https://github.com/ipa320/cob_command_tools/issues/282> from floweisshardt/fix/actionlib_state
  fix actionlib state handling for non initialized action clients
* use GoalStatus message import only
* use GoalStatus enum explicitly
* fix actionlib state handling for non initialized action clients
* Contributors: Felix Messmer, floweisshardt, fmessmer
```

## cob_teleop

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## generic_throttle

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## scenario_test_tools

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #283 <https://github.com/ipa320/cob_command_tools/issues/283> from LoyVanBeek/feature/await_connections
  Allow scripts to await for ScriptableActionServers to be connected
* Allow scripts to await for ScriptableActionSeervers to be connected
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## service_tools

```
* Merge pull request #284 <https://github.com/ipa320/cob_command_tools/issues/284> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
