### PR TITLE
cob_substitute: 0.6.10-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1948,7 +1948,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_substitute-release.git
-      version: 0.6.9-1
+      version: 0.6.10-1
     source:
       type: git
       url: https://github.com/ipa320/cob_substitute.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.10-1`:

- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.9-1`

## cob_docker_control

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_reflector_referencing

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_safety_controller

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_substitute

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
