### PR TITLE
cob_substitute: 0.6.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -505,6 +505,26 @@ repositories:
       url: https://github.com/ipa320/cob_perception_common.git
       version: indigo_dev
     status: maintained
+  cob_substitute:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_docker_control
+      - cob_reflector_referencing
+      - cob_safety_controller
+      - cob_substitute
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_substitute-release.git
+      version: 0.6.10-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_substitute.git
+      version: indigo_dev
+    status: maintained
   cob_supported_robots:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_substitute` to `0.6.10-1`:

- upstream repository: https://github.com/ipa320/cob_substitute.git
- release repository: https://github.com/ipa320/cob_substitute-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## cob_docker_control

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_reflector_referencing

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_safety_controller

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_substitute

```
* Merge pull request #56 <https://github.com/ipa320/cob_substitute/issues/56> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
