### PR TITLE
cob_hand: 0.6.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -480,6 +480,24 @@ repositories:
       url: https://github.com/ipa320/cob_gazebo_plugins.git
       version: kinetic_dev
     status: maintained
+  cob_hand:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_hand.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_hand
+      - cob_hand_bridge
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_hand-release.git
+      version: 0.6.9-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_hand.git
+      version: indigo_dev
+    status: maintained
   cob_perception_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_hand` to `0.6.9-1`:

- upstream repository: https://github.com/ipa320/cob_hand.git
- release repository: https://github.com/ipa320/cob_hand-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## cob_hand

```
* Merge pull request #27 <https://github.com/ipa320/cob_hand/issues/27> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_hand_bridge

```
* Merge pull request #27 <https://github.com/ipa320/cob_hand/issues/27> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
