### PR TITLE
add python3-mechanize

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5969,6 +5969,10 @@ python3-matplotlib:
     '7': null
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
+python3-mechanize:
+  debian: [python3-mechanize]
+  fedora: [python3-mechanize]
+  ubuntu: [python3-mechanize]
 python3-mock:
   alpine: [py3-mock]
   debian: [python3-mock]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5970,9 +5970,14 @@ python3-matplotlib:
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mechanize:
-  debian: [python3-mechanize]
+  debian:
+    '*': [python3-mechanize]
+    buster: null
   fedora: [python3-mechanize]
-  ubuntu: [python3-mechanize]
+  ubuntu:
+    '*': [python3-mechanize]
+    bionic: null
+    xenial: null
 python3-mock:
   alpine: [py3-mock]
   debian: [python3-mock]


### PR DESCRIPTION
`python-mechanize` is not available for `focal`, thus adding a new key for `python3-mechanize`:
- ubuntu: https://packages.ubuntu.com/focal/python3-mechanize
- fedora: https://pkgs.org/search/?q=python3-mechanize
- debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-mechanize

no `python3-mechanize` available for:
- arch: https://www.archlinux.org/packages/?sort=&q=python3-mechanize&maintainer=&flagged=
- gentoo: https://packages.gentoo.org/packages/search?q=python3-mechanize