### PR TITLE
rviz: 1.13.14-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11151,7 +11151,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.13-1
+      version: 1.13.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.14-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.13.13-1`

## rviz

```
* [fix]   SplitterHandle: Consider scrollbar width. Fixes #1545 <https://github.com/ros-visualization/rviz/issues/1545>.
* [fix]   Handle InvalidNameException when loading robot description
* [fix]   WrenchVisual: Add missing initialization of ``hide_small_values_``
* [fix]   Fixup #1519 <https://github.com/ros-visualization/rviz/issues/1519>: Correctly (and efficiently) handle 3-byte pixel formats
* [maint] Adapt to clang-format-10
* Contributors: Robert Haschke, Wolf Vollprecht
```
