### PR TITLE
rviz: 1.14.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5029,7 +5029,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.1-1
+      version: 1.14.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.2-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.14.1-1`

## rviz

```
* Merged melodic-devel improvements
  * [fix]   SplitterHandle: Consider scrollbar width. Fixes #1545 <https://github.com/ros-visualization/rviz/issues/1545>.
  * [fix]   Handle InvalidNameException when loading robot description
  * [fix]   WrenchVisual: Add missing initialization of ``hide_small_values_``
  * [fix]   Fixup #1519 <https://github.com/ros-visualization/rviz/issues/1519>: Correctly (and efficiently) handle 3-byte pixel formats
  * [maint] Adapt to clang-format-10
* [fix]     Selectively install font definition file, suppressing Ogre runtime warning
* [fix]     Suppress cmake warning from libassimp
* [feature] Generic ScrewDisplay for TwistStamped, AccelStamped, and WrenchStamped
* [maint]   Find OGRE based on cmake config and fallback to pkg-config
* [maint]   Correctly link against libassimp for version >= 5.0
* Contributors: Chris Lalancette, Markus Vieth, Robert Haschke, Sean Yen, Wolf Vollprecht
```
