### PR TITLE
leo_desktop: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2290,6 +2290,24 @@ repositories:
       url: https://github.com/LeoRover/leo_common.git
       version: master
     status: maintained
+  leo_desktop:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop.git
+      version: master
+    release:
+      packages:
+      - leo_desktop
+      - leo_viz
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_desktop-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop.git
+      version: master
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `0.2.2-1`:

- upstream repository: https://github.com/LeoRover/leo_desktop.git
- release repository: https://github.com/fictionlab-gbp/leo_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## leo_desktop

```
* Add leo metapackage to dependencies
```

## leo_viz

```
* Update cmake minimum version, change CMakeLists formatting
```
