### PR TITLE
leo_simulator: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2343,24 +2343,6 @@ repositories:
       url: https://github.com/LeoRover/leo_common.git
       version: master
     status: maintained
-  leo_simulator:
-    doc:
-      type: git
-      url: https://github.com/LeoRover/leo_simulator.git
-      version: master
-    release:
-      packages:
-      - leo_gazebo
-      - leo_simulator
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/fictionlab-gbp/leo_simulator-release.git
-      version: 0.1.2-1
-    source:
-      type: git
-      url: https://github.com/LeoRover/leo_simulator.git
-      version: master
-    status: maintained
   leo_desktop:
     doc:
       type: git
@@ -2377,6 +2359,24 @@ repositories:
     source:
       type: git
       url: https://github.com/LeoRover/leo_desktop.git
+      version: master
+    status: maintained
+  leo_simulator:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator.git
+      version: master
+    release:
+      packages:
+      - leo_gazebo
+      - leo_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_simulator-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator.git
       version: master
     status: maintained
   lgsvl_msgs:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2290,6 +2290,24 @@ repositories:
       url: https://github.com/LeoRover/leo_common.git
       version: master
     status: maintained
+  leo_simulator:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator.git
+      version: master
+    release:
+      packages:
+      - leo_gazebo
+      - leo_simulator
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/leo_simulator-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator.git
+      version: master
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `0.1.2-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator.git
- release repository: https://github.com/fictionlab-gbp/leo_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## leo_gazebo

- No changes

## leo_simulator

```
* Add leo_simulator metapackage
```
