### PR TITLE
toposens: 2.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16114,7 +16114,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.0.4-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.3-1`

## toposens

```
* Changed package maintainer
* Fix catkin_lint issues
* Contributors: Tobias Roth
```

## toposens_description

```
* Changed package maintainer
* Fix catkin_lint issues
* Contributors: Tobias Roth
```

## toposens_driver

```
* Changed package maintainer
* Fix catkin_lint issues
* Contributors: Tobias Roth
```

## toposens_markers

```
* Changed package maintainer
* Fix catkin_lint issues
* Contributors: Tobias Roth
```

## toposens_msgs

```
* Changed package maintainer
* Fix catkin_lint issues
* Contributors: Tobias Roth
```

## toposens_pointcloud

```
* Changed package maintainer
* Fix catkin_lint issues
* By default do not log point cloud data
* Contributors: Tobias Roth
```

## toposens_sync

```
* Changed package maintainer
* Fix catkin_lint issues
* Contributors: Tobias Roth
```
