### PR TITLE
seed_smartactuator_sdk: 0.0.5-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11318,7 +11318,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
-      version: 0.0.4-1
+      version: 0.0.5-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_smartactuator_sdk` to `0.0.5-3`:

- upstream repository: https://github.com/seed-solutions/seed_smartactuator_sdk.git
- release repository: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.4-1`
