### PR TITLE
osqp_vendor: 0.0.1-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1787,6 +1787,21 @@ repositories:
       url: https://github.com/ros2/orocos_kinematics_dynamics.git
       version: foxy
     status: maintained
+  osqp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/tier4/osqp_vendor-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    status: maintained
   osrf_pycommon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `0.0.1-3`:

- upstream repository: https://github.com/tier4/osqp_vendor.git
- release repository: https://github.com/tier4/osqp_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
