### PR TITLE
rcutils: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1462,7 +1462,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.1.0-1`

## rcutils

```
* Add rcutils_expand_user() to expand user directory in path (#298 <https://github.com/ros2/rcutils/issues/298>)
* Update the maintainers. (#299 <https://github.com/ros2/rcutils/issues/299>)
* Remove the temporary variable in RCUTILS_LOGGING_AUTOINIT (#290 <https://github.com/ros2/rcutils/issues/290>)
* Contributors: Chris Lalancette, Christophe Bedard, Felix Endres
```
