### PR TITLE
rclpy: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1430,7 +1430,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`

## rclpy

```
* Update maintainers (#627 <https://github.com/ros2/rclpy/issues/627>)
* Add in semicolon on RCUTILS_LOGGING_AUTOINIT. (#624 <https://github.com/ros2/rclpy/issues/624>)
* Add in the topic name when QoS events are fired. (#621 <https://github.com/ros2/rclpy/issues/621>)
* Use best effort, keep last, history depth 1 QoS Profile for '/clock' subscriptions (#619 <https://github.com/ros2/rclpy/issues/619>)
* PARAM_REL_TOL documentation fix (#559 <https://github.com/ros2/rclpy/issues/559>)
* Node get fully qualified name (#598 <https://github.com/ros2/rclpy/issues/598>)
* MultiThreadedExecutor spin_until_future complete should not continue waiting when the future is done (#605 <https://github.com/ros2/rclpy/issues/605>)
* skip test relying on source timestamps with Connext (#615 <https://github.com/ros2/rclpy/issues/615>)
* Use the rpyutils shared import_c_library function. (#610 <https://github.com/ros2/rclpy/issues/610>)
* Add ability to configure domain ID (#596 <https://github.com/ros2/rclpy/issues/596>)
* Use absolute parameter events topic name (#612 <https://github.com/ros2/rclpy/issues/612>)
* Destroy event handlers owned by publishers/subscriptions when calling publisher.destroy()/subscription.destroy() (#603 <https://github.com/ros2/rclpy/issues/603>)
* Default incompatible qos callback should be set when there's no user specified callback (#601 <https://github.com/ros2/rclpy/issues/601>)
* relax rate jitter test for individual periods (#602 <https://github.com/ros2/rclpy/issues/602>)
* add QoSProfile.__str__ (#593 <https://github.com/ros2/rclpy/issues/593>)
* Add useful debug info when trying to publish the wrong type (#581 <https://github.com/ros2/rclpy/issues/581>)
* Pass rcutils_include_dirs to cppcheck  (#577 <https://github.com/ros2/rclpy/issues/577>)
* wrap lines to shorten line length (#586 <https://github.com/ros2/rclpy/issues/586>)
* fix moved troubleshooting url (#579 <https://github.com/ros2/rclpy/issues/579>)
* improve error message if rclpy C extensions are not found (#580 <https://github.com/ros2/rclpy/issues/580>)
* Contributors: Barry Xu, Chris Lalancette, Claire Wang, Dereck Wonnacott, Dirk Thomas, Emerson Knapp, Ivan Santiago Paunovic, Loy, Zhen Ju
```
