### PR TITLE
add python3-influxdb-client-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2151,6 +2151,16 @@ python-influxdb:
     bionic: [python-influxdb]
     disco: [python-influxdb]
     xenial: [python-influxdb]
+python3-influxdb-client-pip:
+  debian:
+    pip:
+      packages: [influxdb-client]
+  fedora:
+    pip:
+      packages: [influxdb-client]
+  ubuntu:
+    pip:
+      packages: [influxdb-client]
 python-inject-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2151,16 +2151,6 @@ python-influxdb:
     bionic: [python-influxdb]
     disco: [python-influxdb]
     xenial: [python-influxdb]
-python3-influxdb-client-pip:
-  debian:
-    pip:
-      packages: [influxdb-client]
-  fedora:
-    pip:
-      packages: [influxdb-client]
-  ubuntu:
-    pip:
-      packages: [influxdb-client]
 python-inject-pip:
   ubuntu:
     pip:
@@ -5879,6 +5869,16 @@ python3-importlib-metadata:
     xenial:
       pip:
         packages: [importlib-metadata]
+python3-influxdb-client-pip:
+  debian:
+    pip:
+      packages: [influxdb-client]
+  fedora:
+    pip:
+      packages: [influxdb-client]
+  ubuntu:
+    pip:
+      packages: [influxdb-client]
 python3-interpreter:
   arch: [python]
   debian: [python3-minimal]


### PR DESCRIPTION
I would like to add the InfluxDB 2.0 Python Client pip package. This is the recent version of influxdb-python, which is already in the deps. This package only exists in pip and requires at least python 3.6.

https://pypi.org/project/influxdb-client/