### PR TITLE
Add cython3 entry

### DIFF
--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -78,6 +78,10 @@ cython:
   osx:
     homebrew:
       packages: [cython]
+cython3:
+  osx:
+    homebrew:
+      packages: [cython]
 doxygen:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -121,6 +121,7 @@ cython:
   gentoo: [dev-python/cython]
   ubuntu: [cython]
 cython3:
+  arch: [cython]
   debian: [cython3]
   fedora: [python3-Cython]
   gentoo: [dev-python/cython]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -120,6 +120,11 @@ cython:
   fedora: [Cython]
   gentoo: [dev-python/cython]
   ubuntu: [cython]
+cython3:
+  debian: [cython3]
+  fedora: [python3-Cython]
+  gentoo: [dev-python/cython]
+  ubuntu: [cython3]
 dpath-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
I checked the entry for Ubuntu, as well as the ones for debian, gentoo, fedora and arch via Docker.

Ubuntu:
https://packages.ubuntu.com/focal/cython3 (also checked bionic)

Debian:
https://packages.debian.org/sid/cython3

Gentoo:
https://packages.gentoo.org/packages/dev-python/cython

Fedora:
https://src.fedoraproject.org/rpms/python3-Cython

Arch:
https://www.archlinux.org/packages/community/x86_64/cython/
https://www.archlinux.org/packages/community/x86_64/cython2/

osx:
https://formulae.brew.sh/formula/cython