### PR TITLE
psen_scan_v2: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8429,6 +8429,21 @@ repositories:
       url: https://github.com/PilzDE/psen_scan.git
       version: melodic-devel
     status: developed
+  psen_scan_v2:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/psen_scan_v2.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PilzDE/psen_scan_v2-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/PilzDE/psen_scan_v2.git
+      version: melodic-devel
+    status: developed
   px4_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.1.0-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## psen_scan_v2

```
* Initial release for the support of PSENscan firmware >= 3.1.0
* Start and stop the PSENscan monitoring function
* Publish measurement data of each monitoring frame as a single ROS LaserScan message
* Retry activation of the monitoring function on start reply timeout
* Adding urdf for scanner and swapping Z axis of TF frame where scan is published to be sent in correct order
* Contributors: Pilz GmbH and Co. KG
```
