### PR TITLE
rcl: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1328,7 +1328,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `2.4.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.3.0-1`

## rcl

```
* Make sure to check the return value of rcl APIs. (#838 <https://github.com/ros2/rcl/issues/838>)
* Add convenient node method to get a final topic/service name (#835 <https://github.com/ros2/rcl/issues/835>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## rcl_action

```
* Make sure to check the return value of rcl APIs. (#838 <https://github.com/ros2/rcl/issues/838>)
* Contributors: Chris Lalancette
```

## rcl_lifecycle

```
* Make sure to check the return value of rcl APIs. (#838 <https://github.com/ros2/rcl/issues/838>)
* Contributors: Chris Lalancette
```

## rcl_yaml_param_parser

```
* Check for valid node names in parameters files (#809 <https://github.com/ros2/rcl/issues/809>)
* Contributors: Chen Lihui
```
