### PR TITLE
fmi_adapter_ros2: 0.1.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -550,7 +550,8 @@ repositories:
       - fmi_adapter_examples
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
+      url: https://github.com/ros2-gbp/fmi_adapter_ros2-release.git
+      version: 0.1.8-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter_ros2` to `0.1.8-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter_ros2.git
- release repository: https://github.com/ros2-gbp/fmi_adapter_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## fmi_adapter

```
* Prepared for Foxy release.
```

## fmi_adapter_examples

```
* Prepared for Foxy release.
```
