### PR TITLE
fetch_tools: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1284,7 +1284,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_tools` to `0.3.3-1`:

- upstream repository: https://github.com/fetchrobotics/fetch_tools.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.2-1`

## fetch_tools

```
* Fix argcomplete hook command for python3
* Contributors: Eric Relson
```
