### PR TITLE
proj: 5.2.0-3 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1922,6 +1922,17 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: dashing
     status: maintained
+  proj:
+    doc:
+      type: git
+      url: https://github.com/OSGeo/PROJ.git
+      version: '5.2'
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/stonier/proj-release.git
+      version: 5.2.0-3
+    status: maintained
   px4_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `proj` to `5.2.0-3`:

- upstream repository: https://github.com/OSGeo/PROJ.git
- release repository: https://github.com/stonier/proj-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
