### PR TITLE
leo_desktop: 0.2.2-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6593,7 +6593,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_desktop-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/LeoRover/leo_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `0.2.2-2`:

- upstream repository: https://github.com/LeoRover/leo_desktop.git
- release repository: https://github.com/fictionlab-gbp/leo_desktop-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.2-1`

## leo_desktop

```
* Add leo metapackage to dependencies
```

## leo_viz

```
* Update cmake minimum version, change CMakeLists formatting
```
