### PR TITLE
leo_common: 1.1.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6575,7 +6575,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/LeoRover/leo_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.1.0-2`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`

## leo

```
* Add leo_teleop package
```

## leo_description

```
* Bump minimum cmake version to 3.0.2
* Update package manifest
```

## leo_teleop

```
* Add leo_teleop package
```
