### PR TITLE
bota_driver: 0.5.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -930,7 +930,6 @@ repositories:
       url: https://gitlab.com/botasys/bota_driver-release.git
       version: 0.5.0-2
     source:
-      test_pull_requests: true
       type: git
       url: https://gitlab.com/botasys/bota_driver.git
       version: master

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -927,7 +927,7 @@ repositories:
       - rokubimini_serial
       tags:
         release: release/melodic/{package}/{version}
-      url: ' https://gitlab.com/botasys/bota_driver-release.git'
+      url: https://gitlab.com/botasys/bota_driver-release.git
       version: 0.5.0-2
     source:
       test_pull_requests: true

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -907,6 +907,34 @@ repositories:
       url: https://github.com/PickNikRobotics/boost_sml.git
       version: master
     status: maintained
+  bota_driver:
+    doc:
+      type: git
+      url: https://gitlab.com/botasys/bota_driver.git
+      version: master
+    release:
+      packages:
+      - bota_device_driver
+      - bota_driver
+      - rokubimini
+      - rokubimini_bus_manager
+      - rokubimini_description
+      - rokubimini_ethercat
+      - rokubimini_examples
+      - rokubimini_factory
+      - rokubimini_manager
+      - rokubimini_msgs
+      - rokubimini_serial
+      tags:
+        release: release/melodic/{package}/{version}
+      url: ' https://gitlab.com/botasys/bota_driver-release.git'
+      version: 0.5.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://gitlab.com/botasys/bota_driver.git
+      version: master
+    status: developed
   brics_actuator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.0-2`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository:  https://gitlab.com/botasys/bota_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## bota_device_driver

```
* Merge branch 'feature/remove-redundant-ethercat-pdos'
* Merge branch 'feature/move-publishers-to-instances'
* Merge branch 'feature/remove-message-logger-dependency'
* remove ethercat_pdo_type from yaml
* fix clang format
* remove rokubimini_msgs from bota_device_driver
* Merge branch 'feature/publish-frame-id' into 'master'
  Add frame_id in published data
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Contributors: Ilias Patsiaouras, Mike Karamousadakis
```

## bota_driver

```
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Contributors: Ilias Patsiaouras, Mike Karamousadakis
```

## rokubimini

```
* Merge branch 'feature/move-publishers-to-instances'
* Merge branch 'feature/remove-message-logger-dependency'
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Merge branch 'feature/remove-yaml-tools-dep' into 'master'
  Remove yaml tools dependency
* Merge branch 'feature/remove-cosmo-dependency' into 'master'
  Remove all dependencies apart from yaml_tools
* Merge branch 'feature/save-config-parameter'
* Merge branch 'feature/add-temperature-serial'
* Merge branch 'feature/add-si-units-imu'
* add temperature publishing functionality. tested locally
* add first implementation. works on Serial, but it's still WIP
* add conversion to SI units for IMU data
* Merge branch 'feature/remove-command-from-repo' into 'master'
  remove Command from repo. Tested locally
* Merge branch 'feature/change-printed-messages' into 'master'
  Feature/change printed messages
* Initial commit
  - change [ForceTorqueSensor::device_name] to [device_name] in RokubiminiSerialImpl.cpp
  - add bus name and/or device_name in RokubiminiEthercatSlave, RokubiminiEthercatBusManager and EthercatBusBase.
* Merge branch 'add-abstract-filters' into 'master'
  Add configuration support in serial devices
* fix bug in assignment operation of Configuration. replace INIT_MODE with ConnectionState in RokubiminiSerialImpl code
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* add clang-formated code. add support for multiple devices in rokubimini_cosmo
* add doxygen documentation
* first abstracted try
* Merged in feature/temperature_reading (pull request #31)
  add temperature in readings
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
* add temperature in readings
* remove redundant orientation. Imu has quaternion
* Merged in feature/publish_standard_ros_msgs (pull request #29)
  remove redundant orientation. Imu has quaternion
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
* remove redundant orientation. Imu has quaternion
* Merge branch 'master' into feature/publish_rokubimini_reading
* Merged in Feature/default_config (pull request #20)
  Feature/default config
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
* add force torque offset support in config
* add IMU filter config and correct range config
* Merged in bugfix/error_reporting (pull request #19)
  Bugfix/error reporting
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
* add serial number readout
* add option to run sync with the FT sample rate
* add force torque filter configuration
* print statusword only on DEBUG mode
* correct error reporting
* Merge branch 'master' into fix/base_sensor_with_2_adapter_plates
* Merged in feature/calibration_only (pull request #16)
  add calibration of the F/T sensor
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
  Approved-by: Dario Nastasi <mailto:nastasid@student.ethz.ch>
* moved doxygen method descriptions to header files
* formatting
* formatting
* add calibration of the F/T sensor
* Merge branch 'feature/ft_dario_testing' into feature/dario_rafael_master_v2
* Removed dep
* Another test
* Removed test dep
* Testing with external dep
* another attempt to prevent memory error when closing simulation
* fix memory error when closing simulation
* apply all changes from force_torque_controllers without ethercat changes
* Merged in feature/OD_clean_up (pull request #8)
  Feature/OD clean up
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
* Adressed pr comments
* Working with newest firmware
* wp 2
* Adapted to latest yaml node changes
* Merged in feature/calibration (pull request #5)
  Feature/calibration
* Removed 2 unused warnings
* Calibration matrix can now be set with sdo
* Added imu ranges to sdo
* Reading calibration matrix from file
* Deleted driver, added more sdos
* to be tested with new firmware
* Trying to write calibration sdo
* Set up the basic structure to run calibration sdo
* another melo include
* Added melo include
* Updated documentation
* Merged in feature/manager (pull request #3)
  Feature/manager
* Started implementing manager classes
* Clang tools
* Added ros conversion trait for reading and command
* Cosmo example back to life
* Started to adapt cosmo example
* Configuration SDO works
* Added first sdo
* Wip to make example master work
* Example compiles
* Wip example, file support, bug fixes
* Rokubimini_ethercat compiles
* Rokubimini compiles, added command
* Wip to make things run
* Wip to implement new structure
* Contributors: Ilias Patsiaouras, Johannes Pankert, Markus Stäuble, Martin, Mike Karamousadakis, markusta, mailto:nastasid@student.ethz.ch
```

## rokubimini_bus_manager

```
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Merge branch 'feature/remove-yaml-tools-dep' into 'master'
  Remove yaml tools dependency
* Merge branch 'feature/remove-cosmo-dependency' into 'master'
  Remove all dependencies apart from yaml_tools
* Merge branch 'add-abstract-filters' into 'master'
  Add configuration support in serial devices
* fix bug in assignment operation of Configuration. replace INIT_MODE with ConnectionState in RokubiminiSerialImpl code
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* add clang-formated code. add support for multiple devices in rokubimini_cosmo
* add doxygen documentation
* first abstracted try
* Contributors: Ilias Patsiaouras, Mike Karamousadakis
```

## rokubimini_description

```
* Merge branch 'feature/remove-message-logger-dependency'
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* double checked tensor, mass and collision cylinder, and formatting
* formatting
* added inertia tensor, mass, collision cylinder
* formatting
* added inertia to parameter file
* Set inertial rpy to zero.
* Added default config file for rokubimega.
* changed sensor coordinate system. updated rokubimega.stl file
* edit FT parameters for Shovel and Gripper mount
* added stl file in mashes, created and adapted parameter and force_torque_sensors files
* Merged in feature/rokubimega (pull request #27)
  Feature/rokubimega
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
  Approved-by: Dominic Jud <mailto:djud@student.ethz.ch>
  Approved-by: Ilias Patsiaouras <mailto:ilias.patsiaouras@gmail.com>
* double checked tensor, mass and collision cylinder, and formatting
* formatting
* added inertia tensor, mass, collision cylinder
* formatting
* Merge branch 'feature/rokubimega' of bitbucket.org:leggedrobotics/rokubimini_ethercat_sdk into feature/rokubimega
* Set inertial rpy to zero.
* Merge branch 'feature/rokubimega' of bitbucket.org:leggedrobotics/rokubimini_ethercat_sdk into feature/rokubimega
* added inertia to parameter file
* Added default config file for rokubimega.
* changed sensor coordinate system. updated rokubimega.stl file
* edit FT parameters for Shovel and Gripper mount
* added stl file in mashes, created and adapted parameter and force_torque_sensors files
* moved sensor frame such that the RKL100 urdf accounts for the second adapter plate
* Merge branch 'feature/fix_simulated_sensor_joint'
* changed standard value of fix_sensor in urdf
* Merged in feature/fix_simulated_sensor_joint (pull request #24)
  Allow to fix sensor joint when simulation flag is set to true
* removed simulation argument from sensor_fixed conditional expression
* the sensor joint type can be set to fixed even when the simulation flag is true. This allows for passing the robot description with fixed sensor joints to the robot_state_publisher.
* Merged in fix/ee_sensor_parameters (pull request #17)
  Fix/ee sensor parameters
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
* Merged in fix/base_sensor_with_2_adapter_plates (pull request #18)
  RKL100 parameters fix
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
* add 2nd adapter plate
* Merge remote-tracking branch 'origin/feature/dario_rafael_master_v2' into fix/ee_sensor_parameters
  # Conflicts:
  #     rokubimini_description/urdf_src/include/R212_parameters.urdf.xacro
* .
* 0.035->0.034
* COM sign
* Merge remote-tracking branch 'origin/fix/urdf_base_sensor' into feature/dario_rafael_master_v2
* Merge remote-tracking branch 'origin/master' into feature/dario_rafael_master_v2
  # Conflicts:
  #     rokubimini_description/urdf_src/include/R212_parameters.urdf.xacro
  #     rokubimini_description/urdf_src/roku_force_torque_sensor.urdf.xacro
  #     rokubimini_gazebo_plugin/config/default.yaml
  #     rokubimini_gazebo_plugin/include/rokubimini_gazebo_plugin/RokubiminiGazeboPlugin.h
  #     rokubimini_gazebo_plugin/src/RokubiminiGazeboPlugin.cpp
* collision model on
* collision off
* base frame position, collision models
* Merged in fix/r212_sensor_frame (pull request #15)
  changed the z offsets of the R212 sensor again to measured values
* changed the z offsets of the R212 sensor again to measured values
* Merged in fix/r212_sensor_frame (pull request #14)
  adapted the sensor frame such that it matches the actual dimensions
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
* Merge branch 'feature/ft_dario_testing' into feature/dario_rafael_master_v2
* adapted the sensor frame such that it matches the actual dimensions
* Merged in feature/base_sensor_urdf (pull request #12)
  Integration of Base F/T Sensor
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
* split force torque xacro
* shift sensor frame to the correct position
* allow for different rokubimini types
* publish joint state of 'tool'
* Merge remote-tracking branch 'origin/feature/different_ee_sensor_rotation' into feature/dario_rafael_master_v2
* different approach on ee sensor rotation issue
* Merge branch 'feature/ft_dario_testing' into feature/dario_rafael_master_v2
* Merge branch 'feature/ft_dario_testing' of bitbucket.org:leggedrobotics/rokubimini_ethercat_sdk into feature/ft_dario_testing
* turn wrist sensor 90 degrees to align it with real sensor axes
* updated sensor mass from weighing
* change name of topics to {link}_forcetorquesensor}
* apply all changes from force_torque_controllers without ethercat changes
* Merged in feature/urdf (pull request #7)
  Feature/urdf
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
* Cleanup mesh.
* Use new version of force sensor
* Use revolute sensor joint only simulation.
* Fix dependencies.
* use PACKAGE_DEPENDENCIES also for catkin_package
* implement comments from PR
* create separate pkg for gazebo plugin and make it independend of any mabi pkg
* Move gazebo plugin xacro here and make joint_states topic adjustable via an argument in the xacro
* move cosmo publisher of readings and jiont status of the force sensor into this repository.
* This configutation works, maybe some tweaking of the friction parameters is needed
* Contributors: Constantin Gemmingen, Dario Nastasi, Ilias Patsiaouras, Johannes Pankert, Martin, Mike Karamousadakis, Rafael Rietmann, nastasid, mailto:nastasid@student.ethz.ch
```

## rokubimini_ethercat

```
* Merge branch 'feature/remove-redundant-ethercat-pdos'
* Merge branch 'feature/move-publishers-to-instances'
* Merge branch 'feature/remove-message-logger-dependency'
* revert some changes
* Merge branch 'fix/fix-flag-isforcetorquesaturated'
* remove message_logger from docs + CI
* fix clang format
* Merge branch 'feature/fix-catkin-make' into 'master'
  Fix broken catkin_make
* Fix broken catkin_make
* Merge branch 'feature/publish-frame-id' into 'master'
  Add frame_id in published data
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* add frame_id in published data
* Merge branch 'feature/remove-yaml-tools-dep' into 'master'
  Remove yaml tools dependency
* Merge branch 'feature/remove-cosmo-dependency' into 'master'
  Remove all dependencies apart from yaml_tools
* Merge branch 'feature/add-init-step-serial'
* Merge branch 'feature/save-config-parameter'
* remove redundant file
* add STATUS check
* Merge branch 'feature/add-temperature-serial'
* Merge branch 'feature/add-si-units-imu'
* add temperature publishing functionality. tested locally
* add first implementation. works on Serial, but it's still WIP
* fix clang format
* add changes to every PdoType
* add conversion to SI units for IMU data
* Merge branch 'feature/remove-command-from-repo' into 'master'
  remove Command from repo. Tested locally
* Merge branch 'feature/change-printed-messages' into 'master'
  Feature/change printed messages
* Initial commit
  - change [ForceTorqueSensor::device_name] to [device_name] in RokubiminiSerialImpl.cpp
  - add bus name and/or device_name in RokubiminiEthercatSlave, RokubiminiEthercatBusManager and EthercatBusBase.
* Merge branch 'add-abstract-filters' into 'master'
  Add configuration support in serial devices
* fix bug in assignment operation of Configuration. replace INIT_MODE with ConnectionState in RokubiminiSerialImpl code
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* add clang-formated code. add support for multiple devices in rokubimini_cosmo
* add doxygen documentation
* fix CI build
* remove soem_interface dependancy
* first abstracted try
* Merged in feature/temperature_reading (pull request #31)
  add temperature in readings
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
* add temperature in readings
* remove redundant orientation. Imu has quaternion
* Merged in feature/publish_standard_ros_msgs (pull request #29)
  remove redundant orientation. Imu has quaternion
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
  Approved-by: Martin Wermelinger <mailto:martiwer@mavt.ethz.ch>
* remove redundant orientation. Imu has quaternion
* removed explicit soem dependency
* Merge branch 'master' into feature/publish_rokubimini_reading
* Merged in Feature/default_config (pull request #20)
  Feature/default config
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
  Approved-by: Johannes Pankert <mailto:johannes@pankert.eu>
* add force torque offset support in config
* move some info to debug level
* add IMU filter config and correct range config
* add serial number readout
* add option to run sync with the FT sample rate
* add force torque filter configuration
* Merge remote-tracking branch 'origin/master' into feature/dario_rafael_master_v2
  # Conflicts:
  #     rokubimini_description/urdf_src/include/R212_parameters.urdf.xacro
  #     rokubimini_description/urdf_src/roku_force_torque_sensor.urdf.xacro
  #     rokubimini_gazebo_plugin/config/default.yaml
  #     rokubimini_gazebo_plugin/include/rokubimini_gazebo_plugin/RokubiminiGazeboPlugin.h
  #     rokubimini_gazebo_plugin/src/RokubiminiGazeboPlugin.cpp
* Merged in feature/euthing_sensor (pull request #11)
  modified TxPDO C to work with euthing feet
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
* modified TxPDO C to work with it
* Merged in feature/OD_clean_up (pull request #8)
  Feature/OD clean up
  Approved-by: Markus Stäuble <mailto:markus.staeuble@mavt.ethz.ch>
* Merged in feature/daisy_chain (pull request #9)
  Feature/daisy chain
* Merge branch 'feature/daisy_chain' into feature/OD_clean_up
* Adressed pr comments
* Working with newest firmware
* wp 2
* wp
* Improved error message
* Clean up, improved methods for daisy chaining
* Merged in feature/unique_ptr (pull request #6)
  Adapted to base class changes, added method to add rokubimini slaves to an existing bus
* Adapted to base class changes, added method to add rokubimini slaves to an existing bus
* Merged in feature/calibration (pull request #5)
  Feature/calibration
* Calibration matrix can now be set with sdo
* Merge branch 'master' into feature/calibration
* Merged in feature/bare_ptr (pull request #4)
  Feature/bare ptr
* Adapted pdo to latest object dictionary changes
* Adapted to soem interface change
* Added imu ranges to sdo
* Reading calibration matrix from file
* Deleted driver, added more sdos
* to be tested with new firmware
* Trying to write calibration sdo
* Set up the basic structure to run calibration sdo
* MONSTER COMMIT!!!!!!!!!!!!!!!!!!!!!
* Updated documentation
* Merged in feature/manager (pull request #3)
  Feature/manager
* Added external imu pdo to use for THING
* Got rid of absolute path in example
* Manager works now with cosmo example
* Fix cmake
* Further manager development
* Cosmo node compiles with manager
* Started implementing manager classes
* Using more shared ptr now
* Clang tools
* Adapted to latest changes, clean up
* Added ros conversion trait for reading and command
* Cosmo example back to life
* Started to adapt cosmo example
* Configuration SDO works
* Added first sdo
* Master working properly with the size check
* Added more PDOs
* Working master example
* Wip to make example master work
* Example compiles
* Wip example, file support, bug fixes
* Rokubimini_ethercat compiles
* Rokubimini compiles, added command
* Wip to make things run
* Wip to implement new structure
* Contributors: Ilias Patsiaouras, Johannes Pankert, Klajd Lika, Markus Stäuble, Martin, Mike Karamousadakis, Rafael Rietmann, markusta
```

## rokubimini_examples

```
* Merge branch 'feature/remove-message-logger-dependency'
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Merge branch 'feature/try-industrial-ci' into 'master'
  Utilize industrial-ci for implementing Continuous Integration.
* add proper build path for non-master branches. master branch CI needs to change. change Dockerfile and gitlab-ci.yml to use .rosinstall file
* Merge branch 'feature/remove-command-from-repo' into 'master'
  remove Command from repo. Tested locally
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* add clang-formated code. add support for multiple devices in rokubimini_cosmo
* fix CI build
* first abstracted try
* Contributors: Ilias Patsiaouras, Mike Karamousadakis
```

## rokubimini_factory

```
* Merge branch 'feature/remove-message-logger-dependency'
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Merge branch 'feature/remove-yaml-tools-dep' into 'master'
  Remove yaml tools dependency
* Merge branch 'feature/remove-cosmo-dependency' into 'master'
  Remove all dependencies apart from yaml_tools
* Merge branch 'add-abstract-filters' into 'master'
  Add configuration support in serial devices
* fix bug in assignment operation of Configuration. replace INIT_MODE with ConnectionState in RokubiminiSerialImpl code
* Merge branch 'change-info-to-debug' into 'master'
  change some INFO to DEBUG
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* add clang-formated code. add support for multiple devices in rokubimini_cosmo
* add doxygen documentation
* first abstracted try
* Contributors: Ilias Patsiaouras, Mike Karamousadakis
```

## rokubimini_manager

```
* Merge branch 'feature/move-publishers-to-instances'
* Merge branch 'feature/remove-message-logger-dependency'
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Merge branch 'feature/remove-yaml-tools-dep' into 'master'
  Remove yaml tools dependency
* Merge branch 'feature/remove-cosmo-dependency' into 'master'
  Remove all dependencies apart from yaml_tools
* Merge branch 'feature/remove-command-from-repo' into 'master'
  remove Command from repo. Tested locally
* Merge branch 'add-abstract-filters' into 'master'
  Add configuration support in serial devices
* fix bug in assignment operation of Configuration. replace INIT_MODE with ConnectionState in RokubiminiSerialImpl code
* Merge branch 'change-info-to-debug' into 'master'
  change some INFO to DEBUG
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* add clang-formated code. add support for multiple devices in rokubimini_cosmo
* add doxygen documentation
* better error reporting
* fix CI build
* first abstracted try
* Contributors: Ilias Patsiaouras, Mike Karamousadakis
```

## rokubimini_msgs

```
* Merge branch 'feature/add-temperature-serial'
* add temperature publishing functionality. tested locally
* Merge branch 'feature/try-industrial-ci' into 'master'
  Utilize industrial-ci for implementing Continuous Integration.
* add proper build path for non-master branches. master branch CI needs to change. change Dockerfile and gitlab-ci.yml to use .rosinstall file
* Merge branch 'feature/remove-command-from-repo' into 'master'
  remove Command from repo. Tested locally
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* first abstracted try
* Merged in feature/manager (pull request #3)
  Feature/manager
* Added ros conversion trait for reading and command
* Started to adapt cosmo example
* Contributors: Ilias Patsiaouras, Markus Stäuble, Mike Karamousadakis, markusta
```

## rokubimini_serial

```
* Merge branch 'feature/move-publishers-to-instances'
* Merge branch 'feature/remove-message-logger-dependency'
* Merge branch 'feature/enable-configuration-object-serial' into 'master'
  Enable configuration object in serial
* Merge branch 'fix/add-charachter_delay' into 'master'
  add inter-character delay 5ms
* Merge branch 'feature/publish-frame-id' into 'master'
  Add frame_id in published data
* Merge branch 'feature/rename-project' into 'master'
  Rename project to bota_driver
* Merge branch 'feature/remove-serial-types-file' into 'master'
  Remove rokubimini_serial/types.hpp file
* Merge branch 'feature/remove-yaml-tools-dep' into 'master'
  Remove yaml tools dependency
* Merge branch 'feature/remove-cosmo-dependency' into 'master'
  Remove all dependencies apart from yaml_tools
* Merge branch 'feature/add-init-step-serial'
* rename setSoftwareReset() to setInitMode()
* Merge branch 'feature/save-config-parameter'
* add setSoftwareReset() in init() of serial
* Merge branch 'feature/add-temperature-serial'
* Merge branch 'feature/add-si-units-imu'
* Merge branch 'feature/add-calibration-matrix-command'
* reduce number of chars to 62 with %9.6f
* add proposed changes
* add temperature publishing functionality. tested locally
* add first implementation. works on Serial, but it's still WIP
* fix mispelled frame name
* add temperature in serial Reading
* add conversion to SI units for IMU data
* add RokubiminiSerialImpl::setSensorCalibration() command. Tested locally.
* Merge branch 'feature/remove-command-from-repo' into 'master'
  remove Command from repo. Tested locally
* Merge branch 'feature/change-printed-messages' into 'master'
  Feature/change printed messages
* Initial commit
  - change [ForceTorqueSensor::device_name] to [device_name] in RokubiminiSerialImpl.cpp
  - add bus name and/or device_name in RokubiminiEthercatSlave, RokubiminiEthercatBusManager and EthercatBusBase.
* Merge branch 'add-abstract-filters' into 'master'
  Add configuration support in serial devices
* fix bug in assignment operation of Configuration. replace INIT_MODE with ConnectionState in RokubiminiSerialImpl code
* Merge branch 'add-baudrate-115200' into 'master'
  add missing baudrate
* Merge branch 'change-info-to-debug' into 'master'
  change some INFO to DEBUG
* Merge branch 'add-linter-test' into 'feature/rokubimini_serial'
  Add linter testing step in CI
* add baud rate functionality: baud rate is taken from the system definitions (termios.h in Linux)
* add clang-formated code. add support for multiple devices in rokubimini_cosmo
* add doxygen documentation
* fix CI build
* first abstracted try
* Contributors: Ilias Patsiaouras, Mike Karamousadakis
```
