### PR TITLE
play_motion_builder: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7945,6 +7945,25 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-gbp/play_motion-release2.git
       version: 0.4.8-1
+  play_motion_builder:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/play_motion_builder.git
+      version: master
+    release:
+      packages:
+      - play_motion_builder
+      - play_motion_builder_msgs
+      - rqt_play_motion_builder
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-robotics/play_motion_builder-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/play_motion_builder.git
+      version: master
+    status: maintained
   plotjuggler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion_builder` to `1.0.1-1`:

- upstream repository: https://github.com/pal-robotics/play_motion_builder.git
- release repository: https://github.com/pal-robotics/play_motion_builder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## play_motion_builder

```
* REname projecto to comply with naming scheme
* Contributors: davidfernandez
```

## play_motion_builder_msgs

```
* REname projecto to comply with naming scheme
* Contributors: davidfernandez
```

## rqt_play_motion_builder

```
* REname projecto to comply with naming scheme
* Contributors: davidfernandez
```
