### PR TITLE
cob_command_tools: 0.6.18-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1296,7 +1296,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.16-1
+      version: 0.6.18-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.18-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.16-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #286 <https://github.com/ipa320/cob_command_tools/issues/286> from fmessmer/fix_noetic
  fix noetic
* ignore pylint assignment-from-none
* ROS_PYTHON_VERSION conditional dependency for psutil
* ROS_PYTHON_VERSION conditional dependency for requests
* ROS_PYTHON_VERSION conditional dependency for mechanize
* Contributors: Felix Messmer, fmessmer
```

## cob_script_server

```
* Merge pull request #286 <https://github.com/ipa320/cob_command_tools/issues/286> from fmessmer/fix_noetic
  fix noetic
* ROS_PYTHON_VERSION conditional dependency for pygraphviz
* ROS_PYTHON_VERSION conditional dependency for ipython
* Contributors: Felix Messmer, fmessmer
```

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
