### PR TITLE
cob_command_tools: 0.6.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -379,6 +379,31 @@ repositories:
       url: https://github.com/ipa320/cob_calibration_data.git
       version: indigo_dev
     status: maintained
+  cob_command_tools:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_command_tools.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_dashboard
+      - cob_helper_tools
+      - cob_interactive_teleop
+      - cob_monitoring
+      - cob_script_server
+      - cob_teleop
+      - generic_throttle
+      - scenario_test_tools
+      - service_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_command_tools-release.git
+      version: 0.6.18-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_command_tools.git
+      version: indigo_dev
+    status: maintained
   cob_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.18-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #286 <https://github.com/ipa320/cob_command_tools/issues/286> from fmessmer/fix_noetic
  fix noetic
* ignore pylint assignment-from-none
* ROS_PYTHON_VERSION conditional dependency for psutil
* ROS_PYTHON_VERSION conditional dependency for requests
* ROS_PYTHON_VERSION conditional dependency for mechanize
* Contributors: Felix Messmer, fmessmer
```

## cob_script_server

```
* Merge pull request #286 <https://github.com/ipa320/cob_command_tools/issues/286> from fmessmer/fix_noetic
  fix noetic
* ROS_PYTHON_VERSION conditional dependency for pygraphviz
* ROS_PYTHON_VERSION conditional dependency for ipython
* Contributors: Felix Messmer, fmessmer
```

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
