### PR TITLE
cob_control: 0.8.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1351,7 +1351,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.8.11-1
+      version: 0.8.12-1
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.12-1`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.11-1`

## cob_base_controller_utils

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_base_velocity_smoother

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_cartesian_controller

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_collision_velocity_filter

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_control

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_control_mode_adapter

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_control_msgs

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_footprint_observer

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_frame_tracker

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* conditional depend for orocos-kdl
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_hardware_emulation

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #244 <https://github.com/ipa320/cob_control/issues/244> from lindemeier/bugfix/length-bug
  [melodic] bugfix/length-bug
* sets correct length and checks for length
* Merge pull request #240 <https://github.com/ipa320/cob_control/issues/240> from benmaidel/feature/base_emu_reset_odom_melodic
  reset odometry service for base emulation
* reset odometry service for base emulation
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer, tsl
```

## cob_mecanum_controller

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_model_identifier

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* conditional depend for orocos-kdl
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_obstacle_distance

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* conditional depend for orocos-kdl
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_omni_drive_controller

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_trajectory_controller

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_tricycle_controller

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_twist_controller

```
* Merge pull request #243 <https://github.com/ipa320/cob_control/issues/243> from fmessmer/test_noetic
  test noetic
* ROS_PYTHON_VERSION conditional dependency for matplotlib
* conditional depend for orocos-kdl
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
