### PR TITLE
performance_test_fixture: 0.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1871,7 +1871,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.0.5-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.4-1`

## performance_test_fixture

```
* Export dependency on benchmark and osrf_testing_tools_cpp (#8 <https://github.com/ros2/performance_test_fixture/issues/8>)
* Update maintainers (#7 <https://github.com/ros2/performance_test_fixture/issues/7>)
* Contributors: Alejandro Hernández Cordero, Scott K Logan
```
