### PR TITLE
lgsvl_msgs: 0.0.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6661,7 +6661,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lgsvl/lgsvl_msgs-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.4-1`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.3-1`

## lgsvl_msgs

```
* Add VehicleOdometry.msg to README
* Adding VehicleOdometry.
* Update README and LICENSE
* Update package description and maintainers
* Add ultrasonic message.
* Contributors: Guodong Rong, Hadi Tabatabaee, Piotr Jaroszek
```
