### PR TITLE
lgsvl_msgs: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2442,11 +2442,12 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/lgsvl/lgsvl_msgs-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: noetic-devel
+    status: developed
   libfranka:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.4-1`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/lgsvl/lgsvl_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.3-1`

## lgsvl_msgs

```
* Add VehicleOdometry.msg to README
* Adding VehicleOdometry.
* Update README and LICENSE
* Update package description and maintainers
* Add ultrasonic message.
* Contributors: Guodong Rong, Hadi Tabatabaee, Piotr Jaroszek
```
