### PR TITLE
grbl_ros: 0.0.14-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -975,7 +975,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/flynneva/grbl_ros-release.git
-      version: 0.1.1-1
+      version: 0.0.14-1
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -970,7 +970,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: eloquent
+      version: main
     release:
       tags:
         release: release/eloquent/{package}/{version}
@@ -979,7 +979,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: eloquent
+      version: main
     status: developed
   hls_lfcd_lds_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_ros` to `0.0.14-1`:

- upstream repository: https://github.com/flynneva/grbl_ros.git
- release repository: https://github.com/flynneva/grbl_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.1-1`
