### PR TITLE
mrpt2: 2.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1565,7 +1565,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
-      version: 2.1.0-3
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.1.3-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.1.0-3`
