### PR TITLE
play_motion_builder: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8003,7 +8003,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-robotics/play_motion_builder-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion_builder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion_builder` to `1.0.2-1`:

- upstream repository: https://github.com/pal-robotics/play_motion_builder.git
- release repository: https://github.com/pal-robotics/play_motion_builder-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.0.1-1`

## play_motion_builder

```
* Fix dependencies
* Contributors: davidfernandez
```

## play_motion_builder_msgs

```
* Fix dependencies
* Contributors: davidfernandez
```

## rqt_play_motion_builder

- No changes
