### PR TITLE
cob_navigation: 0.6.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -571,6 +571,30 @@ repositories:
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
     status: maintained
+  cob_navigation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - cob_linear_nav
+      - cob_map_accessibility_analysis
+      - cob_mapping_slam
+      - cob_navigation
+      - cob_navigation_config
+      - cob_navigation_global
+      - cob_navigation_local
+      - cob_navigation_slam
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_navigation-release.git
+      version: 0.6.11-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_navigation.git
+      version: indigo_dev
+    status: maintained
   cob_perception_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_navigation` to `0.6.11-1`:

- upstream repository: https://github.com/ipa320/cob_navigation.git
- release repository: https://github.com/ipa320/cob_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## cob_linear_nav

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #119 <https://github.com/ipa320/cob_navigation/issues/119> from AravindaDP/feat/cob_linear_nav-velocity_threshold_param
  feat: [cob_linear_nav] Goal abortion speed params
* feat: [cob_linear_nav] Goal abortion speed params
  Support adjusting linear and rotational velocity thresholds for goal
  abortion detection. (No movement due to obstacle)
* Merge pull request #117 <https://github.com/ipa320/cob_navigation/issues/117> from AravindaDP/feat/cob_linear_nav_footprint_tf_param
  feat: robot_footprint_frame rosparam
* feat: robot_footprint_frame rosparam
  Support setting robot_footprint_frame as a rosparam (issues/116)
  (defaults to "base_footprint")
* Contributors: Felix Messmer, Florian Weisshardt, Pramuditha Aravinda, fmessmer
```

## cob_map_accessibility_analysis

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bugfix for OpenCV API change 2
* Bugfix for OpenCV API change
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, Richard Bormann, fmessmer
```

## cob_mapping_slam

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_navigation

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_navigation_config

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_navigation_global

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_navigation_local

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_navigation_slam

```
* Merge pull request #120 <https://github.com/ipa320/cob_navigation/issues/120> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
