### PR TITLE
audio_common: 0.3.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -781,7 +781,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.8-1
+      version: 0.3.9-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.9-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.8-1`

## audio_capture

```
* Merge pull request #160 <https://github.com/ros-drivers/audio_common/issues/160> from knorth55/add-device-play
* use ROS_INFO instead of printf
* Contributors: Shingo Kitagawa
```

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

```
* Merge pull request #160 <https://github.com/ros-drivers/audio_common/issues/160> from knorth55/add-device-play
* refactor audio_play to use same code
* add audioresample in audio_play
* apply caps for both formats
* add device for wave format
* add sync false for alsasink
* use alsasink
* add depth rosparam
* add device arg in play.launch
* fix audio_play to save file
* Contributors: Shingo Kitagawa
```

## sound_play

- No changes
