### PR TITLE
sick_scan2: 0.1.8-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3379,6 +3379,17 @@ repositories:
       url: https://github.com/SBG-Systems/sbg_ros2.git
       version: master
     status: maintained
+  sick_scan2:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/SICKAG/sick_scan2-release.git
+      version: 0.1.8-3
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan2.git
+      version: master
+    status: developed
   slam_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan2` to `0.1.8-3`:

- upstream repository: https://github.com/SICKAG/sick_scan2.git
- release repository: https://github.com/SICKAG/sick_scan2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## sick_scan2

```
* LDMRS support added scanner simulator added
* migraded print statments to ros2
* implemeted software pll and rssi
* MRS 1xxx Imu support activated
* added MRS1104 support
* Update clion debugging
* Adding TiM240 support info.
* support of TiM240
* prepare TiM240
  Correct parameter name "max_ang" in config files to activate the setting.
* Modify max-ang to max_ang in config files.
* Supported hardware list extended
* added new launchfiles and updated readme
* tf2 added
* First draft of LMS511 and LMS111 support and pointcloud2
* Quaternion test added
* Contributors: Michael Lehning, Skyler Pan
```
