### PR TITLE
franka_ros: 0.7.1-1 in 'noetic/distribution.yaml

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1476,7 +1476,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Update packet version from 0.7.0. to 0.7.1. Not releasing 'franka_ros' and 'franka_example_controllers' for now.