### PR TITLE
sick_scan2: 0.1.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3379,6 +3379,17 @@ repositories:
       url: https://github.com/SBG-Systems/sbg_ros2.git
       version: master
     status: maintained
+  sick_scan2:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/SICKAG/sick_scan2-release.git
+      version: 0.1.9-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan2.git
+      version: master
+    status: developed
   slam_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan2` to `0.1.9-1`:

- upstream repository: https://github.com/SICKAG/sick_scan2.git
- release repository: https://github.com/SICKAG/sick_scan2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## sick_scan2

```
* tf2-ros dependency added, temperatur to test server added
* Contributors: Michael Lehning
```
