### PR TITLE
message_logger: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5814,6 +5814,21 @@ repositories:
       url: https://github.com/ros/message_generation.git
       version: kinetic-devel
     status: maintained
+  message_logger:
+    doc:
+      type: git
+      url: https://github.com/ANYbotics/message_logger.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mikekaram/message_logger-release.git
+      version: 0.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ANYbotics/message_logger.git
+      version: master
   message_runtime:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_logger` to `0.2.0-1`:

- upstream repository: https://github.com/ANYbotics/message_logger.git
- release repository: https://github.com/mikekaram/message_logger-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
