### PR TITLE
any_node: 0.5.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -166,6 +166,27 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  any_node:
+    doc:
+      type: git
+      url: https://github.com/ANYbotics/any_node.git
+      version: master
+    release:
+      packages:
+      - any_node
+      - any_node_example
+      - any_worker
+      - param_io
+      - signal_handler
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mikekaram/any_node-release.git
+      version: 0.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ANYbotics/any_node.git
+      version: master
   app_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `any_node` to `0.5.0-1`:

- upstream repository: https://github.com/ANYbotics/any_node.git
- release repository: https://github.com/mikekaram/any_node-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
