### PR TITLE
Gentoo entries for gazebo11 and python3-pykdl

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1001,6 +1001,7 @@ gazebo:
 gazebo11:
   debian:
     buster: [gazebo11]
+  gentoo: [=sci-electronics/gazebo-11*]
   ubuntu:
     focal: [gazebo11]
 gazebo5:
@@ -2448,6 +2449,7 @@ libftgl-dev:
 libgazebo11-dev:
   debian:
     buster: [libgazebo11-dev]
+  gentoo: [=sci-electronics/gazebo-11*]
   ubuntu:
     focal: [libgazebo11-dev]
 libgazebo5-dev:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6238,6 +6238,7 @@ python3-pykdl:
     '*': [python3-pykdl]
     '30': null
     '31': null
+  gentoo: [dev-python/python_orocos_kdl]
   ubuntu:
     '*': [python3-pykdl]
     'bionic': null


### PR DESCRIPTION
https://packages.gentoo.org/packages/sci-electronics/gazebo

https://packages.gentoo.org/packages/dev-python/python_orocos_kdl