### PR TITLE
mapviz: 1.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5541,7 +5541,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.4.1-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.4.0-1`

## mapviz

- No changes

## mapviz_plugins

```
* Constrain the minimum line and point marker sizes to be 1 pixel wide. (#704 <https://github.com/swri-robotics/mapviz/issues/704>)
* Fix compile warning in ROS Noetic (#706 <https://github.com/swri-robotics/mapviz/issues/706>)
* Contributors: Marc Alban, P. J. Reed
```

## multires_image

- No changes

## tile_map

- No changes
