### PR TITLE
mapviz: 2.1.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1481,7 +1481,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.1.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.0-1`

## mapviz

```
* ROS Foxy support (#695 <https://github.com/swri-robotics/mapviz/issues/695>)
* Contributors: P. J. Reed
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Constrain the minimum line and point marker sizes to be 1 pixel wide. (#704 <https://github.com/swri-robotics/mapviz/issues/704>)
* ROS Foxy support (#695 <https://github.com/swri-robotics/mapviz/issues/695>)
* Update the displayed distance continuously while moving a point.
* Use higher precision in the coordinate picker for wgs84 (#692 <https://github.com/swri-robotics/mapviz/issues/692>)
* Clear the namespace list after hitting the clear button. (#691 <https://github.com/swri-robotics/mapviz/issues/691>)
* Contributors: Matt Grogan, Matthew, P. J. Reed, Marc Alban
```

## multires_image

```
* ROS Foxy support (#695 <https://github.com/swri-robotics/mapviz/issues/695>)
* Contributors: P. J. Reed
```

## tile_map

- No changes
