### PR TITLE
mapviz: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1456,6 +1456,28 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: foxy
     status: maintained
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: dashing-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/mapviz-release.git
+      version: 2.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: dashing-devel
+    status: developed
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.1.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## mapviz

```
* ROS Foxy support (#695 <https://github.com/swri-robotics/mapviz/issues/695>)
* Contributors: P. J. Reed
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Constrain the minimum line and point marker sizes to be 1 pixel wide. (#704 <https://github.com/swri-robotics/mapviz/issues/704>)
* ROS Foxy support (#695 <https://github.com/swri-robotics/mapviz/issues/695>)
* Update the displayed distance continuously while moving a point.
* Use higher precision in the coordinate picker for wgs84 (#692 <https://github.com/swri-robotics/mapviz/issues/692>)
* Clear the namespace list after hitting the clear button. (#691 <https://github.com/swri-robotics/mapviz/issues/691>)
* Contributors: Matt Grogan, Matthew, P. J. Reed, Marc Alban
```

## multires_image

```
* ROS Foxy support (#695 <https://github.com/swri-robotics/mapviz/issues/695>)
* Contributors: P. J. Reed
```

## tile_map

- No changes
