### PR TITLE
psen_scan: 1.0.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8492,7 +8492,8 @@ repositories:
       type: git
       url: https://github.com/PilzDE/psen_scan.git
       version: melodic-devel
-    status: developed
+    status: end-of-life
+    status_description: An upgrade is available. See https://github.com/PilzDE/psen_scan_v2/#migration for detailed instruction.
   psen_scan_v2:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8487,7 +8487,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8493,7 +8493,8 @@ repositories:
       url: https://github.com/PilzDE/psen_scan.git
       version: melodic-devel
     status: end-of-life
-    status_description: An upgrade is available. See https://github.com/PilzDE/psen_scan_v2/#migration for detailed instruction.
+    status_description: An upgrade is available. See https://github.com/PilzDE/psen_scan_v2/#migration
+      for detailed instruction.
   psen_scan_v2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan` to `1.0.8-1` (EOL):

- upstream repository: https://github.com/PilzDE/psen_scan.git
- release repository: https://github.com/PilzDE/psen_scan-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.7-1`

## psen_scan

```
* Add deprecation warning: End-of-life reached (#101)
* Add new AcceptanceTest for publish_test. (#100)
* Create test_concept (#41)
* Contributors: Pilz GmbH & Co KG
```
