### PR TITLE
anybotics_message_logger: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -166,6 +166,18 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  anybotics_message_logger:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mikekaram/anybotics_message_logger-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/mikekaram/anybotics_any_node.git
+      version: 0.2.1
+    status: unmaintained
   app_manager:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -176,7 +176,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/mikekaram/anybotics_message_logger.git
-      version: 0.2.1
+      version: feature/rename-repo
     status: unmaintained
   app_manager:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -175,7 +175,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/mikekaram/anybotics_any_node.git
+      url: https://github.com/mikekaram/anybotics_message_logger.git
       version: 0.2.1
     status: unmaintained
   app_manager:


### PR DESCRIPTION
Increasing version of package(s) in repository `anybotics_message_logger` to `0.2.1-1`:

- upstream repository: https://github.com/mikekaram/anybotics_message_logger.git
- release repository: https://github.com/mikekaram/anybotics_message_logger-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
