### PR TITLE
rmw_fastrtps: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1623,7 +1623,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 3.1.4-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `3.1.4-1`

## rmw_fastrtps_cpp

```
* Discriminate when the Client has gone from when the Client has not completely matched (#467 <https://github.com/ros2/rmw_fastrtps/issues/467>)
  * Workaround when the client is gone before server sends response
  * Change add to the map to listener callback
* Update the package.xml files with the latest Open Robotics maintainers (#459 <https://github.com/ros2/rmw_fastrtps/issues/459>)
* Update Quality Declarations and READMEs (#455 <https://github.com/ros2/rmw_fastrtps/issues/455>)
  * Add QD links for dependencies to rmw_fastrtps_cpp QD
  * Provide external dependencies QD links
  * Update rmw_fastrtps README to use Fast DDS
  * Update rmw_fastrtps_cpp QD: Fast DDS & unit test
  * Update README rmw_fastrtps_cpp to QL2
* Contributors: JLBuenoLopez-eProsima, Jaime Martin Losa, José Luis Bueno López, Michael Jeronimo
```

## rmw_fastrtps_dynamic_cpp

```
* Discriminate when the Client has gone from when the Client has not completely matched (#467 <https://github.com/ros2/rmw_fastrtps/issues/467>)
  * Workaround when the client is gone before server sends response
  * Change add to the map to listener callback
* Update the package.xml files with the latest Open Robotics maintainers (#459 <https://github.com/ros2/rmw_fastrtps/issues/459>)
* Update Quality Declarations and READMEs (#455 <https://github.com/ros2/rmw_fastrtps/issues/455>)
  * Add QL of external dependencies to rmw_fastrtps_dynamic_cpp QD
  * Add QD links for dependencies to rmw_fastrtps_dynamic_cpp QD
  * Provide external dependencies QD links
  * Add README to rmw_fastrtps_dynamic
  * Add QD for rmw_fastrtps_dynamic
* Contributors: JLBuenoLopez-eProsima, Jaime Martin Losa, José Luis Bueno López, Michael Jeronimo
```

## rmw_fastrtps_shared_cpp

```
* Discriminate when the Client has gone from when the Client has not completely matched (#467 <https://github.com/ros2/rmw_fastrtps/issues/467>)
  * Workaround when the client is gone before server sends response
  * Change add to the map to listener callback
* Update the package.xml files with the latest Open Robotics maintainers (#459 <https://github.com/ros2/rmw_fastrtps/issues/459>)
* Update Quality Declarations and READMEs (#455 <https://github.com/ros2/rmw_fastrtps/issues/455>)
  * Add QD links for dependencies to rmw_fastrtps_shared_cpp QD.
  * Provide external dependencies QD links.
  * Update rmw_fastrtps_shared_cpp QD: Fast DDS
  * Update README rmw_fastrtps_shared_cpp to QL2
* Contributors: JLBuenoLopez-eProsima, Jaime Martin Losa, José Luis Bueno López, Michael Jeronimo
```
