### PR TITLE
anybotics_any_node: 0.5.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -166,6 +166,24 @@ repositories:
       url: https://github.com/ros/angles.git
       version: master
     status: maintained
+  anybotics_any_node:
+    release:
+      packages:
+      - anybotics_any_node
+      - anybotics_any_node_example
+      - anybotics_any_worker
+      - anybotics_param_io
+      - anybotics_signal_handler
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/mikekaram/anybotics_any_node-release.git
+      version: 0.5.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/mikekaram/anybotics_any_node.git
+      version: feature/rename-repo
+    status: unmaintained
   app_manager:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `anybotics_any_node` to `0.5.1-1`:

- upstream repository: https://github.com/mikekaram/anybotics_any_node.git
- release repository: https://github.com/mikekaram/anybotics_any_node-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
