### PR TITLE
boost_sml: 0.1.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -901,7 +901,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/boost_sml-release.git
-      version: 0.1.0-2
+      version: 0.1.0-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/boost_sml.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_sml` to `0.1.0-3`:

- upstream repository: https://github.com/PickNikRobotics/boost_sml.git
- release repository: https://github.com/PickNikRobotics/boost_sml-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-2`

## boost_sml

```
* [feature] Generate SML diagrams using boost.Graph (#4 <https://github.com/PickNikRobotics/boost_sml/issues/4>)
* [feature] example source to enable catkin to build package that can be depended on (#2 <https://github.com/PickNikRobotics/boost_sml/issues/2>)
* [fix] undefined reference error (#6 <https://github.com/PickNikRobotics/boost_sml/issues/6>)
  * Change static constexpr into const to avoid compiler errors when building in debug mode doesn't inline variables.
* [fix] compilation errors when setting overriding CMAKE_CXX_STANDARD in catkin config. (#5 <https://github.com/PickNikRobotics/boost_sml/issues/5>)
* [maint] move all headers into one directory (#3 <https://github.com/PickNikRobotics/boost_sml/issues/3>)
* Contributors: JafarAbdi, Jere Liukkonen, Mark Moll, Tyler Weaver, picknik-jliukkonen
```
