### PR TITLE
Unrelease ros_numpy from Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4312,7 +4312,6 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/eric-wieser/ros_numpy-release.git
-      version: 0.0.4-4
     source:
       type: git
       url: https://github.com/eric-wieser/ros_numpy.git


### PR DESCRIPTION
Partial revert of https://github.com/ros/rosdistro/pull/26793

The Ubuntu Focal Noetic source job is failing because the release repo is missing a branch.

http://build.ros.org/view/Nsrc_uF/job/Nsrc_uF__ros_numpy__ubuntu_focal__source/26/console

```
17:21:03 Invoking 'git clone --branch debian/ros-noetic-ros-numpy_0.0.4-4_focal --depth 1 --no-single-branch https://github.com/eric-wieser/ros_numpy-release.git /tmp/sourcedeb/source'
17:21:03 Cloning into '/tmp/sourcedeb/source'...
17:21:03 fatal: Remote branch debian/ros-noetic-ros-numpy_0.0.4-4_focal not found in upstream origin
```

@gstavrinos FYI