### PR TITLE
Updating mrpt2 to 2.1.3-2

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1079,7 +1079,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
-      version: 2.1.3-1
+      version: 2.1.3-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Due to the problem discussed [elsewhere](https://github.com/ros-infrastructure/bloom/pull/600), I needed to fix the debian/* files manually and trigger a new release 2.1.3-1 -> 2.1.3-2. 
Unfortunately, I incorrectly hit CTRL+C while bloom-release was about to open this PR, so I'm just doing it manually: 

```diff
--- rolling/distribution.yaml
+++ rolling/distribution.yaml
@@ -1079,7 +1079,7 @@
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/mrpt-ros2-pkg-release/mrpt2-release.git
-      version: 2.1.3-1
+      version: 2.1.3-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git
```