### PR TITLE
baldor: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -189,6 +189,21 @@ repositories:
       url: https://github.com/astuff/avt_vimba_camera.git
       version: master
     status: maintained
+  baldor:
+    doc:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/crigroup/baldor-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/crigroup/baldor.git
+       version: master
+     status: maintained
   basler_tof:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -202,8 +202,8 @@ repositories:
     source:
       type: git
       url: https://github.com/crigroup/baldor.git
-       version: master
-     status: maintained
+      version: master
+    status: maintained
   basler_tof:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `baldor` to `0.1.3-1`:

- upstream repository: https://github.com/crigroup/baldor.git
- release repository: https://github.com/crigroup/baldor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## baldor

```
* Add support for ROS noetic and clean up
* Contributors: fsuarez6
```
