### PR TITLE
criutils: 0.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -845,6 +845,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/costmap_converter.git
       version: master
     status: maintained
+  criutils:
+    doc:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/crigroup/criutils-release.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/crigroup/criutils.git
+      version: master
+    status: maintained
   csm:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.4-1`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## criutils

```
* Add support for ROS noetic and clean up
* Contributors: fsuarez6
```