### PR TITLE
handeye: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1783,6 +1783,21 @@ repositories:
       url: https://github.com/davidfischinger/haf_grasping.git
       version: noetic
     status: maintained
+  handeye:
+    doc:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/crigroup/handeye-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/crigroup/handeye.git
+      version: master
+    status: maintained
   hebi_cpp_api_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.2-1`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## handeye

```
* Add support for ROS noetic and clean up
* PR #4: Fix lambda syntax for Python 3 compatability
* Contributors: John Stechschulte, fsuarez6
```
