### PR TITLE
ros_numpy: 0.0.4-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4312,6 +4312,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/eric-wieser/ros_numpy-release.git
+      version: 0.0.4-5
     source:
       type: git
       url: https://github.com/eric-wieser/ros_numpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_numpy` to `0.0.4-5`:

- upstream repository: https://github.com/eric-wieser/ros_numpy.git
- release repository: https://github.com/eric-wieser/ros_numpy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
