### PR TITLE
mcl_3dl: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2670,7 +2670,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.5.1-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.0-1`

## mcl_3dl

```
* Make hit_range independent from grid size and fix DDA hit/miss state (#350 <https://github.com/at-wat/mcl_3dl/issues/350>)
* Fix crushing when lidar poses are out of map (#351 <https://github.com/at-wat/mcl_3dl/issues/351>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```
