### PR TITLE
realsense2_camera: 2.2.18-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -11637,7 +11637,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.17-1
+      version: 2.2.18-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.18-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.2.17-1`

## realsense2_camera

```
* Fix bug: Remove parameter with invalid value.
* Fix bug: Colorize the aligned depth image.
* Fix bug: Added pointcloud attributes, when RS2_STREAM_ANY is enabled
* Add feature: enable/disable all sensors. Known issues: parameters persistency and not full power drop.
```

## realsense2_description

```
* Feature: Add name to usb_plug to enable multiple copies of usb_plug model.
* Fix mass of d435 - from lgulich
* Contributors: Guillaume, doronhi, lgulich
```
