### PR TITLE
contracts_lite_vendor: 0.4.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -455,7 +455,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-safety/contracts_lite_vendor-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-safety/contracts_lite_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `contracts_lite_vendor` to `0.4.1-1`:

- upstream repository: https://github.com/ros-safety/contracts_lite_vendor.git
- release repository: https://github.com/ros-safety/contracts_lite_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.0-1`

## contracts_lite_vendor

```
* Vendor package update
  
    * Add install instructions to README (#8 <https://github.com/ros-safety/contracts_lite_vendor/pull/8>)
  
* Library update
  
    * Add missing inclue, re-arrange move statement (#13 <https://github.com/ros-safety/contracts_lite/pull/13>)
    * Add note clarifying 'audit' term (#12 <https://github.com/ros-safety/contracts_lite/pull/12>)
    * Add basic requirements (#10 <https://github.com/ros-safety/contracts_lite/pull/10>)
    * Prettier joining of comments (#9 <https://github.com/ros-safety/contracts_lite/pull/9>)
    * Add contact info to README (#8 <https://github.com/ros-safety/contracts_lite/pull/8>)
    * Enforce that audit macros assume ownership of ReturnStatus (#6 <https://github.com/ros-safety/contracts_lite/pull/6>)
  
```
