### PR TITLE
dingo: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2181,7 +2181,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2171,7 +2171,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/dingo-cpr/dingo.git
-      version: master
+      version: melodic-devel
     release:
       packages:
       - dingo_control
@@ -2185,7 +2185,7 @@ repositories:
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git
-      version: master
+      version: melodic-devel
     status: developed
   dingo_desktop:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.4-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.3-1`

## dingo_control

```
* [dingo_control] Fixed angular axis.
* Contributors: Tony Baltovski
```

## dingo_description

```
* [dingo_description] Switched description.launch to use single Dingo URDF which then determines which file should be loaded.
* Add a generic dingo.urdf.xacro (#8 <https://github.com/dingo-cpr/dingo/issues/8>)
  * Add a generic dingo.urdf.xacro which will include dingo-d or dingo-o as-needed. This simplifies adding support for manipulators to the robot
* Contributors: Chris I-B, Tony Baltovski
```

## dingo_msgs

- No changes

## dingo_navigation

- No changes
