### PR TITLE
Revert "proj: 5.2.0-3 in 'dashing/distribution.yaml' [bloom]"

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1923,17 +1923,6 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: dashing
     status: maintained
-  proj:
-    doc:
-      type: git
-      url: https://github.com/OSGeo/PROJ.git
-      version: '5.2'
-    release:
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/stonier/proj-release.git
-      version: 5.2.0-3
-    status: maintained
   px4_msgs:
     release:
       tags:


### PR DESCRIPTION
This reverts commit 65b08bc13ce7bcee8941a6fab5d1ceaffccea296.

See discussion in #27139. Apologies for the mayhem - honestly don't know how I missed there was a system version available.