### PR TITLE
jsk_visualization: 2.1.7-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2265,6 +2265,28 @@ repositories:
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git
       version: master
     status: developed
+  jsk_visualization:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    release:
+      packages:
+      - jsk_interactive
+      - jsk_interactive_marker
+      - jsk_interactive_test
+      - jsk_rqt_plugins
+      - jsk_rviz_plugins
+      - jsk_visualization
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/jsk_visualization-release.git
+      version: 2.1.7-4
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+      version: master
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_visualization` to `2.1.7-4`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_visualization
- release repository: https://github.com/tork-a/jsk_visualization-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## jsk_interactive

- No changes

## jsk_interactive_marker

```
* set property for ccache if cmake version < 3.4 (#780 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/780>)
* Remove meaningless lock (#750 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/750>)
* add noetic test (#774 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/774>)
  
    * run 2to3 -f print
    * support noetic, use c++14, convert to package format 3
  
* Contributors: Kei Okada, Ryohei Ueda, Yuki Furuta
```

## jsk_interactive_test

```
* add noetic test (e`#774 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/774>`_)
  
    * fix python to pass python3 -m compileall
  
* Contributors: Kei Okada
```

## jsk_rqt_plugins

```
* add noetic test (#774 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/774>)
  
    * run 2to3 -f except
    * support noetic, conver to package format 3
  
* Contributors: Kei Okada
```

## jsk_rviz_plugins

```
* Fix programming issues where functions were not getting return values, and variables were not being declared for types (#783 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/783>)
* Support custom color for OverlayMenu (#775 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/775>)
* add human skeleton rviz visualization(#740 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/740>)
  
    * jsk_recognition_msgs < 1.2.15 does not support human_skeleton_array_display.cpp
    * meloidc needs to include OGRE/OgreSceneManager.h
    * human_skeleton_array_display supports indigo build
    * add sphere at all edge ends
    * fix typo: skelton -> skeleton
    * add human skelton rviz visualization
  
* Add fg_color/bg_color to OverlayMenu.msg (#776 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/776>)
* [jsk_rviz_plugins] Add StringDisplay as a new display plugin (#728 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/728>)
* set property for ccache if cmake version < 3.4 (#780 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/780>)
* [jsk_rviz_plugin/PieChart] add clock wise rotate option for pie chart (#782 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/782>)
* Remove meaningless lock (#750 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/750>)
* call processNormal when polygon points has more than 3 point (#771 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/771>)
* add noetic test (#774 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/774>)
  
    * fix typo CV_VERSION_MAJOR -> CV_MAJOR_VERSION
    * run 2to3 -f except
    * run 2to3 -f print
    * support noetic, use c++14, convert to package format 3
    * Merge remote-tracking branch 'ruvu/fix/noetic' into add_noetic
  
* Add Rviz scene publisher (#773 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/773>)
* Improve Overlay Visibility (#769 <https://github.com/jsk-ros-pkg/jsk_visualization/issues/769>)
* Contributors: Kei Okada, Patrick Beeson, Ramon Wijnands, Ryohei Ueda, Shingo Kitagawa, Yuki Furuta, Yuto Uchimi, Iory Yanokura, Taichi Hagashide
```

## jsk_visualization

- No changes
