### PR TITLE
ixblue_ins_stdbin_driver: 0.1.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4431,7 +4431,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_ins_stdbin_driver` to `0.1.4-1`:

- upstream repository: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
- release repository: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.3-1`

## ixblue_ins

```
* Bump minimum CMake version to avoid CMP0048 on Noetic buildfarm
* Contributors: Romain Reignier
```

## ixblue_ins_driver

```
* Add a param to use compensated acceleration (changes previous behavior)
* Add diagnostics publication
* Change default frame_id in launch to match node default
* Fix orientation quaternion content and make NED convention explicit.
* Bump minimum CMake version to avoid CMP0048 on Noetic buildfarm
* Contributors: BARRAL Adrien, Romain Reignier
```

## ixblue_ins_msgs

```
* Bump minimum CMake version to avoid CMP0048 on Noetic buildfarm
* Contributors: Romain Reignier
```
