### PR TITLE
ixblue_ins_stdbin_driver: 0.1.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5668,6 +5668,26 @@ repositories:
       url: https://github.com/ros/ivcon.git
       version: kinetic-devel
     status: maintained
+  ixblue_ins_stdbin_driver:
+    doc:
+      type: git
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
+      version: master
+    release:
+      packages:
+      - ixblue_ins
+      - ixblue_ins_driver
+      - ixblue_ins_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
+      version: 0.1.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
+      version: master
+    status: developed
   ixblue_stdbin_decoder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_ins_stdbin_driver` to `0.1.4-1`:

- upstream repository: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
- release repository: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## ixblue_ins

```
* Bump minimum CMake version to avoid CMP0048 on Noetic buildfarm
* Contributors: Romain Reignier
```

## ixblue_ins_driver

```
* Add a param to use compensated acceleration (changes previous behavior)
* Add diagnostics publication
* Change default frame_id in launch to match node default
* Fix orientation quaternion content and make NED convention explicit.
* Bump minimum CMake version to avoid CMP0048 on Noetic buildfarm
* Contributors: BARRAL Adrien, Romain Reignier
```

## ixblue_ins_msgs

```
* Bump minimum CMake version to avoid CMP0048 on Noetic buildfarm
* Contributors: Romain Reignier
```
