### PR TITLE
bota_driver: 0.5.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -916,6 +916,9 @@ repositories:
       packages:
       - bota_device_driver
       - bota_driver
+      - bota_node
+      - bota_signal_handler
+      - bota_worker
       - rokubimini
       - rokubimini_bus_manager
       - rokubimini_description
@@ -928,7 +931,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.0-6
+      version: 0.5.1-1
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.1-1`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.0-6`

## bota_device_driver

```
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## bota_driver

- No changes

## bota_node

```
* add changelog for bota_node packages
* Merge branch 'feature/remove-any-node-dep' into 'master'
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## bota_signal_handler

```
* add changelog for bota_node packages
* Merge branch 'feature/remove-any-node-dep' into 'master'
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## bota_worker

```
* add changelog for bota_node packages
* Merge branch 'feature/remove-any-node-dep' into 'master'
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## rokubimini

- No changes

## rokubimini_bus_manager

- No changes

## rokubimini_description

- No changes

## rokubimini_ethercat

```
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## rokubimini_examples

- No changes

## rokubimini_factory

- No changes

## rokubimini_manager

```
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## rokubimini_msgs

- No changes

## rokubimini_serial

- No changes
