### PR TITLE
automotive_autonomy_msgs: 3.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -667,7 +667,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/automotive_autonomy_msgs-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.4-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.3-1`

## automotive_autonomy_msgs

```
* Fix package.xml website URL (#19 <https://github.com/astuff/automotive_autonomy_msgs/issues/19>)
* Contributors: Jacob Perron
```

## automotive_navigation_msgs

```
* Change VelocityAccel comment from lateral to longitudinal, also remove trailing whitespace from all messages (#23 <https://github.com/astuff/automotive_autonomy_msgs/issues/23>)
* Fix package.xml website URL (#19 <https://github.com/astuff/automotive_autonomy_msgs/issues/19>)
* Contributors: Jacob Perron, icolwell-as
```

## automotive_platform_msgs

```
* Change VelocityAccel comment from lateral to longitudinal, also remove trailing whitespace from all messages (#23 <https://github.com/astuff/automotive_autonomy_msgs/issues/23>)
* Change velocity comment from lateral to longitudinal (#21 <https://github.com/astuff/automotive_autonomy_msgs/issues/21>)
* Fix package.xml website URL (#19 <https://github.com/astuff/automotive_autonomy_msgs/issues/19>)
* Contributors: Jacob Perron, icolwell-as
```
