### PR TITLE
automotive_autonomy_msgs: 3.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -158,6 +158,25 @@ repositories:
       url: https://github.com/ros-drivers/audio_common.git
       version: master
     status: maintained
+  automotive_autonomy_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    release:
+      packages:
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/astuff/automotive_autonomy_msgs-release.git
+      version: 3.0.4-1
+    source:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    status: maintained
   auv_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `automotive_autonomy_msgs` to `3.0.4-1`:

- upstream repository: https://github.com/astuff/automotive_autonomy_msgs.git
- release repository: https://github.com/astuff/automotive_autonomy_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## automotive_autonomy_msgs

```
* Fix package.xml website URL (#19 <https://github.com/astuff/automotive_autonomy_msgs/issues/19>)
* Contributors: Jacob Perron
```

## automotive_navigation_msgs

```
* Change VelocityAccel comment from lateral to longitudinal, also remove trailing whitespace from all messages (#23 <https://github.com/astuff/automotive_autonomy_msgs/issues/23>)
* Fix package.xml website URL (#19 <https://github.com/astuff/automotive_autonomy_msgs/issues/19>)
* Contributors: Jacob Perron, icolwell-as
```

## automotive_platform_msgs

```
* Change VelocityAccel comment from lateral to longitudinal, also remove trailing whitespace from all messages (#23 <https://github.com/astuff/automotive_autonomy_msgs/issues/23>)
* Change velocity comment from lateral to longitudinal (#21 <https://github.com/astuff/automotive_autonomy_msgs/issues/21>)
* Fix package.xml website URL (#19 <https://github.com/astuff/automotive_autonomy_msgs/issues/19>)
* Contributors: Jacob Perron, icolwell-as
```
