### PR TITLE
rc_genicam_api: 2.4.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2201,7 +2201,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.4.1-1
+      version: 2.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.4.4-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.4.1-1`

## rc_genicam_api

```
* Trying to fix problem that interface handle becomes invalid
```
