### PR TITLE
[dep] Add pip version of boto3.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5486,6 +5486,16 @@ python3-boto3:
     '*': ['python%{python3_pkgversion}-boto3']
     '7': null
   ubuntu: [python3-boto3]
+python3-boto3-pip:
+  debian:
+    pip:
+      packages: [boto3]
+  fedora:
+    pip:
+      packages: [boto3]
+  ubuntu:
+    pip:
+      packages: [boto3]
 python3-bson:
   debian: [python3-bson]
   fedora: [python3-bson]


### PR DESCRIPTION
Rationale for the `pip` key: https://pypi.org/project/boto3/