### PR TITLE
roscompile: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10115,7 +10115,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 1.0.1-0
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/DLu/roscompile.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.0.3-1`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-0`
