### PR TITLE
rviz: 7.0.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3119,7 +3119,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 7.0.5-1
+      version: 7.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `7.0.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `7.0.5-1`

## rviz2

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Contributors: Michael Jeronimo
```

## rviz_assimp_vendor

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Contributors: Michael Jeronimo
```

## rviz_common

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Contributors: Michael Jeronimo
```

## rviz_default_plugins

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Set clock type if Marker frame_locked is true (#482 <https://github.com/ros2/rviz/issues/482>) (#580 <https://github.com/ros2/rviz/issues/580>)
  Fixes #479 <https://github.com/ros2/rviz/issues/479>
* Use dedicated TransformListener thread (#551 <https://github.com/ros2/rviz/issues/551>) (#581 <https://github.com/ros2/rviz/issues/581>)
* Do not use assume every RenderPanel has a ViewController. (#613 <https://github.com/ros2/rviz/issues/613>) (#614 <https://github.com/ros2/rviz/issues/614>)
  Get the Viewport from its RenderWindow instead.
  Ensures interactive markers work (and do not make rviz crash)
  when interaction goes through a camera feed and not the main
  window.
* Fix map display for moving TF frame (#483 <https://github.com/ros2/rviz/issues/483>) (#579 <https://github.com/ros2/rviz/issues/579>)
  Instead of the current time, use Time(0) to get the latest available transform as a fallback.
  This is the same logic that is applied in RViz from ROS 1.
  Resolves #332 <https://github.com/ros2/rviz/issues/332>
* Contributors: Jacob Perron, Michael Jeronimo, Michel Hidalgo, ymd-stella
```

## rviz_ogre_vendor

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Contributors: Michael Jeronimo
```

## rviz_rendering

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Contributors: Michael Jeronimo
```

## rviz_rendering_tests

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Contributors: Michael Jeronimo
```

## rviz_visual_testing_framework

```
* Update maintainer list (#618 <https://github.com/ros2/rviz/issues/618>)
* Contributors: Michael Jeronimo
```
