### PR TITLE
ddynamic_reconfigure: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1050,11 +1050,19 @@ repositories:
       version: master
     status: developed
   ddynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/ddynamic_reconfigure.git
+      version: kinetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pal-gbp/ddynamic_reconfigure.git
-      version: 0.3.0-1
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/ddynamic_reconfigure.git
+      version: kinetic-devel
     status: maintained
   diagnostics:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure` to `0.3.2-1`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.3.0-1`

## ddynamic_reconfigure

```
* Merge branch 'pointer-with-callback' into 'erbium-devel'
  Add new function that takes pointer and a callback
  See merge request control/ddynamic_reconfigure!16
* Add new function that takes pointer and a callback
* Contributors: Victor Lopez, victor
```
