### PR TITLE
rclpy: 1.2.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1461,7 +1461,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.2.0-1
+      version: 1.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.2.1-2`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.0-1`

## rclpy

```
* Deprecate verbose qos policy value names (#634 <https://github.com/ros2/rclpy/issues/634>)
* Remove deprecated set_parameters_callback (#633 <https://github.com/ros2/rclpy/issues/633>)
* Make sure to use Py_XDECREF in rclpy_get_service_names_and_types (#632 <https://github.com/ros2/rclpy/issues/632>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```
