### PR TITLE
ros_babel_fish: 0.9.0-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12697,6 +12697,20 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/ros_additive_manufacturing.git
       version: kinetic
     status: developed
+  ros_babel_fish:
+    release:
+      packages:
+      - ros_babel_fish
+      - ros_babel_fish_test_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/StefanFabian/ros_babel_fish-release.git
+      version: 0.9.0-2
+    source:
+      type: git
+      url: https://github.com/StefanFabian/ros_babel_fish.git
+      version: kinetic
+    status: developed
   ros_canopen:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.9.0-2`:

- upstream repository: https://github.com/StefanFabian/ros_babel_fish.git
- release repository: https://github.com/StefanFabian/ros_babel_fish-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## ros_babel_fish

```
* Added install target for service_info. Cleaned up package.xml
* Fixed service spec loading wrong response if service spec doesn't contain '---'.
* Updated integrated description provider for service descriptions to reflect changes in genmsg that caused some tests to fail.
  Both implementations are interoperable and the change should have no impact on service calls using ros_babel_fish but new implementation is now again consistent with message_traits::definition<...>().
  The new implementation is also less complex and faster.
* Added macros for template calls.
  This replaces the boiler plate code for situations where you would do switch(msg.type()) { ... } and call a template function with the C++ type of the message as a template parameter.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Added install target for service_info. Cleaned up package.xml
* Contributors: Stefan Fabian
```
