### PR TITLE
ros_babel_fish: 0.9.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9648,7 +9648,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/StefanFabian/ros_babel_fish-release.git
-      version: 0.8.0-3
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/StefanFabian/ros_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.9.0-1`:

- upstream repository: https://github.com/StefanFabian/ros_babel_fish.git
- release repository: https://github.com/StefanFabian/ros_babel_fish-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.0-3`

## ros_babel_fish

```
* Added install target for service_info. Cleaned up package.xml
* Fixed service spec loading wrong response if service spec doesn't contain '---'.
* Updated integrated description provider for service descriptions to reflect changes in genmsg that caused some tests to fail.
  Both implementations are interoperable and the change should have no impact on service calls using ros_babel_fish but new implementation is now again consistent with message_traits::definition<...>().
  The new implementation is also less complex and faster.
* Added macros for template calls.
  This replaces the boiler plate code for situations where you would do switch(msg.type()) { ... } and call a template function with the C++ type of the message as a template parameter.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Added install target for service_info. Cleaned up package.xml
* Contributors: Stefan Fabian
```
