### PR TITLE
launch_ros: 0.11.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1386,7 +1386,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.10.3-1
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.10.3-1`

## launch_ros

```
* Update maintainer list for Foxy (#194 <https://github.com/ros2/launch_ros/issues/194>)
* Improve error message if ComposableNodeContainer 'name' or 'namespace' arg is None (#191 <https://github.com/ros2/launch_ros/issues/191>)
* Add a SetParameter action that sets a parameter to all nodes in the same scope (#158 <https://github.com/ros2/launch_ros/issues/158>) (#187 <https://github.com/ros2/launch_ros/issues/187>)
* Avoid using a wildcard to specify parameters if possible (#154 <https://github.com/ros2/launch_ros/issues/154>) (#188 <https://github.com/ros2/launch_ros/issues/188>)
* Assume root namespace if not provided in ComposableNodeContainer (#186 <https://github.com/ros2/launch_ros/issues/186>)
  Fixes a regression introduced in #179 <https://github.com/ros2/launch_ros/issues/179>.
  Fixes #185 <https://github.com/ros2/launch_ros/issues/185>.
  We apply the same logic in LifecycleNode to maintain backwards compatibility in Foxy.
* Contributors: Ivan Santiago Paunovic, Jacob Perron, Michael Jeronimo
```

## launch_testing_ros

```
* Update maintainer list for Foxy (#194 <https://github.com/ros2/launch_ros/issues/194>)
* Contributors: Michael Jeronimo
```

## ros2launch

```
* Update maintainer list for Foxy (#194 <https://github.com/ros2/launch_ros/issues/194>)
* Contributors: Michael Jeronimo
```
