### PR TITLE
Move urdfdom back into the ros organization for eloquent.

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3532,7 +3532,7 @@ repositories:
   urdfdom:
     doc:
       type: git
-      url: https://github.com/ros2/urdfdom.git
+      url: https://github.com/ros/urdfdom.git
       version: eloquent
     release:
       tags:
@@ -3542,7 +3542,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ros2/urdfdom.git
+      url: https://github.com/ros/urdfdom.git
       version: eloquent
     status: maintained
   urdfdom_headers:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Needs to be merged along with https://github.com/ros2-gbp/urdfdom-release/pull/7 and https://github.com/ros2/ros2/pull/1056