### PR TITLE
boost_sml: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -282,7 +282,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PickNikRobotics/boost_sml-release.git
-      version: 0.1.0-2
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/boost_sml.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_sml` to `0.1.1-1`:

- upstream repository: https://github.com/PickNikRobotics/boost_sml.git
- release repository: https://github.com/PickNikRobotics/boost_sml-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-2`

## boost_sml

```
* Add system component to boost cmake include
* Add boost as dependency in package.xml
* Contributors: Tyler Weaver
```
