### PR TITLE
omnibase: 1.0.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7228,7 +7228,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ERC-BPGC/omnibase-release.git
-      version: 1.0.1-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/ERC-BPGC/omnibase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omnibase` to `1.0.2-2`:

- upstream repository: https://github.com/ERC-BPGC/omnibase.git
- release repository: https://github.com/ERC-BPGC/omnibase-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-1`

## omnibase_control

- No changes

## omnibase_description

```
* Merge remote-tracking branch 'origin/master'
* minor changes in the model
* new launch and urdf files
* Realsense D435 added to model
* Contributors: Archit Rungta, Harshal Deshpande
```

## omnibase_gazebo

```
* Merge remote-tracking branch 'origin/master'
* new launch and urdf files
* Contributors: Archit Rungta, Harshal Deshpande
```
