### PR TITLE
bota_driver: 0.5.2-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -931,7 +931,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.1-1
+      version: 0.5.2-2
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.2-2`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.1-1`

## bota_device_driver

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47 <https://gitlab.com/botasys/bota_driver/-/merge_requests/47>
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## bota_driver

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karamousadakis
```

## bota_node

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47 <https://gitlab.com/botasys/bota_driver/-/merge_requests/47>
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## bota_signal_handler

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47 <https://gitlab.com/botasys/bota_driver/-/merge_requests/47>
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## bota_worker

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47 <https://gitlab.com/botasys/bota_driver/-/merge_requests/47>
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## rokubimini

```
* Merge branch 'fix/cmake-eigen3-error' into 'master'
  Fix eigen3 cmake error on ROS buildfarm
  See merge request botasys/bota_driver!49 <https://gitlab.com/botasys/bota_driver/-/merge_requests/49>
* fix eigen3 cmake error on ROS buildfarm
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karamousadakis
```

## rokubimini_description

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karamousadakis
```

## rokubimini_ethercat

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47 <https://gitlab.com/botasys/bota_driver/-/merge_requests/47>
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## rokubimini_examples

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karamousadakis
```

## rokubimini_factory

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karamousadakis
```

## rokubimini_manager

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47 <https://gitlab.com/botasys/bota_driver/-/merge_requests/47>
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## rokubimini_msgs

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karamousadakis
```

## rokubimini_serial

```
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48 <https://gitlab.com/botasys/bota_driver/-/merge_requests/48>
* Increment patch version
* Contributors: Mike Karamousadakis
```
