### PR TITLE
urdfdom_py: 0.4.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5963,7 +5963,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.4.3-1
+      version: 0.4.4-1
     source:
       type: git
       url: https://github.com/ros/urdf_parser_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.4.4-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.3-1`

## urdfdom_py

```
* Replace deprecated function (#60 <https://github.com/ros/urdf_parser_py/issues/60>)
* Contributors: Roel
```
