### PR TITLE
Add python3-cantools-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5512,6 +5512,13 @@ python3-can:
   ubuntu:
     '*': [python3-can]
     xenial: null
+python3-cantools-pip:
+  debian:
+    pip:
+      packages: [cantools]
+  ubuntu:
+    pip:
+      packages: [cantools]
 python3-catkin-lint:
   debian:
     '*': [python3-catkin-lint]


### PR DESCRIPTION
Package manager webpage: https://pypi.org/project/cantools/

Python 2 version is already a rosdep. 

Cantools is a python module that allows parsing of CAN bus message description files (such as .dbc). Additionally it can decode and encode raw CAN frames accordding to the information contained in such files.

It also handles the DID protocol and offers a command line tool that can parse `candump` output straight on your command line. 