### PR TITLE
Adding doosan-robot2 to documentation index for distro

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -616,6 +616,11 @@ repositories:
       type: git
       url: https://github.com/doosan-robotics/doosan-robot2.git
       version: foxy
+    source:
+      type: git
+      url: https://github.com/doosan-robotics/doosan-robot2.git
+      version: foxy
+    status: maintained
   dynamic-graph:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -611,6 +611,11 @@ repositories:
       url: https://github.com/chapulina/dolly.git
       version: foxy
     status: maintained
+  doosan-robot2:
+    doc:
+      type: git
+      url: https://github.com/doosan-robotics/doosan-robot2.git
+      version: foxy
   dynamic-graph:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repository to be indexed and documented on ros.org