### PR TITLE
bota_driver: 0.5.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -931,7 +931,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.2-2
+      version: 0.5.3-1
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.3-1`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.2-2`

## bota_device_driver

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## bota_driver

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## bota_node

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## bota_signal_handler

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## bota_worker

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## rokubimini

```
* Merge branch 'fix/cmake-eigen3-error' into 'melodic-devel'
  Try to fix cmake Eigen3 error on ROS buildfarm again
  See merge request botasys/bota_driver!51 <https://gitlab.com/botasys/bota_driver/-/merge_requests/51>
* add different changes
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## rokubimini_description

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## rokubimini_ethercat

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## rokubimini_examples

```
* merge release 0.5.2 into melodic-devel
* run clang-tidy -fix after building ALL packages under rokubimini_sdk
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_factory

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## rokubimini_manager

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```

## rokubimini_msgs

```
* merge release 0.5.2 into melodic-devel
* fix errors from catkin_lint
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_serial

```
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam
```
