### PR TITLE
Add libgmock-dev to Buster & Focal.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2582,6 +2582,19 @@ libglw1-mesa:
   fedora: [mesa-libGlw]
   gentoo: [x11-libs/libGLw]
   ubuntu: [libglw1-mesa]
+libgmock-dev:
+  alpine: [gmock]
+  arch: [gmock]
+  debian:
+    buster: [libgmock-dev]
+  fedora: [gmock-devel]
+  freebsd: [googlemock]
+  gentoo: [dev-cpp/gtest]
+  openembedded: [gtest@meta-oe]
+  opensuse: [gmock-devel]
+  rhel: [gmock-devel]
+  ubuntu:
+    focal: [libgmock-dev]
 libgmp:
   debian: [libgmp-dev]
   fedora: [gmp-devel]
@@ -2627,19 +2640,6 @@ libgpgme-dev:
     vivid: [libgpgme11-dev]
     wily: [libgpgme11-dev]
     xenial: [libgpgme11-dev]
-libgmock-dev:
-  alpine: [gmock]
-  arch: [gmock]
-  debian:
-    buster: [libgmock-dev]
-  fedora: [gmock-devel]
-  freebsd: [googlemock]
-  gentoo: [dev-cpp/gtest]
-  openembedded: [gtest@meta-oe]
-  opensuse: [gmock-devel]
-  rhel: [gmock-devel]
-  ubuntu:
-    focal: [libgmock-dev]
 libgphoto-dev:
   arch: [libgphoto2]
   debian: [libgphoto2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2627,6 +2627,11 @@ libgpgme-dev:
     vivid: [libgpgme11-dev]
     wily: [libgpgme11-dev]
     xenial: [libgpgme11-dev]
+libgmock-dev:
+  debian:
+    buster: ["libgmock-dev"]
+  ubuntu:
+    focal: ["libgmock-dev"]
 libgphoto-dev:
   arch: [libgphoto2]
   debian: [libgphoto2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1184,14 +1184,18 @@ golang-go:
 google-mock:
   alpine: [gmock]
   arch: [gmock]
-  debian: [google-mock]
+  debian:
+    '*': [google-mock]
+    buster: [libgmock-dev]
   fedora: [gmock-devel]
   freebsd: [googlemock]
   gentoo: [dev-cpp/gtest]
   openembedded: [gtest@meta-oe]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
-  ubuntu: [google-mock]
+  ubuntu:
+    '*': [google-mock]
+    focal: [libgmock-dev]
 gpac:
   debian: [gpac]
   fedora: [gpac]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1184,18 +1184,14 @@ golang-go:
 google-mock:
   alpine: [gmock]
   arch: [gmock]
-  debian:
-    '*': [google-mock]
-    buster: [libgmock-dev]
+  debian: [google-mock]
   fedora: [gmock-devel]
   freebsd: [googlemock]
   gentoo: [dev-cpp/gtest]
   openembedded: [gtest@meta-oe]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
-  ubuntu:
-    '*': [google-mock]
-    focal: [libgmock-dev]
+  ubuntu: [google-mock]
 gpac:
   debian: [gpac]
   fedora: [gpac]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2629,9 +2629,9 @@ libgpgme-dev:
     xenial: [libgpgme11-dev]
 libgmock-dev:
   debian:
-    buster: ["libgmock-dev"]
+    buster: [libgmock-dev]
   ubuntu:
-    focal: ["libgmock-dev"]
+    focal: [libgmock-dev]
 libgphoto-dev:
   arch: [libgphoto2]
   debian: [libgphoto2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2628,8 +2628,16 @@ libgpgme-dev:
     wily: [libgpgme11-dev]
     xenial: [libgpgme11-dev]
 libgmock-dev:
+  alpine: [gmock]
+  arch: [gmock]
   debian:
     buster: [libgmock-dev]
+  fedora: [gmock-devel]
+  freebsd: [googlemock]
+  gentoo: [dev-cpp/gtest]
+  openembedded: [gtest@meta-oe]
+  opensuse: [gmock-devel]
+  rhel: [gmock-devel]
   ubuntu:
     focal: [libgmock-dev]
 libgphoto-dev:


### PR DESCRIPTION
`google-mock` is a transitional package and shouldn't be used anymore.
See https://packages.debian.org/buster/google-mock