### PR TITLE
ddynamic_reconfigure_python: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1064,6 +1064,21 @@ repositories:
       url: https://github.com/pal-robotics/ddynamic_reconfigure.git
       version: kinetic-devel
     status: maintained
+  ddynamic_reconfigure_python:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
+      version: master
+    status: maintained
   diagnostics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure_python` to `0.0.1-1`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## ddynamic_reconfigure_python

```
* Add namespace to reconfigure server
* Added examples, making the api easier to use
* Initial commit
* Contributors: Sam Pfeiffer
```
