### PR TITLE
dingo: 0.1.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2193,7 +2193,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/dingo-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/dingo-cpr/dingo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dingo` to `0.1.5-1`:

- upstream repository: https://github.com/dingo-cpr/dingo.git
- release repository: https://github.com/clearpath-gbp/dingo-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.4-1`

## dingo_control

```
* [dingo_control] Reduced acceleration limit for omnidirectional platform.
* Contributors: Tony Baltovski
```

## dingo_description

```
* Fix the mount links for Dingo-D and Dingo-O; -D doesn't technically have a mid_mount (#9 <https://github.com/dingo-cpr/dingo/issues/9>)
* Contributors: Chris I-B
```

## dingo_msgs

```
* [dingo_msgs] Removed Power msg.
* Contributors: Tony Baltovski
```

## dingo_navigation

- No changes
