### PR TITLE
Revert "ros_babel_fish: 0.9.0-2 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12697,20 +12697,6 @@ repositories:
       url: https://gitlab.com/InstitutMaupertuis/ros_additive_manufacturing.git
       version: kinetic
     status: developed
-  ros_babel_fish:
-    release:
-      packages:
-      - ros_babel_fish
-      - ros_babel_fish_test_msgs
-      tags:
-        release: release/kinetic/{package}/{version}
-      url: https://github.com/StefanFabian/ros_babel_fish-release.git
-      version: 0.9.0-2
-    source:
-      type: git
-      url: https://github.com/StefanFabian/ros_babel_fish.git
-      version: kinetic
-    status: developed
   ros_canopen:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#27174

Sorry for the unnecessary work.
While the code works on kinetic, unfortunately, the gtest version of kinetic seems to be incompatible with the test code.
I don't have the time right now to fix this for a four year old distro, so, removing it seems like the best option for now.