### PR TITLE
cartographer_ros: 1.0.9002-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -342,7 +342,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 1.0.9001-1
+      version: 1.0.9002-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.9002-1`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.9001-1`

## cartographer_ros

```
* Handle multiple ROS messages with the same timestamp (#46 <https://github.com/ros2/cartographer_ros/issues/46>)
* Contributors: Michel Hidalgo
```

## cartographer_ros_msgs

- No changes
