### PR TITLE
extest: 0.0.1-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2794,6 +2794,14 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/exotica_val_description-release.git
       version: 1.0.0-1
+  extest:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nakakura/extest-release.git
+      version: 0.0.1-3
+    status: unmaintained
+    status_description: Test of Rosrust
   eyantra_drone:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `extest` to `0.0.1-3`:

- upstream repository: https://github.com/nakakura/extest-release.git
- release repository: https://github.com/nakakura/extest-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## extest

```
* first commit
* Contributors: Toshiya Nakakura
```
