### PR TITLE
bota_driver: 0.5.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -931,7 +931,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.3-2
+      version: 0.5.4-1
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.4-1`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.3-2`

## bota_device_driver

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_driver

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_node

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_signal_handler

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_worker

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* Merge branch 'fix/cmake-eigen3-error' into 'melodic-devel'
  Try to fix cmake Eigen3 error on ROS buildfarm again
  See merge request botasys/bota_driver!51 <https://gitlab.com/botasys/bota_driver/-/merge_requests/51>
* add different changes
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_description

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_ethercat

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_examples

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* run clang-tidy -fix after building ALL packages under rokubimini_sdk
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_factory

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_manager

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_msgs

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* fix errors from catkin_lint
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_serial

```
* Merge branch 'fix/printf-breaks-build-arm' into 'melodic-devel'
  Fix ROS_DEBUG() breaking ARM build on ROS buildfarm
  See merge request botasys/bota_driver!53 <https://gitlab.com/botasys/bota_driver/-/merge_requests/53>
* change %lu to %zu
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```
