### PR TITLE
bota_driver: 0.5.4-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -288,6 +288,36 @@ repositories:
       url: https://github.com/PickNikRobotics/boost_sml.git
       version: master
     status: developed
+  bota_driver:
+    doc:
+      type: git
+      url: https://gitlab.com/botasys/bota_driver.git
+      version: master
+    release:
+      packages:
+      - bota_device_driver
+      - bota_driver
+      - bota_node
+      - bota_signal_handler
+      - bota_worker
+      - rokubimini
+      - rokubimini_bus_manager
+      - rokubimini_description
+      - rokubimini_ethercat
+      - rokubimini_examples
+      - rokubimini_factory
+      - rokubimini_manager
+      - rokubimini_msgs
+      - rokubimini_serial
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.com/botasys/bota_driver-release.git
+      version: 0.5.4-2
+    source:
+      type: git
+      url: https://gitlab.com/botasys/bota_driver.git
+      version: noetic-devel
+    status: developed
   capabilities:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.4-2`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## bota_device_driver

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_driver

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_node

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_signal_handler

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## bota_worker

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* Merge branch 'fix/cmake-eigen3-error' into 'melodic-devel'
  Try to fix cmake Eigen3 error on ROS buildfarm again
  See merge request botasys/bota_driver!51 <https://gitlab.com/botasys/bota_driver/-/merge_requests/51>
* add different changes
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_description

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_ethercat

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_examples

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* run clang-tidy -fix after building ALL packages under rokubimini_sdk
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_factory

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_manager

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_msgs

```
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* fix errors from catkin_lint
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_serial

```
* Merge branch 'fix/printf-breaks-build-arm' into 'melodic-devel'
  Fix ROS_DEBUG() breaking ARM build on ROS buildfarm
  See merge request botasys/bota_driver!53 <https://gitlab.com/botasys/bota_driver/-/merge_requests/53>
* change %lu to %zu
* Merge branch 'release/0.5.3' into 'melodic-devel'
  Release 0.5.3
  See merge request botasys/bota_driver!52 <https://gitlab.com/botasys/bota_driver/-/merge_requests/52>
* Release 0.5.3
* merge release 0.5.2 into melodic-devel
* Contributors: Mike Karam, Mike Karamousadakis
```
