### PR TITLE
sdformat_urdf: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2381,6 +2381,25 @@ repositories:
       url: https://github.com/ros2/rviz.git
       version: ros2
     status: maintained
+  sdformat_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/sdformat_urdf.git
+      version: ros2
+    release:
+      packages:
+      - sdformat_test_files
+      - sdformat_urdf
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/sdformat_urdf.git
+      version: ros2
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `0.1.0-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## sdformat_test_files

```
* Initial urdf parser plugin that parses sdformat (#1 <https://github.com/ros/sdformat_urdf/issues/1>)
* Contributors: Shane Loretz, Addisu Z. Taddese, Steve Peters, Chris Lalancette, Eric Cousineau
```

## sdformat_urdf

```
* Initial urdf parser plugin that parses sdformat (#1 <https://github.com/ros/sdformat_urdf/issues/1>)
* Contributors: Shane Loretz, Addisu Z. Taddese, Steve Peters, Chris Lalancette, Eric Cousineau
```
