### PR TITLE
ros_comm: 1.12.16-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12762,7 +12762,6 @@ repositories:
       - ros_comm
       - rosbag
       - rosbag_storage
-      - rosconsole
       - roscpp
       - rosgraph
       - roslaunch
@@ -12777,6 +12776,7 @@ repositories:
       - rostest
       - rostopic
       - roswtf
+      - test_rostest
       - topic_tools
       - xmlrpcpp
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.12.16-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.12.16-1`
