### PR TITLE
rclpy: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1461,7 +1461,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.2.1-2
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.3.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.1-2`

## rclpy

```
* qos_policy_name_from_kind() should accept either a QoSPolicyKind or an int (#637 <https://github.com/ros2/rclpy/issues/637>)
* Add method in Node to resolve a topic or service name (#636 <https://github.com/ros2/rclpy/issues/636>)
* Contributors: Ivan Santiago Paunovic
```
