### PR TITLE
robot_calibration: 0.6.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9385,7 +9385,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.6.4-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.3-1`

## robot_calibration

```
* improve visualization (#91 <https://github.com/mikeferguson/robot_calibration/issues/91>)
  * publish joint states for viz
  * publish point clouds
* use all features when features are unspecified (#92 <https://github.com/mikeferguson/robot_calibration/issues/92>)
* only accept organized clouds, fixes #79 <https://github.com/mikeferguson/robot_calibration/issues/79> (#90 <https://github.com/mikeferguson/robot_calibration/issues/90>)
* catch by reference to silence warnings (#89 <https://github.com/mikeferguson/robot_calibration/issues/89>)
* fix opencv build issue (#88 <https://github.com/mikeferguson/robot_calibration/issues/88>)
* update package.xml for noetic (#87 <https://github.com/mikeferguson/robot_calibration/issues/87>)
  orocos-kdl is now a system dependency,
  rosdep key has changed
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

```
* update package.xml for noetic (#87 <https://github.com/mikeferguson/robot_calibration/issues/87>)
  orocos-kdl is now a system dependency,
  rosdep key has changed
* Contributors: Michael Ferguson
```
