### PR TITLE
rclcpp: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1445,7 +1445,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `5.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `5.0.0-1`

## rclcpp

```
* Deprecate Duration(rcl_duration_value_t) in favor of static Duration::from_nanoseconds(rcl_duration_value_t) (#1432 <https://github.com/ros2/rclcpp/issues/1432>)
* Avoid parsing arguments twice in rclcpp::init_and_remove_ros_arguments (#1415 <https://github.com/ros2/rclcpp/issues/1415>)
* Add service and client benchmarks (#1425 <https://github.com/ros2/rclcpp/issues/1425>)
* Set CMakeLists to only use default rmw for benchmarks (#1427 <https://github.com/ros2/rclcpp/issues/1427>)
* Update tracetools' QL in rclcpp's QD (#1428 <https://github.com/ros2/rclcpp/issues/1428>)
* Add missing locking to the rclcpp_action::ServerBase. (#1421 <https://github.com/ros2/rclcpp/issues/1421>)
* Initial benchmark tests for rclcpp::init/shutdown create/destroy node (#1411 <https://github.com/ros2/rclcpp/issues/1411>)
* Refactor test CMakeLists in prep for benchmarks (#1422 <https://github.com/ros2/rclcpp/issues/1422>)
* Add methods in topic and service interface to resolve a name (#1410 <https://github.com/ros2/rclcpp/issues/1410>)
* Update deprecated gtest macros (#1370 <https://github.com/ros2/rclcpp/issues/1370>)
* Clear members for StaticExecutorEntitiesCollector to avoid shared_ptr dependency (#1303 <https://github.com/ros2/rclcpp/issues/1303>)
* Increase test timeouts of slow running tests with rmw_connext_cpp (#1400 <https://github.com/ros2/rclcpp/issues/1400>)
* Avoid self dependency that not destoryed (#1301 <https://github.com/ros2/rclcpp/issues/1301>)
* Update maintainers (#1384 <https://github.com/ros2/rclcpp/issues/1384>)
* Add clock qos to node options (#1375 <https://github.com/ros2/rclcpp/issues/1375>)
* Fix NodeOptions copy constructor (#1376 <https://github.com/ros2/rclcpp/issues/1376>)
* Make sure to clean the external client/service handle. (#1296 <https://github.com/ros2/rclcpp/issues/1296>)
* Increase coverage of WaitSetTemplate (#1368 <https://github.com/ros2/rclcpp/issues/1368>)
* Increase coverage of guard_condition.cpp to 100% (#1369 <https://github.com/ros2/rclcpp/issues/1369>)
* Add coverage statement (#1367 <https://github.com/ros2/rclcpp/issues/1367>)
* Tests for LoanedMessage with mocked loaned message publisher (#1366 <https://github.com/ros2/rclcpp/issues/1366>)
* Add unit tests for qos and qos_event files (#1352 <https://github.com/ros2/rclcpp/issues/1352>)
* Finish coverage of publisher API (#1365 <https://github.com/ros2/rclcpp/issues/1365>)
* Finish API coverage on executors. (#1364 <https://github.com/ros2/rclcpp/issues/1364>)
* Add test for ParameterService (#1355 <https://github.com/ros2/rclcpp/issues/1355>)
* Add time API coverage tests (#1347 <https://github.com/ros2/rclcpp/issues/1347>)
* Add timer coverage tests (#1363 <https://github.com/ros2/rclcpp/issues/1363>)
* Add in additional tests for parameter_client.cpp coverage.
* Minor fixes to the parameter_service.cpp file.
* reset rcl_context shared_ptr after calling rcl_init sucessfully (#1357 <https://github.com/ros2/rclcpp/issues/1357>)
* Improved test publisher - zero qos history depth value exception (#1360 <https://github.com/ros2/rclcpp/issues/1360>)
* Covered resolve_use_intra_process (#1359 <https://github.com/ros2/rclcpp/issues/1359>)
* Improve test_subscription_options (#1358 <https://github.com/ros2/rclcpp/issues/1358>)
* Add in more tests for init_options coverage. (#1353 <https://github.com/ros2/rclcpp/issues/1353>)
* Test the remaining node public API (#1342 <https://github.com/ros2/rclcpp/issues/1342>)
* Complete coverage of Parameter and ParameterValue API (#1344 <https://github.com/ros2/rclcpp/issues/1344>)
* Add in more tests for the utilities. (#1349 <https://github.com/ros2/rclcpp/issues/1349>)
* Add in two more tests for expand_topic_or_service_name. (#1350 <https://github.com/ros2/rclcpp/issues/1350>)
* Add tests for node_options API (#1343 <https://github.com/ros2/rclcpp/issues/1343>)
* Add in more coverage for expand_topic_or_service_name. (#1346 <https://github.com/ros2/rclcpp/issues/1346>)
* Test exception in spin_until_future_complete. (#1345 <https://github.com/ros2/rclcpp/issues/1345>)
* Add coverage tests graph_listener (#1330 <https://github.com/ros2/rclcpp/issues/1330>)
* Add in unit tests for the Executor class.
* Allow mimick patching of methods with up to 9 arguments.
* Improve the error messages in the Executor class.
* Add coverage for client API (#1329 <https://github.com/ros2/rclcpp/issues/1329>)
* Increase service coverage (#1332 <https://github.com/ros2/rclcpp/issues/1332>)
* Make more of the static entity collector API private.
* Const-ify more of the static executor.
* Add more tests for the static single threaded executor.
* Many more tests for the static_executor_entities_collector.
* Get one more line of code coverage in memory_strategy.cpp
* Bugfix when adding callback group.
* Fix typos in comments.
* Remove deprecated executor::FutureReturnCode APIs. (#1327 <https://github.com/ros2/rclcpp/issues/1327>)
* Increase coverage of publisher/subscription API (#1325 <https://github.com/ros2/rclcpp/issues/1325>)
* Not finalize guard condition while destructing SubscriptionIntraProcess (#1307 <https://github.com/ros2/rclcpp/issues/1307>)
* Expose qos setting for /rosout (#1247 <https://github.com/ros2/rclcpp/issues/1247>)
* Add coverage for missing API (except executors) (#1326 <https://github.com/ros2/rclcpp/issues/1326>)
* Include topic name in QoS mismatch warning messages (#1286 <https://github.com/ros2/rclcpp/issues/1286>)
* Add coverage tests context functions (#1321 <https://github.com/ros2/rclcpp/issues/1321>)
* Increase coverage of node_interfaces, including with mocking rcl errors (#1322 <https://github.com/ros2/rclcpp/issues/1322>)
* Contributors: Ada-King, Alejandro Hernández Cordero, Audrow Nash, Barry Xu, Chen Lihui, Chris Lalancette, Christophe Bedard, Ivan Santiago Paunovic, Jorge Perez, Morgan Quigley, brawner
```

## rclcpp_action

```
* Benchmark rclcpp_action action_client (#1429 <https://github.com/ros2/rclcpp/issues/1429>)
* Add missing locking to the rclcpp_action::ServerBase. (#1421 <https://github.com/ros2/rclcpp/issues/1421>)
* Increase test timeouts of slow running tests with rmw_connext_cpp (#1400 <https://github.com/ros2/rclcpp/issues/1400>)
* Update maintainers (#1384 <https://github.com/ros2/rclcpp/issues/1384>)
* Increase coverage rclcpp_action to 95% (#1290 <https://github.com/ros2/rclcpp/issues/1290>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic, brawner
```

## rclcpp_components

```
* Update maintainers (#1384 <https://github.com/ros2/rclcpp/issues/1384>)
* ComponentManager: switch off parameter services and event publisher (#1333 <https://github.com/ros2/rclcpp/issues/1333>)
* Contributors: Ivan Santiago Paunovic, Martijn Buijs
```

## rclcpp_lifecycle

```
* Increase test timeouts of slow running tests with rmw_connext_cpp (#1400 <https://github.com/ros2/rclcpp/issues/1400>)
* Update maintainers (#1384 <https://github.com/ros2/rclcpp/issues/1384>)
* Add clock qos to node options (#1375 <https://github.com/ros2/rclcpp/issues/1375>)
* Contributors: Ivan Santiago Paunovic, brawner
```
