### PR TITLE
geometry2: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -628,6 +628,7 @@ repositories:
       - tf2
       - tf2_bullet
       - tf2_eigen
+      - tf2_eigen_kdl
       - tf2_geometry_msgs
       - tf2_kdl
       - tf2_msgs
@@ -639,7 +640,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.14.1-1
+      version: 0.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.15.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.14.1-1`

## examples_tf2_py

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## geometry2

```
* Port eigen_kdl.h/cpp to ROS2 (#311 <https://github.com/ros2/geometry2/issues/311>)
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette, Jafar Abdi
```

## tf2

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_bullet

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_eigen

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_eigen_kdl

```
* Update package.xml (#333 <https://github.com/ros2/geometry2/issues/333>)
* Port eigen_kdl.h/cpp to ROS2 (#311 <https://github.com/ros2/geometry2/issues/311>)
* Contributors: Jafar Abdi
```

## tf2_geometry_msgs

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_kdl

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_msgs

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_py

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_ros

```
* Remove usage of deprecated rclcpp::Duration constructor (#340 <https://github.com/ros2/geometry2/issues/340>)
* Remove messages_count member from tf2_ros::MessageFilter. (#335 <https://github.com/ros2/geometry2/issues/335>)
* Style fixup in tf2_ros. (#325 <https://github.com/ros2/geometry2/issues/325>)
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic
```

## tf2_ros_py

```
* Update rclpy.Rate TODO with url to issue (#324 <https://github.com/ros2/geometry2/issues/324>)
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette, surfertas
```

## tf2_sensor_msgs

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```

## tf2_tools

```
* Update maintainers of the ros2/geometry2 fork. (#328 <https://github.com/ros2/geometry2/issues/328>)
* Contributors: Chris Lalancette
```
