### PR TITLE
robot_calibration: 0.6.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4090,6 +4090,25 @@ repositories:
       url: https://github.com/ros-drivers/rgbd_launch.git
       version: noetic-devel
     status: maintained
+  robot_calibration:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros1
+    release:
+      packages:
+      - robot_calibration
+      - robot_calibration_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/robot_calibration-release.git
+      version: 0.6.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros1
+    status: developed
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.6.4-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros-gbp/robot_calibration-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## robot_calibration

```
* improve visualization (#91 <https://github.com/mikeferguson/robot_calibration/issues/91>)
  * publish joint states for viz
  * publish point clouds
* use all features when features are unspecified (#92 <https://github.com/mikeferguson/robot_calibration/issues/92>)
* only accept organized clouds, fixes #79 <https://github.com/mikeferguson/robot_calibration/issues/79> (#90 <https://github.com/mikeferguson/robot_calibration/issues/90>)
* catch by reference to silence warnings (#89 <https://github.com/mikeferguson/robot_calibration/issues/89>)
* fix opencv build issue (#88 <https://github.com/mikeferguson/robot_calibration/issues/88>)
* update package.xml for noetic (#87 <https://github.com/mikeferguson/robot_calibration/issues/87>)
  orocos-kdl is now a system dependency,
  rosdep key has changed
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

```
* update package.xml for noetic (#87 <https://github.com/mikeferguson/robot_calibration/issues/87>)
  orocos-kdl is now a system dependency,
  rosdep key has changed
* Contributors: Michael Ferguson
```
