### PR TITLE
navigation_msgs: 1.14.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8630,7 +8630,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_msgs-release.git
-      version: 1.13.0-0
+      version: 1.14.1-1
     status: maintained
   navigation_tutorials:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `1.14.1-1`:

- upstream repository: https://github.com/ros-planning/navigation_msgs.git
- release repository: https://github.com/ros-gbp/navigation_msgs-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.13.0-0`

## map_msgs

- No changes

## move_base_msgs

```
* Merge pull request #19 <https://github.com/ros-planning/navigation_msgs/issues/19> from ros-planning/recovery_behavior_msg
  Recovery behavior msg
* Contributors: David V. Lu, David V. Lu!!, Peter Mitrano
```
