### PR TITLE
navigation_msgs: 1.14.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6727,7 +6727,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_msgs-release.git
-      version: 1.13.0-0
+      version: 1.14.1-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `1.14.1-1`:

- upstream repository: https://github.com/ros-planning/navigation_msgs.git
- release repository: https://github.com/ros-gbp/navigation_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.13.0-0`

## map_msgs

- No changes

## move_base_msgs

```
* Merge pull request #19 <https://github.com/ros-planning/navigation_msgs/issues/19> from ros-planning/recovery_behavior_msg
  Recovery behavior msg
* Contributors: David V. Lu, David V. Lu!!, Peter Mitrano
```
