### PR TITLE
doosan-robot2: 0.1.1-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -616,6 +616,18 @@ repositories:
       type: git
       url: https://github.com/doosan-robotics/doosan-robot2.git
       version: foxy
+    release:
+      packages:
+      - common2
+      - dsr_control2
+      - dsr_description2
+      - dsr_example2_py
+      - dsr_launcher2
+      - dsr_msgs2
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/doosan-robotics/doosan-robot2-release.git
+      version: 0.1.1-4
     source:
       type: git
       url: https://github.com/doosan-robotics/doosan-robot2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `doosan-robot2` to `0.1.1-4`:

- upstream repository: https://github.com/doosan-robotics/doosan-robot2.git
- release repository: https://github.com/doosan-robotics/doosan-robot2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
