### PR TITLE
rcl: 1.1.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2244,7 +2244,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 1.1.8-1
+      version: 1.1.9-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `1.1.9-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.8-1`

## rcl

```
* increase timeouts in test_services fixtures for Connext (#745 <https://github.com/ros2/rcl/issues/745>)
* Add a semicolon to RCUTILS_LOGGING_AUTOINIT. (#816 <https://github.com/ros2/rcl/issues/816>)
* Zero initialize events an size_of_events members of rcl_wait_set_t (#841 <https://github.com/ros2/rcl/issues/841>)
* Return OK when finalizing zero-initialized contexts (#842 <https://github.com/ros2/rcl/issues/842>)
* Make sure to check the return value of rcl APIs. (#838 <https://github.com/ros2/rcl/issues/838>)
* Fix memory leak because of mock test (#800 <https://github.com/ros2/rcl/issues/800>)
* Fix that not to deallocate event impl in some failure case (#790 <https://github.com/ros2/rcl/issues/790>)
* calling fini functions to avoid memory leak (#791 <https://github.com/ros2/rcl/issues/791>)
* Bump rcl arguments' API test coverage. (#777 <https://github.com/ros2/rcl/issues/777>)
* Fix rcl arguments' API memory leaks and bugs. (#778 <https://github.com/ros2/rcl/issues/778>)
* Add coverage tests wait module (#769 <https://github.com/ros2/rcl/issues/769>)
* Fix wait allocation cleanup (#770 <https://github.com/ros2/rcl/issues/770>)
* Bump test coverage. (#764 <https://github.com/ros2/rcl/issues/764>)
* Check rcutils_strdup() outcome immediately. (#768 <https://github.com/ros2/rcl/issues/768>)
* Cleanup rcl_get_secure_root() implementation. (#762 <https://github.com/ros2/rcl/issues/762>)
* Add fault injection macros to rcl functions (#727 <https://github.com/ros2/rcl/issues/727>)
* Yield rcl_context_fini() error codes. (#763 <https://github.com/ros2/rcl/issues/763>)
* Do not invalidate context before successful shutdown. (#761 <https://github.com/ros2/rcl/issues/761>)
* Zero initialize guard condition on failed init. (#760 <https://github.com/ros2/rcl/issues/760>)
* Adding tests to arguments.c (#752 <https://github.com/ros2/rcl/issues/752>)
* Extend rcl_expand_topic_name() API test coverage. (#758 <https://github.com/ros2/rcl/issues/758>)
* Add coverage tests 94% service.c (#756 <https://github.com/ros2/rcl/issues/756>)
* Clean up rcl_expand_topic_name() implementation. (#757 <https://github.com/ros2/rcl/issues/757>)
* Added path_to_fail to mocking_utils in rcl
* Complete rcl enclave validation API coverage. (#751 <https://github.com/ros2/rcl/issues/751>)
* Fix allocation arguments copy (#748 <https://github.com/ros2/rcl/issues/748>)
* Fix rcl package's logging API error specs and handling. (#746 <https://github.com/ros2/rcl/issues/746>)
* Fix bug error handling get_param_files (#743 <https://github.com/ros2/rcl/issues/743>)
* Complete subscription API test coverage (#734 <https://github.com/ros2/rcl/issues/734>)
* Add deallocate calls to free strdup allocated memory (#737 <https://github.com/ros2/rcl/issues/737>)
* Add missing calls to rcl_convert_rmw_ret_to_rcl_ret (#738 <https://github.com/ros2/rcl/issues/738>)
* Add mock tests, publisher 95% coverage (#732 <https://github.com/ros2/rcl/issues/732>)
* Reformat rmw_impl_id_check to call a testable function (#725 <https://github.com/ros2/rcl/issues/725>)
* Make sure to call rcl_arguments_fini at the end of the test.
* Add remap needed null check (#711 <https://github.com/ros2/rcl/issues/711>)
* Make public ini/fini rosout publisher (#704 <https://github.com/ros2/rcl/issues/704>)
* Move rcl_remap_copy to public header (#709 <https://github.com/ros2/rcl/issues/709>)
* Add coverage tests for rcl (#703 <https://github.com/ros2/rcl/issues/703>)
* Add bad arguments tests for coverage (#698 <https://github.com/ros2/rcl/issues/698>)
* Improve error checking and handling in subscription APIs. (#739 <https://github.com/ros2/rcl/issues/739>)
* Fix memory leak in rcl_subscription_init()/rcl_publisher_init() (#794 <https://github.com/ros2/rcl/issues/794>, #834 <https://github.com/ros2/rcl/issues/834>) (#832 <https://github.com/ros2/rcl/issues/832>)
* Improve rcl init test coverage. (#684 <https://github.com/ros2/rcl/issues/684>)
* Remove unused check context.c (#691 <https://github.com/ros2/rcl/issues/691>)
* Improve subscription coverage (#681 <https://github.com/ros2/rcl/issues/681>)
* Improve rcl timer test coverage. (#680 <https://github.com/ros2/rcl/issues/680>)
* Improve wait sets test coverage. (#683 <https://github.com/ros2/rcl/issues/683>)
* Minor fixes to rcl clock implementation. (#688 <https://github.com/ros2/rcl/issues/688>)
* Improve clock test coverage. (#685 <https://github.com/ros2/rcl/issues/685>)
* Improve enclave validation test coverage. (#682 <https://github.com/ros2/rcl/issues/682>)
* Contributors: Chen Lihui, Chris Lalancette, Dirk Thomas, Jacob Perron, Jorge Perez, Michel Hidalgo, ahcorde, brawner
```

## rcl_action

```
* Make sure to always check return values. (#840 <https://github.com/ros2/rcl/issues/840>)
* Make sure to check the return value of rcl APIs. (#838 <https://github.com/ros2/rcl/issues/838>)
* Add fault injection macros and unit tests to rcl_action (#730 <https://github.com/ros2/rcl/issues/730>)
* Contributors: Chris Lalancette, brawner
```

## rcl_lifecycle

```
* Make sure to always check return values. (#840 <https://github.com/ros2/rcl/issues/840>)
* Make sure to check the return value of rcl APIs. (#838 <https://github.com/ros2/rcl/issues/838>)
* Fix test_rcl_lifecycle (#788 <https://github.com/ros2/rcl/issues/788>)
* Add fault injection macros and unit tests to rcl_lifecycle (#731 <https://github.com/ros2/rcl/issues/731>)
* Contributors: Chris Lalancette, brawner
```

## rcl_yaml_param_parser

```
* Add mocking unit tests for rcl_yaml_param_parser (coverage part 3/3) (#772 <https://github.com/ros2/rcl/issues/772>)
* Add fault-injection unit tests (coverage part 2/3) (#766 <https://github.com/ros2/rcl/issues/766>)
* Add basic unit tests for refactored functions in rcl_yaml_param_parser (coverage part 1/3) (#771 <https://github.com/ros2/rcl/issues/771>)
* Fix mem leaks in unit test from 776 (#779 <https://github.com/ros2/rcl/issues/779>)
* remove debugging statements. (#755 <https://github.com/ros2/rcl/issues/755>)
* Removed variant benchmark
* Several memory-related fixes for rcl_variant_t benchmarks (#813 <https://github.com/ros2/rcl/issues/813>)
* Improved rcl_yaml_param_parser benchmark test (#810 <https://github.com/ros2/rcl/issues/810>)
* Added benchmark test to rcl_yaml_param_parser (#803 <https://github.com/ros2/rcl/issues/803>)
* Contributors: Alejandro Hernández Cordero, Scott K Logan, ahcorde, brawner, tomoya
```
