### PR TITLE
bota_driver: 0.5.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1161,7 +1161,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.5-1
+      version: 0.5.6-1
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.6-1`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.5-1`

## bota_device_driver

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Merge branch 'fix/merge-release-0.5.5-into-master' into 'master'
  merge release 0.5.5 into master
  See merge request botasys/bota_driver!64
* Merge branch 'fix/ros-logging-fail' into 'melodic-devel'
  Fix ROS_DEBUG() breaking ARM build on ROS buildfarm
  See merge request botasys/bota_driver!58
  (cherry picked from commit 503d92fc3c5548327386a777f774854fed9fbc14)
* Merge branch 'melodic-devel' into 'master'
  Merge melodic-devel into master
  See merge request botasys/bota_driver!55
* add proper build path for non-master branches. master branch CI needs to change. change Dockerfile and gitlab-ci.yml to use .rosinstall file
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48
* Increment patch version
* Merge branch 'feature/remove-any-node-dep' into 'master'
  Remove any_node dependency
  See merge request botasys/bota_driver!47
* Remove any_node dependency
* Contributors: Mike Karamousadakis
```

## bota_driver

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Merge branch 'fix/merge-release-0.5.5-into-master' into 'master'
  merge release 0.5.5 into master
  See merge request botasys/bota_driver!64
* Merge branch 'fix/ros-logging-fail' into 'melodic-devel'
  Fix ROS_DEBUG() breaking ARM build on ROS buildfarm
  See merge request botasys/bota_driver!58
  (cherry picked from commit 503d92fc3c5548327386a777f774854fed9fbc14)
* Merge branch 'melodic-devel' into 'master'
  Merge melodic-devel into master
  See merge request botasys/bota_driver!55
* add proper build path for non-master branches. master branch CI needs to change. change Dockerfile and gitlab-ci.yml to use .rosinstall file
* Merge branch 'feature/increment-patch-version' into 'master'
  Increment patch version
  See merge request botasys/bota_driver!48
* Increment patch version
* Contributors: Mike Karamousadakis
```

## bota_node

- No changes

## bota_signal_handler

- No changes

## bota_worker

- No changes

## rokubimini

```
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_bus_manager

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_description

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## rokubimini_ethercat

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_examples

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## rokubimini_factory

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_manager

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_msgs

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## rokubimini_serial

```
* Merge branch 'fix/cmake-policy-cmp0048' into 'master'
  change minimum cmake version required to 3.0.2
  Closes #29
  See merge request botasys/bota_driver!66
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```
