### PR TITLE
fadecandy_ros: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2822,7 +2822,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/iron-ox/fadecandy_ros-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/iron-ox/fadecandy_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `0.1.3-1`:

- upstream repository: https://github.com/iron-ox/fadecandy_ros.git
- release repository: https://github.com/iron-ox/fadecandy_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## fadecandy_driver

```
* Merge pull request #13 <https://github.com/iron-ox/fadecandy_ros/issues/13> from eurogroep/fix/noetic-python3-struct-pack: fix(Noetic/Python3): Struct packing
* Contributors: Rein Appeldoorn
```

## fadecandy_msgs

- No changes
