### PR TITLE
sros2: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2425,7 +2425,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.9.2-2
+      version: 0.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.2-2`

## sros2

```
* Expose keystore operations in public API (#241 <https://github.com/ros2/sros2/issues/241>)
* add cyclonedds to the list of rmw using graph info topics (#231 <https://github.com/ros2/sros2/issues/231>)
* Add scope parameter (#230 <https://github.com/ros2/sros2/issues/230>)
* Fix name of argument passed to NodeStrategy (#227 <https://github.com/ros2/sros2/issues/227>)
* Remove the use of pkg_resources. (#225 <https://github.com/ros2/sros2/issues/225>)
* Make use of ros_testing to test policy generation. (#214 <https://github.com/ros2/sros2/issues/214>)
* Add pytest.ini so local tests don't display warning (#224 <https://github.com/ros2/sros2/issues/224>)
* Contributors: Chris Lalancette, Jacob Perron, Jose Luis Rivero, Kyle Fazzari, Michel Hidalgo, Mikael Arguedas
```

## sros2_cmake

- No changes
