### PR TITLE
Update expected Debian sources.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,8 @@ Keys in the rosdep database are required to come from packages contained in the 
 
 #### Debian
 
-* Debian Repositories: Main, Universe, or Multiverse
-* ROS Sources: https://wiki.ros.org/Installation/Ubuntu/Sources
+* Debian Repositories: Main, Contrib, or Non-Free
+* ROS Sources: The Ubuntu guide also works for currently supported Debian distributions: https://wiki.ros.org/Installation/Ubuntu/Sources
 
 #### Fedora
 


### PR DESCRIPTION
This looks like it was copy-pasted from the above entry for Ubuntu and
used the Ubuntu repository components rather than the Debian ones.

The inclusion of contrib and non-free comes from https://wiki.ros.org/Installation/Debian#melodic.2FInstallation.2FDebianSources.Configure_your_Debian_repositories

There is no Debian specific article for setting up ROS sources but the
Ubuntu article applies if you update the distribution name.