### PR TITLE
rmw_cyclonedds: 0.7.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2300,7 +2300,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.5.1-1
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.1-1`

## cyclonedds_cmake_module

- No changes

## rmw_cyclonedds_cpp

```
* Provide a dummy readcdr function if needed
* Fix serialization on non-32-bit, big-endian systems (#159 <https://github.com/ros2/rmw_cyclonedds/issues/159>)
* implement safer align_ function (#141 <https://github.com/ros2/rmw_cyclonedds/issues/141>)
* Enable use of Cyclone DDS security features (#123 <https://github.com/ros2/rmw_cyclonedds/issues/123>)
* Clean up package xml dependencies (#132 <https://github.com/ros2/rmw_cyclonedds/issues/132>)
* API changes to sync with one Participant per Context change in rmw_fastrtps (#106 <https://github.com/ros2/rmw_cyclonedds/issues/106>)
* Improve security logic and memory management
* Include incompatible_qos_events_statuses.h only if rmw >= 0.8.2
* Fix memory leaks
* Support for ON_REQUESTED_INCOMPATIBLE_QOS and ON_OFFERED_INCOMPATIBLE_QOS events (#125 <https://github.com/ros2/rmw_cyclonedds/issues/125>)
* Update conditional compile logic
* uncrustify (#124 <https://github.com/ros2/rmw_cyclonedds/issues/124>)
* Enable use of Cyclone DDS security features
* Prevent undefined behavior when serializing empty vector (#122 <https://github.com/ros2/rmw_cyclonedds/issues/122>)
* Add rmw_*_event_init() functions (#115 <https://github.com/ros2/rmw_cyclonedds/issues/115>)
* Contributors: Dan Rose, Erik Boasson, Ivan Santiago Paunovic, Miaofei Mei, Sid Faber, dodsonmg, eboasson
```
