### PR TITLE
robot_statemachine: 1.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9517,6 +9517,28 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: melodic-devel
     status: maintained
+  robot_statemachine:
+    doc:
+      type: git
+      url: https://github.com/MarcoStb1993/robot_statemachine.git
+      version: melodic-devel
+    release:
+      packages:
+      - robot_statemachine
+      - rsm_additions
+      - rsm_core
+      - rsm_msgs
+      - rsm_rqt_plugins
+      - rsm_rviz_plugins
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/MarcoStb1993/robot_statemachine-release.git
+      version: 1.1.3-1
+    source:
+      type: git
+      url: https://github.com/MarcoStb1993/robot_statemachine.git
+      version: melodic-devel
+    status: maintained
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_statemachine` to `1.1.3-1`:

- upstream repository: https://github.com/MarcoStb1993/robot_statemachine.git
- release repository: https://github.com/MarcoStb1993/robot_statemachine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## robot_statemachine

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_additions

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_core

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_msgs

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_rqt_plugins

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```

## rsm_rviz_plugins

```
* Added all dependencies to CMakeLists and package.xml, that were missing previously
* Contributors: MarcoStb1993
```
