### PR TITLE
robot_statemachine: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9517,6 +9517,28 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: melodic-devel
     status: maintained
+  robot_statemachine:
+    doc:
+      type: git
+      url: https://github.com/MarcoStb1993/robot_statemachine.git
+      version: melodic-devel
+    release:
+      packages:
+      - robot_statemachine
+      - rsm_additions
+      - rsm_core
+      - rsm_msgs
+      - rsm_rqt_plugins
+      - rsm_rviz_plugins
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/MarcoStb1993/robot_statemachine-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/MarcoStb1993/robot_statemachine.git
+      version: melodic-devel
+    status: maintained
   robot_upstart:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_statemachine` to `1.2.0-1`:

- upstream repository: https://github.com/MarcoStb1993/robot_statemachine.git
- release repository: https://github.com/MarcoStb1993/robot_statemachine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## robot_statemachine

```
* Removed double maintainer tags
* Contributors: MarcoStb1993
```

## rsm_additions

```
* Added parameter for navigation behavior on idle timer callback and
  gazeboToTf changed to ground plane
* Fixes for navigation idle timer
* Get Odom tf directly from gazebo instead of EKF
* Node to retrieve TF directly from gazebo
* Added reverse movement as unstuck behavior to navigation state
* Added params for idle timer and pose tolerance
* Compare pose to identify idling and state transition on goal obsolete
* Replaced simulated kinect with Intel RealSense to adapt to husky
  simulator melodic
* Clipped Kinect range to ignore laser scanner
* Now sets goal as finished only after completing mapping or routine state
* Fixed Kinect control joint name
* Exploration Goal Status is now published as a topic to prevent service deadlocks
* Removed failed goal services and added a publisher
* Added GoalCompleted service to give more detailed feedback over navigation completed status
* Added prefix to state name to identify autonomy behavior
* moved goalObsolete service to Additions and exploration completed goal out of navigation completed service
* Added navigation completed service call to goal obsolete callback
* Only publish exploration goals when explore_lite is used
* Additions Service Provider only subscribes and listens to services and topics for active plugins
* Added tutorial details for creating Calculate Goal and Navigation plugins
* Added services for handling completed navigation goals to remove the logic from the navigation plugin
* Link corrections in README
* Moved logic regarding explore_lite to AdditionsServiceProvider from ServiceProvider where they should belong
* Removed double maintainer tags
* Added joystick topic for teleoperation interrupt
* Properly reset shared_ptr to prevent errors on close
* Contributors: Marco Steinbrink, MarcoStb1993, marco
```

## rsm_core

```
* Added parameter for navigation behavior on idle timer callback and
  gazeboToTf changed to ground plane
* Replaced simulated kinect with Intel RealSense to adapt to husky
  simulator melodic
* Now starts exploration with mapping state
* Exploration Goal Status is now published as a topic to prevent service deadlocks
* Removed failed goal services and added a publisher
* Added GoalCompleted service to give more detailed feedback over navigation completed status
* Added prefix to state name to identify autonomy behavior
* moved goalObsolete service to Additions and exploration completed goal out of navigation completed service
* Fix wrong error message on service failure
* Added class and state diagram to documentation
* Added tutorial details for creating Calculate Goal and Navigation plugins
* Added services for handling completed navigation goals to remove the logic from the navigation plugin
* Moved logic regarding explore_lite to AdditionsServiceProvider from ServiceProvider where they should belong
* Removed double maintainer tags
* Updated README with joystick listener addition
* Added joystick topic for teleoperation interrupt
* Properly reset shared_ptr to prevent errors on close
* Contributors: Marco Steinbrink, MarcoStb1993, marco
```

## rsm_msgs

```
* Put GetRobotPose service back in
* Exploration Goal Status is now published as a topic to prevent service deadlocks
* Removed failed goal services and added a publisher
* Added GoalCompleted service to give more detailed feedback over navigation completed status
* Added prefix to state name to identify autonomy behavior
* Added services for handling completed navigation goals to remove the logic from the navigation plugin
* Removed double maintainer tags
* Contributors: MarcoStb1993
```

## rsm_rqt_plugins

```
* Added prefix to state name to identify autonomy behavior
* Removed double maintainer tags
* Debounced operation mode buttons
* Contributors: MarcoStb1993
```

## rsm_rviz_plugins

```
* Now starts exploration with mapping state
* Added prefix to state name to identify autonomy behavior
* Removed double maintainer tags
* Debounced operation mode buttons
* Contributors: MarcoStb1993
```
