### PR TITLE
Add 'conan' rosdep key to be resolved using pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -108,7 +108,7 @@ cmakelint-pip:
   ubuntu:
     pip:
       packages: [cmakelint]
-conan:
+python3-conan-pip:
   debian:
     pip:
       packages: [conan]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -108,16 +108,6 @@ cmakelint-pip:
   ubuntu:
     pip:
       packages: [cmakelint]
-python3-conan-pip:
-  debian:
-    pip:
-      packages: [conan]
-  fedora:
-    pip:
-      packages: [conan]
-  ubuntu:
-    pip:
-      packages: [conan]
 cppcheck-junit-pip:
   debian:
     pip:
@@ -5596,6 +5586,16 @@ python3-colorama:
   gentoo: [dev-python/colorama]
   rhel: ['python%{python3_pkgversion}-colorama']
   ubuntu: [python3-colorama]
+python3-conan-pip:
+  debian:
+    pip:
+      packages: [conan]
+  fedora:
+    pip:
+      packages: [conan]
+  ubuntu:
+    pip:
+      packages: [conan]
 python3-connexion-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -108,6 +108,16 @@ cmakelint-pip:
   ubuntu:
     pip:
       packages: [cmakelint]
+conan:
+  debian:
+    pip:
+      packages: [conan]
+  fedora:
+    pip:
+      packages: [conan]
+  ubuntu:
+    pip:
+      packages: [conan]
 cppcheck-junit-pip:
   debian:
     pip:


### PR DESCRIPTION
This enables using [conan](https://conan.io/) ([pypi package](https://pypi.org/project/conan/)) package manager to resolve dependencies (e.g. using [conan-cmake](https://github.com/conan-io/cmake-conan)) which may not be available via the usual rosdep sources, while respecting the usual workflow to build packages from source.

I reckon this may not be desired for packages to be released as binaries using the buildfarm, but it would be very helpful for packages which are never intended to go through the binary release process.