### PR TITLE
bota_driver: 0.5.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -312,7 +312,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.5-1
+      version: 0.5.7-1
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.7-1`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.5-1`

## bota_device_driver

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## bota_driver

```
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## bota_node

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* Contributors: Mike Karamousadakis
```

## bota_signal_handler

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* Contributors: Mike Karamousadakis
```

## bota_worker

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* Contributors: Mike Karamousadakis
```

## rokubimini

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* Support clang format 8
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_description

```
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## rokubimini_ethercat

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_examples

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## rokubimini_factory

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_manager

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```

## rokubimini_msgs

```
* Fix gcc error for extended alignment
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Contributors: Mike Karamousadakis
```

## rokubimini_serial

```
* Release master 0.5.6
* change minimum cmake version required to 3.0.2
* Support clang format 8
* Contributors: Mike Karamousadakis
```
