### PR TITLE
rostest_node_interface_validation: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10442,6 +10442,21 @@ repositories:
       url: https://github.com/OUXT-Polaris/rostate_machine.git
       version: master
     status: developed
+  rostest_node_interface_validation:
+    doc:
+      type: git
+      url: https://github.com/tecnalia-advancedmanufacturing-robotics/rostest_node_interface_validation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tecnalia-advancedmanufacturing-robotics/rostest_node_interface_validation-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/tecnalia-advancedmanufacturing-robotics/rostest_node_interface_validation.git
+      version: melodic-devel
+    status: maintained
   rosthrottle:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rostest_node_interface_validation` to `0.2.0-1`:

- upstream repository: https://github.com/tecnalia-advancedmanufacturing-robotics/rostest_node_interface_validation.git
- release repository: https://github.com/tecnalia-advancedmanufacturing-robotics/rostest_node_interface_validation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rostest_node_interface_validation

```
* update package name
* Contributors: Anthony Remazeilles
```
