### PR TITLE
rmw: 2.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1551,7 +1551,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 2.1.0-1
+      version: 2.2.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `2.2.0-2`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.1.0-1`

## rmw

```
* Extend rmw_qos_policy_kind_t, add functions to convert it to/from a string (#285 <https://github.com/ros2/rmw/issues/285>)
* Add functions to convert between qos policy values and strings (#284 <https://github.com/ros2/rmw/issues/284>)
* Update maintainers (#282 <https://github.com/ros2/rmw/issues/282>)
* Update service request/response API documentation (#279 <https://github.com/ros2/rmw/issues/279>)
* Update rmw_get_serialized_message_size docblock (#281 <https://github.com/ros2/rmw/issues/281>)
* Update rmw_service_server_is_available doc (#280 <https://github.com/ros2/rmw/issues/280>)
* Update wait and wait sets' API documentation (#275 <https://github.com/ros2/rmw/issues/275>)
* Update graph API documentation (#272 <https://github.com/ros2/rmw/issues/272>)
* Update service server/client creation/destruction API documentation. (#276 <https://github.com/ros2/rmw/issues/276>)
* Update rmw_*_*_allocation return values (#278 <https://github.com/ros2/rmw/issues/278>)
* Update gid API documentation (#274 <https://github.com/ros2/rmw/issues/274>)
* Do not link against pthread on Android (#267 <https://github.com/ros2/rmw/issues/267>)
* Update taking API documentation (#271 <https://github.com/ros2/rmw/issues/271>)
* Update publishing API documentation (#270 <https://github.com/ros2/rmw/issues/270>)
* Add fault injection macros for use in other packages (#254 <https://github.com/ros2/rmw/issues/254>)
* Add bad_alloc return to topic_endpoint_info functions (#269 <https://github.com/ros2/rmw/issues/269>)
* Update publisher/subscription matched count API documentation (#262 <https://github.com/ros2/rmw/issues/262>)
* Update publisher/subscription QoS query API documentation (#263 <https://github.com/ros2/rmw/issues/263>)
* Extend rmw_serialized_message_t tests (#261 <https://github.com/ros2/rmw/issues/261>)
* Update serialization/deserialization API documentation (#258 <https://github.com/ros2/rmw/issues/258>)
* Update subscription API documentation (#256 <https://github.com/ros2/rmw/issues/256>)
* Update publisher creation/destruction API documentation (#252 <https://github.com/ros2/rmw/issues/252>)
* Contributors: Alejandro Hernández Cordero, Ivan Santiago Paunovic, Jacob Perron, Michel Hidalgo, brawner
```

## rmw_implementation_cmake

```
* Update maintainers (#282 <https://github.com/ros2/rmw/issues/282>)
* Contributors: Ivan Santiago Paunovic
```
