### PR TITLE
Adding llvm and llvm-dev to rosdep.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4686,6 +4686,16 @@ linux-kernel-headers:
   fedora: [kernel-headers]
   gentoo: [sys-kernel/linux-headers]
   ubuntu: [linux-libc-dev]
+llvm:
+  arch: [llvm]
+  debian: [llvm]
+  gentoo: [sys-devel/llvm]
+  ubuntu: [llvm]
+llvm-dev:
+  arch: [llvm]
+  debian: [llvm-dev]
+  gentoo: [sys-devel/llvm]
+  ubuntu: [llvm-dev]
 lm-sensors:
   arch: [lm_sensors]
   debian: [lm-sensors]


### PR DESCRIPTION
LLVM:
  - debian: https://packages.debian.org/search?keywords=llvm&searchon=names&suite=all&section=all
  - ubuntu: https://packages.ubuntu.com/search?keywords=llvm&searchon=names&suite=all&section=all

LLVM dev:
  - debian: https://packages.debian.org/search?searchon=names&keywords=llvm-dev
  - ubuntu: https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=llvm-dev&searchon=names

LLVM and LLVM dev:
  - arch: https://www.archlinux.org/packages/?sort=&q=llvm&maintainer=&flagged=
  - gentoo: https://packages.gentoo.org/packages/sys-devel/llvm