### PR TITLE
navigation2: 0.4.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1666,10 +1666,11 @@ repositories:
       - nav_2d_msgs
       - nav_2d_utils
       - navigation2
+      - smac_planner
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.4.3-1
+      version: 0.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.4.5-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.3-1`
