### PR TITLE
toposens: 2.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5822,6 +5822,24 @@ repositories:
       version: master
     status: maintained
   toposens:
+    doc:
+      type: git
+      url: https://gitlab.com/toposens/public/ros-packages.git
+      version: master
+    release:
+      packages:
+      - toposens
+      - toposens_bringup
+      - toposens_description
+      - toposens_driver
+      - toposens_markers
+      - toposens_msgs
+      - toposens_pointcloud
+      - toposens_sync
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.com/toposens/public/toposens-release.git
+      version: 2.1.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.1.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## toposens

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_bringup

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_description

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_driver

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_markers

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_msgs

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_pointcloud

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_sync

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```
