### PR TITLE
industrial_core: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2102,6 +2102,15 @@ repositories:
       url: https://github.com/ccny-ros-pkg/imu_tools.git
       version: noetic
     status: developed
+  industrial_core:
+    release:
+      packages:
+      - industrial_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/industrial_core-release.git
+      version: 0.7.1-1
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_core` to `0.7.1-1`:

- upstream repository: https://github.com/ros-industrial/industrial_core.git
- release repository: https://github.com/ros-industrial-release/industrial_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## industrial_msgs

```
* Updated all package xml files to version 2 (#232 <https://github.com/ros-industrial/industrial_core/issues/232>)
* all: update maintainer email addresses (#222 <https://github.com/ros-industrial/industrial_core/issues/222>)
* remove unneeded genmsg dependency (#223 <https://github.com/ros-industrial/industrial_core/issues/223>)
* Contributors: Jeremy Zoss, Jorge Nicho, gavanderhoorn
```
