### PR TITLE
grasping_msgs: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1875,6 +1875,21 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/graph_msgs.git
       version: jade-devel
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros1
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mikeferguson/grasping_msgs-gbp.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros1
+    status: maintained
   haf_grasping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grasping_msgs` to `0.3.1-1`:

- upstream repository: git@github.com:mikeferguson/grasping_msgs.git
- release repository: https://github.com/mikeferguson/grasping_msgs-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## grasping_msgs

```
* update email
* update description in package.xml
* Contributors: Michael Ferguson
```
