### PR TITLE
move_base_flex: 0.3.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6067,7 +6067,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.3.3-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.2-1`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

```
* On move_base action, handle properly RECALLED, REJECTED and LOST status, see #228
* Fill recovery result field used_plugin, see #229
* Signal from setState function, see #236
* Controller fails if robot pose gets older than tf_timeout, see #231
* Send move_base result when canceled during exe_path and recovery, see #218
* On controller cancel, wait for the control loop to stop, see #215
* Ensure MBF does not crash upon receiving an empty path, see #214
* Make robot_info a reference to keep one single instance, see #204
* mbf_abstract_nav action event logging from INFO to DEBUG, see #203
* Fix deallocation on shutdown by discarding all plugins and resetting action server pointers, see #199
* Move RobotInformation to mbf_utility, as it can be used generaly, see #196
```

## mbf_costmap_core

```
* Fix reference to TF is ambiguous, see #221
```

## mbf_costmap_nav

```
* Fix controller fails if robot pose gets older than tf_timeout, see #231
* clear the costmap before deactivating it, see #220
* Use catkin_install_python to install legacy relay. see #219
* For move_base_legacy_relay, keep configured base local and global planners to send to MBF, see #209
* Fix deallocation on shutdown by discarding all plugins and resetting action server pointers, see #199
* Make reference symbol position consistent across the project, see #198
* Move RobotInformation to mbf_utility, as it can be used generaly, see #196
* Prevent unrelated type casts for Cell, see #197
```

## mbf_msgs

- No changes

## mbf_simple_nav

- No changes

## mbf_utility

```
* fix controller fails if robot pose gets older than tf_timeout
* Make reference symbol position consistent across the project
* Move RobotInformation to mbf_utility, as it can be used generally
```

## move_base_flex

```
* Add mbf_utility to move_base_flex metapackag
```
