### PR TITLE
bond_core: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -205,6 +205,28 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: ros2
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - smclib
+      - test_bond
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/bond_core-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: ros2
+    status: maintained
   cartographer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `2.0.0-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## bond

```
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas
```

## bond_core

```
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas
```

## bondcpp

```
* Lifecycle support 2 (#67 <https://github.com/ros/bond_core/issues/67>)
* find uuid correctly on ubuntu and osx (#55 <https://github.com/ros/bond_core/issues/55>)
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas, Steve Macenski
```

## smclib

```
* fix deprecation warnings (#56 <https://github.com/ros/bond_core/issues/56>)
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas
```

## test_bond

```
* Lifecycle support 2 (#67 <https://github.com/ros/bond_core/issues/67>)
* find uuid correctly on ubuntu and osx (#55 <https://github.com/ros/bond_core/issues/55>)
* Ros2 devel (#54 <https://github.com/ros/bond_core/issues/54>)
* Make Michael Carroll the maintainer (#40 <https://github.com/ros/bond_core/issues/40>)
* Contributors: Karsten Knese, Mikael Arguedas, Steve Macenski
```
