### PR TITLE
industrial_robot_status_controller: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2151,6 +2151,24 @@ repositories:
       url: https://github.com/ros-industrial-release/industrial_core-release.git
       version: 0.7.1-1
     status: maintained
+  industrial_robot_status_controller:
+    doc:
+      type: git
+      url: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
+      version: master
+    release:
+      packages:
+      - industrial_robot_status_controller
+      - industrial_robot_status_interface
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
+      version: master
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `industrial_robot_status_controller` to `0.1.2-1`:

- upstream repository: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
- release repository: https://github.com/gavanderhoorn/industrial_robot_status_controller-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## industrial_robot_status_controller

```
* Fix potential build ordering problem with industrial_msgs pkg. (#4 <https://github.com/gavanderhoorn/industrial_robot_status_controller/issues/4>)
* Contributors: Bianca Homberg
```

## industrial_robot_status_interface

- No changes
