### PR TITLE
pointgrey_camera_driver: 0.15.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3838,7 +3838,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
-      version: master
+      version: noetic-devel
     release:
       packages:
       - image_exposure_msgs
@@ -3853,7 +3853,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/pointgrey_camera_driver.git
-      version: master
+      version: noetic-devel
     status: maintained
   power_msgs:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3834,6 +3834,27 @@ repositories:
       url: https://github.com/ros-perception/pointcloud_to_laserscan.git
       version: lunar-devel
     status: maintained
+  pointgrey_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    release:
+      packages:
+      - image_exposure_msgs
+      - pointgrey_camera_description
+      - pointgrey_camera_driver
+      - statistics_msgs
+      - wfov_camera_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
+      version: 0.15.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/pointgrey_camera_driver.git
+      version: master
+    status: maintained
   power_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointgrey_camera_driver` to `0.15.0-1`:

- upstream repository: https://github.com/ros-drivers/pointgrey_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## image_exposure_msgs

- No changes

## pointgrey_camera_description

- No changes

## pointgrey_camera_driver

```
* [pointgrey_camera_driver] Added support for Focal. Updated CI for Noetic.
* Fix the script & cmake file so that the archives are downloaded & unpacked correctly
* Fix the flycap download script to work with Python3
* Contributors: Chris I-B, Chris Iverach-Brereton, Tony Baltovski
```

## statistics_msgs

- No changes

## wfov_camera_msgs

- No changes
