### PR TITLE
exotica: 6.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1450,6 +1450,44 @@ repositories:
       url: https://github.com/ros-visualization/executive_smach_visualization.git
       version: melodic-devel
     status: unmaintained
+  exotica:
+    doc:
+      type: git
+      url: https://github.com/ipab-slmc/exotica.git
+      version: master
+    release:
+      packages:
+      - exotica
+      - exotica_aico_solver
+      - exotica_cartpole_dynamics_solver
+      - exotica_collision_scene_fcl_latest
+      - exotica_core
+      - exotica_core_task_maps
+      - exotica_ddp_solver
+      - exotica_double_integrator_dynamics_solver
+      - exotica_dynamics_solvers
+      - exotica_examples
+      - exotica_ik_solver
+      - exotica_ilqg_solver
+      - exotica_ilqr_solver
+      - exotica_levenberg_marquardt_solver
+      - exotica_ompl_control_solver
+      - exotica_ompl_solver
+      - exotica_pendulum_dynamics_solver
+      - exotica_pinocchio_dynamics_solver
+      - exotica_python
+      - exotica_quadrotor_dynamics_solver
+      - exotica_scipy_solver
+      - exotica_time_indexed_rrt_connect_solver
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipab-slmc/exotica-release.git
+      version: 6.0.0-1
+    source:
+      type: git
+      url: https://github.com/ipab-slmc/exotica.git
+      version: master
+    status: developed
   exotica_val_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica` to `6.0.0-1`:

- upstream repository: https://github.com/ipab-slmc/exotica.git
- release repository: https://github.com/ipab-slmc/exotica-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## exotica

```
* Remove usage of exotica_collision_scene_fcl
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* ROS Noetic/Python3 compatibility
* Make CollisionScene Instantiable
  - Makes CollisionScene instantiable with an Initializer
  - Moves CollisionScene related properties from SceneInitializer to
  CollisionSceneInitializer
  - Adds ability to _not_ load any default CollisionScene. E.g., when not
  considering collision avoidance. This makes exotica_core
  runtime-independent of exotica_collision-scene_fcl and also allows for
  faster start.
  - Adds property of a robot link replacement config to CollisionScene
* Move ROS Indigo (14.04) instructions to separate file
* Added visualisation docs
* Contributors: Vladimir Ivan, Wolfgang Merkt
```

## exotica_aico_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Contributors: Wolfgang Merkt
```

## exotica_cartpole_dynamics_solver

```
* Remove test dependency on exotica_collision_scene_fcl (#726 <https://github.com/ipab-slmc/exotica/issues/726>)
* Move URDF/SRDF from exotica_examples to dynamics solver package to resolve circular dependency
* DynamicsSolver: add has_second_order_derivatives
* Code clean-up, e.g., remove unused private member variables
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Contributors: Wolfgang Merkt
```

## exotica_collision_scene_fcl_latest

```
* Remove usage of exotica_collision_scene_fcl; add backwards compatibility using exotica_collision_scene_fcl_latest (#726 <https://github.com/ipab-slmc/exotica/issues/726>)
* Fix transform bug fix, remove usage of tf_conversions (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Merge remote-tracking branch 'origin/master'
* Return after first ACM entry is found
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Move to Initializer initialisation of collision scenes
* Check whether transform contains NaNs (translation)
* CollisionScene: Store whether update of objects is required
* CollisionScene: Add setter/getter for replace_cylinder_with_capsule, do not store duplicate company of world links to be excluded from collision scene
* Contributors: Vladimir Ivan, Wolfgang Merkt
```

## exotica_core

```
* Upgrade standard to C++14 for new pybind11 version
* Updates and fixes, including speed optimisation, to many areas including: DynamicsSolver, DynamicTimeIndexedShootingProblem, CollisionScene (now instantiable), support for instantiating geometry shapes, meshes, and octrees from initialisers, etc.
* Added support for kinematic Hessians
* New integration schemes for dynamic problems: symplectic integrators; added state transition function
* Add support for dynamic task maps, i.e., those that depend on both x (configuration+velocity) and u (control)
* Add sparse costs
* Add a second BoxQP
* Meshcat visualisation
* Joint velocity and acceleration limits
* Contributors: Matt Timmons-Brown, Traiko Dinev, Vladimir Ivan, Wolfgang Merkt
```

## exotica_core_task_maps

```
* Remove usage of exotica_collision_scene_fcl; add backwards compatibility
* Fix segmentation fault for joint smoothing task maps
* test_maps: Upgrade collision scene to initializer
* EffFrame: Fix indexing bug for >1 end-effector
* test_maps: Add multi-end-effector unit test for EffFrame
* JointPose: Add set_joint_ref
* test_maps: testCollisionDistance - update initialiser, deactivate Jacobian test
* test_maps: Change to lp-Infinity-norm
* CollisionDistance: Fix Jacobian being off by -1
* test_maps: Change test_jacobian to central difference
* test_maps: Add collision links to the URDF
* Fix unittests for older versions of googletest
* Do not re-define GoogleTest color constants
* More informative exceptions
* package.xml: Add missing test dependencies
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Add note to test_maps that SphereCollision throws
* SmoothCollisionDistance: Fix in point Jacobian
* Add VariableSizeCollisionDistance
* SmoothCollisionDistance: Support nullptr for collision elements
* SmoothCollisionDistance: Make more readable, allocate less in loop
* JointPose: Implement get_joint_ref, get_joint_map
* EffAxisAlignment: Efficiency improvements
* Distance: Implement Hessian
* Add README tracking Hessian implementations
* test_maps: Test ContinuousJointPose Hessian
* PointToPlane: Implement Hessian, Simplify equation to EffPositionZ
* Test JointLimit, expose ControlRegularization to Python
* JointPose: Implement Hessian
* EffFrame: Implement Hessian
* test_maps: Test hessians for EffPosition, EffPositionXY, EffOrientation
* EffOrientation: Implement Hessian
* EffPositionXY: Implement Hessian
* test_maps: More informative exception handling
* test_maps: Set default DerivativeOrder to 2
* test_maps: Add test_hessian
* test_maps: Change test_jacobian to central difference
* Add ControlRegularization
* EffPosition: Fix Hessian indexing
* Make rotation_type private, add getter, fix instantiation
* EffPosition: Implement Hessian
* JointLimit: Fix Jacobian, add dynamic update methods
* Fix unit test for testJointLimit
* ContinuousJointPose: Add Hessian
* test_maps: Use const-ref
* SumOfPenetrations: Update to new, faster collision distance
* EffAxisAlignment: Clear debug topic on start
* EffAxisAlignment: Added debug visualisation
* Add unittest for EffPositionXY
* Contributors: Wolfgang Merkt
```

## exotica_ddp_solver

```
* FDDP: More verbosity on NaN
* Use state transition function + derivative in place of hard-coded scheme
* BoxFDDP: Set default BoxQP options
* (Box)FDDP: Add GradientTolerance convergence criterion
* Add steplength and regularization evolution
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* FDDP: Only allocate if T changed
* FDDP: Use const-ref for warm-start
* Expose all internal data via const-ref getter
* Switch FDDP to LDLT decomposition
* Only contract with 2nd order derivatives if DynamicsSolver has them
* Pre-allocate, go over equations, convert to trajectory pre-allocation
* ControlLimitedDDPSolver: Clean-up Qxx, Qxu, Quu computation
* Move costs from Solver to Problem
* ControlLimitedDDPSolver: Add parameter for switching different BoxQP solvers
* Introduce thresholds for increase/decrease of regularization
* ControlLimitedDDPSolver: Add state regularization
* Re-use already allocated variables. Fixes #678 <https://github.com/ipab-slmc/exotica/issues/678>
* Control-limited DDP: Use fixed, low regularization for BoxQP
* FDDP: Remove exception in ForwardPass
* FDDP: Replace exception to adapt regularisation
* FDDP: Use copy instead of reference to reset shooting nodes
* BoxDDP: Clamp in forward-pass
* Refactor FDDP to Abstract + Implementation
* Fix NX => NDX bugs
* Add BoxFDDP
* Correctly resize matrices, speed up AnalyticDDPSolver::BackwardPass by using LLT
* Use DynamicsSolver::ComputeDerivatives
* Add FeasibilityDrivenDDPSolver
* Contributors: Traiko Dinev, Wolfgang Merkt
```

## exotica_double_integrator_dynamics_solver

```
* Implement ComputeDerivatives, correctly set up state transition derivatives. This includes updating Fx, Fu when changing integrators
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Moved unit test to exotica_examples due to circular dependency
* Bug fixes, added unit test
* Contributors: Wolfgang Merkt
```

## exotica_dynamics_solvers

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Contributors: Wolfgang Merkt
```

## exotica_examples

```
* Add new examples for sparsity-inducing optimal control and fix optimal control examples
* Add unit tests
* Add example for Dubin's state space
* Contributors: Traiko Dinev, Vladimir Ivan, Wolfgang Merkt
```

## exotica_ik_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Re-wrote the IK solver as regularised, weighted pseudo-inverse
  Re-wrote the IK solver from scratch:
  - It now implements a regularised and weighted Jacobian pseudo-inverse
  instead of solving a linear system.
  - The support for NominalState regularisation by appending a nominal
  state to the error vector was removed.
  - Adaptive regularisation and backtracking line-search result in better
  convergence and numerical behaviour.
  - Use of pre-allocation and Cholesky decomposition makes the solver fast
  :-).
  - MaxStep for interactive IK is still supported, however, only when
  MaxIterations == 1.
  - example_ik now converges in 5 iterations, previously 41.
* Contributors: Vladimir Ivan, Wolfgang Merkt
```

## exotica_ilqg_solver

```
* Use state transition derivatives (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048 (#720 <https://github.com/ipab-slmc/exotica/issues/720>)
* Upgrade get_num_positions etc. (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Use DynamicsSolver::ComputeDerivatives (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Move costs from Solver to Problem (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Numerous bug fixes (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Contributors: Traiko Dinev, Wolfgang Merkt
```

## exotica_ilqr_solver

```
* Use state transition derivatives (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048 (#720 <https://github.com/ipab-slmc/exotica/issues/720>)
* Upgrade get_num_positions etc. (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Use DynamicsSolver::ComputeDerivatives (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Contributors: Wolfgang Merkt
```

## exotica_levenberg_marquardt_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Use pre-allocation & Cholesky decomposition: 16% speed-up
* Contributors: Wolfgang Merkt
```

## exotica_ompl_control_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048 (#720 <https://github.com/ipab-slmc/exotica/issues/720>)
* Upgrade get_num_positions etc. (#723 <https://github.com/ipab-slmc/exotica/issues/723>)
* Contributors: Wolfgang Merkt
```

## exotica_ompl_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048 (#720 <https://github.com/ipab-slmc/exotica/issues/720>)
  Add Dubin's state-space support for OMPL solvers (#707 <https://github.com/ipab-slmc/exotica/issues/707>)
* Contributors: Wolfgang Merkt, mspahn
```

## exotica_pendulum_dynamics_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Contributors: Wolfgang Merkt
```

## exotica_pinocchio_dynamics_solver

```
* Add state transition function, derivative.
* Support explicit Euler and semi-implicit Euler integration schemes
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Fix Pinocchio packaging (for later versions)
* Add dynamics solver with gravity compensation
* Fix analytic derivatives and remove memory allocation during the computation
* Contributors: Wolfgang Merkt
```

## exotica_python

```
* Noetic/20.04 compatibility
* More unit testing tools and tests
* Expose more features to Python
* Fix issues with instantiation from Python using Initializers and tuple lists
* Contributors: Matt Timmons-Brown, Traiko Dinev, Vladimir Ivan, Wolfgang Merkt
```

## exotica_quadrotor_dynamics_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Code clean-up
* Contributors: Wolfgang Merkt
```

## exotica_scipy_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048 (#720 <https://github.com/ipab-slmc/exotica/issues/720>)
* ROS Noetic/Python3 compatibility (#720 <https://github.com/ipab-slmc/exotica/issues/720>)
* Code clean-up (#702 <https://github.com/ipab-slmc/exotica/issues/702>)
* Contributors: Wolfgang Merkt
```

## exotica_time_indexed_rrt_connect_solver

```
* CMakeLists: Upgrade minimum version to 3.0.2 to avoid CMP0048
* Fix and reset time-space bounds, add planning time
* Contributors: Wolfgang Merkt
```
