### PR TITLE
seed_smartactuator_sdk: 0.0.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -14869,7 +14869,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `seed_smartactuator_sdk` to `0.0.5-1`:

- upstream repository: https://github.com/seed-solutions/seed_smartactuator_sdk.git
- release repository: https://github.com/seed-solutions/seed_smartactuator_sdk-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.4-1`
