### PR TITLE
rospy_message_converter: 0.5.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4872,7 +4872,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/rospy_message_converter-release.git
-      version: 0.5.4-1
+      version: 0.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.5-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.4-1`

## rospy_message_converter

```
* Decode strings from ROS messages as UTF8
  This makes the python2 behavior equal to python3.
* python3 only: Validate base64 strings
* Add bytes to python3 string types
  This means that bytes will now also be base64-decoded, which fixes the following tests on python3:
  * test_dictionary_with_uint8_array_bytes
  * test_dictionary_with_uint8_array_bytes_unencoded
  * test_dictionary_with_3uint8_array_bytes
  On python2, bytes is just an alias for str, which is why it worked
  without this.
* Fix and add tests
* Contributors: Martin Günther
```
