### PR TITLE
backward_ros: 0.1.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -233,6 +233,21 @@ repositories:
       url: https://github.com/astuff/avt_vimba_camera.git
       version: master
     status: maintained
+  backward_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pal-gbp/backward_ros-release.git
+      version: 0.1.7-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: kinetic-devel
+    status: maintained
   baldor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `0.1.7-1`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/pal-gbp/backward_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## backward_ros

```
* Merge pull request #3 from veimox/bugfix/fix-tests-headers
  modified heders to be included with current cmake configuration
* modified heders to be included with current cmake configuration
* Contributors: Jorge Rodriguez, Victor Lopez
```
