### PR TITLE
toposens: 2.1.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16167,6 +16167,7 @@ repositories:
     release:
       packages:
       - toposens
+      - toposens_bringup
       - toposens_description
       - toposens_driver
       - toposens_markers
@@ -16176,7 +16177,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.0.4-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.1.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.4-1`

## toposens

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_bringup

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_description

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_driver

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_markers

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_msgs

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_pointcloud

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```

## toposens_sync

```
* Introduce bringup package and general updates.
* Prepare for Noetic release
* Run separate CI stages for melodic+noetic. Bump up CMake version to 3.0.2.
* Contributors: Tobias Roth
```
