### PR TITLE
rosbag_snapshot: 1.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4657,7 +4657,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rosbag_snapshot-release.git
-      version: 1.0.1-1
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_snapshot` to `1.0.3-1`:

- upstream repository: https://github.com/ros/rosbag_snapshot.git
- release repository: https://github.com/ros-gbp/rosbag_snapshot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-1`
