### PR TITLE
rosdep: add libcgroup-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2141,6 +2141,12 @@ libceres-dev:
   rhel:
     '7': [ceres-solver-devel]
   ubuntu: [libceres-dev]
+libcgroup-dev:
+  debian: [libcgroup-dev]
+  fedora: [libcgroup-devel]
+  gentoo: [dev-libs/libcgroup]
+  openembedded: [libcgroup@openembedded-core]
+  ubuntu: [libcgroup-dev]
 libclang-dev:
   arch: [clang]
   debian: [libclang-dev]


### PR DESCRIPTION
## Package name:

libcgroup-dev

## Package Upstream Source:

https://github.com/libcgroup/libcgroup

## Purpose of using this:

libcgroup-dev is useful to controlling cgroups. Specifically it can be
useful for managing memory usage and oom behavior for systemd services.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/libcgroup-dev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/xenial/libcgroup-dev
- Fedora: https://apps.fedoraproject.org/packages/
  - This link seems to be broken and it's not clear where to find this kind of information for Fedora now. This package does exist on fedora and has been added.
- Arch: https://www.archlinux.org/packages/
  - Not available
- Gentoo: https://packages.gentoo.org/packages/
  - https://packages.gentoo.org/packages/dev-libs/libcgroup
- macOS: https://formulae.brew.sh/
  - Not available (cgroups don't exist on mac)
