### PR TITLE
v4l2_camera: 0.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3960,7 +3960,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.3.1-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.0-1`

## v4l2_camera

```
* Handle non discrete frame sizes; fixes support for Raspberry Pi + Camera Module
* Contributors: Sander G. van Dijk
```
