### PR TITLE
Change the teleop_twist_joy branch to foxy.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3596,7 +3596,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: eloquent
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -3606,7 +3606,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: eloquent
+      version: foxy
     status: maintained
   teleop_twist_keyboard:
     doc:


### PR DESCRIPTION
This has some fixes which are only relevant for Foxy and later.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>