### PR TITLE
Change the Rolling teleop_twist_joy branch to foxy.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2516,7 +2516,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: eloquent
+      version: foxy
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2526,7 +2526,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/teleop_twist_joy.git
-      version: eloquent
+      version: foxy
     status: maintained
   teleop_twist_keyboard:
     doc:


### PR DESCRIPTION
This has some fixes which are only relevant for Foxy and later.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>