### PR TITLE
teleop_twist_joy: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2521,7 +2521,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.4.0-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.3.0-1`

## teleop_twist_joy

```
* Switch to modern ReadyToTest for the tests.
* Switch from node_executable -> executable for Foxy.
* Update README for Ros2 (#17 <https://github.com/ros2/teleop_twist_joy/issues/17>) (#18 <https://github.com/ros2/teleop_twist_joy/issues/18>)
* Contributors: Chris Lalancette, nfry321
```
