### PR TITLE
velodyne: 1.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6213,7 +6213,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/velodyne-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.6.1-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros-drivers-gbp/velodyne-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.6.0-1`

## velodyne

- No changes

## velodyne_driver

- No changes

## velodyne_laserscan

- No changes

## velodyne_msgs

- No changes

## velodyne_pcl

```
* Fix typo in velodyne_pcl/point_types.h (#357 <https://github.com/ros-drivers/velodyne/issues/357>)
  Fixes an issue where the POINT_CLOUD_REGISTER_POINT_STRUCT function was using the old PointXYZIR and not PointXYZIRT.
* Contributors: Matthew Hannay
```

## velodyne_pointcloud

```
* Add invalid points in organized cloud (#360 <https://github.com/ros-drivers/velodyne/issues/360>)
  * Set NaN in ordered point cloud in case of no return
  * Adapt to current master
  * consider min/max angle and timing_offsets also in organized mode
  Co-authored-by: Nuernberg Thomas (CR/AEV4) <mailto:thomas.nuernberg@de.bosch.com>
* build and export library data_containers so it can be used in other packages (#359 <https://github.com/ros-drivers/velodyne/issues/359>)
* Contributors: Sebastian Scherer
```
