### PR TITLE
core_perception: 1.14.9-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -936,8 +936,8 @@ repositories:
   core_perception:
     doc:
       type: git
-      url: https://github.com/Autoware-AI/core_perception.git
-      version: master
+      url: https://github.com/nobleo/core_perception.git
+      version: points_preprocessor_release_noetic
     release:
       packages:
       - points_preprocessor
@@ -945,6 +945,10 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/core_perception-release.git
       version: 1.14.9-2
+    source:
+      type: git
+      url: https://github.com/nobleo/core_perception.git
+      version: points_preprocessor_release_noetic
     status: maintained
   costmap_converter:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -933,6 +933,19 @@ repositories:
       url: https://github.com/ros/convex_decomposition.git
       version: melodic-devel
     status: unmaintained
+  core_perception:
+    doc:
+      type: git
+      url: https://github.com/Autoware-AI/core_perception.git
+      version: master
+    release:
+      packages:
+      - points_preprocessor
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/core_perception-release.git
+      version: 1.14.9-2
+    status: maintained
   costmap_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `core_perception` to `1.14.9-2`:

- upstream repository: https://github.com/nobleo/core_perception.git
- release repository: https://github.com/nobleo/core_perception-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## points_preprocessor

```
* Remove Autoware Health Checker as dependency
* Contributors: Tim Clephas
```
