### PR TITLE
rmw_fastrtps: 1.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2555,7 +2555,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.2.3-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.2-1`

## rmw_fastrtps_cpp

```
* Update maintainer list for Foxy (#474 <https://github.com/ros2/rmw_fastrtps/issues/474>)
* Updated QD
* Provide external dependencies QD links
* Update Quality Declarations to QL3 (#404 <https://github.com/ros2/rmw_fastrtps/issues/404>)(#403 <https://github.com/ros2/rmw_fastrtps/issues/403>)
* Contributors: Alejandro Hernández Cordero, JLBuenoLopez-eProsima, Michael Jeronimo, Michel Hidalgo
```

## rmw_fastrtps_dynamic_cpp

```
* Update maintainer list for Foxy (#474 <https://github.com/ros2/rmw_fastrtps/issues/474>)
* Updated QD
* Provide external dependencies QD links
* Contributors: Alejandro Hernández Cordero, JLBuenoLopez-eProsima, Michael Jeronimo
```

## rmw_fastrtps_shared_cpp

```
* Remove unused headers MessageTypeSupport.hpp and ServiceTypeSupport.hpp (#481 <https://github.com/ros2/rmw_fastrtps/issues/481>) (#482 <https://github.com/ros2/rmw_fastrtps/issues/482>)
* Update maintainer list for Foxy (#474 <https://github.com/ros2/rmw_fastrtps/issues/474>)
* Updated QD
* Provide external dependencies QD links
* Update Quality Declarations to QL3 (#404 <https://github.com/ros2/rmw_fastrtps/issues/404>)
* Contributors: Alejandro Hernández Cordero, JLBuenoLopez-eProsima, Jacob Perron, Michael Jeronimo, Michel Hidalgo
```
