### PR TITLE
robotont_description: 0.0.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9580,7 +9580,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/robotont-release/robotont_description-release.git
-      version: 0.0.5-2
+      version: 0.0.7-1
   rocon_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotont_description` to `0.0.7-1`:

- upstream repository: https://github.com/robotont/robotont_description.git
- release repository: https://github.com/robotont-release/robotont_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.5-2`
