### PR TITLE
pal_statistics: 1.4.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7719,6 +7719,25 @@ repositories:
       url: https://github.com/astuff/pacmod_game_control.git
       version: master
     status: developed
+  pal_statistics:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: kinetic-devel
+    release:
+      packages:
+      - pal_carbon_collector
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/pal-gbp/pal_statistics-release.git
+      version: 1.4.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: kinetic-devel
+    status: maintained
   panda_moveit_config:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `1.4.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/pal-gbp/pal_statistics-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## pal_carbon_collector

```
* Remove pal_statistics_msgs from CMakeLists
* Comment out graphitesend dependency
* Change License to MIT
  fixes #5
* Contributors: Victor Lopez
```

## pal_statistics

```
* Update license on headers
  refs #5
* Change License to MIT
  fixes #5
* Contributors: Victor Lopez
```

## pal_statistics_msgs

```
* Change License to MIT
  fixes #5
* Contributors: Victor Lopez
```
