### PR TITLE
mavros: 1.5.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7367,7 +7367,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.5.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.4.0-1`

## libmavconn

```
* libmavconn: Fix build warnings
* Contributors: Morten Fyhn Amundsen
```

## mavros

```
* mavros/sys_status: Fill flight_custom_version field
* mavros: Add override specifiers
* mavros: Move ECEF tf enums to separate enum class
  This avoids a bunch of unhandled switch cases, and should
  improve type safety a bit.
* Contributors: Morten Fyhn Amundsen
```

## mavros_extras

```
* mavros_extras: Fix member initialization order
* mavros_extras: Add override specifiers
* mavros_extras: distance_sensor: Don't publish data when orientation configuration does not match incomming data.
* fake_gps: Fix assignment typo
  This colon should probably be an equals sign.
  With the colon, this assignment becomes a label instead,
  and _gps_rate after the colon becomes an unused
  expression result.
* Contributors: Kristian Klausen, Morten Fyhn Amundsen
```

## mavros_msgs

```
* mavros_msgs/VehicleInfo: Add flight_custom_version field
  Mirroring the field in the corresponding MAVLink message.
* mavros_msgs/State: Fix PX4 flight mode constants
  Turns out ROS message string literals don't need quotes,
  so adding quotes creates strings including the quotes.
* mavros_msgs/State: Add flight mode constants
* mavros_msgs: Don't move temporary objects
* Contributors: Morten Fyhn Amundsen
```

## test_mavros

- No changes
