### PR TITLE
sick_safetyscanners: 1.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5652,7 +5652,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners` to `1.0.7-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners.git
- release repository: https://github.com/SICKAG/sick_safetyscanners-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.6-1`

## sick_safetyscanners

```
* fixed parsing error in current config data
* added intensity filter
* fix for out of range while creating output path message
* Contributors: Heiko, Lennart Puck
```
