### PR TITLE
lvr2: 20.11.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5523,7 +5523,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/lvr2-release.git
-      version: 20.7.1-1
+      version: 20.11.1-1
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `20.11.1-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/uos-gbp/lvr2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `20.7.1-1`

## lvr2

```
* fix for vtk8 issue
* add missing include and clean up using std
* use double for precision and refactor cl sor tool
* adds sor filter tool based on gpu knn
* added hdf5features example
* faster loading. map buffers instead of insert next cells
* added embree dep to cmake.in
* merged raycaster and cleanup
* working OpenCL Raycaster with better structure
* fix colors in filtering
* some performance optimizations
* migrated dmc approach
```
