### PR TITLE
rmw_dds_common: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2534,7 +2534,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-1`

## rmw_dds_common

```
* Update QD links to Foxy
* Updated performance section QD (#30 <https://github.com/ros2/rmw_dds_common/issues/30>)
* Update Quality Declaration to QL2 (#31 <https://github.com/ros2/rmw_dds_common/issues/31>)
* Add fault injection macro unit tests (#27 <https://github.com/ros2/rmw_dds_common/issues/27>)
* Added benchmark test to rmw_dds_common (#29 <https://github.com/ros2/rmw_dds_common/issues/29>)
* Contributors: Alejandro Hernández Cordero, Michel Hidalgo, Stephen Brawner
```
