### PR TITLE
aws-robomaker-simulation-ros-pkgs: 1.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -327,6 +327,20 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  aws-robomaker-simulation-ros-pkgs:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-simulation-ros-pkgs.git
+      version: dashing
+    release:
+      packages:
+      - aws_robomaker_simulation_ros_pkgs
+      - robomaker_simulation_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release.git
+      version: 1.2.1-1
+    status: maintained
   aws_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aws-robomaker-simulation-ros-pkgs` to `1.2.1-1`:

- upstream repository: https://github.com/aws-robotics/aws-robomaker-simulation-ros-pkgs
- release repository: https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
