### PR TITLE
rmw_dds_common: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1626,7 +1626,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.0.1-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-2`

## rmw_dds_common

```
* Create a utility function to limit rmw_time_t to 32-bit values (#37 <https://github.com/ros2/rmw_dds_common/issues/37>)
* Update maintainers (#34 <https://github.com/ros2/rmw_dds_common/issues/34>)
* Updated performance section QD (#30 <https://github.com/ros2/rmw_dds_common/issues/30>)
* Update Quality Declaration to QL2 (#31 <https://github.com/ros2/rmw_dds_common/issues/31>)
* Added benchmark test to rmw_dds_common (#29 <https://github.com/ros2/rmw_dds_common/issues/29>)
* Fix potential memory leak (#28 <https://github.com/ros2/rmw_dds_common/issues/28>)
* Add fault injection macro unit tests (#27 <https://github.com/ros2/rmw_dds_common/issues/27>)
* Fixed some doxygen warnings (#26 <https://github.com/ros2/rmw_dds_common/issues/26>)
* Update Quality Declaration to QL3 (#24 <https://github.com/ros2/rmw_dds_common/issues/24>)
* Update QD and documentation (#23 <https://github.com/ros2/rmw_dds_common/issues/23>)
* Contributors: Alejandro Hernández Cordero, Chen Lihui, Ivan Santiago Paunovic, Michael Jeronimo, Michel Hidalgo, Stephen Brawner
```
