### PR TITLE
neonavigation: 0.10.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6797,7 +6797,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.10.3-1
+      version: 0.10.4-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.10.4-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.10.3-1`

## costmap_cspace

```
* costmap_cspace: make Costmap3dLayerPlain and Costmap3dLayerOutput faster (#562 <https://github.com/at-wat/neonavigation/issues/562>)
* Contributors: Naotaka Hatao
```

## joystick_interrupt

- No changes

## map_organizer

```
* Migrate to GitHub Actions (#559 <https://github.com/at-wat/neonavigation/issues/559>)
* Contributors: Atsushi Watanabe
```

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

- No changes

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
