### PR TITLE
remove extest package

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2793,14 +2793,6 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/exotica_val_description-release.git
       version: 1.0.0-1
-  extest:
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/nakakura/extest-release.git
-      version: 0.0.1-3
-    status: unmaintained
-    status_description: Test of Rosrust
   eyantra_drone:
     doc:
       type: git


### PR DESCRIPTION
I'm getting errors during the build and my attempts to fix it aren't working, so I remove the package once.
I will peruse this document and ask you to add it again after the test is completed in local.
http://wiki.ros.org/regression_tests
Sorry for bother you.