### PR TITLE
bota_driver: 0.5.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -352,7 +352,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.7-1
+      version: 0.5.8-1
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.8-1`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.7-1`

## bota_device_driver

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karamousadakis
```

## bota_driver

- No changes

## bota_node

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karamousadakis
```

## bota_signal_handler

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karamousadakis
```

## bota_worker

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karamousadakis
```

## rokubimini

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

- No changes

## rokubimini_description

- No changes

## rokubimini_ethercat

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karamousadakis
```

## rokubimini_examples

- No changes

## rokubimini_factory

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karamousadakis
```

## rokubimini_manager

```
* Release 0.5.7 into master
* add condition for adding -faligned-new flag in GCC
* Contributors: Mike Karamousadakis
```

## rokubimini_msgs

- No changes

## rokubimini_serial

- No changes
