### PR TITLE
dynamic-graph: 4.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2317,7 +2317,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
-      version: 4.2.2-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/dynamic-graph.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph` to `4.3.0-1`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `4.2.2-1`
