### PR TITLE
dynamic-graph-python: 4.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2332,7 +2332,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-python-ros-release.git
-      version: 3.5.3-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph-python` to `4.0.0-1`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph-python.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-python-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.5.3-2`
