### PR TITLE
ixblue_stdbin_decoder: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2282,7 +2282,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
-      version: 0.1.3-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_stdbin_decoder` to `0.2.0-1`:

- upstream repository: https://github.com/ixblue/ixblue_stdbin_decoder.git
- release repository: https://github.com/ixblue/ixblue_stdbin_decoder-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.3-1`

## ixblue_stdbin_decoder

```
* Fix strict aliasing warning by using memcpy
* Fix the protocol version test condition
* Do not force SHARED library to use static lib on Windows
* Add checksum checking on frame reception
  Allow to use on unreliable communication like serial ports
* Breaking change: Allow the decoder to parse partial frames by reconstructing
  the frames internally using a circular buffer
  This allows to work properly on TCP and moreover, serial ports.
  This change changes the API as reflected in README minimal example.
* Add usage examples
* Add bits enums for INSAlgorithmStatus and INSSystemStatus
* Contributors: BARRAL Adrien, Romain Reignier
```
