### PR TITLE
bagger: 0.1.3-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -248,6 +248,21 @@ repositories:
       url: https://github.com/pal-robotics/backward_ros.git
       version: kinetic-devel
     status: maintained
+  bagger:
+    doc:
+      type: git
+      url: https://github.com/squarerobot/bagger.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/squarerobot/bagger-release.git
+      version: 0.1.3-4
+    source:
+      type: git
+      url: https://github.com/squarerobot/bagger.git
+      version: master
+    status: maintained
   baldor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bagger` to `0.1.3-4`:

- upstream repository: https://github.com/squarerobot/bagger.git
- release repository: https://github.com/squarerobot/bagger-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## bagger

```
* Infer and publish bag names and directories for each bag profile
* Add CL option to not decompress bags.  Fixes #4 <https://github.com/squarerobot/bagger/issues/4>
* Contributors: Brenden Gibbons
```
