### PR TITLE
ixblue_ins_stdbin_driver: 0.1.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -5724,7 +5724,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_ins_stdbin_driver` to `0.1.5-1`:

- upstream repository: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
- release repository: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.4-1`

## ixblue_ins

- No changes

## ixblue_ins_driver

```
* Use new std_bin_decoder API to reconstruct incomplete frames
  Avoid the copy of the frame in this driver
* Contributors: Romain Reignier
```

## ixblue_ins_msgs

- No changes
