### PR TITLE
ixblue_ins_stdbin_driver: 0.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2283,7 +2283,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ixblue_ins_stdbin_driver` to `0.1.5-1`:

- upstream repository: https://github.com/ixblue/ixblue_ins_stdbin_driver.git
- release repository: https://github.com/ixblue/ixblue_ins_stdbin_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.4-1`

## ixblue_ins

- No changes

## ixblue_ins_driver

```
* Use new std_bin_decoder API to reconstruct incomplete frames
  Avoid the copy of the frame in this driver
* Contributors: Romain Reignier
```

## ixblue_ins_msgs

- No changes
