### PR TITLE
add python3-selenium-pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6575,6 +6575,16 @@ python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
   ubuntu: [python3-scp]
+python3-selenium-pip:
+  debian:
+    pip:
+      packages: [selenium]
+  fedora:
+    pip:
+      packages: [selenium]
+  ubuntu:
+    pip:
+      packages: [selenium]
 python3-sense-emu-pip:
   debian:
     pip:


### PR DESCRIPTION
I add `selenium` pip package for `python3`.

https://pypi.org/project/selenium/
