### PR TITLE
Add rosdep key ruby-backports

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -87,7 +87,6 @@ ruby:
     yakkety: [ruby, ruby-dev]
     zesty: [ruby, ruby-dev]
 ruby-backports:
-  arch: [ruby-backports]
   debian: [ruby-backports]
   gentoo: [dev-ruby/backports]
   ubuntu: [ruby-backports]

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -86,6 +86,11 @@ ruby:
     xenial: [ruby, ruby-dev]
     yakkety: [ruby, ruby-dev]
     zesty: [ruby, ruby-dev]
+ruby-backports:
+  arch: [ruby-backports]
+  debian: [ruby-backports]
+  gentoo: [dev-ruby/backports]
+  ubuntu: [ruby-backports]
 ruby-dev:
   arch: [ruby]
   debian: [ruby-dev]


### PR DESCRIPTION
Adds [ruby-backports](https://github.com/marcandre/backports) to the rosdep database. The package is a dependency of Orocos [typelib](https://github.com/orocos-toolchain/typelib) since https://github.com/orocos-toolchain/typelib/pull/107.

Links to package databases:
- https://aur.archlinux.org/packages/ruby-backports/
- https://packages.debian.org/search?keywords=ruby-backports
- https://packages.gentoo.org/packages/dev-ruby/backports
- https://packages.ubuntu.com/search?keywords=ruby-backports

I did not find the package in any database of Fedora packages. https://apps.fedoraproject.org/packages/ seems to be offline at the moment.