### PR TITLE
xacro: 2.0.4-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3996,7 +3996,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.4-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.3-1`

## xacro

```
* Merge improvements of noetic branch into dashing-devel: see 1.14.5 for details
* Append test directory to existing AMENT_PREFIX_PATH (#260 <https://github.com/ros/xacro/issues/260>)
* Contributors: Chen Bainian, Robert Haschke, G.A. vd. Hoorn
```
