### PR TITLE
lvr2: 20.11.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2795,6 +2795,21 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/lusb.git
       version: master
     status: developed
+  lvr2:
+    doc:
+      type: git
+      url: https://github.com/uos/lvr2.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/uos-gbp/lvr2-release.git
+      version: 20.11.1-1
+    source:
+      type: git
+      url: https://github.com/uos/lvr2.git
+      version: master
+    status: developed
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `20.11.1-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/uos-gbp/lvr2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## lvr2

```
* fix for vtk8 issue
* add missing include and clean up using std
* use double for precision and refactor cl sor tool
* adds sor filter tool based on gpu knn
* added hdf5features example
* faster loading. map buffers instead of insert next cells
* added embree dep to cmake.in
* merged raycaster and cleanup
* working OpenCL Raycaster with better structure
* fix colors in filtering
* some performance optimizations
* migrated dmc approach
```
