### PR TITLE
fcl: 0.6.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1542,11 +1542,15 @@ repositories:
       version: master
     status: developed
   fcl:
+    doc:
+      type: git
+      url: https://github.com/flexible-collision-library/fcl.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/fcl-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/flexible-collision-library/fcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.6.1-2`:

- upstream repository: https://github.com/flexible-collision-library/fcl.git
- release repository: https://github.com/ros-gbp/fcl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.1-1`
