### PR TITLE
rviz: 1.13.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11346,7 +11346,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.14-1
+      version: 1.13.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.15-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.13.14-1`

## rviz

```
* [fix] Enforce GLSL 1.4 on Mesa systems (#1559 <https://github.com/ros-visualization/rviz/issues/1559>)
* [fix] Fix layout of editors in PropertyWidget (#1558 <https://github.com/ros-visualization/rviz/issues/1558>)
* Contributors: Robert Haschke
```
