### PR TITLE
rcpputils: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.0.2-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.1-1`

## rcpputils

```
* Fix working with filesystem parent paths. (#112 <https://github.com/ros2/rcpputils/issues/112>)
* Cleanup mislabeled BSD license (#37 <https://github.com/ros2/rcpputils/issues/37>)
* overload functions for has_symbol and get_symbol with raw string literal (#110 <https://github.com/ros2/rcpputils/issues/110>)
* Add an ASSERT to the pointer traits tests. (#111 <https://github.com/ros2/rcpputils/issues/111>)
* replace custom get env login into rcutils_get_env(). (#99 <https://github.com/ros2/rcpputils/issues/99>)
* Removed Github Actions (#105 <https://github.com/ros2/rcpputils/issues/105>)
* Update the package.xml files with the latest Open Robotics maintainers (#102 <https://github.com/ros2/rcpputils/issues/102>)
* Contributors: Alejandro Hernández Cordero, Chen Lihui, Chris Lalancette, Michael Jeronimo, Tully Foote, tomoya
```
