### PR TITLE
rviz: 1.14.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5553,7 +5553,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.3-1
+      version: 1.14.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.4-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.14.3-1`

## rviz

```
* [fix] MessageFilterDisplay: process messages synchronously (#1560 <https://github.com/ros-visualization/rviz/issues/1560>)
* [fix] Enforce GLSL 1.4 on Mesa systems (#1559 <https://github.com/ros-visualization/rviz/issues/1559>)
* [fix] Fix layout of editors in PropertyWidget (#1558 <https://github.com/ros-visualization/rviz/issues/1558>)
* Contributors: Robert Haschke
```
