### PR TITLE
dataspeed_pds: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1048,7 +1048,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dataspeed_pds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_pds` to `1.0.6-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/dataspeed_pds.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_pds-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.5-1`

## dataspeed_pds

```
* Renamed PDS to iPDS
* Contributors: Michael Lohrer
```

## dataspeed_pds_can

```
* Updated license year for 2020
* Renamed PDS to iPDS
* Support new Temperature message
* Contributors: Michael Lohrer
```

## dataspeed_pds_lcm

```
* Updated license year for 2020
* Renamed PDS to iPDS
* Update LCM status message
* Support all 3 internal temp sensors on RevI hardware
* Contributors: Michael Lohrer
```

## dataspeed_pds_msgs

```
* Renamed PDS to iPDS
* Support all 3 internal temp sensors and up to 4 external
* Contributors: Michael Lohrer
```

## dataspeed_pds_rqt

```
* Updated license year for 2020
* Renamed PDS to iPDS
* Contributors: Michael Lohrer
```

## dataspeed_pds_scripts

```
* Updated license year for 2020
* Renamed PDS to iPDS
* Contributors: Michael Lohrer
```
