### PR TITLE
adds yujin_lidar to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13697,6 +13697,11 @@ repositories:
       url: https://github.com/openspur/ypspur_ros.git
       version: master
     status: developed
+  yujin_lidar:
+    doc:
+      type: git
+      url: https://github.com/yujinrobot/yujin_lidar.git
+      version: master
   yujin_ocs:
     doc:
       type: git


### PR DESCRIPTION
I'd like yujin_lidar to be indexed and documented on ros.org.