### PR TITLE
openzen_sensor: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7576,7 +7576,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lp-research/openzen_sensor-release.git
-      version: 1.0.1-2
+      version: 1.2.0-1
     source:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openzen_sensor` to `1.2.0-1`:

- upstream repository: https://bitbucket.org/lpresearch/openzenros.git
- release repository: https://github.com/lp-research/openzen_sensor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-2`

## openzen_sensor

```
* fixed conditions check for build or download OpenZen options
* fixed name of primary maintainer
* added install target for openzen_node
* manually setting component ID in case a TestSensor is used
* running rostest as part of the catkin CMake file
* switched binary downloads to OpenZen 1.2.0
* updated OpenZen to version 1.2.0
* added output of GNSS measurement as ROS NavSatFix message
* Contributors: LP-Research Inc. Team
```
