### PR TITLE
pilz_robots: 0.5.20-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7985,7 +7985,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.19-1
+      version: 0.5.20-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.20-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.19-1`

## pilz_control

```
* Remove ROSNotOKException (#458)
* Fix wrong include for logger mock (#461)
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robots

- No changes

## pilz_status_indicator_rqt

```
* Update package.xml for python 3
* Contributors: Pilz GmbH and Co. KG
```

## pilz_testutils

```
* Fix include own header before system (#466)
* Better log output on mismatches (#462)
* Remove ROSNotOKException (#458)
* Fix compiler errors in MockAppender (#464)
* Fix wrong include for logger mock (#461)
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

- No changes

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Fix catkin_lint errors (#459)
* Update acceptancetest_stop1.md (#447)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* Add named pose all-zeros (#455)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

```
* Fix acceptancetest_joint_limits (#448)
* Contributors: Pilz GmbH and Co. KG
```
