### PR TITLE
volta_simulation: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17455,6 +17455,13 @@ repositories:
       type: git
       url: https://github.com/uos/volksbot_driver.git
       version: kinetic
+  volta_simulation:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/botsync/volta_simulation-release.git
+      version: 1.0.0-1
+    status: developed
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `volta_simulation` to `1.0.0-1`:

- upstream repository: https://github.com/botsync/volta_simulation.git
- release repository: https://github.com/botsync/volta_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
