### PR TITLE
Add python3-pymongo key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3442,14 +3442,7 @@ python-pymongo:
   osx:
     pip:
       packages: [pymongo]
-  ubuntu:
-    '*': [python-pymongo]
-    focal: [python3-pymongo]
-    trusty_python3: [python3-pymongo]
-    utopic_python3: [python3-pymongo]
-    vivid_python3: [python3-pymongo]
-    wily_python3: [python3-pymongo]
-    xenial_python3: [python3-pymongo]
+  ubuntu: [python-pymongo]
 python-pymouse:
   debian:
     pip:
@@ -6027,6 +6020,12 @@ python3-mock:
   openembedded: [python3-mock@meta-ros]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
+python3-pymongo:
+  arch: [python-pymongo]
+  debian: [python3-pymongo]
+  fedora: [python3-pymongo]
+  gentoo: [dev-python/pymongo]
+  ubuntu: [python3-pymongo]
 python3-msgpack:
   debian:
     '*': [python3-msgpack]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3444,6 +3444,7 @@ python-pymongo:
       packages: [pymongo]
   ubuntu:
     '*': [python-pymongo]
+    focal: [python3-pymongo]
     trusty_python3: [python3-pymongo]
     utopic_python3: [python3-pymongo]
     vivid_python3: [python3-pymongo]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3442,7 +3442,13 @@ python-pymongo:
   osx:
     pip:
       packages: [pymongo]
-  ubuntu: [python-pymongo]
+  ubuntu:
+    '*': [python-pymongo]
+    trusty_python3: [python3-pymongo]
+    utopic_python3: [python3-pymongo]
+    vivid_python3: [python3-pymongo]
+    wily_python3: [python3-pymongo]
+    xenial_python3: [python3-pymongo]
 python-pymouse:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6020,12 +6020,6 @@ python3-mock:
   openembedded: [python3-mock@meta-ros]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
-python3-pymongo:
-  arch: [python-pymongo]
-  debian: [python3-pymongo]
-  fedora: [python3-pymongo]
-  gentoo: [dev-python/pymongo]
-  ubuntu: [python3-pymongo]
 python3-msgpack:
   debian:
     '*': [python3-msgpack]
@@ -6332,6 +6326,12 @@ python3-pymodbus:
   ubuntu:
     '*': [python3-pymodbus]
     xenial: null
+python3-pymongo:
+  arch: [python-pymongo]
+  debian: [python3-pymongo]
+  fedora: [python3-pymongo]
+  gentoo: [dev-python/pymongo]
+  ubuntu: [python3-pymongo]
 python3-pyosmium:
   debian: [python3-pyosmium]
   fedora: [python3-osmium]


### PR DESCRIPTION
python-pymongo cannot be found in Ubuntu focal packages and is named _python3-pymongo_ instead: https://packages.ubuntu.com/focal/python3-pymongo