### PR TITLE
exotica: 6.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2795,7 +2795,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/exotica-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       type: git
       url: https://github.com/ipab-slmc/exotica.git


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica` to `6.0.1-1`:

- upstream repository: https://github.com/ipab-slmc/exotica.git
- release repository: https://github.com/ipab-slmc/exotica-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `6.0.0-1`

## exotica

```
* Minor updates to documentation
* Contributors: Wolfgang Merkt
```

## exotica_aico_solver

- No changes

## exotica_cartpole_dynamics_solver

- No changes

## exotica_collision_scene_fcl_latest

- No changes

## exotica_core

```
* Disable treating compiler warnings as errors due to buildfarm failure on Debian Stretch
  This change will result in "unstable" build notifications from the buildfarm but prevent failures.
* Contributors: Wolfgang Merkt
```

## exotica_core_task_maps

- No changes

## exotica_ddp_solver

- No changes

## exotica_double_integrator_dynamics_solver

- No changes

## exotica_dynamics_solvers

- No changes

## exotica_examples

```
* Fix some SparseDDP examples and remove old ones (#728 <https://github.com/ipab-slmc/exotica/issues/728>)
* Contributors: Traiko Dinev, Wolfgang Merkt
```

## exotica_ik_solver

- No changes

## exotica_ilqg_solver

- No changes

## exotica_ilqr_solver

- No changes

## exotica_levenberg_marquardt_solver

- No changes

## exotica_ompl_control_solver

- No changes

## exotica_ompl_solver

- No changes

## exotica_pendulum_dynamics_solver

- No changes

## exotica_pinocchio_dynamics_solver

- No changes

## exotica_python

```
* Fix some SparseDDP examples and remove old ones (#728 <https://github.com/ipab-slmc/exotica/issues/728>)
* Contributors: Traiko Dinev, Wolfgang Merkt
```

## exotica_quadrotor_dynamics_solver

- No changes

## exotica_scipy_solver

```
* Fix buildfarm configuration failure due to search for exec-only dependency
* Contributors: Wolfgang Merkt
```

## exotica_time_indexed_rrt_connect_solver

- No changes
