### PR TITLE
sros2: 0.9.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3516,7 +3516,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.9.3-1
+      version: 0.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.9.4-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.3-1`

## sros2

```
* parameter_events topic is now absolute (#233 <https://github.com/ros2/sros2/issues/233>) (#245 <https://github.com/ros2/sros2/issues/245>)
* Contributors: Mikael Arguedas
```

## sros2_cmake

- No changes
