### PR TITLE
Added new package 'stag_ros' to noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5854,6 +5854,17 @@ repositories:
       url: https://github.com/ros-planning/srdfdom.git
       version: noetic-devel
     status: maintained
+  stag_ros:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/usrl-uofsc/stag_ros-release.git
+      version: 0.3.4-2
+    source:
+      type: git
+      url: https://github.com/usrl-uofsc/stag_ros.git
+      version: noetic-devel
+    status: developed
   stage:
     release:
       tags:


### PR DESCRIPTION
Added an entry in noetic/distributions.yaml for a new ros package 'stag_ros'. Bloom was used to create the release and this is a manual pull request.