### PR TITLE
volta_simulation: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13291,6 +13291,13 @@ repositories:
       url: https://github.com/uos/volksbot_driver.git
       version: melodic
     status: maintained
+  volta_simulation:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/botsync/volta_simulation-release.git
+      version: 1.0.0-1
+    status: developed
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `volta_simulation` to `1.0.0-1`:

- upstream repository: https://github.com/botsync/volta_simulation.git
- release repository: https://github.com/botsync/volta_simulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
