### PR TITLE
geometry2: 0.13.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1049,7 +1049,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.6-1
+      version: 0.13.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.7-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.13.6-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* [Foxy backport] Fixed memory leak in Buffer::waitForTransform (#281 <https://github.com/ros2/geometry2/issues/281>) (#330 <https://github.com/ros2/geometry2/issues/330>)
* Contributors: Matthijs den Toom
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* [Foxy backport] Fixed memory leak in Buffer::waitForTransform (#281 <https://github.com/ros2/geometry2/issues/281>) (#330 <https://github.com/ros2/geometry2/issues/330>)
* Contributors: Matthijs den Toom
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
