### PR TITLE
rclcpp: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1468,7 +1468,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 5.1.0-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `5.1.0-1`

## rclcpp

```
* Move ownership of shutdown_guard_condition to executors/graph_listener (#1404 <https://github.com/ros2/rclcpp/issues/1404>)
* Add options to automatically declare qos parameters when creating a publisher/subscription (#1465 <https://github.com/ros2/rclcpp/issues/1465>)
* Add take_data to Waitable and data to AnyExecutable (#1241 <https://github.com/ros2/rclcpp/issues/1241>)
* Add benchmarks for node parameters interface (#1444 <https://github.com/ros2/rclcpp/issues/1444>)
* Remove allocation from executor::remove_node() (#1448 <https://github.com/ros2/rclcpp/issues/1448>)
* Fix test crashes on CentOS 7 (#1449 <https://github.com/ros2/rclcpp/issues/1449>)
* Bump rclcpp packages to Quality Level 2 (#1445 <https://github.com/ros2/rclcpp/issues/1445>)
* Added executor benchmark tests (#1413 <https://github.com/ros2/rclcpp/issues/1413>)
* Add fully-qualified namespace to WeakCallbackGroupsToNodesMap (#1435 <https://github.com/ros2/rclcpp/issues/1435>)
* Contributors: Alejandro Hernández Cordero, Audrow Nash, Chris Lalancette, Ivan Santiago Paunovic, Louise Poubel, Scott K Logan, brawner
```

## rclcpp_action

```
* Add take_data to Waitable and data to AnyExecutable (#1241 <https://github.com/ros2/rclcpp/issues/1241>)
* Fix test crashes on CentOS 7 (#1449 <https://github.com/ros2/rclcpp/issues/1449>)
* Bump rclcpp packages to Quality Level 2 (#1445 <https://github.com/ros2/rclcpp/issues/1445>)
* Add rclcpp_action action_server benchmarks (#1433 <https://github.com/ros2/rclcpp/issues/1433>)
* Contributors: Audrow Nash, Chris Lalancette, Louise Poubel, brawner
```

## rclcpp_components

```
* Bump rclcpp packages to Quality Level 2 (#1445 <https://github.com/ros2/rclcpp/issues/1445>)
* Contributors: Louise Poubel
```

## rclcpp_lifecycle

```
* Reserve vector capacities and use emplace_back for constructing vectors (#1464 <https://github.com/ros2/rclcpp/issues/1464>)
* [rclcpp_lifecycle] Change uint8_t iterator variables to size_t (#1461 <https://github.com/ros2/rclcpp/issues/1461>)
* Bump rclcpp packages to Quality Level 2 (#1445 <https://github.com/ros2/rclcpp/issues/1445>)
* Contributors: Louise Poubel, brawner
```
