### PR TITLE
librealsense2: 2.40.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5393,7 +5393,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.39.0-1
+      version: 2.40.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.40.0-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.39.0-1`
