### PR TITLE
Change python-rpi.gpio install's on Ubuntu Bionic

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4069,7 +4069,9 @@ python-rpi.gpio:
         packages: [RPi.GPIO]
   ubuntu:
     artful: [python-rpi.gpio]
-    bionic: [python-rpi.gpio]
+    bionic:
+      pip:
+        packages: [RPi.GPIO]
     trusty:
       pip:
         packages: [RPi.GPIO]


### PR DESCRIPTION
What ?
I changed **python-rpi.gpio** package installation from _apt_ to _pip_ on Bionic.

Why ?
_apt_ only work for arm architecture for this package (see the following link) : https://packages.ubuntu.com/bionic/python-rpi.gpio

Cheers
