### PR TITLE
volta: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13291,6 +13291,31 @@ repositories:
       url: https://github.com/uos/volksbot_driver.git
       version: melodic
     status: maintained
+  volta:
+    doc:
+      type: git
+      url: https://github.com/botsync/volta.git
+      version: melodic-devel
+    release:
+      packages:
+      - volta_base
+      - volta_control
+      - volta_description
+      - volta_localization
+      - volta_msgs
+      - volta_navigation
+      - volta_rules
+      - volta_teleoperator
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/botsync-gbp/volta-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/botsync/volta.git
+      version: melodic-devel
+    status: maintained
   vrpn:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13311,7 +13311,6 @@ repositories:
       url: https://github.com/botsync-gbp/volta-release.git
       version: 1.1.0-1
     source:
-      test_pull_requests: true
       type: git
       url: https://github.com/botsync/volta.git
       version: melodic-devel


### PR DESCRIPTION
Increasing version of package(s) in repository `volta` to `1.1.0-1`:

- upstream repository: https://github.com/botsync/volta.git
- release repository: https://github.com/botsync-gbp/volta-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## volta_base

```
* First Release
```

## volta_control

```
* First Release
```

## volta_description

```
* First Release
```

## volta_localization

```
* First Release
```

## volta_msgs

```
* First Release
```

## volta_navigation

```
* First Release
```

## volta_rules

```
* First Release
```

## volta_teleoperator

```
* First Release
```
