### PR TITLE
volta: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17455,6 +17455,30 @@ repositories:
       type: git
       url: https://github.com/uos/volksbot_driver.git
       version: kinetic
+  volta:
+    doc:
+      type: git
+      url: https://github.com/botsync/volta.git
+      version: kinetic-devel
+    release:
+      packages:
+      - volta_base
+      - volta_control
+      - volta_description
+      - volta_localization
+      - volta_msgs
+      - volta_navigation
+      - volta_rules
+      - volta_teleoperator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/botsync-gbp/volta-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/botsync/volta.git
+      version: kinetic-devel
+    status: maintained
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `volta` to `1.0.0-1`:

- upstream repository: https://github.com/botsync/volta.git
- release repository: https://github.com/botsync-gbp/volta-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## volta_base

```
* First Release
```

## volta_control

```
* First Release
```

## volta_description

```
* First Release
```

## volta_localization

```
* First Release
```

## volta_msgs

```
* First Release
```

## volta_navigation

```
* First Release
```

## volta_rules

```
* First Release
```

## volta_teleoperator

```
* First Release
```
