### PR TITLE
realsense2_camera: 2.2.20-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9161,7 +9161,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.18-1
+      version: 2.2.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.20-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.2.18-1`

## realsense2_camera

```
* Add Support - Noetic
* Add demo for using intrinsics from camera_info (show_center_depth.py).
* Add launch option: send logs to ros log file.
* Add feature: get rgb stream from infrared sensor (applies to D415)
* Add feature: Add notification if connected using USB2.1 port.
* Fix bug: Avoid z16h format
* Fix bug: monitor streams frequency without subsribing.
* Fix bug: extrinsincs for right stereo camera refers to the left stereo camera.
* Contributors: Abhijit Majumdar, Isaac I. Y. Saito, Jakub, M-frctrl, Thomas Jespersen, doronhi
```

## realsense2_description

```
* Add urdf file for l515
* Contributors: doronhi
```
