### PR TITLE
volta_simulation: 1.0.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17492,6 +17492,8 @@ repositories:
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git
+      version: kinetic-devel	
+    status: maintained
   vrpn:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17455,6 +17455,21 @@ repositories:
       type: git
       url: https://github.com/uos/volksbot_driver.git
       version: kinetic
+  volta_simulation:
+    doc:
+      type: git
+      url: https://github.com/botsync/volta_simulation.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/botsync-gbp/volta_simulation-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/botsync/volta_simulation.git
+      version: kinetic-devel
+    status: maintained
   vrpn:
     doc:
       type: git

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17492,7 +17492,7 @@ repositories:
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git
-      version: kinetic-devel	
+      version: kinetic-devel
     status: maintained
   vrpn:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `volta_simulation` to `1.0.0-1`:

- upstream repository: https://github.com/botsync/volta_simulation.git
- release repository: https://github.com/botsync-gbp/volta_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## volta_simulation

```
* First Release
```
