### PR TITLE
marti_messages: 1.2.0-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1408,7 +1408,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_messages-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/marti_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.2.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/swri-robotics-gbp/marti_messages-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_dbw_msgs

- No changes

## marti_nav_msgs

```
* Add path message (#109 <https://github.com/swri-robotics/marti_messages/issues/109>) (#111 <https://github.com/swri-robotics/marti_messages/issues/111>)
* Contributors: Matthew Bries, P. J. Reed
```

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
