### PR TITLE
adding qt4-linguist-tools rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5541,8 +5541,8 @@ qt4-linguist-tools:
   gentoo: ['dev-qt/linguist-tools']
   ubuntu:
     '*': null
-    xenial: [qt4-linguist-tools]
     bionic: [qt4-linguist-tools]
+    xenial: [qt4-linguist-tools]
 qt4-qmake:
   arch: [qt4]
   debian: [qt4-qmake]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5541,8 +5541,8 @@ qt4-linguist-tools:
   gentoo: ['dev-qt/linguist-tools']
   ubuntu:
     '*': null
-    xenial: qt4-linguist-tools
-    bionic: qt4-linguist-tools
+    xenial: [qt4-linguist-tools]
+    bionic: [qt4-linguist-tools]
 qt4-qmake:
   arch: [qt4]
   debian: [qt4-qmake]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5535,6 +5535,11 @@ qt4-dev-tools:
   gentoo: ['dev-qt/assistant:4', 'dev-qt/linguist:4', 'dev-qt/pixeltool:4']
   opensuse: [libqt4-devel-doc]
   ubuntu: [qt4-dev-tools]
+qt4-linguist-tools:
+  debian: [qt4-linguist-tools]
+  fedora: [qt]
+  gentoo: ['dev-qt/linguist-tools']
+  ubuntu: [qt4-linguist-tools]
 qt4-qmake:
   arch: [qt4]
   debian: [qt4-qmake]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5537,9 +5537,12 @@ qt4-dev-tools:
   ubuntu: [qt4-dev-tools]
 qt4-linguist-tools:
   debian: [qt4-linguist-tools]
-  fedora: [qt]
+  fedora: [qt-devel]
   gentoo: ['dev-qt/linguist-tools']
-  ubuntu: [qt4-linguist-tools]
+  ubuntu:
+    '*': null
+    xenial: qt4-linguist-tools
+    bionic: qt4-linguist-tools
 qt4-qmake:
   arch: [qt4]
   debian: [qt4-qmake]


### PR DESCRIPTION
Provides binaries `lrealease` and `lupdate`

* Debian: https://packages.debian.org/buster/qt4-linguist-tools
* Ubuntu: https://packages.ubuntu.com/bionic/qt4-linguist-tools
* Gentoo: https://packages.gentoo.org/packages/dev-qt/linguist-tools
* Fedora: https://src.fedoraproject.org/rpms/qt/blob/master/f/qt.spec