### PR TITLE
roscompile: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10189,7 +10189,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 1.0.3-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/DLu/roscompile.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10191,6 +10191,7 @@ repositories:
       url: https://github.com/wu-robotics/roscompile-release.git
       version: 1.1.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/DLu/roscompile.git
       version: main


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.1.0-1`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.3-1`
