### PR TITLE
roscompile: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4795,6 +4795,25 @@ repositories:
       url: https://github.com/RobotWebTools/rosbridge_suite.git
       version: develop
     status: maintained
+  roscompile:
+    doc:
+      type: git
+      url: https://github.com/DLu/roscompile.git
+      version: main
+    release:
+      packages:
+      - ros_introspection
+      - roscompile
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/wu-robotics/roscompile-release.git
+      version: 1.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/roscompile.git
+      version: main
+    status: developed
   rosconsole:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.1.1-1`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
