### PR TITLE
Add touchegg to rosdep base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6168,6 +6168,9 @@ tmux:
   fedora: [tmux]
   gentoo: [app-misc/tmux]
   ubuntu: [tmux]
+touchegg:
+  arch: [touchegg]
+  ubuntu: [touchegg]
 trang:
   debian: [trang]
   fedora: [trang]


### PR DESCRIPTION
I add `touchegg` (Multitouch gesture recognizer) to rosdep base.yaml

I looked for debian, gentoo, fedra packages, but I did not find them...

Links:
arch: https://aur.archlinux.org/packages/touchegg/
ubuntu: https://packages.ubuntu.com/bionic/touchegg