### PR TITLE
webots_ros2: 1.0.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2889,6 +2889,35 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: ros2
     status: maintained
+  webots_ros2:
+    doc:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: master
+    release:
+      packages:
+      - webots_ros2
+      - webots_ros2_abb
+      - webots_ros2_core
+      - webots_ros2_demos
+      - webots_ros2_epuck
+      - webots_ros2_examples
+      - webots_ros2_importer
+      - webots_ros2_msgs
+      - webots_ros2_tiago
+      - webots_ros2_tutorials
+      - webots_ros2_universal_robot
+      - webots_ros2_ur_e_description
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/cyberbotics/webots_ros2-release.git
+      version: 1.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: master
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
## webots_ros2 (rolling) - 1.0.2-2

The packages in the `webots_ros2` repository were released into the `rolling` distro by running `/home/lukic/.local/bin/bloom-release --rosdistro rolling webots_ros2 --edit` on `Fri, 20 Nov 2020 13:23:00 -0000`

These packages were released:
- `webots_ros2`
- `webots_ros2_abb`
- `webots_ros2_core`
- `webots_ros2_demos`
- `webots_ros2_epuck`
- `webots_ros2_examples`
- `webots_ros2_importer`
- `webots_ros2_msgs`
- `webots_ros2_tiago`
- `webots_ros2_tutorials`
- `webots_ros2_universal_robot`
- `webots_ros2_ur_e_description`

Version of package(s) in repository `webots_ros2`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: unknown
- rosdistro version: `null`
- old version: `1.0.2-1`
- new version: `1.0.2-2`

Versions of tools used:

- bloom version: `0.10.0`
- catkin_pkg version: `0.4.23`
- rosdep version: `0.20.0`
- rosdistro version: `0.8.3`
- vcstools version: `0.1.42`