### PR TITLE
cob_android: 0.1.8-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1637,7 +1637,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_android-release.git
-      version: 0.1.7-2
+      version: 0.1.8-1
     source:
       type: git
       url: https://github.com/ipa320/cob_android.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_android` to `0.1.8-1`:

- upstream repository: https://github.com/ipa320/cob_android.git
- release repository: https://github.com/ipa320/cob_android-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.7-2`

## cob_android

```
* Merge pull request #40 <https://github.com/ipa320/cob_android/issues/40> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_android_msgs

```
* Merge pull request #40 <https://github.com/ipa320/cob_android/issues/40> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #41 <https://github.com/ipa320/cob_android/issues/41> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_android_resource_server

```
* Merge pull request #40 <https://github.com/ipa320/cob_android/issues/40> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_android_script_server

```
* Merge pull request #40 <https://github.com/ipa320/cob_android/issues/40> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #41 <https://github.com/ipa320/cob_android/issues/41> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_android_settings

```
* Merge pull request #40 <https://github.com/ipa320/cob_android/issues/40> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #41 <https://github.com/ipa320/cob_android/issues/41> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```
