### PR TITLE
Rollbacks to fix ROS Noetic November 2020 Regressions

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3159,7 +3159,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4600,7 +4600,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.18.0-1
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Reverts #26938 and  #26904 to get ROS Noetic into a sync'able state (#27401)

@tylerjw @bmagyar FYI