### PR TITLE
tvm_vendor: 0.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12571,6 +12571,17 @@ repositories:
       url: https://github.com/tuw-robotics/tuw_rviz.git
       version: melodic
     status: developed
+  tvm_vendor:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/autowarefoundation/tvm_vendor-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/tvm_vendor.git
+      version: main
+    status: maintained
   twist_mux:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tvm_vendor` to `0.7.0-1`:

- upstream repository: https://github.com/autowarefoundation/tvm_vendor.git
- release repository: https://github.com/autowarefoundation/tvm_vendor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## tvm_vendor

```
* Initial release.
* Contributors: Joshua Whitley
```
