### PR TITLE
performance_test_fixture to 0.0.6

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1243,7 +1243,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
First time creating a PR for a release, so I'm hoping this is all that needs to be done.

https://github.com/ros2-gbp/performance_test_fixture-release/tags

Signed-off-by: Stephen Brawner <brawner@gmail.com>