### PR TITLE
performance_test_fixture: 0.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1961,7 +1961,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.0.6-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.5-1`

## performance_test_fixture

```
* Make allocation counter atomic (#13 <https://github.com/ros2/performance_test_fixture/issues/13>)
  Even if the benchmark itself isn't threaded, the process we're testing
  could be. In any case, this should prevent those shenanigans from
  messing up the measurement.
* Add methods for pausing/resuming performance metrics (#10 <https://github.com/ros2/performance_test_fixture/issues/10>)
  * Add methods for pausing/resuming performance metrics
* Add benchmarks to evaluate overhead (#11 <https://github.com/ros2/performance_test_fixture/issues/11>)
  * Add benchmarks to evaluate overhead in performance tests
* Add namespace performance_test_fixture to .cpp (#9 <https://github.com/ros2/performance_test_fixture/issues/9>)
* Contributors: Scott K Logan, brawner
```
