### PR TITLE
cob_common: 0.7.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -539,7 +539,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_common-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ipa320/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.4-1`:

- upstream repository: https://github.com/ipa320/cob_common.git
- release repository: https://github.com/ipa320/cob_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.3-1`

## cob_actions

```
* Merge pull request #289 <https://github.com/ipa320/cob_common/issues/289> from HannesBachter/feature/dock_service_action
  add Dock service and -action
* add Dock service and action
* Contributors: Felix Messmer, hyb
```

## cob_common

- No changes

## cob_description

- No changes

## cob_msgs

- No changes

## cob_srvs

```
* Merge pull request #289 <https://github.com/ipa320/cob_common/issues/289> from HannesBachter/feature/dock_service_action
  add Dock service and -action
* add Dock service and action
* Contributors: Felix Messmer, hyb
```

## raw_description

- No changes
