### PR TITLE
nodl: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1154,7 +1154,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
-      version: 0.1.0-2
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodl` to `0.3.1-1`:

- upstream repository: https://github.com/ubuntu-robotics/nodl.git
- release repository: https://github.com/ros2-gbp/nodl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-2`

## nodl_python

```
* relicense project as Apache 2.0
* Contributors: Ted Kern
```

## ros2nodl

```
* relicense project as Apache 2.0
* Contributors: Ted Kern
```
