### PR TITLE
nodl: 0.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1767,7 +1767,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodl` to `0.3.1-1`:

- upstream repository: https://github.com/ubuntu-robotics/nodl.git
- release repository: https://github.com/ros2-gbp/nodl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.0-1`

## nodl_python

```
* relicense project as Apache 2.0
* Contributors: Ted Kern
```

## ros2nodl

```
* relicense project as Apache 2.0
* Contributors: Ted Kern
```
