### PR TITLE
rosbag2: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1873,6 +1873,8 @@ repositories:
       - rosbag2_compression
       - rosbag2_converter_default_plugins
       - rosbag2_cpp
+      - rosbag2_performance_writer_benchmarking
+      - rosbag2_py
       - rosbag2_storage
       - rosbag2_storage_default_plugins
       - rosbag2_test_common
@@ -1884,7 +1886,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.2-2
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.4.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.2-2`

## ros2bag

```
* read yaml config file (#497 <https://github.com/ros2/rosbag2/issues/497>)
* List all storage plugins in plugin xml file (#554 <https://github.com/ros2/rosbag2/issues/554>)
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Update deprecated qos policy value names (#548 <https://github.com/ros2/rosbag2/issues/548>)
* Add record test for ros2bag (#523 <https://github.com/ros2/rosbag2/issues/523>)
* Removed duplicated code in record (#534 <https://github.com/ros2/rosbag2/issues/534>)
* Change default cache size for sequential_writer to a non zero value (#533 <https://github.com/ros2/rosbag2/issues/533>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* [ros2bag test_record] Gets rid of time.sleep and move to using command.wait_for_output (#525 <https://github.com/ros2/rosbag2/issues/525>)
* Add pytest.ini back to ros2bag. (#492 <https://github.com/ros2/rosbag2/issues/492>)
* performance testing packages (#442 <https://github.com/ros2/rosbag2/issues/442>)
* Validate QoS profile values are not negative. (#483 <https://github.com/ros2/rosbag2/issues/483>)
* catch parent exception (#472 <https://github.com/ros2/rosbag2/issues/472>)
* add wait for closed file handles on Windows (#470 <https://github.com/ros2/rosbag2/issues/470>)
* introduce ros2 bag list <plugins> (#468 <https://github.com/ros2/rosbag2/issues/468>)
* move wait_for_shutdown() call out of the context manager (#466 <https://github.com/ros2/rosbag2/issues/466>)
* Adding db directory creation to rosbag2_cpp (#450 <https://github.com/ros2/rosbag2/issues/450>)
* use a single temp dir for the test class (#462 <https://github.com/ros2/rosbag2/issues/462>)
* Add per-message ZSTD compression (#418 <https://github.com/ros2/rosbag2/issues/418>)
* Add split by time to recording (#409 <https://github.com/ros2/rosbag2/issues/409>)
* Add pytest.ini so local tests don't display warning (#446 <https://github.com/ros2/rosbag2/issues/446>)
* Contributors: Adam Dąbrowski, Barry Xu, Chris Lalancette, Dirk Thomas, Ivan Santiago Paunovic, Jacob Perron, Jaison Titus, Jesse Ikawa, Karsten Knese, Marwan Taher, Michael Jeronimo, P. J. Reed, jhdcs
```

## rosbag2

```
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* AMENT_IGNORE rosbag2_py for now (#509 <https://github.com/ros2/rosbag2/issues/509>)
* rosbag2_py reader and writer (#308 <https://github.com/ros2/rosbag2/issues/308>)
* Contributors: Karsten Knese, Mabel Zhang, Michael Jeronimo
```

## rosbag2_compression

```
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Do not expect empty StorageOptions URI to work in CompressionWriterTest (#526 <https://github.com/ros2/rosbag2/issues/526>)
* Remove some code duplication between SequentialWriter and SequentialCompressionWriter (#527 <https://github.com/ros2/rosbag2/issues/527>)
* Fix exception thrown given invalid arguments with compression enabled (#488 <https://github.com/ros2/rosbag2/issues/488>)
* Adding db directory creation to rosbag2_cpp (#450 <https://github.com/ros2/rosbag2/issues/450>)
* Consolidate ZSTD utility functions (#459 <https://github.com/ros2/rosbag2/issues/459>)
* Add per-message ZSTD compression (#418 <https://github.com/ros2/rosbag2/issues/418>)
* Contributors: Christophe Bedard, Devin Bonnie, Jaison Titus, Karsten Knese, Marwan Taher, Michael Jeronimo, P. J. Reed
```

## rosbag2_converter_default_plugins

```
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Contributors: Michael Jeronimo
```

## rosbag2_cpp

```
* correct master build (#552 <https://github.com/ros2/rosbag2/issues/552>)
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Mutex around writer access in recorder (#491 <https://github.com/ros2/rosbag2/issues/491>)
* if cache data exists, it needs to flush the data into the storage before shutdown (#541 <https://github.com/ros2/rosbag2/issues/541>)
* Change default cache size for sequential_writer to a non zero value (#533 <https://github.com/ros2/rosbag2/issues/533>)
* SequentialWriter to cache by message size instead of message count (#530 <https://github.com/ros2/rosbag2/issues/530>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Remove some code duplication between SequentialWriter and SequentialCompressionWriter (#527 <https://github.com/ros2/rosbag2/issues/527>)
* disable sanitizer by default (#517 <https://github.com/ros2/rosbag2/issues/517>)
* Fix typo in error message (#475 <https://github.com/ros2/rosbag2/issues/475>)
* introduce defaults for the C++ API (#452 <https://github.com/ros2/rosbag2/issues/452>)
* Adding db directory creation to rosbag2_cpp (#450 <https://github.com/ros2/rosbag2/issues/450>)
* comment out unused variable (#460 <https://github.com/ros2/rosbag2/issues/460>)
* minimal c++ API test (#451 <https://github.com/ros2/rosbag2/issues/451>)
* Add split by time to recording (#409 <https://github.com/ros2/rosbag2/issues/409>)
* Contributors: Dirk Thomas, Jacob Perron, Jaison Titus, Karsten Knese, Marwan Taher, Michael Jeronimo, Patrick Spieler, jhdcs, Tomoya Fujita
```

## rosbag2_performance_writer_benchmarking

```
* read yaml config file (#497 <https://github.com/ros2/rosbag2/issues/497>)
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* performance testing packages (#442 <https://github.com/ros2/rosbag2/issues/442>)
* Contributors: Adam Dąbrowski, Karsten Knese, Michael Jeronimo
```

## rosbag2_py

```
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Workaround pybind11 bug on Windows when CMAKE_BUILD_TYPE=RelWithDebInfo (#538 <https://github.com/ros2/rosbag2/issues/538>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Fix rosbag2_py on Windows debug and stop ignoring the package (#531 <https://github.com/ros2/rosbag2/issues/531>)
* Fix rosbag2_py bug when using libc++ (#529 <https://github.com/ros2/rosbag2/issues/529>)
* AMENT_IGNORE rosbag2_py for now (#509 <https://github.com/ros2/rosbag2/issues/509>)
* rosbag2_py reader and writer (#308 <https://github.com/ros2/rosbag2/issues/308>)
* Contributors: Ivan Santiago Paunovic, Karsten Knese, Mabel Zhang, Michael Jeronimo
```

## rosbag2_storage

```
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Add split by time to recording (#409 <https://github.com/ros2/rosbag2/issues/409>)
* Contributors: Karsten Knese, Michael Jeronimo, jhdcs
```

## rosbag2_storage_default_plugins

```
* read yaml config file (#497 <https://github.com/ros2/rosbag2/issues/497>)
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Contributors: Karsten Knese, Michael Jeronimo
```

## rosbag2_test_common

```
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Contributors: Michael Jeronimo
```

## rosbag2_tests

```
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Removed duplicated code in record (#534 <https://github.com/ros2/rosbag2/issues/534>)
* Change default cache size for sequential_writer to a non zero value (#533 <https://github.com/ros2/rosbag2/issues/533>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Mark flaky tests as xfail for now (#520 <https://github.com/ros2/rosbag2/issues/520>)
* introduce defaults for the C++ API (#452 <https://github.com/ros2/rosbag2/issues/452>)
* Adding db directory creation to rosbag2_cpp (#450 <https://github.com/ros2/rosbag2/issues/450>)
* minimal c++ API test (#451 <https://github.com/ros2/rosbag2/issues/451>)
* Add split by time to recording (#409 <https://github.com/ros2/rosbag2/issues/409>)
* Contributors: Emerson Knapp, Jaison Titus, Karsten Knese, Marwan Taher, Michael Jeronimo, jhdcs
```

## rosbag2_transport

```
* add storage_config_uri (#493 <https://github.com/ros2/rosbag2/issues/493>)
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* resolve memory leak for serialized message (#502 <https://github.com/ros2/rosbag2/issues/502>)
* Use shared logic for importing the rosbag2_transport_py library in Python (#482 <https://github.com/ros2/rosbag2/issues/482>)
* fix missing target dependencies (#479 <https://github.com/ros2/rosbag2/issues/479>)
* reenable cppcheck for rosbag2_transport (#461 <https://github.com/ros2/rosbag2/issues/461>)
* More reliable topic remapping test (#456 <https://github.com/ros2/rosbag2/issues/456>)
* Add split by time to recording (#409 <https://github.com/ros2/rosbag2/issues/409>)
* export shared_queues_vendor (#434 <https://github.com/ros2/rosbag2/issues/434>)
* Contributors: Dirk Thomas, Emerson Knapp, Karsten Knese, Michael Jeronimo, jhdcs
```

## shared_queues_vendor

```
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Contributors: Michael Jeronimo
```

## sqlite3_vendor

```
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* use interface_include_directories (#426 <https://github.com/ros2/rosbag2/issues/426>)
* Contributors: Karsten Knese, Michael Jeronimo
```

## zstd_vendor

```
* Update the package.xml files with the latest Open Robotics maintainers (#535 <https://github.com/ros2/rosbag2/issues/535>)
* Contributors: Michael Jeronimo
```
