### PR TITLE
rosdep: add xclip

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6427,6 +6427,15 @@ x11proto-print-dev:
   debian: [x11proto-print-dev]
   fedora: [xorg-x11-proto-devel]
   ubuntu: [x11proto-print-dev]
+xclip:
+  arch: [xclip]
+  debian: [xclip]
+  fedora: [xclip]
+  gentoo: [x11-misc/xclip]
+  osx:
+    homebrew:
+      packages: [xclip]
+  ubuntu: [xclip]
 xdotool:
   arch: [xdotool]
   debian: [xdotool]


### PR DESCRIPTION
## Package name:
xclip
 
## Package Upstream Source:
https://github.com/astrand/xclip

## Purpose of using this:
xclip is a command line interface to X selections (clipboard).  This simplifies putting data in the clipboard when not using a framework like qt.

## Links to Distribution Packages
- Ubuntu: https://packages.ubuntu.com/xenial/xclip
- Debian: https://packages.debian.org/buster/xclip
- Fedora: https://src.fedoraproject.org/rpms/xclip
- Arch: https://www.archlinux.org/packages/extra/x86_64/xclip/
- Gentoo: https://packages.gentoo.org/packages/x11-misc/xclip
- macOS: https://formulae.brew.sh/formula/xclip