### PR TITLE
Add rosdep key for python3 owlready2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6105,6 +6105,16 @@ python3-opengl:
   fedora: [python3-pyopengl]
   gentoo: [dev-python/pyopengl]
   ubuntu: [python3-opengl]
+python3-owlready2-pip:
+  debian:
+    pip:
+      packages: [owlready2]
+  fedora:
+    pip:
+      packages: [owlready2]
+  ubuntu:
+    pip:
+      packages: [owlready2]
 python3-packaging:
   debian: [python3-packaging]
   fedora: [python3-packaging]


### PR DESCRIPTION
Adds `python3-owlready2-pip` to `rosdep/python.yaml` file

Owlready2 is used for ontology-oriented programming in Python. It can load OWL 2.0 ontologies as Python objects, modify them, save them, and perform reasoning.

pip: https://pypi.org/project/Owlready2/
source: https://bitbucket.org/jibalamy/owlready2/commits/