### PR TITLE
plotjuggler_ros: 1.0.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8100,6 +8100,21 @@ repositories:
       url: https://github.com/facontidavide/plotjuggler_msgs.git
       version: ros1
     status: developed
+  plotjuggler_ros:
+    doc:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: development
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: development
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.0.0-2`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## plotjuggler_ros

```
* Initial commit
* Contributors: Davide Faconti
```
