### PR TITLE
rclc: 0.1.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2353,10 +2353,11 @@ repositories:
       packages:
       - rclc
       - rclc_examples
+      - rclc_lifecycle
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/micro-ROS/rclc-release.git
-      version: 0.1.2-1
+      version: 0.1.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `0.1.3-2`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/micro-ROS/rclc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.2-1`

## rclc

```
* Added rclc_lifecycle package
* Change maintainer information
* Minor fixes, updated unit tests
```

## rclc_examples

```
* Added rclc_lifecycle package
```

## rclc_lifecycle

```
* Aligned version number to rclc repository
```
