### PR TITLE
plotjuggler_ros: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3913,11 +3913,19 @@ repositories:
       version: ros1
     status: developed
   plotjuggler_ros:
+    doc:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: development
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
       version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: development
     status: developed
   pluginlib:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3912,6 +3912,13 @@ repositories:
       url: https://github.com/facontidavide/plotjuggler_msgs.git
       version: ros1
     status: developed
+  plotjuggler_ros:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
+      version: 1.0.0-1
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.0.0-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## plotjuggler_ros

```
* Initial commit
* Contributors: Davide Faconti
```
