### PR TITLE
interactive_marker_twist_server: 1.2.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2279,6 +2279,21 @@ repositories:
       url: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
       version: master
     status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
+      version: 1.2.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: kinetic-devel
+    status: maintained
   interactive_markers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.2.0-2`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## interactive_marker_twist_server

```
* Fixed CMake warning and updated to package format 2. (#11 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/11>)
* Install the default config files. (#10 <https://github.com/ros-visualization/interactive_marker_twist_server/issues/10>)
* Contributors: Tony Baltovski
```
