### PR TITLE
microstrain_3dmgx2_imu: 1.5.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3078,6 +3078,21 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: noetic-devel
     status: maintained
+  microstrain_3dmgx2_imu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
+      version: 1.5.13-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
+      version: indigo-devel
+    status: maintained
   mir_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_3dmgx2_imu` to `1.5.13-1`:

- upstream repository: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
- release repository: https://github.com/ros-gbp/microstrain_3dmgx2_imu-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## microstrain_3dmgx2_imu

```
* Merge pull request #11 <https://github.com/ros-drivers/microstrain_3dmgx2_imu/issues/11> from scpeters/fix_melodic_build
  Fix melodic build (backwards compatible alternative to #10 <https://github.com/ros-drivers/microstrain_3dmgx2_imu/issues/10>)
* from C++11, constexpr specifier is requred for double
* Contributors: Kei Okada, Tony Baltovski
```
