### PR TITLE
Add cnpy package

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -483,6 +483,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cnpy:
+    doc:
+      type: git
+      url: https://github.com/PeterMitrano/cnpy.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PeterMitrano/cnpy-release.git
+      version: 0.0.0
+    source:
+      type: git
+      url: https://github.com/PeterMitrano/cnpy.git
+      version: master
+    status: maintained
   cob_android:
     doc:
       type: git


### PR DESCRIPTION
Forgive me if I'm mistaken, but I think this is the first step towards releasing. This package has a dependency on zlib, so I feel like that should be listed somewhere (rosdep?)