### PR TITLE
Updating llvm in Debian Stretch to match Ubuntu 18.04 version.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4694,12 +4694,16 @@ linux-kernel-headers:
   ubuntu: [linux-libc-dev]
 llvm:
   arch: [llvm]
-  debian: [llvm]
+  debian:
+    '*': [llvm]
+    stretch: [llvm-6.0]
   gentoo: [sys-devel/llvm]
   ubuntu: [llvm]
 llvm-dev:
   arch: [llvm]
-  debian: [llvm-dev]
+  debian:
+    '*': [llvm-dev]
+    stretch: [llvm-6.0-dev]
   gentoo: [sys-devel/llvm]
   ubuntu: [llvm-dev]
 lm-sensors:


### PR DESCRIPTION
The default version of LLVM tied to the `llvm` and `llvm-dev` packages in Debian Stretch is _very_ old and does not match the version provided in Ubuntu 18.04. This updates the version for Debian Stretch to match the version available in the equivalent Ubuntu version.