### PR TITLE
pilz_robots: 0.5.21-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8001,7 +8001,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_robots-release.git
-      version: 0.5.20-1
+      version: 0.5.21-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_robots` to `0.5.21-1`:

- upstream repository: https://github.com/PilzDE/pilz_robots.git
- release repository: https://github.com/PilzDE/pilz_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.20-1`

## pilz_control

- No changes

## pilz_robots

- No changes

## pilz_status_indicator_rqt

```
* Update references to OperationMode msg and GetOperationMode srv (moved to pilz_msgs)
* Contributors: Pilz GmbH and Co. KG
```

## prbt_gazebo

- No changes

## prbt_hardware_support

```
* Move OperationMode msg and GetOperationMode srv to pilz_msgs
* Contributors: Pilz GmbH and Co. KG
```

## prbt_ikfast_manipulator_plugin

- No changes

## prbt_moveit_config

```
* Move capabilities arguments into planning pipeline
* Contributors: Pilz GmbH and Co. KG
```

## prbt_support

- No changes
