### PR TITLE
Melodic: Update exotica to 6.0.2 to address memory exhaustion

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2795,7 +2795,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/exotica-release.git
-      version: 6.0.1-1
+      version: 6.0.2-1
     source:
       type: git
       url: https://github.com/ipab-slmc/exotica.git


### PR DESCRIPTION
This should reduce the memory consumption for single core compilation of `exotica_pinocchio_dynamics_solver` enough to not fail (by splitting a couple methods that require extensive headers into their own cpp files). Due to Pinocchio, we cannot reduce it further :-(. Measured locally - previously 7.6 GB peak, now 6.1 GB peak.