### PR TITLE
cnpy: 0.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -483,6 +483,21 @@ repositories:
       url: https://github.com/ros/cmake_modules.git
       version: 0.4-devel
     status: maintained
+  cnpy:
+    doc:
+      type: git
+      url: https://github.com/PeterMitrano/cnpy.git
+      version: 0.0.1
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PeterMitrano/cnpy-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/PeterMitrano/cnpy.git
+      version: 0.0.1
+    status: maintained
   cob_android:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cnpy` to `0.0.1-1`:

- upstream repository: https://github.com/PeterMitrano/cnpy.git
- release repository: https://github.com/PeterMitrano/cnpy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
