### PR TITLE
log_view: 0.1.0 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7003,6 +7003,17 @@ repositories:
       url: https://github.com/easymov/log_server-release.git
       version: 0.1.4-1
     status: developed
+  log_view:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/hatchbed/log_view-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: devel
+    status: developed
   loki_base_node:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository log_view to 0.1.0:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: kinetic/distribution.yaml
- bloom version: 0.10.0
- previous version for package: null

## log_view
```
* Initial working version.
* Initial code.
* Contributors: Marc Alban
```