### PR TITLE
log_view: 0.1.0 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5505,6 +5505,21 @@ repositories:
       url: https://github.com/clearpathrobotics/lms1xx.git
       version: melodic-devel
     status: maintained
+  log_view:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/hatchbed/log_view-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: devel
+    status: developed
   lusb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository log_view to 0.1.0:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: melodic/distribution.yaml
- bloom version: 0.10.0
- previous version for package: null

## log_view
```
* Initial working version.
* Initial code.
* Contributors: Marc Alban
```