### PR TITLE
log_view: 0.1.0 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2835,6 +2835,21 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  log_view:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/hatchbed/log_view-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: devel
+    status: developed
   lusb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository log_view to 0.1.0:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: noetic/distribution.yaml
- bloom version: 0.10.0
- previous version for package: null

## log_view
```
* Initial working version.
* Initial code.
* Contributors: Marc Alban
```