### PR TITLE
Add new key for gurumdds-2.7.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1412,6 +1412,8 @@ gtk3:
   ubuntu: [libgtk-3-dev]
 gurumdds-2.6:
   ubuntu: [gurumdds-2.6]
+gurumdds-2.7:
+  ubuntu: [gurumdds-2.7]
 gv:
   arch: [gv]
   debian: [gv]


### PR DESCRIPTION
GurumDDS 2.7 is being imported into the ROS bootstrap repositories. I'll post the upload jobs here when they are available.