### PR TITLE
psen_scan_v2: 0.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8575,7 +8575,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git
-      version: melodic-devel
+      version: main
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -8584,7 +8584,7 @@ repositories:
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git
-      version: melodic-devel
+      version: main
     status: developed
   px4_msgs:
     release:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8580,7 +8580,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.1.2-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.1-1`

## psen_scan_v2

```
* Add Scanner ports in ScannerConfiguration
* Switch branching model: Introduce main branch
* Use github actions
* Adds missing error bit
* Contributors: Pilz GmbH and Co. KG
```
