### PR TITLE
rc_visard: 3.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9134,7 +9134,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_visard-release.git
-      version: 3.0.5-1
+      version: 3.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_visard` to `3.1.0-2`:

- upstream repository: https://github.com/roboception/rc_visard_ros.git
- release repository: https://github.com/roboception-gbp/rc_visard-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.5-1`

## rc_hand_eye_calibration_client

- No changes

## rc_pick_client

- No changes

## rc_roi_manager_gui

- No changes

## rc_silhouettematch_client

- No changes

## rc_tagdetect_client

- No changes

## rc_visard

- No changes

## rc_visard_description

- No changes

## rc_visard_driver

```
* Change: publish all images on */image_rect topics, meaning don't filter out1 low in alternate mode
* Change: always publish *_out1_low and *_out1_high topics even if no iocontrol license is available
* debug messages when GenICam params are changed
* rename adaptive_out1_reduction to out1_reduction
* add Out1High camera_exp_auto_mode (requires rc_visard firmware <= 20.10.1)
* add depth_double_shot parameter (requires rc_visard firmware <= 20.10.1)
```
