### PR TITLE
rc_genicam_driver: 0.4.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9109,7 +9109,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
-      version: 0.2.0-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.4.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.0-1`

## rc_genicam_driver

```
* Added new parameter depth_double_shot
```
