### PR TITLE
robot_statemachine: 1.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9597,7 +9597,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/MarcoStb1993/robot_statemachine-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/MarcoStb1993/robot_statemachine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_statemachine` to `1.2.1-1`:

- upstream repository: https://github.com/MarcoStb1993/robot_statemachine.git
- release repository: https://github.com/MarcoStb1993/robot_statemachine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.0-1`

## robot_statemachine

- No changes

## rsm_additions

```
* Add nav_msgs dependency
* Add nav msgs dependency
* Contributors: MarcoStb1993
```

## rsm_core

- No changes

## rsm_msgs

- No changes

## rsm_rqt_plugins

```
* Next try fixing qt dependencies
* (Hopefully) fixed missing qt5 build errors
* Contributors: Marco Steinbrink
```

## rsm_rviz_plugins

```
* Next try fixing qt dependencies
* (Hopefully) fixed missing qt5 build errors
* Contributors: Marco Steinbrink
```
