### PR TITLE
pilz_industrial_motion: 0.4.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7977,7 +7977,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/pilz_industrial_motion-release.git
-      version: 0.4.11-1
+      version: 0.4.12-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_industrial_motion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_industrial_motion` to `0.4.12-1`:

- upstream repository: https://github.com/PilzDE/pilz_industrial_motion.git
- release repository: https://github.com/PilzDE/pilz_industrial_motion-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.11-1`

## pilz_extensions

- No changes

## pilz_industrial_motion

```
* Remove pilz_msgs from meta-package
* Contributors: Pilz GmbH and Co. KG
```

## pilz_robot_programming

```
* Adapt to generalized test-utils
* Add missing test-depend on prbt_hardware_support
* Contributors: Pilz GmbH and Co. KG
```

## pilz_store_positions

```
* Use new coverage feature of ros_pytest
* Contributors: Pilz GmbH and Co. KG
```

## pilz_trajectory_generation

- No changes
