### PR TITLE
rqt_bag: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2143,6 +2143,24 @@ repositories:
       url: https://github.com/ros-visualization/rqt_action.git
       version: crystal-devel
     status: maintained
+  rqt_bag:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: ros2
+    release:
+      packages:
+      - rqt_bag
+      - rqt_bag_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_bag-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: ros2
+    status: maintained
   rqt_common_plugins:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rqt_bag

```
* Fix exec_depend (#89 <https://github.com/ros-visualization/rqt_bag/issues/89>)
* Use updated HistoryPolicy values to avoid deprecation warnings (#88 <https://github.com/ros-visualization/rqt_bag/issues/88>)
* Enable recording for ROS2 (#87 <https://github.com/ros-visualization/rqt_bag/issues/87>)
* Enable the playback functionality for ROS2 (#85 <https://github.com/ros-visualization/rqt_bag/issues/85>)
* Port the topic and node selection dialogs to ROS2 (#86 <https://github.com/ros-visualization/rqt_bag/issues/86>)
* Save the serialization format and offered_qos_profiles when exporting (#84 <https://github.com/ros-visualization/rqt_bag/issues/84>)
* Enable the export/save bag functionality for ROS2 (#82 <https://github.com/ros-visualization/rqt_bag/issues/82>)
* Update known message types and associated colors (#81 <https://github.com/ros-visualization/rqt_bag/issues/81>)
* Open the bag directory instead of a single file (#80 <https://github.com/ros-visualization/rqt_bag/issues/80>)
* Port the image_view plugin to ROS2 (#78 <https://github.com/ros-visualization/rqt_bag/issues/78>)
* Clean up widgets in plot_view layout correctly (#69 <https://github.com/ros-visualization/rqt_bag/issues/69>) (#77 <https://github.com/ros-visualization/rqt_bag/issues/77>)
* Fix tuples for bisect calls (#67 <https://github.com/ros-visualization/rqt_bag/issues/67>) (#76 <https://github.com/ros-visualization/rqt_bag/issues/76>)
* Fix issue: no vertical scroll bar until window is resized (#63 <https://github.com/ros-visualization/rqt_bag/issues/63>) (#75 <https://github.com/ros-visualization/rqt_bag/issues/75>)
* Update the basic plugins for ROS2 (#72 <https://github.com/ros-visualization/rqt_bag/issues/72>)
* Update the rosbag2 python module (#71 <https://github.com/ros-visualization/rqt_bag/issues/71>)
* Dynamically resize the timeline when recording (#66 <https://github.com/ros-visualization/rqt_bag/issues/66>)
* Starting point for resuming the ROS2 port (#70 <https://github.com/ros-visualization/rqt_bag/issues/70>)
* Fix a bug with the status line progress bar (#62 <https://github.com/ros-visualization/rqt_bag/issues/62>)
* Update a few minor status bar-related items (#61 <https://github.com/ros-visualization/rqt_bag/issues/61>)
* Make the tree controls in the Raw View and Plot View consistent (#57 <https://github.com/ros-visualization/rqt_bag/issues/57>)
* Update the package.xml files with the latest Open Robotics maintainers (#58 <https://github.com/ros-visualization/rqt_bag/issues/58>)
* Contributors: Chris Lalancette, Michael Jeronimo
```

## rqt_bag_plugins

```
* Port the plot view to ROS2 (#79 <https://github.com/ros-visualization/rqt_bag/issues/79>)
* Port the image_view plugin to ROS2 (#78 <https://github.com/ros-visualization/rqt_bag/issues/78>)
* Starting point for resuming the ROS2 port (#70 <https://github.com/ros-visualization/rqt_bag/issues/70>)
* Make the tree controls in the Raw View and Plot View consistent (#57 <https://github.com/ros-visualization/rqt_bag/issues/57>)
* Update the package.xml files with the latest Open Robotics maintainers (#58 <https://github.com/ros-visualization/rqt_bag/issues/58>)
* initialize pil_mode when image is compressed (#54 <https://github.com/ros-visualization/rqt_bag/issues/54>)
* Contributors: John Stechschulte, Michael Jeronimo
```
