### PR TITLE
[rosdep] Adding llvm-7 and llvm-7-dev keys.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4697,6 +4697,20 @@ llvm:
   debian: [llvm]
   gentoo: [sys-devel/llvm]
   ubuntu: [llvm]
+llvm-7:
+  debian:
+    buster: [llvm-7]
+    stretch: [llvm-7]
+  ubuntu:
+    bionic: [llvm-7]
+    focal: [llvm-7]
+llvm-7-dev:
+  debian:
+    buster: [llvm-7-dev]
+    stretch: [llvm-7-dev]
+  ubuntu:
+    bionic: [llvm-7-dev]
+    focal: [llvm-7-dev]
 llvm-dev:
   arch: [llvm]
   debian: [llvm-dev]


### PR DESCRIPTION
Solves problem described in #27432 

- Debian: https://packages.debian.org/search?keywords=llvm-7&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/search?keywords=llvm-7&searchon=names&suite=all&section=all