### PR TITLE
ament_cmake: 0.7.6-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -49,7 +49,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       test_abi: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `0.7.6-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.5-1`
