### PR TITLE
poco_vendor: 1.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1953,7 +1953,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/poco_vendor-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `poco_vendor` to `1.2.1-1`:

- upstream repository: https://github.com/ros2/poco_vendor.git
- release repository: https://github.com/ros2-gbp/poco_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.0-1`
