### PR TITLE
exotica: 6.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1550,7 +1550,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipab-slmc/exotica-release.git
-      version: 6.0.1-1
+      version: 6.0.2-1
     source:
       type: git
       url: https://github.com/ipab-slmc/exotica.git


### PR DESCRIPTION
Increasing version of package(s) in repository `exotica` to `6.0.2-1`:

- upstream repository: https://github.com/ipab-slmc/exotica.git
- release repository: https://github.com/ipab-slmc/exotica-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `6.0.1-1`

## exotica

- No changes

## exotica_aico_solver

- No changes

## exotica_cartpole_dynamics_solver

- No changes

## exotica_collision_scene_fcl_latest

- No changes

## exotica_core

- No changes

## exotica_core_task_maps

- No changes

## exotica_ddp_solver

- No changes

## exotica_double_integrator_dynamics_solver

- No changes

## exotica_dynamics_solvers

- No changes

## exotica_examples

- No changes

## exotica_ik_solver

- No changes

## exotica_ilqg_solver

- No changes

## exotica_ilqr_solver

- No changes

## exotica_levenberg_marquardt_solver

- No changes

## exotica_ompl_control_solver

- No changes

## exotica_ompl_solver

- No changes

## exotica_pendulum_dynamics_solver

- No changes

## exotica_pinocchio_dynamics_solver

```
* Split derivatives into separate compile units to reduce memory consumption (7.6 GB peak to 6.1 GB peak) (#729 <https://github.com/ipab-slmc/exotica/issues/729>)
* Contributors: Wolfgang Merkt
```

## exotica_python

- No changes

## exotica_quadrotor_dynamics_solver

- No changes

## exotica_scipy_solver

- No changes

## exotica_time_indexed_rrt_connect_solver

- No changes
