### PR TITLE
log_view: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7004,11 +7004,15 @@ repositories:
       version: 0.1.4-1
     status: developed
   log_view:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/hatchbed/log_view-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.1.1-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-1`

## log_view

```
* Fixes for build farm.
* Contributors: Marc Alban
```
