### PR TITLE
launch_ros: 0.8.9-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1406,7 +1406,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.8.8-1
+      version: 0.8.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.8.9-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.8-1`

## launch_ros

```
* Resolve libyaml warning when loading parameters from file. (#161 <https://github.com/ros2/launch_ros/issues/161>) (#204 <https://github.com/ros2/launch_ros/issues/204>)
* Update maintainers for Dashing. (#192 <https://github.com/ros2/launch_ros/issues/192>)
* Contributors: Dereck Wonnacott, Jacob Perron, Michael Jeronimo
```

## launch_testing_ros

```
* Update maintainers for Dashing. (#192 <https://github.com/ros2/launch_ros/issues/192>)
* Contributors: Michael Jeronimo
```

## ros2launch

```
* Update maintainers for Dashing. (#192 <https://github.com/ros2/launch_ros/issues/192>)
* Contributors: Michael Jeronimo
```
