### PR TITLE
rviz: 6.1.7-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3364,7 +3364,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 6.1.6-1
+      version: 6.1.7-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `6.1.7-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `6.1.6-1`

## rviz2

```
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Michael Jeronimo
```

## rviz_assimp_vendor

```
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Michael Jeronimo
```

## rviz_common

```
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Michael Jeronimo
```

## rviz_default_plugins

```
* Fix map display for moving TF frame. (#483 <https://github.com/ros2/rviz/issues/483>) (#582 <https://github.com/ros2/rviz/issues/582>)
* Set clock type if Marker frame_locked is true. (#482 <https://github.com/ros2/rviz/issues/482>) (#583 <https://github.com/ros2/rviz/issues/583>)
* Use dedicated TransformListener thread. (#551 <https://github.com/ros2/rviz/issues/551>) (#584 <https://github.com/ros2/rviz/issues/584>)
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Jacob Perron, Michael Jeronimo
```

## rviz_ogre_vendor

```
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Michael Jeronimo
```

## rviz_rendering

```
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Michael Jeronimo
```

## rviz_rendering_tests

```
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Michael Jeronimo
```

## rviz_visual_testing_framework

```
* Update maintainers. (#617 <https://github.com/ros2/rviz/issues/617>)
* Contributors: Michael Jeronimo
```
