### PR TITLE
Add rosdep key for python3 thriftpy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6730,10 +6730,9 @@ python3-texttable:
   gentoo: [dev-python/texttable]
   rhel: ['python%{python3_pkgversion}-texttable']
   ubuntu: [python3-texttable]
-python3-thriftpy-pip:
-  ubuntu:
-    pip:
-      packages: [thriftpy]
+python3-thriftpy:
+  fedora: [python3-thriftpy]
+  ubuntu: [python3-thriftpy]
 python3-tilestache-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6730,6 +6730,10 @@ python3-texttable:
   gentoo: [dev-python/texttable]
   rhel: ['python%{python3_pkgversion}-texttable']
   ubuntu: [python3-texttable]
+python3-thriftpy-pip:
+  ubuntu:
+    pip:
+      packages: [thriftpy]
 python3-tilestache-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6732,7 +6732,11 @@ python3-texttable:
   ubuntu: [python3-texttable]
 python3-thriftpy:
   fedora: [python3-thriftpy]
-  ubuntu: [python3-thriftpy]
+  ubuntu:
+    '*': [python3-thiftpy]
+    xenial:
+      pip:
+        packages: [thriftpy]
 python3-tilestache-pip:
   debian:
     pip:


### PR DESCRIPTION
Adds python3-thriftpy-pip to rosdep/python.yaml file

ThriftPy is a pure python implementation of Apache Thrift in a pythonic way.

pip: https://pypi.org/project/thriftpy/
doc: https://thriftpy.readthedocs.io/en/latest/