### PR TITLE
leo_robot: 1.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5261,7 +5261,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_robot-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.1.2-1`:

- upstream repository: https://github.com/LeoRover/leo_robot.git
- release repository: https://github.com/fictionlab-gbp/leo_robot-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.1-1`

## leo_bringup

```
* Add rosapi node
```

## leo_fw

- No changes

## leo_robot

- No changes
