### PR TITLE
Revert rosbridge_suite kinetic to 0.11.10-1

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13258,7 +13258,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.11-1
+      version: 0.11.10-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Python 2 is broken in 0.11.11, must not be synced.