### PR TITLE
gazebo_ros_pkgs: 3.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -616,7 +616,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.5.0-1
+      version: 3.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.5.1-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.5.0-1`

## gazebo_dev

```
* colcon.pkg: build gazebo first in colcon workspace (#1192 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1192>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
  Signed-off-by: Steve Peters <mailto:scpeters@openrobotics.org>
* Contributors: Steve Peters
```

## gazebo_msgs

```
* [ROS 2] Bridge to republish PerformanceMetrics in ROS 2 (#1147 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1147>)
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero
```

## gazebo_plugins

```
* colcon.pkg: build gazebo first in colcon workspace (#1192 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1192>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
  Signed-off-by: Steve Peters <mailto:scpeters@openrobotics.org>
* Fixed Parameterized testing on Rolling (#1184 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1184>)
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* adding buffer to gzebo ros hand of god plugin (#1179 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1179>)
  Fixes #1178 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1178>.
* [gazebo_plugins] address warnings (#1151 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1151>)
  * use .c_str() for variadic template
  * silence warnings
  Signed-off-by: Karsten Knese <mailto:Karsten1987@users.noreply.github.com>
  Signed-off-by: Steve Peters <mailto:scpeters@openrobotics.org>
* Port wheel slip plugin to ros2 (forward port from eloquent) (#1148 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1148>)
  Forward port of wheel slip plugin from eloquent (#1099 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1099>)
  to foxy.
  It includes a similar change to #1111 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1111>, which moved the
  WheelSlipPlugin::Load call before the parameter callback
  so that the values from SDF/URDF are set first.
  Then the callback is changed to ignore negative values, and the
  default slip parameter values are set to -1, so that the SDF/URDF
  values are still preferred unless a different parameter value
  is specified in a launch file.
  Signed-off-by: Steve Peters <scpeters@openrobotics.org>
* Added ignition common profiler to ros2 (#1141 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1141>)
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero, Karsten Knese, Steve Macenski, Steve Peters
```

## gazebo_ros

```
* colcon.pkg: build gazebo first in colcon workspace (#1192 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1192>)
  Add a colcon.pkg file to gazebo_dev with gazebo's cmake project
  name "Gazebo" listed as a dependency to support building
  gazebo from source in a colcon workspace.
  * Add colcon.pkg files for other packages
  Copy colcon.pkg to gazebo_ros, gazebo_plugins, and
  gazebo_ros_control so that --merge-install won't be required.
  Signed-off-by: Steve Peters <mailto:scpeters@openrobotics.org>
* Fixed Parameterized testing on Rolling (#1184 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1184>)
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* [ROS 2] Bridge to republish PerformanceMetrics in ROS 2 (#1147 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1147>)
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* [Windows] Add missing visibility control. (#1150 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1150>)
* [ros2] Enable the force system on launch files (#1035 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1035>)
  Signed-off-by: Louise Poubel <mailto:louise@openrobotics.org>
* make compile wo/ warnings on osx (#1149 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1149>)
  Signed-off-by: Karsten Knese <mailto:Karsten1987@users.noreply.github.com>
* Added lockstep argument to gzserver (#1146 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1146>)
  Signed-off-by: ahcorde <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero, Karsten Knese, Louise Poubel, Sean Yen, Steve Peters
```

## gazebo_ros_pkgs

- No changes
