### PR TITLE
robot_controllers: 0.8.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2621,6 +2621,25 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: foxy
     status: developed
+  robot_controllers:
+    doc:
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: ros2
+    release:
+      packages:
+      - robot_controllers
+      - robot_controllers_interface
+      - robot_controllers_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
+      version: 0.8.0-1
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: ros2
+    status: maintained
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.8.0-1`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## robot_controllers

```
* Add initial support for ROS2
* fix threading bug in point head controller (#62 <https://github.com/fetchrobotics/robot_controllers/issues/62>)
* get latest transform (#60 <https://github.com/fetchrobotics/robot_controllers/issues/60>)
* add linter, fix errors (#48 <https://github.com/fetchrobotics/robot_controllers/issues/48>)
* parallel gripper tested (#56 <https://github.com/fetchrobotics/robot_controllers/issues/56>)
* remove hard coded frame in point_head (#55 <https://github.com/fetchrobotics/robot_controllers/issues/55>)
* build fixes on eloquent (#54 <https://github.com/fetchrobotics/robot_controllers/issues/54>)
* add support for 4wd bases (#53 <https://github.com/fetchrobotics/robot_controllers/issues/53>)
* test, fix and improve scaled_mimic (#52 <https://github.com/fetchrobotics/robot_controllers/issues/52>)
* fix bug in laser checking: robot would always go slow if laser safety was on.
* Uses C++14
* make preemption work
* fix uninitialized time that would occasionally cause std::runtime_error* improve logging
* switch to service interface
* port all controllers and tested
* add util/declare_parameter_once
* Add time_from_start information to feedback topic (#38 <https://github.com/fetchrobotics/robot_controllers/issues/38>)
* [GCC][Warnings] SYSTEM includes and catch ref (#36 <https://github.com/fetchrobotics/robot_controllers/issues/36>)
  This is an attempt to fix (silence) the buildbot failures from -Werror
* Updates maintainers
* Add init trajectory for future start time (#40 <https://github.com/fetchrobotics/robot_controllers/issues/40>)
* Contributors: Alex Moriarty, Michael Ferguson, Naoya Yamaguchi, Russell Toris, Shingo Kitagawa
```

## robot_controllers_interface

```
* Add initial support for ROS2
* implement getJointNames/getControllerNames (#51 <https://github.com/fetchrobotics/robot_controllers/issues/51>)
  this was discussed in #39 <https://github.com/fetchrobotics/robot_controllers/issues/39>
* Merge pull request #47 <https://github.com/fetchrobotics/robot_controllers/issues/47> from mikeferguson/ros2
* improve logging
* switch to service interface
* gravity compensation controller working in ros2
* Various bug and API fixes
* Added gyro interface to robot controllers (#43 <https://github.com/fetchrobotics/robot_controllers/issues/43>)
* Updates maintainers
* Contributors: Alex Moriarty, Carl Saldanha, Michael Ferguson, Russell Toris
```

## robot_controllers_msgs

```
* Add initial support for ROS2
* Port messages to ros2
* Switch to service interface
* Updates maintainers
* Contributors: Alex Moriarty, Michael Ferguson, Russell Toris
```
