### PR TITLE
add python3-xmltodict-pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5239,7 +5239,7 @@ python-wrapt:
   ubuntu: [python-wrapt]
 python-ws4py:
   debian: [python-ws4py]
-  ubuntu: [python-ws4py]python3-w
+  ubuntu: [python-ws4py]
 python-ws4py-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6874,15 +6874,11 @@ python3-wxgtk4.0:
   fedora: [python3-wxpython4]
   gentoo: [dev-python/wxpython]
   ubuntu: [python3-wxgtk4.0]
-python3-xmltodict-pip:
-  debian:
-    pip: [xmltodict]
-  fedora:
-    pip: [xmltodict]
-  osx:
-    pip: [xmltodict]
-  ubuntu:
-    pip: [xmltodict]
+python3-xmltodict:
+  alpine: [py3-xmltodict]
+  arch: [python-xmltodict]
+  debian: [python3-xmltodict]
+  ubuntu: [python3-xmltodict]
 python3-yaml:
   alpine: [py3-yaml]
   debian: [python3-yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5239,7 +5239,7 @@ python-wrapt:
   ubuntu: [python-wrapt]
 python-ws4py:
   debian: [python-ws4py]
-  ubuntu: [python-ws4py]
+  ubuntu: [python-ws4py]python3-w
 python-ws4py-pip:
   ubuntu:
     pip:
@@ -6874,6 +6874,15 @@ python3-wxgtk4.0:
   fedora: [python3-wxpython4]
   gentoo: [dev-python/wxpython]
   ubuntu: [python3-wxgtk4.0]
+python3-xmltodict-pip:
+  debian:
+    pip: [xmltodict]
+  fedora:
+    pip: [xmltodict]
+  osx:
+    pip: [xmltodict]
+  ubuntu:
+    pip: [xmltodict]
 python3-yaml:
   alpine: [py3-yaml]
   debian: [python3-yaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6878,6 +6878,7 @@ python3-xmltodict:
   alpine: [py3-xmltodict]
   arch: [python-xmltodict]
   debian: [python3-xmltodict]
+  fedora: [python3-xmltodict]
   ubuntu: [python3-xmltodict]
 python3-yaml:
   alpine: [py3-yaml]


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

xmltodict Packages in rosdistro is Python2 version.
https://packages.ubuntu.com/search?keywords=python-xmltodict&searchon=names&suite=groovy&section=all

We want to use it with Python3, so we want to add python3-xmltodict-pip package to rosdistro.