### PR TITLE
realsense2_camera: 2.2.20-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4302,6 +4302,25 @@ repositories:
       url: https://github.com/roboception/rcdiscover.git
       version: master
     status: developed
+  realsense2_camera:
+    doc:
+      type: git
+      url: https://github.com/intel-ros/realsense.git
+      version: development
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_description
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/IntelRealSense/realsense-ros-release.git
+      version: 2.2.20-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: development
+    status: developed
   realtime_tools:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4305,7 +4305,7 @@ repositories:
   realsense2_camera:
     doc:
       type: git
-      url: https://github.com/intel-ros/realsense.git
+      url: https://github.com/IntelRealSense/realsense-ros.git
       version: development
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.20-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## realsense2_camera

```
* Add Support - Noetic
* Add demo for using intrinsics from camera_info (show_center_depth.py).
* Add launch option: send logs to ros log file.
* Add feature: get rgb stream from infrared sensor (applies to D415)
* Add feature: Add notification if connected using USB2.1 port.
* Fix bug: Avoid z16h format
* Fix bug: monitor streams frequency without subsribing.
* Fix bug: extrinsincs for right stereo camera refers to the left stereo camera.
* Contributors: Abhijit Majumdar, Isaac I. Y. Saito, Jakub, M-frctrl, Thomas Jespersen, doronhi
```

## realsense2_description

```
* Add urdf file for l515
* Contributors: doronhi
```
