### PR TITLE
volta_simulation: 1.0.0-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17503,7 +17503,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/botsync-gbp/volta_simulation-release.git
-      version: 1.0.0-1
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `volta_simulation` to `1.0.0-3`:

- upstream repository: https://github.com/botsync/volta_simulation.git
- release repository: https://github.com/botsync-gbp/volta_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## volta_simulation

```
* First Release
```
