### PR TITLE
volta_simulation: 1.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13408,7 +13408,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/botsync-gbp/volta_simulation-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `volta_simulation` to `1.1.0-2`:

- upstream repository: https://github.com/botsync/volta_simulation.git
- release repository: https://github.com/botsync-gbp/volta_simulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`

## volta_simulation

```
* First Release
```
