### PR TITLE
fkie_multimaster: 1.2.5-2 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1671,7 +1671,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 1.2.3-1
+      version: 1.2.5-2
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository fkie_multimaster to 1.2.5-2

upstream repository: [https://github.com/fkie/multimaster_fkie.git](https://github.com/fkie/multimaster_fkie.git)
release repository: [https://github.com/fkie-release/multimaster_fkie-release.git](https://github.com/fkie-release/multimaster_fkie-release.git)
previous version for package: 1.2.3-1