### PR TITLE
plotjuggler: 3.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3936,7 +3936,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.0.2-1`:

- upstream repository: https://github.com/PlotJuggler/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.1-1`

## plotjuggler

```
* fix icon color in dark mode
* updated to latest Qads
* temporary fix for #349 <https://github.com/PlotJuggler/PlotJuggler/issues/349>
* link updated
* use correct dependency
* fix issue #348 <https://github.com/PlotJuggler/PlotJuggler/issues/348>
* Contributors: Davide Faconti
```
