### PR TITLE
plotjuggler: 3.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2009,7 +2009,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.8.4-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.0.2-1`:

- upstream repository: https://github.com/PlotJuggler/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.8.4-1`

## plotjuggler

```
* fix icon color in dark mode
* updated to latest Qads
* temporary fix for #349 <https://github.com/PlotJuggler/PlotJuggler/issues/349>
* link updated
* use correct dependency
* fix issue #348 <https://github.com/PlotJuggler/PlotJuggler/issues/348>
* Contributors: Davide Faconti
```
