### PR TITLE
plotjuggler: 3.0.2-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8093,8 +8093,8 @@ repositories:
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.0.1-1
+      url: https://github.com/PlotJuggler/plotjuggler-release.git
+      version: 3.0.2-3
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.0.2-3`:

- upstream repository: https://github.com/PlotJuggler/PlotJuggler.git
- release repository: https://github.com/PlotJuggler/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.1-1`

## plotjuggler

```
* fix icon color in dark mode
* updated to latest Qads
* temporary fix for #349 <https://github.com/PlotJuggler/PlotJuggler/issues/349>
* link updated
* use correct dependency
* fix issue #348 <https://github.com/PlotJuggler/PlotJuggler/issues/348>
* Contributors: Davide Faconti
```
