### PR TITLE
plotjuggler_ros: 1.0.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2021,6 +2021,21 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler_msgs-release.git
       version: 0.1.2-1
+  plotjuggler_ros:
+    doc:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: development
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: development
+    status: developed
   pluginlib:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.0.0-2`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## plotjuggler_ros

```
* Initial commit
* Contributors: Davide Faconti
```
