### PR TITLE
plotjuggler: 3.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8089,7 +8089,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
-      version: master
+      version: main
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -8098,7 +8098,7 @@ repositories:
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
-      version: master
+      version: main
     status: maintained
   plotjuggler_msgs:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8094,7 +8094,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.0.1-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.0.3-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.1-1`
