### PR TITLE
carla_msgs: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -389,6 +389,21 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  carla_msgs:
+    doc:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/carla-simulator/ros-carla-msgs-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    status: developed
   cartesian_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carla_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/carla-simulator/ros-carla-msgs.git
- release repository: https://github.com/carla-simulator/ros-carla-msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
