### PR TITLE
pilz_common: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3912,6 +3912,26 @@ repositories:
       url: https://bitbucket.org/AndyZe/pid.git
       version: master
     status: maintained
+  pilz_common:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/pilz_common.git
+      version: noetic-devel
+    release:
+      packages:
+      - pilz_industrial_motion_testutils
+      - pilz_msgs
+      - pilz_testutils
+      - pilz_utils
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PilzDE/pilz_common-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/PilzDE/pilz_common.git
+      version: noetic-devel
+    status: developed
   pinocchio:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_common` to `0.7.0-1`:

- upstream repository: https://github.com/PilzDE/pilz_common.git
- release repository: https://github.com/PilzDE/pilz_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## pilz_industrial_motion_testutils

```
* Remove cpp testutils (moved to moveit in noetic)
* Update maintainer list
* Contributors: Pilz GmbH and Co. KG
```

## pilz_msgs

```
* Remove msgs which have been moved to moveit for noetic
* Update maintainer list
* Contributors: Pilz GmbH and Co. KG
```

## pilz_testutils

```
* Update maintainer list
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

```
* Update maintainer list
* Contributors: Pilz GmbH and Co. KG
```
