### PR TITLE
rt_usb_9axisimu_driver: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3464,6 +3464,22 @@ repositories:
       url: https://github.com/ros-visualization/rqt_topic.git
       version: dashing-devel
     status: maintained
+  rt_usb_9axisimu_driver:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
+      version: 2.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: foxy-devel
+    status: maintained
   rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `2.0.1-1`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rt_usb_9axisimu_driver

```
* Update for foxy (#29 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/29>)
* Contributors: Shota Aoki
```
