### PR TITLE
Bumped version for stag_ros

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6110,7 +6110,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/usrl-uofsc/stag_ros-release.git
-      version: 0.3.4-2
+      version: 0.3.6-1
     source:
       type: git
       url: https://github.com/usrl-uofsc/stag_ros.git


### PR DESCRIPTION
This new release should fix issues in the build farm. I had run the prerelease before the original release, but the build farm sent additional errors while building. This will hopefully increase compatibility so that it will not fail.