### PR TITLE
use python2 pycodestyle for python-pycodestyle rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3270,11 +3270,16 @@ python-pyaudio:
   ubuntu: [python-pyaudio]
 python-pycodestyle:
   arch: [python2-pycodestyle]
-  debian: [pycodestyle]
+  debian:
+    '*': null
+    buster: [python-pycodestyle]
+    stretch: [python-pycodestyle]
   fedora: [python-pycodestyle]
   gentoo: [dev-python/pycodestyle]
   rhel: [python2-pycodestyle]
-  ubuntu: [pycodestyle]
+  ubuntu:
+    '*': null
+    bionic: [python-pycodestyle]
 python-pycpd-pip:
   debian:
     pip:


### PR DESCRIPTION
Currently the rules point to the `pycodestyle` package on debian and ubuntu. That is a Python3 package and not Python2.

This PR changes the rule to point to the Python2 version.

Unveiled by https://github.com/osrf/capabilities/pull/94

Debian:
  buster: https://packages.debian.org/buster/python-pycodestyle
  stretch: https://packages.debian.org/stretch/python-pycodestyle
Ubuntu:
  bionic: https://packages.ubuntu.com/bionic/python-pycodestyle