### PR TITLE
cob_command_tools: 0.6.19-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -556,6 +556,8 @@ repositories:
       version: indigo_release_candidate
     release:
       packages:
+      - cob_command_gui
+      - cob_command_tools
       - cob_dashboard
       - cob_helper_tools
       - cob_interactive_teleop
@@ -568,7 +570,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.18-1
+      version: 0.6.19-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.19-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.18-1`

## cob_command_gui

```
* Merge pull request #288 <https://github.com/ipa320/cob_command_tools/issues/288> from benmaidel/noetic_migration
  [noetic] cob_command_gui migration
* switch from pygtk to pygobject's pygtkcompat compatibility layer
* Contributors: Benjamin Maidel, Felix Messmer
```

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

```
* Merge pull request #287 <https://github.com/ipa320/cob_command_tools/issues/287> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_interactive_teleop

```
* Merge pull request #287 <https://github.com/ipa320/cob_command_tools/issues/287> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_monitoring

```
* Merge pull request #287 <https://github.com/ipa320/cob_command_tools/issues/287> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_script_server

```
* Merge pull request #287 <https://github.com/ipa320/cob_command_tools/issues/287> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_teleop

```
* Merge pull request #287 <https://github.com/ipa320/cob_command_tools/issues/287> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
