### PR TITLE
cob_robots: 0.7.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1950,7 +1950,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_robots-release.git
-      version: 0.7.4-1
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.4-1`

## cob_bringup

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Revert "comment rplidar"
  This reverts commit 35cd5235ec046365b6ba48aa4ccf4e03afc4117f.
* comment rplidar
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #814 <https://github.com/ipa320/cob_robots/issues/814> from fmessmer/fix_catkin_lint
  fix catkin lint
* reactivate dependency for cob_collision_monitor
* add missing exec_depend rgbd_launch
* Merge pull request #811 <https://github.com/ipa320/cob_robots/issues/811> from floweisshardt/feature/cob4-3
  add auto init to cob4-3
* add auto init to cob4-3
* Merge pull request #795 <https://github.com/ipa320/cob_robots/issues/795> from HannesBachter/update_cob4-8
  update cob4-8 (kinetic + d435 cams)
* update realsense serial_no
* update cob4-8 (is now running kinetic with d435 cams)
* Contributors: Felix Messmer, Florian Weisshardt, fmessmer, hyb, mailto:myuser@myrobot, mailto:robot@cob4-3
```

## cob_default_robot_behavior

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_default_robot_config

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #795 <https://github.com/ipa320/cob_robots/issues/795> from HannesBachter/update_cob4-8
  update cob4-8 (kinetic + d435 cams)
* head joint configs for head with joint-2 on left side
* Contributors: Felix Messmer, fmessmer, hyb
```

## cob_hardware_config

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #810 <https://github.com/ipa320/cob_robots/issues/810> from ipa-fog/feature/tf2_fix
  canTransform argument target_frame in tf2 frame_ids cannot start with…
* canTransform argument target_frame in tf2 frame_ids cannot start with a '/'
* Merge pull request #795 <https://github.com/ipa320/cob_robots/issues/795> from HannesBachter/update_cob4-8
  update cob4-8 (kinetic + d435 cams)
* calibrate cob4-8 base
* fix diagnostics_analyzers for cob4-8
* correct mount position for sensorring
* use cad-conform version of head
* harmonize head urdf fix with update
* remove legacy transformation and fix indent
* Better comment plus 6 mm fix (from doing the math)
* Fix on the urdf: sensorring's parent link moved to head_2_link (previously on head_3_link, which is not how the hardware works)
* update cob4-8 (is now running kinetic with d435 cams)
* Contributors: Benjamin Maidel, FOG, Felix Messmer, MattiaRacca, fmessmer, hyb, ipa-cob4-8, mailto:myuser@myrobot
```

## cob_moveit_config

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_robots

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
