### PR TITLE
cob_simulation: 0.7.5-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1972,7 +1972,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_simulation-release.git
-      version: 0.7.4-1
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.4-1`

## cob_bringup_sim

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_objects

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_tools

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* ROS_PYTHON_VERSION conditional dependency
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_worlds

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_simulation

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
