### PR TITLE
cob_robots: 0.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -790,6 +790,26 @@ repositories:
       url: https://github.com/ipa320/cob_perception_common.git
       version: indigo_dev
     status: maintained
+  cob_robots:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_robots.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_default_robot_behavior
+      - cob_default_robot_config
+      - cob_hardware_config
+      - cob_moveit_config
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_robots-release.git
+      version: 0.7.5-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_robots.git
+      version: kinetic_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_robots` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_robots.git
- release repository: https://github.com/ipa320/cob_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## cob_default_robot_behavior

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_default_robot_config

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #795 <https://github.com/ipa320/cob_robots/issues/795> from HannesBachter/update_cob4-8
  update cob4-8 (kinetic + d435 cams)
* head joint configs for head with joint-2 on left side
* Contributors: Felix Messmer, fmessmer, hyb
```

## cob_hardware_config

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #810 <https://github.com/ipa320/cob_robots/issues/810> from ipa-fog/feature/tf2_fix
  canTransform argument target_frame in tf2 frame_ids cannot start with…
* canTransform argument target_frame in tf2 frame_ids cannot start with a '/'
* Merge pull request #795 <https://github.com/ipa320/cob_robots/issues/795> from HannesBachter/update_cob4-8
  update cob4-8 (kinetic + d435 cams)
* calibrate cob4-8 base
* fix diagnostics_analyzers for cob4-8
* correct mount position for sensorring
* use cad-conform version of head
* harmonize head urdf fix with update
* remove legacy transformation and fix indent
* Better comment plus 6 mm fix (from doing the math)
* Fix on the urdf: sensorring's parent link moved to head_2_link (previously on head_3_link, which is not how the hardware works)
* update cob4-8 (is now running kinetic with d435 cams)
* Contributors: Benjamin Maidel, FOG, Felix Messmer, MattiaRacca, fmessmer, hyb, ipa-cob4-8, mailto:myuser@myrobot
```

## cob_moveit_config

```
* Merge pull request #812 <https://github.com/ipa320/cob_robots/issues/812> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
