### PR TITLE
pr2_mechanism: 1.8.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4181,6 +4181,27 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: melodic-devel
     status: unmaintained
+  pr2_mechanism:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: melodic-devel
+    release:
+      packages:
+      - pr2_controller_interface
+      - pr2_controller_manager
+      - pr2_hardware_interface
+      - pr2_mechanism
+      - pr2_mechanism_diagnostics
+      - pr2_mechanism_model
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_mechanism-release.git
+      version: 1.8.18-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_mechanism.git
+      version: kinetic-devel
   pr2_mechanism_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_mechanism` to `1.8.18-1`:

- upstream repository: https://github.com/pr2/pr2_mechanism.git
- release repository: https://github.com/pr2-gbp/pr2_mechanism-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## pr2_controller_interface

- No changes

## pr2_controller_manager

- No changes

## pr2_hardware_interface

- No changes

## pr2_mechanism

- No changes

## pr2_mechanism_diagnostics

- No changes

## pr2_mechanism_model

```
* Merge pull request #338 <https://github.com/pr2/pr2_mechanism/issues/338> from k-okada/add_travis
  update travis.yml
* fix urdf::JointConstSharedPtr for test directory
* fix for urdfmodel >= 1.0.0 (melodic)
* to pass catkin run_tests, partially copied from https://github.com/PR2/pr2_mechanism/pull/329
* Contributors: Kei Okada
```
