### PR TITLE
move_base_flex: 0.3.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7824,7 +7824,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/move_base_flex-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/magazino/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `0.3.4-1`:

- upstream repository: https://github.com/magazino/move_base_flex.git
- release repository: https://github.com/uos-gbp/move_base_flex-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.3-1`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

- No changes

## mbf_costmap_core

- No changes

## mbf_costmap_nav

```
* fix blind driving (#243 <https://github.com/magazino/move_base_flex/issues/243>)
```

## mbf_msgs

- No changes

## mbf_simple_nav

- No changes

## mbf_utility

- No changes

## move_base_flex

- No changes
