### PR TITLE
random_numbers: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2234,8 +2234,8 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros-gbp/random_numbers-release.git
-      version: 1.0.0-1
+      url: https://github.com/moveit/random_numbers-release.git
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/random_numbers.git
- release repository: https://github.com/moveit/random_numbers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## random_numbers

```
* [maint] Run Travis on Foxy and check ament_lint
* Contributors: Henning Kayser
```
