### PR TITLE
cob_simulation: 0.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -812,6 +812,25 @@ repositories:
       url: https://github.com/ipa320/cob_robots.git
       version: kinetic_dev
     status: maintained
+  cob_simulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_gazebo_objects
+      - cob_gazebo_tools
+      - cob_gazebo_worlds
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_simulation-release.git
+      version: 0.7.5-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_simulation.git
+      version: kinetic_dev
+    status: maintained
   cob_substitute:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_simulation` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_simulation.git
- release repository: https://github.com/ipa320/cob_simulation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## cob_gazebo_objects

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_tools

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* ROS_PYTHON_VERSION conditional dependency
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_gazebo_worlds

```
* Merge pull request #178 <https://github.com/ipa320/cob_simulation/issues/178> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
