### PR TITLE
srdfdom: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3574,6 +3574,21 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: foxy
     status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/moveit/srdfdom-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    status: maintained
   sros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/moveit/srdfdom-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## srdfdom

```
* [fix] Conflicting upstream dependency console_bridge
  * Add console_bridge libs with ament_target_dependencies (#59 <https://github.com/ros-planning/srdfdom/issues/59>)
  * Use console_bridge_vendor dependency wrapper (#61 <https://github.com/ros-planning/srdfdom/issues/61>)
* [maint] Inherit package VERSION from package.xml (#74 <https://github.com/ros-planning/srdfdom/issues/74>)
* [maint] Symbol visibility for Windows support (#69 <https://github.com/ros-planning/srdfdom/issues/69>)
* [maint] Proper exporting of TinyXML2 library to dependent ament packages (#54 <https://github.com/ros-planning/srdfdom/issues/54>)
* [ros2-migration] Port to ROS 2 (#52 <https://github.com/ros-planning/srdfdom/issues/52>)
  * Apply initial port by AcutronicsRobotics (AcutronicRobotics:srdfdom#1 <https://github.com/AcutronicRobotics/srdfdom/issues/1>, AcutronicRobotics:srdfdom#2 <https://github.com/AcutronicRobotics/srdfdom/issues/2>, AcutronicRobotics:srdfdom#3 <https://github.com/AcutronicRobotics/srdfdom/issues/3>, AcutronicRobotics:srdfdom#4 <https://github.com/AcutronicRobotics/srdfdom/issues/4>)
  * Enable Travis CI
* Contributors: Alejandro Hernandez Cordero, Anas Mchichou El Harrak, Henning Kayser, Hunter L. Allen, Josh Langsfeld, Lior Lustgarten, Patrick Beeson, Robert Haschke
```
