### PR TITLE
geometric_shapes: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1045,6 +1045,21 @@ repositories:
       url: https://github.com/ros-geographic-info/geographic_info.git
       version: ros2
     status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/moveit/geometric_shapes-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    status: maintained
   geometry2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/moveit/geometric_shapes-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## geometric_shapes

```
* [maint] Travis: Disable warnings as gcc warns about redundant declarations in qhull includes
* [maint] Inherit package VERSION (for library soname) from package.xml
* [maint] Trim boost dependencies #156 <https://github.com/ros-planning/geometric_shapes/issues/156>
  * libboost-math libraries unnecessary as only headers-only parts are used
  * move author tags below to comply with the xsd
* [maint] Compile on ROS2 Foxy (#153 <https://github.com/ros-planning/geometric_shapes/issues/153>)
  * Suppress assimp CMP0012 policy warning
  * Use console_bridge_vendor dependency wrapper
  * Fix CMakeLists issues:remove ASSIMP export dependency
  
  fix linking of OCTOMAP, resource_retriever
* [maint] Resolve octomap dependency with rosdep (#124 <https://github.com/ros-planning/geometric_shapes/issues/124>)
* [maint] struct SolidPrimitiveDimCount -> function solidPrimitiveDimCount() (#121 <https://github.com/ros-planning/geometric_shapes/issues/121>)
* [ros2-migration] Port to ROS 2 (#122 <https://github.com/ros-planning/geometric_shapes/issues/122>)
  * Migrate CMakeLists.txt, package.xml, messages
  * Enable Travis: Run on ROS 2, enable ament_lint_cmake
* Contributors: Henning Kayser, Mikael Arguedas, Robert Haschke, Víctor Mayoral Vilches
```
