### PR TITLE
warehouse_ros_mongo: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4181,6 +4181,21 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
+  warehouse_ros_mongo:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    release:
+      packages:
+      - warehouse_ros
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros_mongo-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
       version: ros2
     status: maintained
   webots_ros2:


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/moveit/warehouse_ros_mongo-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## warehouse_ros

```
* [maint] Fix -Wcast-qual compile warnings (#49 <https://github.com/ros-planning/warehouse_ros/issues/49>)
* [ros2-migration] Port to ROS 2 (#48 <https://github.com/ros-planning/warehouse_ros/issues/48>)
  * Migrate CMakeLists.txt, package.xml to ROS 2
  * ROS 2 API Migration (Logging, messages, node, tf2)
  * Implement ROS 2 message serialization
  * Hotfix for MD5sum message type matching
  * Enable CI: clang-format, ament_lint on Foxy
* Contributors: Yu Yan
```
