### PR TITLE
moveit_msgs: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1659,6 +1659,21 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: master
     status: maintained
+  moveit_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/moveit/moveit_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    status: developed
   moveit_resources:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/moveit/moveit_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## moveit_msgs

```
* [maint] Switch Travis to Foxy (#98 <https://github.com/ros-planning/moveit_msgs/issues/98>)
  * Remove obsolete moveit_msgs.repos
  * Enable CI test ament_lint
* [maint] Suppress Wredundant-decls warnings (#59 <https://github.com/ros-planning/moveit_msgs/issues/59>)
* [ros2-migration] Port moveit_msgs to ROS 2
  * Migration to ROS 2 (AcutronicRobotics/moveit_msgs#1 <https://github.com/AcutronicRobotics/moveit_msgs/issues/1>)
  * Add actions and include rosidl_default_runtime (AcutronicRobotics/moveit_msgs#2 <https://github.com/AcutronicRobotics/moveit_msgs/issues/2>, AcutronicRobotics/moveit_msgs#3 <https://github.com/AcutronicRobotics/moveit_msgs/issues/3>)
* Contributors: Alejandro Hernández Cordero, Henning Kayser, Lander Usategui San Juan, Mike Lautman, Robert Haschke, Víctor Mayoral Vilches, Yu Yan, ibaiape
```
