### PR TITLE
rcutils: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1522,7 +1522,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 2.2.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.2.0-1`

## rcutils

```
* Update rcutils_calculate_directory_size() to support recursion (#306 <https://github.com/ros2/rcutils/issues/306>)
* Updating QD to QL 1 (#317 <https://github.com/ros2/rcutils/issues/317>)
* Address unused return values found in scan-build (#316 <https://github.com/ros2/rcutils/issues/316>)
* use one copy for continuous area instead of loop copy (#312 <https://github.com/ros2/rcutils/issues/312>)
* use a better way to check whether string is empty (#315 <https://github.com/ros2/rcutils/issues/315>)
* Use helper funciton to copy string (#314 <https://github.com/ros2/rcutils/issues/314>)
* Disable a Windows platform warning. (#311 <https://github.com/ros2/rcutils/issues/311>)
* Fix format of code description on document (#313 <https://github.com/ros2/rcutils/issues/313>)
* Make sure to check the return values of rcutils APIs. (#302 <https://github.com/ros2/rcutils/issues/302>)
* Contributors: Barry Xu, Chen Lihui, Chris Lalancette, Stephen Brawner
```
