### PR TITLE
robot_controllers: 0.8.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2649,7 +2649,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.8.1-1`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.0-1`

## robot_controllers

```
* add Fergs as maintainer (#65 <https://github.com/fetchrobotics/robot_controllers/issues/65>)
* additional boost disabling (#64 <https://github.com/fetchrobotics/robot_controllers/issues/64>)
* disable boost components of pluginlib (#63 <https://github.com/fetchrobotics/robot_controllers/issues/63>)
* Contributors: Michael Ferguson
```

## robot_controllers_interface

```
* add Fergs as maintainer (#65 <https://github.com/fetchrobotics/robot_controllers/issues/65>)
* additional boost disabling (#64 <https://github.com/fetchrobotics/robot_controllers/issues/64>)
* Contributors: Michael Ferguson
```

## robot_controllers_msgs

```
* add Fergs as maintainer (#65 <https://github.com/fetchrobotics/robot_controllers/issues/65>)
* Contributors: Michael Ferguson
```
