### PR TITLE
rosbag2: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1892,7 +1892,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.5.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.0-1`

## ros2bag

```
* Sqlite storage double buffering (#546 <https://github.com/ros2/rosbag2/issues/546>)
  * Double buffers
  * Circular queue and FLUSH option as define
  * Minor naming and lexical fixes.
  * Removed FLUSH_BUFFERS define check.
  * Sqlite3 storage logging fixes.
  * Sqlite3 storage circular buffer with pre allocated memory.
  * Sqlite3 storage buffers moved to shared_ptrs.
  * Uncrustify
  * Moved double buffers to writer
  * Buffer layer reset in seq compression writer in rosbag2 cpp
  * Buffer layer for rosbag2 writer refactor
  * Changed buffers in BufferLayer to std vectors.
  * BufferLayer uncrustify
  * Removed non-applicable test for writer cache.
  * BufferLayer review fixes
  * Rosbag metadata msgs count fixed for BufferLayer
  * Condition variable for buffer layer sync.
  * Fixed buffer locks
  * Buffers in BufferLayer refactored, moved into new class
  * Buffer layer split bags fixed.
  * Storage options include fix in buffer layer header.
  * Mutex around swapping buffers in buffer layer.
  * Fixed cache 0 bug in buffer layer.
  * Minor buffer layer refactor.
  * Counting messages in writer refactored.
  * Changed default cache size to 100Mb and updated parameter description
  * Applied review remarks:
  - significant refactoring: separation of cache classes
  - applied suggested improvements
  - some renaming
  - reduce code duplication that would otherwise increase with cache refactor, between compression and plain writers
  * Applied review comments
  - cache consumer now takes a callback and is independent of storage
  - namespace changes, renaming, cleaning
  - counting and logging messages by topic
  * linter
  * Changes after review: fixing flushing, topic counts, and more
  * Fix for splitting - flushing state now correctly turns off
  * cache classes documentation
  * simplified signature
  * a couple of tests for cache
  * address review: explicit constructor and doxygen styling
  * Windows warnings fix
  * fixed type mismatch warning on Windows
  * added minor comment
  Co-authored-by: Piotr Jaroszek <mailto:piotr.jaroszek@robotec.ai>
* Contributors: Adam Dąbrowski
```

## rosbag2

- No changes

## rosbag2_compression

```
* Sqlite storage double buffering (#546 <https://github.com/ros2/rosbag2/issues/546>)
* Contributors: Adam Dąbrowski
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

```
* Add back rosbag2_cpp::StorageOptions as deprecated (#563 <https://github.com/ros2/rosbag2/issues/563>)
* Sqlite storage double buffering (#546 <https://github.com/ros2/rosbag2/issues/546>)
* Contributors: Adam Dąbrowski, Jacob Perron
```

## rosbag2_performance_writer_benchmarking

```
* Sqlite storage double buffering (#546 <https://github.com/ros2/rosbag2/issues/546>)
* Contributors: Adam Dąbrowski
```

## rosbag2_py

- No changes

## rosbag2_storage

```
* Update codes since rcutils_calculate_directory_size() is changed (#567 <https://github.com/ros2/rosbag2/issues/567>)
* Contributors: Barry Xu
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
