### PR TITLE
stag_ros: 0.3.6-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6172,7 +6172,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/usrl-uofsc/stag_ros-release.git
-      version: 0.3.4-2
+      version: 0.3.6-3
     source:
       type: git
       url: https://github.com/usrl-uofsc/stag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stag_ros` to `0.3.6-3`:

- upstream repository: https://github.com/usrl-uofsc/stag_ros.git
- release repository: https://github.com/usrl-uofsc/stag_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.4-2`

## stag_ros

- No changes
