### PR TITLE
rviz: 7.0.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3120,7 +3120,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 7.0.6-1
+      version: 7.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `7.0.7-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `7.0.6-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Prevent rviz_rendering::AssimpLoader from loading materials twice. (#622 <https://github.com/ros2/rviz/issues/622>) (#630 <https://github.com/ros2/rviz/issues/630>)
  Retrieve material if it already exists. Assumes resource path uniqueness.
* Contributors: Michel Hidalgo
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
