### PR TITLE
Adding new repository for indexing: tb3_tools

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -18289,5 +18289,15 @@ repositories:
       url: https://github.com/zivid/zivid-ros.git
       version: master
     status: maintained
+  tb3_tools:
+    doc:
+      type: git
+      url: https://github.com/xuyuan-ict/tb3_tools.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/xuyuan-ict/tb3_tools.git
+      version: main
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
We want to add tb3_tools repo to rosdistro.
It includes some extended packages for monitoring and controlling turtlebot3 robot and we will enrich this repository in the near future.

Thanks