### PR TITLE
vesc: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13220,6 +13220,26 @@ repositories:
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
       version: master
     status: maintained
+  vesc:
+    doc:
+      type: git
+      url: https://github.com/f1tenth/vesc.git
+      version: main
+    release:
+      packages:
+      - vesc
+      - vesc_ackermann
+      - vesc_driver
+      - vesc_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/f1tenth/vesc-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/f1tenth/vesc.git
+      version: main
+    status: maintained
   video_stream_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vesc` to `1.0.0-1`:

- upstream repository: https://github.com/f1tenth/vesc.git
- release repository: https://github.com/f1tenth/vesc-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## vesc

```
* Updating maintainers, authors, and URLs.
* added onboard car
* Contributors: Joshua Whitley, billyzheng
```

## vesc_ackermann

```
* Applying roslint to vesc_ackerman.
* Adding roslint.
* Adding licenses.
* Updating maintainers, authors, and URLs.
* added onboard car
* Contributors: Joshua Whitley, billyzheng
```

## vesc_driver

```
* Applying roslint and replacing registration macro with templated class.
* Adding roslint.
* Adding licenses.
* Updating maintainers, authors, and URLs.
* added onboard car
* Contributors: Joshua Whitley, billyzheng
```

## vesc_msgs

```
* Adding roslint.
* Updating maintainers, authors, and URLs.
* added onboard car
* Contributors: Joshua Whitley, billyzheng
```
