### PR TITLE
ros_controllers: 0.18.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4883,7 +4883,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.17.0-1
+      version: 0.18.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_controllers` to `0.18.1-1`:

- upstream repository: https://github.com/ros-controls/ros_controllers.git
- release repository: https://github.com/ros-gbp/ros_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.17.0-1`

## ackermann_steering_controller

```
* Use version-agnostic FindBoost for headers
* Contributors: Matt Reynolds
```

## diff_drive_controller

```
* Fix null pointer checks in diff_drive_controller
* Use version-agnostic FindBoost for headers
* Contributors: David V. Lu, Matt Reynolds
```

## effort_controllers

- No changes

## force_torque_sensor_controller

```
* Add missing exec_depend on controller_manager
* Move floating .launch and .yaml files to launch/ and config/ folders
* Format package.xml and CMakeLists.txt + clean deps + move pluginlib header to .cpp file
* Contributors: Mateus Amarante Araújo
```

## forward_command_controller

- No changes

## four_wheel_steering_controller

```
* Remove explicit dependency on Boost::headers to avoid issue #537 <https://github.com/ros-controls/ros_controllers/issues/537>
* Add boost dependency
* Format CMakeLists.txt and package.xml files + clean deps of 4ws_controller pkg
* Contributors: Mateus Amarante, Mateus Amarante Araújo
```

## gripper_action_controller

```
* Format package.xml and CMakeLists.txt + clean deps of gripper_action_controller pkg
* Contributors: Mateus Amarante Araújo
```

## imu_sensor_controller

```
* Add missing exec_depend on controller_manager
* Move .launch and .yaml files to launch/ and config/ folders
* Format package.xml and CMakeLIstst.txt + clean dependencies
* Contributors: Mateus Amarante Araújo
```

## joint_state_controller

- No changes

## joint_trajectory_controller

```
* Format CMakeLists.txt and package.xml files + clean deps of joint_trajectory_controller
* Contributors: Mateus Amarante Araújo
```

## position_controllers

```
* Simplify roscpp dep + sort lib sources
* Format package.xml and CMakeLists.txt + clean deps of position_controllers pkg
* Contributors: Mateus Amarante Araújo
```

## ros_controllers

```
* Update package.xml of ros_controllers meta-package to format 3
* Contributors: Mateus Amarante Araújo
```

## rqt_joint_trajectory_controller

```
* Fix dependency on rospkg
* Format package.xml and CMakeLists.txt files + clean deps of rqt_joint_trajectory_controller pkg
* Contributors: Mateus Amarante Araújo
```

## velocity_controllers

```
* Format package.xml and CMakeLists.txt files + clean deps of velocity_controllers pkg
* Contributors: Mateus Amarante Araújo
```
