### PR TITLE
Fix rosdep key for python3 thriftpy 

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6762,9 +6762,9 @@ python3-texttable:
   rhel: ['python%{python3_pkgversion}-texttable']
   ubuntu: [python3-texttable]
 python3-thriftpy:
-  fedora: [python3-thriftpy]
+  debian: [python3-thriftpy]
   ubuntu:
-    '*': [python3-thiftpy]
+    '*': [python3-thriftpy]
     xenial:
       pip:
         packages: [thriftpy]


### PR DESCRIPTION
I realised I made a typo in the previous pull request #27488. I have fixed it and I have also changed fedora to debian repository. I am really sorry for the inconveniences.