### PR TITLE
warehouse_ros_mongo: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4183,6 +4183,21 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros.git
       version: ros2
     status: maintained
+  warehouse_ros_mongo:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/moveit/warehouse_ros_mongo-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_mongo.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_mongo` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_mongo.git
- release repository: https://github.com/moveit/warehouse_ros_mongo-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## warehouse_ros_mongo

```
* [ros2-migration] Port to ROS 2 (#38 <https://github.com/ros-planning/warehouse_ros_mongo/issues/38>)
  * Migrate package.xml and cmake files to ROS 2
  * Apply ROS 2 migration steps to source files
  * Compile on ROS 2 Foxy, enable CI
  * Check clang-format, ament_lint
* Contributors: Yu Yan
```
