### PR TITLE
[dep] apt-transport-https

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -79,6 +79,9 @@ apr:
     slackpkg:
       packages: [apr, apr-util]
   ubuntu: [libapr1-dev, libaprutil1-dev]
+apt-transport-https:
+  debian: [apt-transport-https]
+  ubuntu: [apt-transport-https]
 aravis:
   debian: [libaravis-0.6-0]
   gentoo: [media-video/aravis]


### PR DESCRIPTION
- debian: https://packages.debian.org/jessie/apt-transport-https
- fedora: Not sure. Although https://fedora.pkgs.org/33/fedora-aarch64/apt-2.1.10-1.fc33.aarch64.rpm.html reads to me `apt` provides the pkg in question. If I'm right I feel like not adding a new key. I just thought of `fedora` as I know [there's `apt` pkg there](https://docs.fedoraproject.org/en-US/quick-docs/dnf-vs-apt/). 
- Ubuntu: https://packages.ubuntu.com/search?keywords=apt-transport-https