### PR TITLE
urdfdom_py: 0.4.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6564,7 +6564,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/ros/urdf_parser_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_py` to `0.4.5-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros-gbp/urdfdom_py-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.4-1`

## urdfdom_py

```
* Make sure to add the version when creating a new URDF. (#62 <https://github.com/ros/urdf_parser_py/issues/62>) (#66 <https://github.com/ros/urdf_parser_py/issues/66>)
* Contributors: Chris Lalancette
```
