### PR TITLE
ament_lint: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -120,7 +120,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.8.2-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.1-1`
