### PR TITLE
pluginlib: 2.4.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1751,7 +1751,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `2.4.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.4.1-1`

## pluginlib

```
* Fix filesystem linking on clang9 (#183 <https://github.com/ros/pluginlib/issues/183>) (#185 <https://github.com/ros/pluginlib/issues/185>)
* Contributors: Jose Pardeiro
```
