### PR TITLE
rcl: 0.8.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2031,7 +2031,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.8.4-1
+      version: 0.8.5-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `0.8.5-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.4-1`

## rcl

```
* Fix memory leak in rcl_subscription_init()/rcl_publisher_init() (#794 <https://github.com/ros2/rcl/issues/794>) (#833 <https://github.com/ros2/rcl/issues/833>)
* [Eloquent] Don't check history depth if RMW_QOS_POLICY_HISTORY_KEEP_ALL (#595 <https://github.com/ros2/rcl/issues/595>) (#596 <https://github.com/ros2/rcl/issues/596>)
* Fix behavior when provided a malformed parameters file (#556 <https://github.com/ros2/rcl/issues/556>)
* Contributors: Dan Rose, Jacob Perron
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* added rcl yaml param parser doxyfile (#634 <https://github.com/ros2/rcl/issues/634>) (#700 <https://github.com/ros2/rcl/issues/700>)
* Fix behavior when provided a malformed parameters file (#556 <https://github.com/ros2/rcl/issues/556>)
```
