### PR TITLE
launch: 0.9.7-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1265,7 +1265,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.6-1
+      version: 0.9.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.9.7-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.6-1`

## launch

```
* Delete unnecessary loading of 'launch.frontend.interpolate_substitution_method' entry point that was never used (#434 <https://github.com/ros2/launch/issues/434>) (#464 <https://github.com/ros2/launch/issues/464>)
* Fix parsing of cmd line arguments in XML and yaml file (#379 <https://github.com/ros2/launch/issues/379>) (#403 <https://github.com/ros2/launch/issues/403>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron
```

## launch_testing

```
* [Eloquent backport] stop using constructors deprecated in pytest 5.4 (#391 <https://github.com/ros2/launch/issues/391>) Switch to from_parent (partial #421 <https://github.com/ros2/launch/issues/421>) avoid deprecation warning, use from_parent (#402 <https://github.com/ros2/launch/issues/402>) (#459 <https://github.com/ros2/launch/issues/459>)
* Contributors: Shane Loretz
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
