### PR TITLE
launch_ros: 0.9.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -1285,7 +1285,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.9.5-1
+      version: 0.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.9.6-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.5-1`

## launch_ros

```
* Update maintainer list for Eloquent (#193 <https://github.com/ros2/launch_ros/issues/193>)
* Fix LoadComposableNodes action so that loading happens asynchronously (#113 <https://github.com/ros2/launch_ros/issues/113>) (#132 <https://github.com/ros2/launch_ros/issues/132>)
* Contributors: Jacob Perron, Michael Jeronimo
```

## launch_testing_ros

```
* Update maintainer list for Eloquent (#193 <https://github.com/ros2/launch_ros/issues/193>)
* [Eloquent backport] avoid deprecation warning, use from_parent (#141 <https://github.com/ros2/launch_ros/issues/141>) Call LaunchROSTestModule with the new API. (#150 <https://github.com/ros2/launch_ros/issues/150>)  (#176 <https://github.com/ros2/launch_ros/issues/176>)
* Contributors: Michael Jeronimo, Shane Loretz
```

## ros2launch

```
* Update maintainer list for Eloquent (#193 <https://github.com/ros2/launch_ros/issues/193>)
* Fix linter by removing unused import (#110 <https://github.com/ros2/launch_ros/issues/110>) (#117 <https://github.com/ros2/launch_ros/issues/117>)
* Contributors: Michael Jeronimo, Zachary Michaels
```
