### PR TITLE
rcutils: 0.8.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2169,7 +2169,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 0.8.4-1
+      version: 0.8.5-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `0.8.5-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.4-1`

## rcutils

```
* Update the maintainers. (#299 <https://github.com/ros2/rcutils/issues/299>)
* check and link against libatomic (#172 <https://github.com/ros2/rcutils/issues/172>) (#178 <https://github.com/ros2/rcutils/issues/178>) (#217 <https://github.com/ros2/rcutils/issues/217>)
* Contributors: Chris Lalancette, Shane Loretz
```
