### PR TITLE
rosidl: 0.8.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2636,7 +2636,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `0.8.3-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.2-1`

## rosidl_adapter

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_parser

```
* allow zero length string constants (#507 <https://github.com/ros2/rosidl/issues/507>) (#550 <https://github.com/ros2/rosidl/issues/550>)
* Contributors: Jacob Perron
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
