### PR TITLE
rosidl_typesupport: 0.8.1-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2727,7 +2727,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 0.8.0-2
+      version: 0.8.1-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.0-2`

## rosidl_typesupport_c

```
* Make Poco optional again (#54 <https://github.com/ros2/rosidl_typesupport/issues/54>) (#57 <https://github.com/ros2/rosidl_typesupport/issues/57>)
* Contributors: Sean Kelly
```

## rosidl_typesupport_cpp

```
* Make Poco optional again (#54 <https://github.com/ros2/rosidl_typesupport/issues/54>) (#57 <https://github.com/ros2/rosidl_typesupport/issues/57>)
* Contributors: Sean Kelly
```
