### PR TITLE
rmw_fastrtps: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2321,7 +2321,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.1-1`

## rmw_fastrtps_cpp

```
* Update maintainer list for Eloquent (#473 <https://github.com/ros2/rmw_fastrtps/issues/473>)
* Contributors: Michael Jeronimo
```

## rmw_fastrtps_dynamic_cpp

```
* Update maintainer list for Eloquent (#473 <https://github.com/ros2/rmw_fastrtps/issues/473>)
* Contributors: Michael Jeronimo
```

## rmw_fastrtps_shared_cpp

```
* Remove unused headers MessageTypeSupport.hpp and ServiceTypeSupport.hpp (#481 <https://github.com/ros2/rmw_fastrtps/issues/481>) (#483 <https://github.com/ros2/rmw_fastrtps/issues/483>)
* Update maintainer list for Eloquent (#473 <https://github.com/ros2/rmw_fastrtps/issues/473>)
* Contributors: Jacob Perron, Michael Jeronimo
```
