### PR TITLE
rmw_connext: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2282,7 +2282,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.1-1`

## rmw_connext_cpp

```
* Fix wrong error messages (#458 <https://github.com/ros2/rmw_connext/issues/458>) (#479 <https://github.com/ros2/rmw_connext/issues/479>)
* Update maintainers (#468 <https://github.com/ros2/rmw_connext/issues/468>) (#471 <https://github.com/ros2/rmw_connext/issues/471>)
* avoid using build time Connext library paths, determine them when downstream packages are built (#385 <https://github.com/ros2/rmw_connext/issues/385>) (#433 <https://github.com/ros2/rmw_connext/issues/433>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Ivan Santiago Paunovic
```

## rmw_connext_shared_cpp

```
* Update maintainers (#468 <https://github.com/ros2/rmw_connext/issues/468>) (#471 <https://github.com/ros2/rmw_connext/issues/471>)
* avoid using build time Connext library paths, determine them when downstream packages are built (#385 <https://github.com/ros2/rmw_connext/issues/385>) (#433 <https://github.com/ros2/rmw_connext/issues/433>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas
```
