### PR TITLE
rosidl_python: 0.8.2-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2692,7 +2692,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.1-1`

## rosidl_generator_py

```
* fix too early decref of WString when converting from Python to C (#117 <https://github.com/ros2/rosidl_python/issues/117>) (#121 <https://github.com/ros2/rosidl_python/issues/121>)
* Contributors: Jacob Perron
```
