### PR TITLE
rclpy: 0.8.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2135,7 +2135,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.8.4-1
+      version: 0.8.5-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `0.8.5-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.4-1`

## rclpy

```
* fix moved troubleshooting url (#579 <https://github.com/ros2/rclpy/issues/579>) (#589 <https://github.com/ros2/rclpy/issues/589>)
* improve error message if rclpy C extensions are not found (#580 <https://github.com/ros2/rclpy/issues/580>) (#591 <https://github.com/ros2/rclpy/issues/591>)
* Contributors: Dirk Thomas
```
