### PR TITLE
ros_control: 0.18.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9884,7 +9884,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.18.2-1
+      version: 0.18.3-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.18.3-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.18.2-1`

## combined_robot_hw

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## combined_robot_hw_tests

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## controller_interface

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## controller_manager

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## controller_manager_msgs

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## controller_manager_tests

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## hardware_interface

```
* [hardware_interface] Update documentation (#457 <https://github.com/ros-controls/ros_control/issues/457>)
  * doc: update robot_hw.h docstrings
  update docstring of class and init method.
  * doc: add mainpage.dox including examples
  * doc: add README.md for hardware_interface
  * Update hardware_interface/mainpage.dox
  - Use JointStateHandle in case of read-only operations
  - Explain JointStateInterface and PositionJointInterface
  - Explain how to use potential software transmissions
  - Link to transmission_interface examples
* remove whitespace
* Update mainpage.dox with comments from @bmagyar
  - Explain JointStateInterface and PositionJointInterface
  - Explain how to use potential software transmissions
  - Link to transmission_interface examples
* Update doc of robot_hw.h with comments of @bmagyar
  - Use JointStateHandle in case of read-only operations
* Clarified documentation for InterfaceManager sub-manager handling
* Updated InterfaceManager documentation
* Removed duplicate error message
  Previously, trying to combine two non-ResourceManager interfaces yielded
  two identical error messages.
* Remove inconsistent InterfaceManager manager registering behavior
  All InterfaceManager now handle registered InterfaceManagers
  transparently. This allows chains of multiple InterfaceManagers
  registered to each other to work corectly, mostly relevant for
  registering a manager from a combined_robot_hw RobotHW.
* doc: add README.md for hardware_interface
* doc: add mainpage.dox including examples
* doc: update robot_hw.h docstrings
  update docstring of class and init method.
* Contributors: Bence Magyar, Franz Pucher, Robert Wilbrandt
```

## joint_limits_interface

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## ros_control

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## rqt_controller_manager

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```

## transmission_interface

```
* Update docs in hardware_interface
* Contributors: Franz Pucher
```
