### PR TITLE
ros_control: 0.19.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4838,7 +4838,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.19.3-2
+      version: 0.19.4-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control` to `0.19.4-1`:

- upstream repository: https://github.com/ros-controls/ros_control.git
- release repository: https://github.com/ros-gbp/ros_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.19.3-2`

## combined_robot_hw

- No changes

## combined_robot_hw_tests

- No changes

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## controller_manager_tests

- No changes

## hardware_interface

```
* Clarified documentation for InterfaceManager sub-manager handling
* Updated InterfaceManager documentation
* Removed duplicate error message
  Previously, trying to combine two non-ResourceManager interfaces yielded
  two identical error messages.
* Remove inconsistent InterfaceManager manager registering behavior
  All InterfaceManager now handle registered InterfaceManagers
  transparently. This allows chains of multiple InterfaceManagers
  registered to each other to work corectly, mostly relevant for
  registering a manager from a combined_robot_hw RobotHW.
  Resolves #452 <https://github.com/ros-controls/ros_control/issues/452>
* Contributors: Robert Wilbrandt
```

## joint_limits_interface

- No changes

## ros_control

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
