### PR TITLE
diagnostics: 1.10.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1291,7 +1291,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.10.2-3
+      version: 1.10.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `1.10.3-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.10.2-3`

## diagnostic_aggregator

```
* Add mutex for other analyzers (#170 <https://github.com/ros/diagnostics/issues/170>)
* Update maintainer info
* Contributors: Guglielmo Gemignani, gemignani
```

## diagnostic_analysis

```
* Update maintainer info
* Contributors: gemignani
```

## diagnostic_common_diagnostics

```
* Update maintainer info
* Contributors: gemignani
```

## diagnostic_updater

```
* Use get_param_cached in diagnostic_updater
* Diagnostic status msg is not included but being used (#163 <https://github.com/ros/diagnostics/issues/163>)
  * Diagnostic status msg is not included but being used
  * Update update_functions.h
* Change depends to catkin_depends for catkin packages (#162 <https://github.com/ros/diagnostics/issues/162>)
  * Change depends to catkin_depends for catkin packages
  * The library also depends on catkin_libs
* Update maintainer info
* Contributors: Tobias Fischer, gemignani
```

## diagnostics

```
* Update maintainer info
* Contributors: gemignani
```

## rosdiagnostic

- No changes

## self_test

```
* Set cmake_policy CMP0054 to NEW
* Update maintainer info
* Contributors: gemignani
```

## test_diagnostic_aggregator

```
* Update maintainer info
* Contributors: gemignani
```
