### PR TITLE
leo_simulator: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2882,7 +2882,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_simulator-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `0.1.3-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator.git
- release repository: https://github.com/fictionlab-gbp/leo_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## leo_gazebo

```
* Use gazebo_dev dependency instead of gazebo (fix building on debian)
* Update package description
```

## leo_simulator

- No changes
