### PR TITLE
iris_lama: 1.1.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4423,7 +4423,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/eupedrosa/iris_lama-release.git
-      version: 1.0.0-1
+      version: 1.1.0-2
     status: developed
   iris_lama_ros:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama` to `1.1.0-2`:

- upstream repository: https://github.com/iris-ua/iris_lama.git
- release repository: https://github.com/eupedrosa/iris_lama-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## iris_lama

```
* Expose the global localization parameters as options
* Add option to mark free cells when there is no hit in SLAM (i.e. truncated ranges)
* Add non-motion update trigger to location
* Fix infinite loop in global localization
* Use C++14
* Fix eigen aligment issues
```
