### PR TITLE
iris_lama_ros: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4430,7 +4430,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/eupedrosa/iris_lama_ros-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     status: developed
   ivcon:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama_ros` to `1.1.0-1`:

- upstream repository: https://github.com/iris-ua/iris_lama_ros.git
- release repository: https://github.com/eupedrosa/iris_lama_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## iris_lama_ros

```
* Add "truncate" parameters
* Add a service to trigger global localization
* Add a service to trigger localization non-motion updates
* Localization node can now subscribe to maps instead of just using the static_map service
* Enable TCP_NODELAY for laser scan subscribers to reduce communications delay
* Filter "map" transformations when mapping offline
* Fix inverted lidar
* Use C++14
* Fix eigen aligment issues
```
