### PR TITLE
Remove gazebo_video_monitor_plugins

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3314,21 +3314,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: melodic-devel
     status: developed
-  gazebo_video_monitor_plugins:
-    doc:
-      type: git
-      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
-      version: master
-    release:
-      tags:
-        release: release/melodic/{package}/{version}
-      url: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
-      version: 0.5.0-2
-    source:
-      type: git
-      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
-      version: master
-    status: maintained
   gencpp:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1858,21 +1858,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: noetic-devel
     status: maintained
-  gazebo_video_monitor_plugins:
-    doc:
-      type: git
-      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
-      version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/nlamprian/gazebo_video_monitor_plugins-release.git
-      version: 0.5.0-1
-    source:
-      type: git
-      url: https://github.com/nlamprian/gazebo_video_monitor_plugins.git
-      version: master
-    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
I extracted the msgs from the plugins package and introduced a metapackage. PRs will follow to add the entries for the metapackage.

The repository now goes by the name [gazebo_video_monitors](https://github.com/nlamprian/gazebo_video_monitors)