### PR TITLE
rqt_robot_monitor: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2309,7 +2309,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_monitor` to `1.0.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_monitor.git
- release repository: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.3-1`

## rqt_robot_monitor

```
* prevent freezing of gui if no aggregator is present, fixes #31 <https://github.com/ros-visualization/rqt_robot_monitor/issues/31>
* added alternative view of devices for treeview
```
