### PR TITLE
Adding diffdrive_arduino to documentation index for melodic

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2193,6 +2193,12 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: indigo-devel
     status: maintained
+  diffdrive_arduino:
+    source:
+      type: git
+      url: https://github.com/joshnewans/diffdrive_arduino.git
+      version: melodic-devel
+    status: maintained
   dingo:
     doc:
       type: git


### PR DESCRIPTION
I would like my new package (diffdrive_arduino) to be indexed and documented.
It provides a `hardware_interface` between ros_control's `diff_drive_controller` and an Arduino running the differential drive firmware from `ros_arduino_bridge`.

It is currently source-only (however I hope to have a release eventually).