### PR TITLE
moveit: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1659,6 +1659,39 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: master
     status: maintained
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    release:
+      packages:
+      - moveit_common
+      - moveit_core
+      - moveit_fake_controller_manager
+      - moveit_kinematics
+      - moveit_planners_ompl
+      - moveit_ros_benchmarks
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_servo
+      - moveit_simple_controller_manager
+      - run_move_group
+      - run_moveit_cpp
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/moveit/moveit2-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    status: developed
   moveit_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.1.0-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/moveit/moveit2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## moveit_common

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* Contributors: Lior Lustgarten
```

## moveit_core

```
* [fix] Clang-tidy fixes (#264 <https://github.com/ros-planning/moveit2/issues/264>, #210 <https://github.com/ros-planning/moveit2/issues/210>)
  * Suppress false-positive clang-tidy fix in DistanceResultsData
  * Fix Eigen alignment in DistanceResultsData
  * Fix readability-identifier-naming, performance-for-range-copy, readability-named-parameter
* [fix] Fixup moveit_resources usage in moveit_core test (#259 <https://github.com/ros-planning/moveit2/issues/259>)
* [maint] Remove deprecated namespaces robot_model, robot_state  (#276 <https://github.com/ros-planning/moveit2/issues/276>)
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] Compilation fixes for macOS (#271 <https://github.com/ros-planning/moveit2/issues/271>)
* [maint] kinematics_base: remove deprecated initialize function (#232 <https://github.com/ros-planning/moveit2/issues/232>)
* [maint] Update to new moveit_resources layout (#247 <https://github.com/ros-planning/moveit2/issues/247>)
* [maint] Enable "test_time_optimal_trajectory_generation" unit test (#241 <https://github.com/ros-planning/moveit2/issues/241>)
* [maint] CMakeLists dependency cleanup and fixes (#226 <https://github.com/ros-planning/moveit2/issues/226>, #228 <https://github.com/ros-planning/moveit2/issues/228>)
* [ros2-migration] Migrate to ROS 2 Foxy (#227 <https://github.com/ros-planning/moveit2/issues/227>)
* Contributors: Abdullah Alzaidy, Dave Coleman, Henning Kayser, Jafar Abdi, Lior Lustgarten, Mark Moll, Mohmmad Ayman, Robert Haschke, Yu Yan, Tyler Weaver, Sebastian Jahr
```

## moveit_fake_controller_manager

```
* [improvement] Enable MoveIt fake controller in demo (#231 <https://github.com/ros-planning/moveit2/issues/231>)
  * Fix inital group_state lookup
* [maint] Remove deprecated namespaces robot_model, robot_state  (#276 <https://github.com/ros-planning/moveit2/issues/276>)
* [maint] Enable clang-tidy-fix and ament_lint_cmake (#210 <https://github.com/ros-planning/moveit2/issues/210>)
* [ros2-migration] Port moveit_fake_controller_manager to ROS2 (#202 <https://github.com/ros-planning/moveit2/issues/202>)
* [ros2-migration] Port moveit_simple_controller_manager to ROS 2 (#158 <https://github.com/ros-planning/moveit2/issues/158>)
* Contributors: Abdullah Alzaidy, Edwin Fan, Henning Kayser, Jafar Abdi
```

## moveit_kinematics

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] small compilation fixes for macOS (#271 <https://github.com/ros-planning/moveit2/issues/271>)
* [maint] kinematics_base: remove deprecated initialize function (#232 <https://github.com/ros-planning/moveit2/issues/232>)
* [maint] Enable clang-tidy-fix and ament_lint_cmake (#210 <https://github.com/ros-planning/moveit2/issues/210>)
* [maint] Simplify kdl now that kinetic support is dropped (#237 <https://github.com/ros-planning/moveit2/issues/237>)
* [ros2-migration] Migrate to ROS 2 Foxy (#227 <https://github.com/ros-planning/moveit2/issues/227>)
* [ros2-migration] Port Ikfast kinematics solver (#205 <https://github.com/ros-planning/moveit2/issues/205>)
* [ros2-migration] Port CachedIKKinematicsPlugin to ROS2 (#207 <https://github.com/ros-planning/moveit2/issues/207>)
* Contributors: Henning Kayser, Jafar Abdi, Lior Lustgarten, Mark Moll, Mohmmad Ayman, Nathan Brooks, Ruffin
```

## moveit_planners_ompl

```
* [fix] Rosdep dependencies for ros_testing, OpenMP (#309 <https://github.com/ros-planning/moveit2/issues/309>)
* [fix] OMPL parameter loading (#178 <https://github.com/ros-planning/moveit2/issues/178>)
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] Update to new moveit_resources layout (#247 <https://github.com/ros-planning/moveit2/issues/247>)
* [maint] Enable clang-tidy-fix and ament_lint_cmake (#210 <https://github.com/ros-planning/moveit2/issues/210>)
* [ros2-migration] Port move_group to ROS2 (#217 <https://github.com/ros-planning/moveit2/issues/217>)
  * switch OMPL to use pluginlib
* Contributors: Edwin Fan, Henning Kayser, Jonathan Chapple, Lior Lustgarten
```

## moveit_ros_benchmarks

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [ros2-migration] Enable warehouse in moveit_ros_benchmarks (#301 <https://github.com/ros-planning/moveit2/issues/301>)
* [ros2-migration] Port moveit_ros_benchmarks to ROS 2 (#225 <https://github.com/ros-planning/moveit2/issues/225>)
* Contributors: Lior Lustgarten, Yu Yan
```

## moveit_ros_move_group

```
* [fix] Interactive markers not visible in motion planning plugin (#299 <https://github.com/ros-planning/moveit2/issues/299>)
* [fix] Rosdep dependencies ros_testing, OpenMP (#309 <https://github.com/ros-planning/moveit2/issues/309>)
* [maint] Remove deprecated namespaces robot_model, robot_state  (#276 <https://github.com/ros-planning/moveit2/issues/276>)
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] Compilation fixes for macOS (#271 <https://github.com/ros-planning/moveit2/issues/271>)
* [ros2-migration] Enable warehouse in moveit_ros_benchmarks (#301 <https://github.com/ros-planning/moveit2/issues/301>)
* [ros2-migration] Port moveit_ros_warehouse to ROS 2 (#273 <https://github.com/ros-planning/moveit2/issues/273>)
* [ros2-migration] Port moveit_ros_benchmarks to ROS 2 (#225 <https://github.com/ros-planning/moveit2/issues/225>)
* [ros2-migration] Port moveit_group to ROS 2 (#217 <https://github.com/ros-planning/moveit2/issues/217>)
* Contributors: Abdullah Alzaidy, Edwin Fan, Henning Kayser, Jafar Abdi, Lior Lustgarten, Yu Yan
```

## moveit_ros_occupancy_map_monitor

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* Contributors: Lior Lustgarten
```

## moveit_ros_planning

```
* [improvement] Planning Scene Monitor Node Executor (#230 <https://github.com/ros-planning/moveit2/issues/230>, #257 <https://github.com/ros-planning/moveit2/issues/257>, #262 <https://github.com/ros-planning/moveit2/issues/262>, #266 <https://github.com/ros-planning/moveit2/issues/266>)
  * Fix PSM private node name
  * Initializes all ros interfaces with the private node
  * Runs timer callback using async single threaded executor
  * Fix duplicate PSM ndes (from ros-planning/navigation2#1940 <https://github.com/ros-planning/navigation2/issues/1940>)
* [improvement] Enable MoveIt fake controller in demo (#231 <https://github.com/ros-planning/moveit2/issues/231>)
* [fix] Interactive markers not visible in motion planning plugin (#299 <https://github.com/ros-planning/moveit2/issues/299>)
* [maint] Remove deprecated namespaces robot_model, robot_state  (#276 <https://github.com/ros-planning/moveit2/issues/276>)
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] Compilation fixes for macOS (#271 <https://github.com/ros-planning/moveit2/issues/271>)
* [maint] kinematics_base: remove deprecated initialize function (#232 <https://github.com/ros-planning/moveit2/issues/232>)
* [maint] Update to new moveit_resources layout (#247 <https://github.com/ros-planning/moveit2/issues/247>)
* [maint] Cleanup and fix CMakeLists target dependencies (#226 <https://github.com/ros-planning/moveit2/issues/226>, #228 <https://github.com/ros-planning/moveit2/issues/228>)
* [maint] Enable clang-tidy-fix and ament_lint_cmake (#210 <https://github.com/ros-planning/moveit2/issues/210>, #215 <https://github.com/ros-planning/moveit2/issues/215>, #264 <https://github.com/ros-planning/moveit2/issues/264>)
* [ros2-migration] Port MoveGroupInterface and MotionPlanning display to ROS 2 (#272 <https://github.com/ros-planning/moveit2/issues/272>)
  * Add private executor for the internal trajectory_execution_manager node
  * Use private MGI node, cleanup & fixes
* [ros2-migration] Port move_group to ROS 2 (#217 <https://github.com/ros-planning/moveit2/issues/217>)
* [ros2-migration] Port planning_pipeline to ROS 2 (#75 <https://github.com/ros-planning/moveit2/issues/75>)
* Contributors: Adam Pettinger, Edwin Fan, Henning Kayser, Jafar Abdi, Jorge Nicho, Lior Lustgarten, Mark Moll, Tyler Weaver, Yu Yan, anasarrak
```

## moveit_ros_planning_interface

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] Compilation fixes for macOS (#271 <https://github.com/ros-planning/moveit2/issues/271>)
* [ros2-migration] Port MoveGroupInterface and MotionPlanning display (#272 <https://github.com/ros-planning/moveit2/issues/272>)
* Contributors: Henning Kayser, Jafar Abdi, Lior Lustgarten, Mark Moll, Yu Yan
```

## moveit_ros_robot_interaction

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [ros2-migration] Port robot_interaction to ROS 2 (#211 <https://github.com/ros-planning/moveit2/issues/211>)
* Contributors: Jafar Abdi, Lior Lustgarten, Edwin Fan
```

## moveit_ros_visualization

```
* [fix] Interactive markers not visible in motion planning plugin (#299 <https://github.com/ros-planning/moveit2/issues/299>)
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] Compilation fixes for macOS (#271 <https://github.com/ros-planning/moveit2/issues/271>)
* [ros2-migration] Port moveit_ros_warehouse to ROS 2 (#273 <https://github.com/ros-planning/moveit2/issues/273>)
* [ros2-migration] Port trajectory_rviz_plugin to ROS 2 (#201 <https://github.com/ros-planning/moveit2/issues/201>)
* Contributors: Henning Kayser, Jafar Abdi, Lior Lustgarten, Mark Moll, Yu Yan, Edwin Fan
```

## moveit_ros_warehouse

```
* [ros2-migration] Port moveit_ros_warehouse to ROS 2 (#273 <https://github.com/ros-planning/moveit2/issues/273>)
* Contributors: Yu Yan
```

## moveit_servo

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [fix] Servo runtime issues (#257 <https://github.com/ros-planning/moveit2/issues/257>, #265 <https://github.com/ros-planning/moveit2/issues/265>, #294 <https://github.com/ros-planning/moveit2/issues/294>)
* [ros2-migration] Port moveit_servo to ROS 2 (#248 <https://github.com/ros-planning/moveit2/issues/248>)
  * Ports the source from MoveIt
  * Adds examples (C++ interface, composable node interface, teleoperation demo for gamepad)
  * Adds integration and unit tests
* Contributors: Adam Pettinger, Henning Kayser, Lior Lustgarten, Tyler Weaver
```

## moveit_simple_controller_manager

- No changes

## run_move_group

```
* [maint] Wrap common cmake code in 'moveit_package()' macro (#285 <https://github.com/ros-planning/moveit2/issues/285>)
  * New moveit_package() macro for compile flags, Windows support etc
  * Add package 'moveit_common' as build dependency for moveit_package()
  * Added -Wno-overloaded-virtual compiler flag for moveit_ros_planners_ompl
* [maint] Update MoveIt logo URLs in the demos' README (#289 <https://github.com/ros-planning/moveit2/issues/289>)
* [ros2-migration] Port moveit_ros_warehouse to ROS 2 (#273 <https://github.com/ros-planning/moveit2/issues/273>)
  * Port moveit_ros_warehouse package.xml, CMakeLists.txt
  * Apply ROS 2 migration steps
  * Enable warehouse in motion_planning_frame
  * Run mongo db in run_move_group.launch
* [ros2-migration] Port MoveGroupInterface and MotionPlanning display (#272 <https://github.com/ros-planning/moveit2/issues/272>)
* Contributors: Henning Kayser, Jafar Abdi, Lior Lustgarten, Yu Yan
```

## run_moveit_cpp

- No changes
