### PR TITLE
video_stream_opencv: 1.1.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13229,7 +13229,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers/video_stream_opencv-release.git
-      version: 1.1.5-0
+      version: 1.1.5-1
     source:
       type: git
       url: https://github.com/ros-drivers/video_stream_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_stream_opencv` to `1.1.5-1`:

- upstream repository: https://github.com/ros-drivers/video_stream_opencv.git
- release repository: https://github.com/ros-drivers/video_stream_opencv-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.5-0`

## video_stream_opencv

```
* Exit the program if we reach the end of the video when playing a video file (Issue #23)
* Throw exception when a frame cant be captured (Issue #23, PR #27)
* Add loop_video parameter for videofiles (PR #24)
* Contributors: Sammy Pfeiffer, iory
```
