### PR TITLE
Remove stretch from the distribution as it is no longer supported.

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3,8 +3,6 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
-  debian:
-  - stretch
   ubuntu:
   - bionic
 repositories:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>