### PR TITLE
[dep] python3-git.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5852,6 +5852,12 @@ python3-gi:
   gentoo: [dev-python/pygobject]
   openembedded: [python3-pygobject@openembedded-core]
   ubuntu: [python3-gi]
+python3-git:
+  arch: [python-gitpython]
+  debian: [python3-git]
+  fedora: [python3-GitPython]
+  gentoo: [dev-python/git-python]
+  ubuntu: [python3-git]
 python3-github:
   debian: [python3-github]
   fedora: [python3-github]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1786,7 +1786,7 @@ python-gi-cairo:
   gentoo: [dev-python/pygobject]
   ubuntu: [python-gi-cairo]
 python-git:
-  arch: [python2-gobject]
+  arch: [python2-gitpython]
   debian: [python-git]
   fedora: [GitPython]
   gentoo: [dev-python/git-python]


### PR DESCRIPTION
- arch https://www.archlinux.org/packages/extra/x86_64/python-gobject/ Note I do not see explicitly in this link that this pkgs is py3 compatible. Looking at other rosdep key for py3 pkgs for arch, this seems to be the convention?
- Debian https://packages.debian.org/search?keywords=python3-git
- Fedora https://www.rpmfind.net/linux/rpm2html/search.php?query=python3-GitPython
- gentoo https://packages.gentoo.org/packages/dev-python/GitPython. Note that the pkg name is the same one as `python-git` key. I actually haven't found explicit info about the package in this link is python3 not 2, but looking at other `gentoo` rosdep keys for py3 pkgs this seems to still work?
- Ubuntu https://packages.ubuntu.com/search?keywords=python3-git