### PR TITLE
ament_package: 0.9.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -166,7 +166,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.9.2-1
+      version: 0.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.9.3-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.2-1`

## ament_package

```
* make AMENT_TRACE_SETUP_FILES output sourceable (#120 <https://github.com/ament/ament_package/issues/120>) (#121 <https://github.com/ament/ament_package/issues/121>)
* Contributors: Dirk Thomas
```
