### PR TITLE
ament_package: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -150,7 +150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.9.2-2
+      version: 0.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.10.0-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.2-2`

## ament_package

```
* make AMENT_TRACE_SETUP_FILES output sourceable (#120 <https://github.com/ament/ament_package/issues/120>)
* update maintainers
* Switch ament_package to using importlib. (#118 <https://github.com/ament/ament_package/issues/118>)
* Add pytest.ini so local tests don't display warning (#117 <https://github.com/ament/ament_package/issues/117>)
* Contributors: Chris Lalancette, Dirk Thomas, Mabel Zhang
```
