### PR TITLE
osrf_pycommon: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1192,7 +1192,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 0.1.10-2
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `0.2.0-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.10-2`

## osrf_pycommon

```
* Python 2/3 version conflict (#69 <https://github.com/osrf/osrf_pycommon/issues/69>)
* remove jessie because we no longer support 3.4 (#67 <https://github.com/osrf/osrf_pycommon/issues/67>)
* Remove deprecated use of asyncio.coroutine decorator. (#64 <https://github.com/osrf/osrf_pycommon/issues/64>)
* Fix the __str__ method for windows terminal_color. (#65 <https://github.com/osrf/osrf_pycommon/issues/65>)
* Contributors: Chris Lalancette, Jochen Sprickerhof, William Woodall
```
