### PR TITLE
video_stream_opencv: 1.1.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6702,7 +6702,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers/video_stream_opencv-release.git
-      version: 1.1.5-3
+      version: 1.1.6-1
     source:
       type: git
       url: https://github.com/ros-drivers/video_stream_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_stream_opencv` to `1.1.6-1`:

- upstream repository: https://github.com/ros-drivers/video_stream_opencv.git
- release repository: https://github.com/ros-drivers/video_stream_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.5-3`

## video_stream_opencv

```
* #67 Deal better with looping on a video file and the start and stop frame selection
* #77 Noticed the default camera info was actually wrong, corrected
* #69 Get canonical file for target device and give a warning if we convert to a canonical path
* Fix typo when moving log to debug
* #57 Enable to select the start and stop points for playing video file.
* Avoid the excess of start_frame compared to stop_frame for playing video file.
* #55 Add title and travis badge
* #54 Enable testing on melodic
* Add linesep for each mp jpeg
* #53 Upgrade to OpenCV 4
* #52 video_stream: fix disconnect callbacks never being called
* Video_stream: make sure to always increase suscriber count
* #50 Add option to set output_encoding
* Add link to cv_bridge::cvtColor
* Add config to set output_encoding
* #49 Use variable config instead of class properties
* #51 install with source permissions, install small.mp4, install test directory to enable testing in catkin install space
* #45 libvideo_stream_opencv now depends on gencfg
* #44 Don't download test data on source directory
* #43 Add option to re-open camera device on read failure
* #39 Add dependency for gencfg
* #37 Support camera property settings on dynamic reconfigure
* #36 Fix bugs for thread initialization/deinitialization
* #34 Support changing parameter by using dynamic reconfigure
* Add dependencies for test
* Support dynamic_reconfigure
* #33 Convert video_stream node to nodelet, use nodelet for video_stream
* #31 Do not flip old image multiple times, closes #30
* #35 Enable CI
* Contributors: Alexander Rössler, GITAI, Leonardo Lai, Michael Sobrepera, Ryohei Ueda, Sam Pfeiffer, Sammy Pfeiffer, Yuki Furuta, moju zhao
```
