### PR TITLE
raspimouse2: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2327,6 +2327,25 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: ros2
     status: maintained
+  raspimouse2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: foxy-devel
+    release:
+      packages:
+      - raspimouse
+      - raspimouse_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/rt-net/raspimouse2-release.git
+      version: 1.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: foxy-devel
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse2` to `1.0.2-1`:

- upstream repository: https://github.com/rt-net/raspimouse2.git
- release repository: https://github.com/rt-net/raspimouse2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## raspimouse

```
* Update for foxy (#29 <https://github.com/rt-net/raspimouse2/issues/29>)
* Contributors: Shota Aoki
```

## raspimouse_msgs

- No changes
