### PR TITLE
rviz: 8.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2423,7 +2423,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.0-1
+      version: 8.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.3.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `8.2.0-1`

## rviz2

```
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* Move and update documentation for ROS 2 (#600 <https://github.com/ros2/rviz/issues/600>)
* Contributors: Chris Lalancette, Jacob Perron
```

## rviz_assimp_vendor

```
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* Contributors: Jacob Perron
```

## rviz_common

```
* Fix for mousewheel to zoom in/out (#623 <https://github.com/ros2/rviz/issues/623>)
* Ensure rviz_common::MessageFilterDisplay processes messages in the main thread (#620 <https://github.com/ros2/rviz/issues/620>)
* Fix render window disppearing after saving image (#611 <https://github.com/ros2/rviz/issues/611>)
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* TimePanel port (#599 <https://github.com/ros2/rviz/issues/599>)
* Upgrade to tinyxml2 for rviz (#418 <https://github.com/ros2/rviz/issues/418>)
* Fix segfault on changing filter size for non-existent topic (#597 <https://github.com/ros2/rviz/issues/597>)
* improve color support for themes (#590 <https://github.com/ros2/rviz/issues/590>)
* Fix topic IntProperty number ranges (#596 <https://github.com/ros2/rviz/issues/596>)
* Switch to nullptr everywhere. (#592 <https://github.com/ros2/rviz/issues/592>)
* Expose MessageFilterDisplay's queue size (#593 <https://github.com/ros2/rviz/issues/593>)
* Filter topics in drop down menu (#591 <https://github.com/ros2/rviz/issues/591>)
* rviz_common: Remove variadic macro warning check (#421 <https://github.com/ros2/rviz/issues/421>)
* Use retriever.hpp (#589 <https://github.com/ros2/rviz/issues/589>)
* Fix the order of destructors (#572 <https://github.com/ros2/rviz/issues/572>)
* Contributors: Audrow Nash, Chen Lihui, Chris Lalancette, Jacob Perron, Martin Idel, Michael Ferguson, Michael Jeronimo, Michel Hidalgo, Nico Neumann, Rich Mattes, Shane Loretz, spiralray
```

## rviz_default_plugins

```
* Fix for mousewheel to zoom in/out (#623 <https://github.com/ros2/rviz/issues/623>)
* Make the types explicit in quaternion_helper.hpp. (#625 <https://github.com/ros2/rviz/issues/625>)
* Update status message by removing colon or adjust colon position (#624 <https://github.com/ros2/rviz/issues/624>)
* Do not use assume every RenderPanel has a ViewController. (#613 <https://github.com/ros2/rviz/issues/613>)
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* TimePanel port (#599 <https://github.com/ros2/rviz/issues/599>)
* Upgrade to tinyxml2 for rviz (#418 <https://github.com/ros2/rviz/issues/418>)
* Use retriever.hpp (#589 <https://github.com/ros2/rviz/issues/589>)
* Added covariance settings to set pose estimate (#569 <https://github.com/ros2/rviz/issues/569>)
* use reference in range loops to avoid copy (#577 <https://github.com/ros2/rviz/issues/577>)
* Contributors: Chen Lihui, Chris Lalancette, Dirk Thomas, Jacob Perron, Martin Idel, Matthijs den Toom, Michel Hidalgo, Nico Neumann, Shane Loretz
```

## rviz_ogre_vendor

```
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* Pass through CMAKE_{C,CXX}_FLAGS to OGRE build (#587 <https://github.com/ros2/rviz/issues/587>)
* Contributors: Jacob Perron, Scott K Logan
```

## rviz_rendering

```
* Prevent rviz_rendering::AssimpLoader from loading materials twice. (#622 <https://github.com/ros2/rviz/issues/622>)
* Support loading meshes other than .mesh and .stl with package URIs (#610 <https://github.com/ros2/rviz/issues/610>)
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* Switch to nullptr everywhere. (#592 <https://github.com/ros2/rviz/issues/592>)
* Use retriever.hpp (#589 <https://github.com/ros2/rviz/issues/589>)
* Avoid hidding base class getRenderOperation in PointCloudRenderable (#586 <https://github.com/ros2/rviz/issues/586>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic, Jacob Perron, Michel Hidalgo, Shane Loretz
```

## rviz_rendering_tests

```
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* Use retriever.hpp (#589 <https://github.com/ros2/rviz/issues/589>)
* Contributors: Jacob Perron, Shane Loretz
```

## rviz_visual_testing_framework

```
* use rcutils_get_env. (#609 <https://github.com/ros2/rviz/issues/609>)
* Add linters and use ament_lint_auto (#608 <https://github.com/ros2/rviz/issues/608>)
* Update maintainers (#607 <https://github.com/ros2/rviz/issues/607>)
* Contributors: Jacob Perron, tomoya
```
