### PR TITLE
spdlog_vendor: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2454,7 +2454,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.1.2-2
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.2-2`

## spdlog_vendor

```
* Updated QD to 1 (#16 <https://github.com/ros2/spdlog_vendor/issues/16>)
* bump spdlog version to 1.6.1 (#15 <https://github.com/ros2/spdlog_vendor/issues/15>)
* Bump QD to level 3 and updated QD (#14 <https://github.com/ros2/spdlog_vendor/issues/14>)
* Add Security Vulnerability Policy pointing to REP-2006. (#13 <https://github.com/ros2/spdlog_vendor/issues/13>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Dirk Thomas
```
