### PR TITLE
rmw_connext: 3.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1598,7 +1598,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 3.4.2-1
+      version: 3.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `3.5.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.4.2-1`

## rmw_connext_cpp

```
* typo fix for ConnextStaticSerializedDataSupport of subscription. (#475 <https://github.com/ros2/rmw_connext/issues/475>)
* Allow more flexible usage of XML QoS profiles (#460 <https://github.com/ros2/rmw_connext/issues/460>)
* Update maintainers (#468 <https://github.com/ros2/rmw_connext/issues/468>)
* Contributors: Alejandro Hernández Cordero, Ivan Santiago Paunovic, tomoya
```

## rmw_connext_shared_cpp

```
* Revert "Use new time_utils function to limit rmw_time_t values to 32-bits (#477 <https://github.com/ros2/rmw_connext/issues/477>)" (#482 <https://github.com/ros2/rmw_connext/issues/482>)
* Reduce the shutdown_cleanup_period. (#473 <https://github.com/ros2/rmw_connext/issues/473>)
* Use new time_utils function to limit rmw_time_t values to 32-bits (#477 <https://github.com/ros2/rmw_connext/issues/477>)
* Allow more flexible usage of XML QoS profiles (#460 <https://github.com/ros2/rmw_connext/issues/460>)
* Update maintainers (#468 <https://github.com/ros2/rmw_connext/issues/468>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Ivan Santiago Paunovic, Michael Jeronimo
```
