### PR TITLE
rclpy: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1490,7 +1490,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.4.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.3.0-1`

## rclpy

```
* Fix Enum not being comparable with ints in get_parameter_types service
* Qos configurability (#635 <https://github.com/ros2/rclpy/issues/635>)
* Use Py_XDECREF for pytopic_names_and_types. (#638 <https://github.com/ros2/rclpy/issues/638>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic, tomoya
```
