### PR TITLE
rcl_logging: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1433,7 +1433,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.1-1`

## rcl_logging_interface

```
* Update QD to QL 1 (#66 <https://github.com/ros2/rcl_logging/issues/66>)
* Use rcutils_expand_user in rcl_logging_get_logging_directory (#59 <https://github.com/ros2/rcl_logging/issues/59>)
* Allow configuring logging directory through environment variables (#53 <https://github.com/ros2/rcl_logging/issues/53>)
* Update the maintainers. (#55 <https://github.com/ros2/rcl_logging/issues/55>)
* Contributors: Chris Lalancette, Christophe Bedard, Stephen Brawner
```

## rcl_logging_log4cxx

```
* Allow configuring logging directory through environment variables (#53 <https://github.com/ros2/rcl_logging/issues/53>)
* Update the maintainers. (#55 <https://github.com/ros2/rcl_logging/issues/55>)
* Contributors: Chris Lalancette, Christophe Bedard
```

## rcl_logging_noop

```
* Make internal dependencies private (#60 <https://github.com/ros2/rcl_logging/issues/60>)
* Update the maintainers. (#55 <https://github.com/ros2/rcl_logging/issues/55>)
* Contributors: Chris Lalancette, Shane Loretz
```

## rcl_logging_spdlog

```
* Update QD to QL 1 (#66 <https://github.com/ros2/rcl_logging/issues/66>)
* Make sure to check return value from external_initialize. (#65 <https://github.com/ros2/rcl_logging/issues/65>)
* updated QD section 3.i and 3ii and spelling error (#63 <https://github.com/ros2/rcl_logging/issues/63>)
* rcl_logging_spdlog: Increased QL to 2 in QD
* Updated spdlog QL in QD
* Make internal dependencies private (#60 <https://github.com/ros2/rcl_logging/issues/60>)
* [rcl_logging_spdlog] Add warnings (#54 <https://github.com/ros2/rcl_logging/issues/54>)
* Allow configuring logging directory through environment variables (#53 <https://github.com/ros2/rcl_logging/issues/53>)
* Update the maintainers. (#55 <https://github.com/ros2/rcl_logging/issues/55>)
* Added benchmark test to rcl_logging_spdlog (#52 <https://github.com/ros2/rcl_logging/issues/52>)
* Used current_path() function from rcpputils (#51 <https://github.com/ros2/rcl_logging/issues/51>)
* Add fault injection unittest to increase coverage (#49 <https://github.com/ros2/rcl_logging/issues/49>)
* Contributors: Alejandro Hernández Cordero, Audrow Nash, Chris Lalancette, Christophe Bedard, Shane Loretz, Stephen Brawner, ahcorde, brawner
```
