### PR TITLE
launch: 0.14.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -943,7 +943,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.13.0-1
+      version: 0.14.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.14.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.13.0-1`

## launch

```
* print stderr message when command failed (#474 <https://github.com/ros2/launch/issues/474>)
* Add frontend support for LogInfo action (#467 <https://github.com/ros2/launch/issues/467>)
* Contributors: Jacob Perron, Takamasa Horibe
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Add frontend support for LogInfo action (#467 <https://github.com/ros2/launch/issues/467>)
* Contributors: Jacob Perron
```

## launch_yaml

```
* Add frontend support for LogInfo action (#467 <https://github.com/ros2/launch/issues/467>)
* Contributors: Jacob Perron
```
