### PR TITLE
launch_ros: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -963,7 +963,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.10.2-2
+      version: 0.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.10.2-2`

## launch_ros

```
* Fix docblock in LoadComposableNodes (#207 <https://github.com/ros2/launch_ros/issues/207>)
* Validate complex attributes of 'node' action (#198 <https://github.com/ros2/launch_ros/issues/198>)
* Node.__init__() executable and ComposableNode.__init__() plugin arguments aren't optional (#197 <https://github.com/ros2/launch_ros/issues/197>)
* Remove constructors arguments deprecated since Foxy (#190 <https://github.com/ros2/launch_ros/issues/190>)
* Make name and namespace mandatory in ComposableNodeContainer, remove deprecated alternatives (#189 <https://github.com/ros2/launch_ros/issues/189>)
* Merge pull request #183 <https://github.com/ros2/launch_ros/issues/183> from ros2/update-maintainers
  Update the package.xml files with the latest Open Robotics maintainers
* Move previous maintainer to <author>
* Update the package.xml files with the latest Open Robotics maintainers
* Fix AttributeError when accessing component container name (#177 <https://github.com/ros2/launch_ros/issues/177>)
* Handle any substitution types for SetParameter name argument (#182 <https://github.com/ros2/launch_ros/issues/182>)
* Asynchronously wait for load node service response (#174 <https://github.com/ros2/launch_ros/issues/174>)
* Fix case where list of composable nodes is zero (#173 <https://github.com/ros2/launch_ros/issues/173>)
* Do not use event handler for loading composable nodes (#170 <https://github.com/ros2/launch_ros/issues/170>)
* Fix race with launch context changes when loading composable nodes (#166 <https://github.com/ros2/launch_ros/issues/166>)
* Substitutions in parameter files (#168 <https://github.com/ros2/launch_ros/issues/168>)
* Fix documentation typo (#167 <https://github.com/ros2/launch_ros/issues/167>)
* Fix problems when parsing a Command Substitution as a parameter value (#137 <https://github.com/ros2/launch_ros/issues/137>)
* Add a way to set remapping rules for all nodes in the same scope (#163 <https://github.com/ros2/launch_ros/issues/163>)
* Resolve libyaml warning when loading parameters from file (#161 <https://github.com/ros2/launch_ros/issues/161>)
* Fix ComposableNode ignoring PushRosNamespace actions (#162 <https://github.com/ros2/launch_ros/issues/162>)
* Add a SetParameter action that sets a parameter to all nodes in the same scope (#158 <https://github.com/ros2/launch_ros/issues/158>)
* Make namespace parameter mandatory in LifecycleNode constructor (#157 <https://github.com/ros2/launch_ros/issues/157>)
* Avoid using a wildcard to specify parameters if possible (#154 <https://github.com/ros2/launch_ros/issues/154>)
* Fix no specified namespace (#153 <https://github.com/ros2/launch_ros/issues/153>)
* Add pytest.ini so local tests don't display warning (#152 <https://github.com/ros2/launch_ros/issues/152>)
* Contributors: Chris Lalancette, Dereck Wonnacott, Ivan Santiago Paunovic, Jacob Perron, Michael Jeronimo
```

## launch_testing_ros

```
* Merge pull request #183 <https://github.com/ros2/launch_ros/issues/183> from ros2/update-maintainers
* Move Pete to author, per clalancette
* Update the package.xml files with the latest Open Robotics maintainers
* Add pytest.ini so local tests don't display warning (#152 <https://github.com/ros2/launch_ros/issues/152>)
* Contributors: Chris Lalancette, Michael Jeronimo
```

## ros2launch

```
* Merge pull request #183 <https://github.com/ros2/launch_ros/issues/183> from ros2/update-maintainers
* Move previous maintainer to <author>
* Update the package.xml files with the latest Open Robotics maintainers
* Add pytest.ini so local tests don't display warning (#152 <https://github.com/ros2/launch_ros/issues/152>)
* Contributors: Chris Lalancette, Michael Jeronimo
```
