### PR TITLE
geometry2: 0.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -667,7 +667,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.15.0-1
+      version: 0.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.15.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.15.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

```
* fix order of find eigen3_cmake_module & find eigen3 (#344 <https://github.com/ros2/geometry2/issues/344>)
* Contributors: Ahmed Sobhy
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Clarify the role of child_frame_id and header.frame_id in the documentation. (#345 <https://github.com/ros2/geometry2/issues/345>)
* Contributors: Vikas Dhiman
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Cleanup tf2_tools to be more modern. (#351 <https://github.com/ros2/geometry2/issues/351>)
* Contributors: Chris Lalancette
```
