### PR TITLE
pluginlib: 2.5.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2130,7 +2130,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 2.5.2-1
+      version: 2.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `2.5.3-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.5.2-1`

## pluginlib

```
* Add QNX C++ fs library compiler option (#205 <https://github.com/ros/pluginlib/issues/205>) (#213 <https://github.com/ros/pluginlib/issues/213>)
* Contributors: Ahmed Sobhy
```
