### PR TITLE
pluginlib: 4.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1296,7 +1296,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 4.1.1-1
+      version: 4.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `4.1.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `4.1.1-1`

## pluginlib

```
* Check for NULL in XMLElement::Attribute
* Check for NULL in XMLElement::GetText
* Check for NULL in XMLNode::Value
* Remove unused variable output_library (#211 <https://github.com/ros/pluginlib/issues/211>)
* Make Chris a maintainer of pluginlib. (#210 <https://github.com/ros/pluginlib/issues/210>)
* Add QNX C++ fs library compiler option (#205 <https://github.com/ros/pluginlib/issues/205>)
* Contributors: Ahmed Sobhy, Chris Lalancette, Jeremie Deray, Shane Loretz
```
