### PR TITLE
resource_retriever: 2.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1560,7 +1560,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `2.4.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.4.0-1`

## libcurl_vendor

```
* Update maintainers (#53 <https://github.com/ros/resource_retriever/issues/53>)
* Contributors: Alejandro Hernández Cordero
```

## resource_retriever

```
* Throw exception if package name is empty (#54 <https://github.com/ros/resource_retriever/issues/54>)
* Update maintainers (#53 <https://github.com/ros/resource_retriever/issues/53>)
* Contributors: Alejandro Hernández Cordero, Jacob Perron
```
