### PR TITLE
launch: 0.10.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1447,7 +1447,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.10.3-1
+      version: 0.10.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.10.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.10.3-1`

## launch

```
* Fix dollar symbols in substitution grammar (#461 <https://github.com/ros2/launch/issues/461>) (#472 <https://github.com/ros2/launch/issues/472>)
* Delete unnecessary loading of 'launch.frontend.interpolate_substitution_method' entry point that was never used (#434 <https://github.com/ros2/launch/issues/434>) (#463 <https://github.com/ros2/launch/issues/463>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
