### PR TITLE
mimick_vendor: 0.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1092,7 +1092,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.2.3-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.2-1`

## mimick_vendor

```
* Update tag for new cmake version requirement (#14 <https://github.com/ros2/mimick_vendor/issues/14>)
* Export include directories (#13 <https://github.com/ros2/mimick_vendor/issues/13>)
* Update package maintainers (#10 <https://github.com/ros2/mimick_vendor/issues/10>)
* Contributors: Michel Hidalgo, Stephen Brawner
```
