### PR TITLE
mimick_vendor: 0.2.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1653,7 +1653,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.2.3-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.2-1`

## mimick_vendor

```
* Update tag for new cmake version requirement (#14 <https://github.com/ros2/mimick_vendor/issues/14>)
* Export include directories (#13 <https://github.com/ros2/mimick_vendor/issues/13>)
* Update package maintainers (#10 <https://github.com/ros2/mimick_vendor/issues/10>)
* Contributors: Michel Hidalgo, Stephen Brawner
```
