### PR TITLE
rcl: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1387,7 +1387,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `2.5.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.4.0-1`

## rcl

```
* Add const to constant rcl_context functions (#872 <https://github.com/ros2/rcl/issues/872>)
* Fix another failing test on CentOS 7 (#863 <https://github.com/ros2/rcl/issues/863>)
* Update QDs to QL 1 (#866 <https://github.com/ros2/rcl/issues/866>)
* Address clang static analysis issues (#865 <https://github.com/ros2/rcl/issues/865>)
* Fix flaky test_info_by_topic (#859 <https://github.com/ros2/rcl/issues/859>)
* Update QL (#858 <https://github.com/ros2/rcl/issues/858>)
* Refactor for removing unnecessary source code (#857 <https://github.com/ros2/rcl/issues/857>)
* Clarify storing of current_time (#850 <https://github.com/ros2/rcl/issues/850>)
* Make tests in test_graph.cpp more reliable (#854 <https://github.com/ros2/rcl/issues/854>)
* Fix for external log segfault after SIGINT (#844 <https://github.com/ros2/rcl/issues/844>)
* Update tracetools QL and add to rcl_lifecycle's QD (#845 <https://github.com/ros2/rcl/issues/845>)
* Make test logging rosout more reliable (#846 <https://github.com/ros2/rcl/issues/846>)
* Return OK when finalizing zero-initialized contexts (#842 <https://github.com/ros2/rcl/issues/842>)
* Zero initialize events an size_of_events members of rcl_wait_set_t (#841 <https://github.com/ros2/rcl/issues/841>)
* Update deprecated gtest macros (#818 <https://github.com/ros2/rcl/issues/818>)
* Contributors: Alejandro Hernández Cordero, Audrow Nash, Chen Lihui, Chris Lalancette, Christophe Bedard, Ivan Santiago Paunovic, Jacob Perron, Stephen Brawner, Thijs Raymakers, tomoya
```

## rcl_action

```
* Address various clang static analysis fixes (#864 <https://github.com/ros2/rcl/issues/864>)
* Update QDs to QL 1 (#866 <https://github.com/ros2/rcl/issues/866>)
* Update QL (#858 <https://github.com/ros2/rcl/issues/858>)
* Make sure to always check return values (#840 <https://github.com/ros2/rcl/issues/840>)
* Update deprecated gtest macros (#818 <https://github.com/ros2/rcl/issues/818>)
* Contributors: Alejandro Hernández Cordero, Audrow Nash, Chris Lalancette, Stephen Brawner
```

## rcl_lifecycle

```
* Update QDs to QL 1 (#866 <https://github.com/ros2/rcl/issues/866>)
* Update QL (#858 <https://github.com/ros2/rcl/issues/858>)
* Make sure to always check return values (#840 <https://github.com/ros2/rcl/issues/840>)
* Update tracetools QL and add to rcl_lifecycle's QD (#845 <https://github.com/ros2/rcl/issues/845>)
* Add compiler warnings (#830 <https://github.com/ros2/rcl/issues/830>)
* Contributors: Alejandro Hernández Cordero, Audrow Nash, Chris Lalancette, Christophe Bedard, Stephen Brawner
```

## rcl_yaml_param_parser

```
* Enable compiler warnings (#831 <https://github.com/ros2/rcl/issues/831>)
* Update QDs to QL 1 (#866 <https://github.com/ros2/rcl/issues/866>)
* Rearrange test logic to avoid reference to null (#862 <https://github.com/ros2/rcl/issues/862>)
* Update QL (#858 <https://github.com/ros2/rcl/issues/858>)
* Make sure to initialize the end_mark for yaml_event_t (#849 <https://github.com/ros2/rcl/issues/849>)
* Contributors: Alejandro Hernández Cordero, Audrow Nash, Chris Lalancette, Stephen Brawner
```
