### PR TITLE
cob_manipulation: 0.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -743,6 +743,27 @@ repositories:
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
     status: maintained
+  cob_manipulation:
+    doc:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_collision_monitor
+      - cob_grasp_generation
+      - cob_lookat_action
+      - cob_moveit_bringup
+      - cob_moveit_interface
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ipa320/cob_manipulation-release.git
+      version: 0.7.5-1
+    source:
+      type: git
+      url: https://github.com/ipa320/cob_manipulation.git
+      version: kinetic_dev
+    status: maintained
   cob_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_manipulation` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_manipulation.git
- release repository: https://github.com/ipa320/cob_manipulation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## cob_collision_monitor

```
* Merge pull request #148 <https://github.com/ipa320/cob_manipulation/issues/148> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #149 <https://github.com/ipa320/cob_manipulation/issues/149> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_grasp_generation

```
* Merge pull request #148 <https://github.com/ipa320/cob_manipulation/issues/148> from fmessmer/test_noetic
  test noetic
* ROS_PYTHON_VERSION conditional dependency
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```

## cob_lookat_action

```
* Merge pull request #148 <https://github.com/ipa320/cob_manipulation/issues/148> from fmessmer/test_noetic
  test noetic
* conditional depend for orocos-kdl
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #149 <https://github.com/ipa320/cob_manipulation/issues/149> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Merge pull request #146 <https://github.com/ipa320/cob_manipulation/issues/146> from fmessmer/lookat_improve_fjt_goal
  [cob_lookat] improve fjt goal
* do not set tolerances
* set velocities and accelerations to 0.0 for traj_point
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_bringup

```
* Merge pull request #148 <https://github.com/ipa320/cob_manipulation/issues/148> from fmessmer/test_noetic
  test noetic
* Bump CMake version to avoid CMP0048 warning
* Merge pull request #149 <https://github.com/ipa320/cob_manipulation/issues/149> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_moveit_interface

```
* Merge pull request #148 <https://github.com/ipa320/cob_manipulation/issues/148> from fmessmer/test_noetic
  test noetic
* ROS_PYTHON_VERSION conditional dependency
* use setuptools instead of distutils
* Bump CMake version to avoid CMP0048 warning
* Contributors: Felix Messmer, fmessmer
```
