### PR TITLE
rcutils: 1.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2528,7 +2528,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `1.1.2-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.1-1`

## rcutils

```
* Disable a Windows platform warning (#311 <https://github.com/ros2/rcutils/issues/311>) (#319 <https://github.com/ros2/rcutils/issues/319>)
* Update QD to QL 1 (#318 <https://github.com/ros2/rcutils/issues/318>)
* Add QNX support for rcutils_get_executable_name (#282 <https://github.com/ros2/rcutils/issues/282>) (#307 <https://github.com/ros2/rcutils/issues/307>)
* DefinesQNX implementation for rcutils_get_platform_library_name (#287 <https://github.com/ros2/rcutils/issues/287>) (#309 <https://github.com/ros2/rcutils/issues/309>)
* Update the maintainers (#299 <https://github.com/ros2/rcutils/issues/299>) (#300 <https://github.com/ros2/rcutils/issues/300>)
* Contributors: Ahmed Sobhy, Alejandro Hernández Cordero, Chris Lalancette, Jacob Perron, Stephen Brawner
```
