### PR TITLE
Adding diffdrive_arduino to documentation index for melodic (correction)

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2194,6 +2194,10 @@ repositories:
       version: indigo-devel
     status: maintained
   diffdrive_arduino:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/diffdrive_arduino.git
+      version: melodic-devel
     source:
       type: git
       url: https://github.com/joshnewans/diffdrive_arduino.git


### PR DESCRIPTION
Addition of a new package to the documentation index.
I had misunderstood the process and my previous PR (#27636) included only the `source` component but not the `doc` component (no release).