### PR TITLE
rosidl: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3071,7 +3071,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`

## rosidl_adapter

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Strip action service suffixes from C include prefix (#538 <https://github.com/ros2/rosidl/issues/538>) (#539 <https://github.com/ros2/rosidl/issues/539>)
* Contributors: Jacob Perron
```

## rosidl_generator_cpp

- No changes

## rosidl_parser

```
* Fix parsing of small floats (#554 <https://github.com/ros2/rosidl/issues/554>)
* Contributors: Chris Lalancette
```

## rosidl_runtime_c

```
* Fix item number in QD (#546 <https://github.com/ros2/rosidl/issues/546>) (#547 <https://github.com/ros2/rosidl/issues/547>)
* Update QD links for Foxy
* QD: Add links to hosted API docs (#533 <https://github.com/ros2/rosidl/issues/533>)
* Updated Quality Level to 1 (#532 <https://github.com/ros2/rosidl/issues/532>)
* Add benchmarks for rosidl_runtime_* packages (#521 <https://github.com/ros2/rosidl/issues/521>)
* Add rcutils dependency (#534 <https://github.com/ros2/rosidl/issues/534>)
* Add fault injection macros and test (#509 <https://github.com/ros2/rosidl/issues/509>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Louise Poubel, Scott K Logan, Stephen Brawner
```

## rosidl_runtime_cpp

```
* Fix item number in QD (#546 <https://github.com/ros2/rosidl/issues/546>) (#547 <https://github.com/ros2/rosidl/issues/547>)
* Update QD links for Foxy
* QD: Add links to hosted API docs (#533 <https://github.com/ros2/rosidl/issues/533>)
* Updated Quality Level to 1 (#532 <https://github.com/ros2/rosidl/issues/532>)
* Add benchmarks for rosidl_runtime_* packages (#521 <https://github.com/ros2/rosidl/issues/521>)
* Contributors: Alejandro Hernández Cordero, Louise Poubel, Scott K Logan
```

## rosidl_typesupport_interface

```
* Fix item number in QD (#546 <https://github.com/ros2/rosidl/issues/546>) (#547 <https://github.com/ros2/rosidl/issues/547>)
* QD: Add links to hosted API docs (#533 <https://github.com/ros2/rosidl/issues/533>)
* Update Quality Declaration to QL 1 for rosidl_typesupport_interface (#519 <https://github.com/ros2/rosidl/issues/519>)
* Contributors: Louise Poubel, Stephen Brawner
```

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
