### PR TITLE
rosidl_typesupport: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2028,7 +2028,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.0.0-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-2`

## rosidl_typesupport_c

```
* Explicitly check lib pointer for null (#95 <https://github.com/ros2/rosidl_typesupport/issues/95>)
* Update Quality Declaration to QL 1 (#96 <https://github.com/ros2/rosidl_typesupport/issues/96>)
* Add mock for rcutils_get_symbol failure (#93 <https://github.com/ros2/rosidl_typesupport/issues/93>)
* Update the maintainers (#89 <https://github.com/ros2/rosidl_typesupport/issues/89>)
* Catch exception from has_symbol (#86 <https://github.com/ros2/rosidl_typesupport/issues/86>)
* Added benchmark test to rosidl_typesupport_c/cpp (#84 <https://github.com/ros2/rosidl_typesupport/issues/84>)
* Handle rcpputils::find_library_path() failure (#85 <https://github.com/ros2/rosidl_typesupport/issues/85>)
* Add fault injection macros and unit tests (#80 <https://github.com/ros2/rosidl_typesupport/issues/80>)
* Remove rethrow in extern c code (#82 <https://github.com/ros2/rosidl_typesupport/issues/82>)
* Add Security Vulnerability Policy pointing to REP-2006 (#76 <https://github.com/ros2/rosidl_typesupport/issues/76>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jose Luis Rivero, Jose Tomas Lorente, Louise Poubel, Michel Hidalgo, Stephen Brawner
```

## rosidl_typesupport_cpp

```
* Explicitly check lib pointer for null (#95 <https://github.com/ros2/rosidl_typesupport/issues/95>)
* Update Quality Declaration to QL 1 (#96 <https://github.com/ros2/rosidl_typesupport/issues/96>)
* Update the maintainers (#89 <https://github.com/ros2/rosidl_typesupport/issues/89>)
* Added benchmark test to rosidl_typesupport_c/cpp (#84 <https://github.com/ros2/rosidl_typesupport/issues/84>)
* Handle rcpputils::find_library_path() failure (#85 <https://github.com/ros2/rosidl_typesupport/issues/85>)
* De-duplicate type_support_map.h header (#81 <https://github.com/ros2/rosidl_typesupport/issues/81>)
* Add fault injection macros and unit tests (#80 <https://github.com/ros2/rosidl_typesupport/issues/80>)
* Add Security Vulnerability Policy pointing to REP-2006 (#76 <https://github.com/ros2/rosidl_typesupport/issues/76>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jose Luis Rivero, Louise Poubel, Michel Hidalgo, Stephen Brawner
```
