### PR TITLE
rosidl_typesupport: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3163,7 +3163,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## rosidl_typesupport_c

```
* Update Quality Declaration to QL 1 (#97 <https://github.com/ros2/rosidl_typesupport/issues/97>)
* Add mock for rcutils_get_symbol failure (#93 <https://github.com/ros2/rosidl_typesupport/issues/93>) (#94 <https://github.com/ros2/rosidl_typesupport/issues/94>)
* Added benchmark test to rosidl_typesupport_c/cpp (#84 <https://github.com/ros2/rosidl_typesupport/issues/84>)
* Catch exception from has_symbol (#86 <https://github.com/ros2/rosidl_typesupport/issues/86>)
* Handle rcpputils::find_library_path() failure (#85 <https://github.com/ros2/rosidl_typesupport/issues/85>)
* Add fault injection macros and unit tests (#80 <https://github.com/ros2/rosidl_typesupport/issues/80>)
* Remove rethrow in extern c code (#82 <https://github.com/ros2/rosidl_typesupport/issues/82>)
* Add Security Vulnerability Policy pointing to REP-2006. (#76 <https://github.com/ros2/rosidl_typesupport/issues/76>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jose Luis Rivero, Jose Tomas Lorente, Louise Poubel, Michel Hidalgo, Stephen Brawner
```

## rosidl_typesupport_cpp

```
* Update Quality Declaration to QL 1 (#97 <https://github.com/ros2/rosidl_typesupport/issues/97>)
* De-deplicate type_support_map.h header (#83 <https://github.com/ros2/rosidl_typesupport/issues/83>)
* Added benchmark test to rosidl_typesupport_c/cpp (#84 <https://github.com/ros2/rosidl_typesupport/issues/84>)
* Handle rcpputils::find_library_path() failure. (#85 <https://github.com/ros2/rosidl_typesupport/issues/85>)
* Add fault injection macros and unit tests (#80 <https://github.com/ros2/rosidl_typesupport/issues/80>)
* Add Security Vulnerability Policy pointing to REP-2006. (#76 <https://github.com/ros2/rosidl_typesupport/issues/76>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jose Luis Rivero, Louise Poubel, Michel Hidalgo, Stephen Brawner
```
