### PR TITLE
simple_launch: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3626,6 +3626,21 @@ repositories:
       url: https://github.com/SICKAG/sick_scan2.git
       version: master
     status: developed
+  simple_launch:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: 1.0.2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/oKermorgant/simple_launch-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: devel
+    status: developed
   slam_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.0.2-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/oKermorgant/simple_launch-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## simple_launch

```
* composition with existing container
* Contributors: Olivier Kermorgant
```
