### PR TITLE
psen_scan_v2: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4276,6 +4276,21 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: unmaintained
+  psen_scan_v2:
+    doc:
+      type: git
+      url: https://github.com/PilzDE/psen_scan_v2.git
+      version: main
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/PilzDE/psen_scan_v2-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/PilzDE/psen_scan_v2.git
+      version: main
+    status: developed
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.1.3-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## psen_scan_v2

```
* Add ROS noetic support (#103 <https://github.com/PilzDE/psen_scan_v2/issues/103>)
* Use TYPED_TEST_SUITE instead of deprecated TYPED_TEST_CASE
* Apply fixes from clang-format (#113 <https://github.com/PilzDE/psen_scan_v2/issues/113>)
* Spelling measurements (#112 <https://github.com/PilzDE/psen_scan_v2/issues/112>)
* Directly use fmt lib instead of rosfmt (#108 <https://github.com/PilzDE/psen_scan_v2/issues/108>)
* Fix clang tidy errors (#109 <https://github.com/PilzDE/psen_scan_v2/issues/109>)
* Feature/api documentation improvement (#100 <https://github.com/PilzDE/psen_scan_v2/issues/100>)
* Improve the API documentation
* Add ROS Noetic support
* Contributors: Pilz GmbH and Co. KG
```
