### PR TITLE
psen_scan_v2: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8605,7 +8605,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.1.3-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## psen_scan_v2

```
* Add ROS noetic support (#103 <https://github.com/PilzDE/psen_scan_v2/issues/103>)
* Use TYPED_TEST_SUITE instead of deprecated TYPED_TEST_CASE
* Apply fixes from clang-format (#113 <https://github.com/PilzDE/psen_scan_v2/issues/113>)
* Spelling measurements (#112 <https://github.com/PilzDE/psen_scan_v2/issues/112>)
* Directly use fmt lib instead of rosfmt (#108 <https://github.com/PilzDE/psen_scan_v2/issues/108>)
* Fix clang tidy errors (#109 <https://github.com/PilzDE/psen_scan_v2/issues/109>)
* Feature/api documentation improvement (#100 <https://github.com/PilzDE/psen_scan_v2/issues/100>)
* Improve the API documentation
* Add ROS Noetic support
* Contributors: Pilz GmbH and Co. KG
```
