### PR TITLE
Add flawfinder to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -864,6 +864,12 @@ flac:
   fedora: [flac]
   gentoo: [media-libs/flac]
   ubuntu: [flac]
+flawfinder:
+  arch: [flawfinder]
+  debian: [flawfinder]
+  fedora: [flawfinder]
+  gentoo: [dev-util/flawfinder]
+  ubuntu: [flawfinder]
 flex:
   arch: [flex]
   debian: [flex]


### PR DESCRIPTION
Flawfinder is a tool used to scan C/C++ source code for security flaws.

GitHub repository: https://github.com/david-a-wheeler/flawfinder

Arch: https://www.archlinux.org/packages/community/any/flawfinder/
Debian: https://packages.debian.org/buster/flawfinder
Fedora: https://src.fedoraproject.org/rpms/flawfinder
Gentoo: https://packages.gentoo.org/packages/dev-util/flawfinder
Ubuntu: https://packages.ubuntu.com/focal/flawfinder

Distro A, OPSEC 4584

Signed-off-by: P. J. Reed <preed@swri.org>