### PR TITLE
add flask-restplus from pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1626,10 +1626,6 @@ python-flask-restful:
         packages: [flask-restful]
     xenial: [python-flask-restful]
     yakkety: [python-flask-restful]
-python3-flask-restplus-pip:
-  ubuntu:
-    pip:
-      packages: [flask-restplus]
 python-flatdict-pip:
   ubuntu:
     pip:
@@ -5774,6 +5770,10 @@ python3-flake8:
     '*': ['python%{python3_pkgversion}-flake8']
     '7': null
   ubuntu: [python3-flake8]
+python3-flask-restplus-pip:
+  ubuntu:
+    pip:
+      packages: [flask-restplus]
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1626,7 +1626,7 @@ python-flask-restful:
         packages: [flask-restful]
     xenial: [python-flask-restful]
     yakkety: [python-flask-restful]
-python-flask-restplus-pip:
+python3-flask-restplus-pip:
   ubuntu:
     pip:
       packages: [flask-restplus]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1626,6 +1626,10 @@ python-flask-restful:
         packages: [flask-restful]
     xenial: [python-flask-restful]
     yakkety: [python-flask-restful]
+python-flask-restplus-pip:
+  ubuntu:
+    pip:
+      packages: [flask-restplus]
 python-flatdict-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
**Added package**: flask-restplus
**Pypi Link**: https://pypi.org/project/flask-restplus/
**Description**: Fully featured framework for fast, easy and documented API development with Flask
**Usage**: Making an API interacting with ROS. Flask is quite famous but for APIs, restplus gives some nice features such as integrated modelling, marshalling, swaggers and more. It is very easy to use if you already know some flask.

I added it as pip since there is no deb for it.

