### PR TITLE
rosidl_typesupport_fastrtps: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2067,7 +2067,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 1.0.1-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-2`

## fastrtps_cmake_module

```
* Use CMake config dirs as hint for header/library search (#56 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/56>)
* Update package maintainers (#55 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/55>)
* QD Update Version Stability to stable version (#46 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/46>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Michel Hidalgo
```

## rosidl_typesupport_fastrtps_c

```
* Update QDs with up-to-date content (#64 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/64>)
* Fix item number in QD (#59 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/59>)
* Update QL to 2
* Update package maintainers (#55 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/55>)
* Updat QD (#53 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/53>)
* Fix invalid return on deserialize function (#51 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/51>)
* Added benchmark test to rosidl_typesupport_fastrtps_c/cpp (#52 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/52>)
* Update exec dependencies (#50 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/50>)
* Add Security Vulnerability Policy pointing to REP-2006 (#44 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/44>)
* QD Update Version Stability to stable version (#46 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/46>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jorge Perez, Louise Poubel, Michel Hidalgo, Stephen Brawner, sung-goo-kim
```

## rosidl_typesupport_fastrtps_cpp

```
* Update QDs with up-to-date content (#64 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/64>)
* Fix item number in QD (#59 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/59>)
* Update QL to 2
* Update package maintainers (#55 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/55>)
* Update QD (#53 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/53>)
* Add benchmark test to rosidl_typesupport_fastrtps_c/cpp (#52 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/52>)
* Update exec dependencies (#50 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/50>)
* Add Security Vulnerability Policy pointing to REP-2006 (#44 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/44>)
* QD Update Version Stability to stable version (#46 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/46>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jorge Perez, Louise Poubel, Michel Hidalgo, Stephen Brawner
```
