### PR TITLE
ros1_bridge: 0.8.3-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2388,7 +2388,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.8.2-3
+      version: 0.8.3-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.8.3-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.8.2-3`

## ros1_bridge

```
* [backport] support idl files on the ROS 2 side of the bridge (#302 <https://github.com/ros2/ros1_bridge/issues/302>)
  * [backport] update to use rosidl_parser and .idl files rather than rosidl_adapter and .msg files (#296 <https://github.com/ros2/ros1_bridge/issues/296>)
  * [backport] fix bug with sizeof when type of the arrays differ (#298 <https://github.com/ros2/ros1_bridge/issues/298>)
* fix multiple definition if message with same name as service exists (#272 <https://github.com/ros2/ros1_bridge/issues/272>) (#274 <https://github.com/ros2/ros1_bridge/issues/274>)
* Contributors: Dirk Thomas, William Woodall
```
