### PR TITLE
Added 11 packages for the purpose of micro-ROS install on OSX

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1192,6 +1192,7 @@ google-mock:
   opensuse: [gmock-devel]
   rhel: [gmock-devel]
   ubuntu: [google-mock]
+  osx: [gtest]
 gpac:
   debian: [gpac]
   fedora: [gpac]
@@ -2340,6 +2341,7 @@ libffi-dev:
   fedora: [libffi-devel]
   gentoo: [virtual/libffi]
   ubuntu: [libffi-dev]
+  osx: [libffi]
 libfftw3:
   arch: [fftw]
   debian: [libfftw3-3, libfftw3-dev]
@@ -4699,6 +4701,9 @@ llvm:
   debian: [llvm]
   gentoo: [sys-devel/llvm]
   ubuntu: [llvm]
+  osx:
+    homebrew:
+      packages: [llvm]
 llvm-7:
   debian:
     buster: [llvm-7]
@@ -6356,6 +6361,7 @@ wget:
   freebsd: [wget]
   gentoo: [net-misc/wget]
   macports: [wget]
+  osx: [wget]
   opensuse: [wget]
   ubuntu: [wget]
 wireless-tools:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5379,6 +5379,7 @@ python3:
   gentoo: [dev-lang/python]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
+  osx: [python3]
 python3-adafruit-blinka-pip:
   debian:
     pip:
@@ -6050,6 +6051,9 @@ python3-mypy:
   fedora: [python3-mypy]
   gentoo: [dev-python/mypy]
   ubuntu: [python3-mypy]
+  osx:
+    pip:
+      packages: [mypy]
 python3-nclib-pip:
   arch:
     pip:
@@ -6086,6 +6090,9 @@ python3-nose:
   openembedded: [python3-nose@openembedded-core]
   rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
+  osx:
+    pip:
+      packages: [nose]
 python3-nose-yanc:
   debian: [python3-nose-yanc]
   openembedded: [python3-nose-yanc@meta-ros]
@@ -6283,6 +6290,9 @@ python3-pycodestyle:
   gentoo: [dev-python/pycodestyle]
   rhel: ['python%{python3_pkgversion}-pycodestyle']
   ubuntu: [python3-pycodestyle]
+  osx:
+    pip:
+      packages: [pycodestyle]
 python3-pycryptodome:
   alpine: [py3-pycryptodome]
   arch: [python-pycryptodome]
@@ -6446,6 +6456,9 @@ python3-pytest-mock:
     '*': ['python%{python3_pkgversion}-pytest-mock']
     '7': null
   ubuntu: [python3-pytest-mock]
+  osx:
+    pip:
+      packages: [pytest-mock]
 python3-pytest-timeout:
   debian: [python3-pytest-timeout]
   fedora: [python3-pytest-timeout]
@@ -6712,10 +6725,7 @@ python3-siphon-pip:
     pip:
       packages: [siphon]
 python3-six:
-  arch: [python-six]
   debian: [python3-six]
-  fedora: [python3-six]
-  gentoo: [dev-python/six]
   ubuntu: [python3-six]
 python3-skimage:
   debian: [python3-skimage]
@@ -6883,6 +6893,9 @@ python3-vcstool:
   macports:
     pip:
       packages: [vcstool]
+  osx:
+    pip:
+      packages: [vcstool]
   ubuntu: [python3-vcstool]
 python3-vedo-pip:
   debian:
@@ -6898,6 +6911,9 @@ python3-venv:
   debian: [python3-venv]
   fedora: [python3-libs]
   ubuntu: [python3-venv]
+  osx:
+    pip:
+      packages: [virtualenv]
 python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]


### PR DESCRIPTION
This is to get the scripts running for the micro_ros_setup tools on OSX.  This required the inclusion of some common packages like python3 and wget.