### PR TITLE
geometry2: 0.13.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1072,6 +1072,7 @@ repositories:
       - tf2
       - tf2_bullet
       - tf2_eigen
+      - tf2_eigen_kdl
       - tf2_geometry_msgs
       - tf2_kdl
       - tf2_msgs
@@ -1082,7 +1083,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.13.7-1
+      version: 0.13.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.13.9-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.13.7-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

```
* Port tf2_eigen_kdl to ROS 2 (#356 <https://github.com/ros2/geometry2/issues/356>)
* Contributors: Esteve Fernandez
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
