### PR TITLE
ros1_bridge: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.9.4-2
+      version: 0.10.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.9.4-2`
