### PR TITLE
rmw_fastrtps: 1.2.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2678,7 +2678,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 1.2.3-1
+      version: 1.2.4-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `1.2.4-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.3-1`

## rmw_fastrtps_cpp

```
* Discriminate when the Client has gone from when the Client has not completely matched (#479 <https://github.com/ros2/rmw_fastrtps/issues/479>)
* Contributors: Jacob Perron
```

## rmw_fastrtps_dynamic_cpp

```
* Discriminate when the Client has gone from when the Client has not completely matched (#479 <https://github.com/ros2/rmw_fastrtps/issues/479>) (#489 <https://github.com/ros2/rmw_fastrtps/issues/489>) (#490 <https://github.com/ros2/rmw_fastrtps/issues/490>)
* Contributors: Jacob Perron
```

## rmw_fastrtps_shared_cpp

```
* Make sure to lock the mutex protecting client_endpoints_ (#492 <https://github.com/ros2/rmw_fastrtps/issues/492>) (#493 <https://github.com/ros2/rmw_fastrtps/issues/493>)
* Discriminate when the Client has gone from when the Client has not completely matched (#479 <https://github.com/ros2/rmw_fastrtps/issues/479>)
* Contributors: Chris Lalancette, Jacob Perron
```
