### PR TITLE
launch_ros: 0.11.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1467,7 +1467,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.11.0-1`

## launch_ros

```
* Fix case where list of composable nodes is zero (#173 <https://github.com/ros2/launch_ros/issues/173>) (#209 <https://github.com/ros2/launch_ros/issues/209>)
* Do not use event handler for loading composable nodes (#170 <https://github.com/ros2/launch_ros/issues/170>) (#208 <https://github.com/ros2/launch_ros/issues/208>)
* Fix race with launch context changes when loading composable nodes (#166 <https://github.com/ros2/launch_ros/issues/166>) (#206 <https://github.com/ros2/launch_ros/issues/206>)
* Add a way to set remapping rules for all nodes in the same scope (#163 <https://github.com/ros2/launch_ros/issues/163>) (#203 <https://github.com/ros2/launch_ros/issues/203>)
* Resolve libyaml warning when loading parameters from file (#161 <https://github.com/ros2/launch_ros/issues/161>) (#202 <https://github.com/ros2/launch_ros/issues/202>)
* Fix ComposableNode ignoring PushRosNamespace actions (#162 <https://github.com/ros2/launch_ros/issues/162>) (#201 <https://github.com/ros2/launch_ros/issues/201>)
* Contributors: Dereck Wonnacott, Ivan Santiago Paunovic, Jacob Perron
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
