### PR TITLE
rviz: 8.2.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3612,7 +3612,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.2.0-1
+      version: 8.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.2.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `8.2.0-1`

## rviz2

```
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* changelogs
* Contributors: Michael Jeronimo, William Woodall
```

## rviz_assimp_vendor

```
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* [foxy-backport] fast forward of ros2 (default) to foxy (#570 <https://github.com/ros2/rviz/issues/570>)
  * restore compatibility with older Qt versions (#561 <https://github.com/ros2/rviz/issues/561>)
  * Suppress warnings when building with older Qt versions. (#562 <https://github.com/ros2/rviz/issues/562>)
  * Don't try to moc generate env_config.hpp file. (#550 <https://github.com/ros2/rviz/issues/550>)
  This removes one more warning from rviz_common builds.
  * rewrite hack to avoid CMake warning with assimp 5.0.1 and older, apply cross platform (#565 <https://github.com/ros2/rviz/issues/565>)
  * Use dedicated TransformListener thread (#551 <https://github.com/ros2/rviz/issues/551>)
  * restore alphabetical include order (#563 <https://github.com/ros2/rviz/issues/563>)
  * Don't install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Contributors: Michael Jeronimo, William Woodall, Dirk Thomas, Chris Lalancette, ymd-stella, Karsten Knese
```

## rviz_common

```
* Fix for mousewheel to zoom in/out (#623 <https://github.com/ros2/rviz/issues/623>) (#626 <https://github.com/ros2/rviz/issues/626>)
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* [foxy-backport] fast forward of ros2 (default) to foxy (#570 <https://github.com/ros2/rviz/issues/570>)
  * restore compatibility with older Qt versions (#561 <https://github.com/ros2/rviz/issues/561>)
  * Suppress warnings when building with older Qt versions. (#562 <https://github.com/ros2/rviz/issues/562>)
  * Don't try to moc generate env_config.hpp file. (#550 <https://github.com/ros2/rviz/issues/550>)
  This removes one more warning from rviz_common builds.
  * rewrite hack to avoid CMake warning with assimp 5.0.1 and older, apply cross platform (#565 <https://github.com/ros2/rviz/issues/565>)
  * Use dedicated TransformListener thread (#551 <https://github.com/ros2/rviz/issues/551>)
  * restore alphabetical include order (#563 <https://github.com/ros2/rviz/issues/563>)
  * Don't install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Contributors: Jacob Perron, Michael Jeronimo, William Woodall, Chen Lihui, Dirk Thomas, Chris Lalancette, ymd-stella, Karsten Knese
```

## rviz_default_plugins

```
* Fix for mousewheel to zoom in/out (#623 <https://github.com/ros2/rviz/issues/623>) (#626 <https://github.com/ros2/rviz/issues/626>)
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* Do not use assume every RenderPanel has a ViewController. (#613 <https://github.com/ros2/rviz/issues/613>) (#615 <https://github.com/ros2/rviz/issues/615>)
* [foxy-backport] fast forward of ros2 (default) to foxy (#570 <https://github.com/ros2/rviz/issues/570>)
  * restore compatibility with older Qt versions (#561 <https://github.com/ros2/rviz/issues/561>)
  * Suppress warnings when building with older Qt versions. (#562 <https://github.com/ros2/rviz/issues/562>)
  * Don't try to moc generate env_config.hpp file. (#550 <https://github.com/ros2/rviz/issues/550>)
  This removes one more warning from rviz_common builds.
  * rewrite hack to avoid CMake warning with assimp 5.0.1 and older, apply cross platform (#565 <https://github.com/ros2/rviz/issues/565>)
  * Use dedicated TransformListener thread (#551 <https://github.com/ros2/rviz/issues/551>)
  * restore alphabetical include order (#563 <https://github.com/ros2/rviz/issues/563>)
  * Don't install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Contributors: Jacob Perron, Michael Jeronimo, Michel Hidalgo, William Woodall, Chen Lihui, Dirk Thomas, Chris Lalancette, ymd-stella
  Karsten Knese
```

## rviz_ogre_vendor

```
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* changelogs
* Contributors: Michael Jeronimo, William Woodall
```

## rviz_rendering

```
* Prevent rviz_rendering::AssimpLoader from loading materials twice. (#622 <https://github.com/ros2/rviz/issues/622>) (#629 <https://github.com/ros2/rviz/issues/629>)
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* [foxy-backport] fast forward of ros2 (default) to foxy (#570 <https://github.com/ros2/rviz/issues/570>)
  * restore compatibility with older Qt versions (#561 <https://github.com/ros2/rviz/issues/561>)
  * Suppress warnings when building with older Qt versions. (#562 <https://github.com/ros2/rviz/issues/562>)
  * Don't try to moc generate env_config.hpp file. (#550 <https://github.com/ros2/rviz/issues/550>)
  This removes one more warning from rviz_common builds.
  * rewrite hack to avoid CMake warning with assimp 5.0.1 and older, apply cross platform (#565 <https://github.com/ros2/rviz/issues/565>)
  * Use dedicated TransformListener thread (#551 <https://github.com/ros2/rviz/issues/551>)
  * restore alphabetical include order (#563 <https://github.com/ros2/rviz/issues/563>)
  * Don't install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Contributors: Michael Jeronimo, Michel Hidalgo, William Woodall, Dirk Thomas, Chris Lalancette, ymd-stella, Karsten Knese
```

## rviz_rendering_tests

```
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* [foxy-backport] fast forward of ros2 (default) to foxy (#570 <https://github.com/ros2/rviz/issues/570>)
  * restore compatibility with older Qt versions (#561 <https://github.com/ros2/rviz/issues/561>)
  * Suppress warnings when building with older Qt versions. (#562 <https://github.com/ros2/rviz/issues/562>)
  * Don't try to moc generate env_config.hpp file. (#550 <https://github.com/ros2/rviz/issues/550>)
  This removes one more warning from rviz_common builds.
  * rewrite hack to avoid CMake warning with assimp 5.0.1 and older, apply cross platform (#565 <https://github.com/ros2/rviz/issues/565>)
  * Use dedicated TransformListener thread (#551 <https://github.com/ros2/rviz/issues/551>)
  * restore alphabetical include order (#563 <https://github.com/ros2/rviz/issues/563>)
  * Don't install test header files in rviz_rendering. (#564 <https://github.com/ros2/rviz/issues/564>)
* Contributors: Michael Jeronimo, William Woodall, Dirk Thomas, Chris Lalancette, ymd-stella, Karsten Knese
```

## rviz_visual_testing_framework

```
* Update maintainer list (#619 <https://github.com/ros2/rviz/issues/619>)
* changelogs
* Contributors: Michael Jeronimo, William Woodall
```
