### PR TITLE
jsk_control: 0.1.15-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4765,6 +4765,34 @@ repositories:
       url: https://github.com/tork-a/jsk_common_msgs-release.git
       version: 4.3.1-0
     status: developed
+  jsk_control:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
+    release:
+      packages:
+      - cmd_vel_smoother
+      - contact_states_observer
+      - eus_nlopt
+      - eus_qp
+      - eus_qpoases
+      - joy_mouse
+      - jsk_calibration
+      - jsk_control
+      - jsk_footstep_controller
+      - jsk_footstep_planner
+      - jsk_ik_server
+      - jsk_teleop_joy
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/jsk_control-release.git
+      version: 0.1.15-1
+    source:
+      type: git
+      url: https://github.com/jsk-ros-pkg/jsk_control.git
+      version: master
+    status: developed
   jsk_model_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.15-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## cmd_vel_smoother

- No changes

## contact_states_observer

- No changes

## eus_nlopt

- No changes

## eus_qp

- No changes

## eus_qpoases

- No changes

## joy_mouse

- No changes

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

```
* Merge pull request #692 <https://github.com/jsk-ros-pkg/jsk_control/issues/692> from orikuma/replace-footstep-state-to-state-ptr
  Replace FootstepState::Ptr to StatePtr in footstep_astar_solver to be used with a GraphT which has different state type
* [jsk_footstep_planner] Replace FootstepState::Ptr -> StatePtr in footstep_astar_solver to be used with a GraphT which has different state type
* Contributors: Iori Kumagai, Yohei Kakiuchi
```

## jsk_ik_server

- No changes

## jsk_teleop_joy

```
* Merge pull request #693 <https://github.com/jsk-ros-pkg/jsk_control/issues/693> from k-okada/fix_apt_slow
  remove unused build_depends
* remove unused build_depends
* Contributors: Kei Okada
```
