### PR TITLE
tvm_vendor: 0.7.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12658,7 +12658,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/autowarefoundation/tvm_vendor-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/autowarefoundation/tvm_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tvm_vendor` to `0.7.2-1`:

- upstream repository: https://github.com/autowarefoundation/tvm_vendor.git
- release repository: https://github.com/autowarefoundation/tvm_vendor-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.1-1`

## tvm_vendor

```
* Removing LLVM dependency.
* Contributors: Joshua Whitley
```
