### PR TITLE
add opencv-contrib-python package for pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2848,6 +2848,19 @@ python-opencv:
     '7': [opencv-python]
   slackware: [opencv]
   ubuntu: [python-opencv]
+python-opencv-contrib-pip:
+  debian:
+    pip:
+      packages: [opencv-contrib-python]
+  fedora:
+    pip:
+      packages: [opencv-contrib-python]
+  gentoo:
+    pip:
+      packages: [opencv-contrib-python]
+  ubuntu:
+    pip:
+      packages: [opencv-contrib-python]
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]


### PR DESCRIPTION
This PR adds a rosdep key for the pip package `opencv-contrib-python`. I am using the Charuco checkerboard detection functions in this library to perform robot hand-eye calibration. 

Package page is here:
https://pypi.org/project/opencv-contrib-python/