### PR TITLE
urdf: 2.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2757,7 +2757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.5.1-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.5.0-1`

## urdf

```
* Work around Windows min/max bug. (#21 <https://github.com/ros2/urdf/issues/21>)
* Contributors: Chris Lalancette
```

## urdf_parser_plugin

- No changes
