### PR TITLE
rclcpp: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1474,7 +1474,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 6.0.0-1
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `6.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `6.0.0-1`

## rclcpp

```
* Add getters to rclcpp::qos and rclcpp::Policy enum classes (#1467 <https://github.com/ros2/rclcpp/issues/1467>)
* Change nullptr checks to use ASSERT_TRUE. (#1486 <https://github.com/ros2/rclcpp/issues/1486>)
* Adjust logic around finding and erasing guard_condition (#1474 <https://github.com/ros2/rclcpp/issues/1474>)
* Update QDs to QL 1 (#1477 <https://github.com/ros2/rclcpp/issues/1477>)
* Add performance tests for parameter transport (#1463 <https://github.com/ros2/rclcpp/issues/1463>)
* Contributors: Chris Lalancette, Ivan Santiago Paunovic, Scott K Logan, Stephen Brawner
```

## rclcpp_action

```
* Update QDs to QL 1 (#1477 <https://github.com/ros2/rclcpp/issues/1477>)
* Contributors: Stephen Brawner
```

## rclcpp_components

```
* Update QDs to QL 1 (#1477 <https://github.com/ros2/rclcpp/issues/1477>)
* Add benchmarks for components (#1476 <https://github.com/ros2/rclcpp/issues/1476>)
* Contributors: Scott K Logan, Stephen Brawner
```

## rclcpp_lifecycle

```
* add LifecycleNode::get_transition_graph to match services. (#1472 <https://github.com/ros2/rclcpp/issues/1472>)
* Update QDs to QL 1 (#1477 <https://github.com/ros2/rclcpp/issues/1477>)
* Benchmark lifecycle features (#1462 <https://github.com/ros2/rclcpp/issues/1462>)
* Contributors: Stephen Brawner, brawner, tomoya
```
