### PR TITLE
plotjuggler: 3.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4116,7 +4116,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.0.4-1
+      version: 3.0.5-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.0.5-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.4-1`

## plotjuggler

```
* fix a crash when data is cleared during streaming (LuaCustomFunction)
* should fix issue #360 <https://github.com/PlotJuggler/PlotJuggler/issues/360> with stylesheet
* fix bug #359 <https://github.com/PlotJuggler/PlotJuggler/issues/359>
* fix compilation error
* Some template types have an enum ItemType. MSVC fails with compilation (#358 <https://github.com/PlotJuggler/PlotJuggler/issues/358>)
  error.
* Add required Qt5::Network for DataStreamUDP (#356 <https://github.com/PlotJuggler/PlotJuggler/issues/356>)
* Contributors: Davide Faconti, Tobias Fischer, gabm
```
