### PR TITLE
fix inconistent naming of the package behaviortree_cpp_v3

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -315,7 +315,7 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
-  behaviortree_cpp:
+  behaviortree_cpp_v3:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -839,7 +839,7 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
-  behaviotree_cpp_v3:
+  behaviortree_cpp_v3:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -289,7 +289,7 @@ repositories:
       url: https://github.com/uos/basler_tof.git
       version: noetic
     status: developed
-  behaviortree_cpp:
+  behaviortree_cpp_v3:
     doc:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
In the past I used inconsistent names for the library (my bad) and I think it is finally time to try fixing that.

Is there anything else that I need to change to make this work?