### PR TITLE
variants: 0.8.5-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -3637,7 +3637,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.8.4-1
+      version: 0.8.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.8.5-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.8.4-1`

## desktop

```
* add turtlesim to desktop (#29 <https://github.com/ros2/variants/issues/29>) (#30 <https://github.com/ros2/variants/issues/30>)
* Contributors: Dirk Thomas
```

## ros_base

- No changes

## ros_core

- No changes
