### PR TITLE
flexbe: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3145,7 +3145,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe` to `1.3.1-1`:

- upstream repository: https://github.com/team-vigir/flexbe_behavior_engine.git
- release repository: https://github.com/FlexBE/flexbe_behavior_engine-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.3.0-1`

## flexbe_behavior_engine

- No changes

## flexbe_core

```
* [flexbe_core] Replace set conversion for python3 compatibility
  (see #136 <https://github.com/team-vigir/flexbe_behavior_engine/issues/136>)
* Contributors: Philipp Schillinger
```

## flexbe_input

- No changes

## flexbe_mirror

- No changes

## flexbe_msgs

- No changes

## flexbe_onboard

```
* [flexbe_onboard] Fix assertion in onboard test
* [flexbe_onboard] Offer option to enable clearing of imports
  (see #135 <https://github.com/team-vigir/flexbe_behavior_engine/issues/135>)
* [flexbe_onboard] Print stack trace on behavior import errors
* Contributors: Philipp Schillinger
```

## flexbe_states

```
* [flexbe_states] Pass flexible calculation state input as kwargs for python3 compatibility
* Contributors: Philipp Schillinger
```

## flexbe_testing

- No changes

## flexbe_widget

- No changes
