### PR TITLE
sr_hand_detector: 0.0.3-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11919,7 +11919,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/shadow-robot/sr_hand_detector-release.git
-      version: 0.0.2-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/shadow-robot/sr_hand_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sr_hand_detector` to `0.0.3-2`:

- upstream repository: https://github.com/shadow-robot/sr_hand_detector.git
- release repository: https://github.com/shadow-robot/sr_hand_detector-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.2-1`

## sr_hand_detector

- No changes
