### PR TITLE
iris_lama: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2406,6 +2406,13 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: noetic-devel
     status: maintained
+  iris_lama:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/eupedrosa/iris_lama-release.git
+      version: 1.1.0-1
+    status: developed
   ivcon:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iris_lama` to `1.1.0-1`:

- upstream repository: https://github.com/iris-ua/iris_lama.git
- release repository: https://github.com/eupedrosa/iris_lama-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## iris_lama

```
* Expose the global localization parameters as options
* Add option to mark free cells when there is no hit in SLAM (i.e. truncated ranges)
* Add non-motion update trigger to location
* Fix infinite loop in global localization
* Use C++14
* Fix eigen aligment issues
```
