### PR TITLE
fcl: 0.6.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1657,7 +1657,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/fcl-release.git
-      version: 0.6.1-2
+      version: 0.6.1-3
     source:
       type: git
       url: https://github.com/flexible-collision-library/fcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fcl` to `0.6.1-3`:

- upstream repository: https://github.com/flexible-collision-library/fcl.git
- release repository: https://github.com/ros-gbp/fcl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.1-2`
