### PR TITLE
image_pipeline: 1.15.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2280,7 +2280,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.15.2-1
+      version: 1.15.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `1.15.3-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros-gbp/image_pipeline-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.15.2-1`

## camera_calibration

```
* Update fisheye distortion model definition
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* Fix calibration yaml formatting (#580 <https://github.com/ros-perception/image_pipeline/issues/580>) (#585 <https://github.com/ros-perception/image_pipeline/issues/585>)
  Co-authored-by: David Torres Ocaña <mailto:david.torres.ocana@gmail.com>
* updated linear_error function to handle partial board views (#561 <https://github.com/ros-perception/image_pipeline/issues/561>)
  * updated linear_error function to handle partial board views
  * more charuco fixes
  * filter len fix
* Fix missing detected checkerboard points (#558 <https://github.com/ros-perception/image_pipeline/issues/558>)
  Variables are swapped
* Removed basestring (no longer exists in new python 3 version). (#552 <https://github.com/ros-perception/image_pipeline/issues/552>)
  Fixes #551 <https://github.com/ros-perception/image_pipeline/issues/551>
* ChArUco board, Noetic (#549 <https://github.com/ros-perception/image_pipeline/issues/549>)
* fix #503 <https://github.com/ros-perception/image_pipeline/issues/503>: (#545 <https://github.com/ros-perception/image_pipeline/issues/545>)
  set_cammodel of StereoCalibrator need to override the method of parent class
  fix related to opencv/opencv#11085 <https://github.com/opencv/opencv/issues/11085>:
  unlike cv2.calibrate, the cv2.fisheye.calibrate method expects float64 points and in an array with an extra dimension. The same for cv2.stereoCalibrate vs cv2.fisheye.stereoCalibrate
* Contributors: DavidTorresOcana, John Stechschulte, Joshua Whitley, PfeifferMicha, Photon, Steve Macenski, soeroesg
```

## depth_image_proc

```
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* Contributors: Steve Macenski
```

## image_pipeline

```
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* Contributors: Steve Macenski
```

## image_proc

```
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* Contributors: Steve Macenski
```

## image_publisher

```
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* Contributors: Steve Macenski
```

## image_rotate

```
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* Contributors: Steve Macenski
```

## image_view

```
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* [image_view] Warn when filename_format is invalid (#587 <https://github.com/ros-perception/image_pipeline/issues/587>)
* Contributors: Naoya Yamaguchi, Steve Macenski
```

## stereo_image_proc

```
* remove email blasts from steve macenski (#595 <https://github.com/ros-perception/image_pipeline/issues/595>)
* Contributors: Steve Macenski
```
