### PR TITLE
robot_navigation: 0.3.0-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -12038,6 +12038,7 @@ repositories:
       version: kinetic
     release:
       packages:
+      - color_util
       - costmap_queue
       - dlux_global_planner
       - dlux_plugins
@@ -12056,11 +12057,15 @@ repositories:
       - nav_grid
       - nav_grid_iterators
       - nav_grid_pub_sub
+      - nav_grid_server
+      - robot_nav_rviz_plugins
+      - robot_nav_tools
+      - robot_nav_viz_demos
       - robot_navigation
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/locusrobotics/robot_navigation-release.git
-      version: 0.2.5-0
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.3.0-1`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/locusrobotics/robot_navigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.5-0`
