### PR TITLE
robot_navigation: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9550,6 +9550,7 @@ repositories:
       version: melodic
     release:
       packages:
+      - color_util
       - costmap_queue
       - dlux_global_planner
       - dlux_plugins
@@ -9568,11 +9569,15 @@ repositories:
       - nav_grid
       - nav_grid_iterators
       - nav_grid_pub_sub
+      - nav_grid_server
+      - robot_nav_rviz_plugins
+      - robot_nav_tools
+      - robot_nav_viz_demos
       - robot_navigation
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DLu/robot_navigation-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.3.0-1`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/DLu/robot_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.5-1`
