### PR TITLE
robot_navigation: 0.3.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4639,6 +4639,7 @@ repositories:
       version: noetic
     release:
       packages:
+      - color_util
       - costmap_queue
       - dlux_global_planner
       - dlux_plugins
@@ -4657,11 +4658,15 @@ repositories:
       - nav_grid
       - nav_grid_iterators
       - nav_grid_pub_sub
+      - nav_grid_server
+      - robot_nav_rviz_plugins
+      - robot_nav_tools
+      - robot_nav_viz_demos
       - robot_navigation
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DLu/robot_navigation-release.git
-      version: 0.2.6-1
+      version: 0.3.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.3.0-2`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/DLu/robot_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.6-1`
