### PR TITLE
v4l2_camera: 0.1.2-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3902,7 +3902,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.1.2-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.1-1`

## v4l2_camera

```
* Set frame_id on published images, default to "camera"
* Output FOURCC code of available formats
* Add parameter for setting the pixel format
* Fix camera device parameter declaration
* Contributors: Sander G. van Dijk
```
