### PR TITLE
vesc: 1.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13274,7 +13274,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/f1tenth/vesc-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/f1tenth/vesc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vesc` to `1.1.0-1`:

- upstream repository: https://github.com/f1tenth/vesc.git
- release repository: https://github.com/f1tenth/vesc-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## vesc

```
* Merge pull request #1 <https://github.com/f1tenth/vesc/issues/1> from f1tenth/melodic-devel
  Updating for Melodic
* Updating package.xml to format 3 and setting C++ standard to 11.
* Contributors: Joshua Whitley
```

## vesc_ackermann

```
* Merge pull request #1 <https://github.com/f1tenth/vesc/issues/1> from f1tenth/melodic-devel
  Updating for Melodic
* Remove unused Boost dependency.
* Replacing boost::shared_ptr with Standard Library equivalent.
* Fixing roslint error.
* Updating package.xml to format 3 and setting C++ standard to 11.
* Contributors: Joshua Whitley
```

## vesc_driver

```
* Merge pull request #1 <https://github.com/f1tenth/vesc/issues/1> from f1tenth/melodic-devel
  Updating for Melodic
* Exclude crc.h from roslint.
* Replacing boost::crc with CRCPP.
* Replacing boost::begin, boost::end, and boost::distance with Standard Library equivalents.
* Replacing boost::bind with Standard Library equivalent.
* Replaing boost::noncopyable with C++ equivalent.
* Replacing boost::function with Standard Library version.
* Replacing Boost smart pointers with Standard Library equivalents.
* Removing unnecessary v8stdint.h.
* Updating package.xml to format 3 and setting C++ standard to 11.
* Contributors: Joshua Whitley
```

## vesc_msgs

```
* Merge pull request #1 <https://github.com/f1tenth/vesc/issues/1> from f1tenth/melodic-devel
  Updating for Melodic
* Updating package.xml to format 3 and setting C++ standard to 11.
* Contributors: Joshua Whitley
```
