### PR TITLE
criutils: 0.1.4-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1082,7 +1082,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/crigroup/criutils-release.git
-      version: 0.1.4-1
+      version: 0.1.4-2
     source:
       type: git
       url: https://github.com/crigroup/criutils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `criutils` to `0.1.4-2`:

- upstream repository: https://github.com/crigroup/criutils.git
- release repository: https://github.com/crigroup/criutils-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.4-1`

## criutils

```
* Add support for ROS noetic and clean up
* Contributors: fsuarez6
```
