### PR TITLE
handeye: 0.1.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2140,7 +2140,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/crigroup/handeye-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/crigroup/handeye.git


### PR DESCRIPTION
Increasing version of package(s) in repository `handeye` to `0.1.2-2`:

- upstream repository: https://github.com/crigroup/handeye.git
- release repository: https://github.com/crigroup/handeye-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## handeye

```
* Add support for ROS noetic and clean up
* PR #4: Fix lambda syntax for Python 3 compatability
* Contributors: John Stechschulte, fsuarez6
```
