### PR TITLE
rosauth: 2.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3022,6 +3022,21 @@ repositories:
       url: https://github.com/ros2/ros_workspace.git
       version: latest
     status: maintained
+  rosauth:
+    doc:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosauth-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/GT-RAIL/rosauth.git
+      version: ros2
+    status: maintained
   rosbag2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosauth` to `2.0.2-1`:

- upstream repository: https://github.com/GT-RAIL/rosauth.git
- release repository: https://github.com/ros2-gbp/rosauth-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rosauth

```
* Fixing tests for foxy. (#32 <https://github.com/GT-RAIL/rosauth/issues/32>)
* Contributors: Joshua Whitley
```
