### PR TITLE
stag_ros: 0.3.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6190,7 +6190,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/usrl-uofsc/stag_ros-release.git
-      version: 0.3.6-3
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/usrl-uofsc/stag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `stag_ros` to `0.3.7-1`:

- upstream repository: https://github.com/usrl-uofsc/stag_ros.git
- release repository: https://github.com/usrl-uofsc/stag_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.6-3`

## stag_ros

```
* increased cmake version
* removed reference to nodelet implementation in runnable. fixed nodelet namespacing warning
* removed old tag configuration
* added libraryhd exception handling to nodelet
* Solved pose overwrite for multiple markers
* added exception checking for the HD for stag
* Fixed single launch file
* bumped melodic branch to 0.2.0
* added URLS to package xml
* Contributors: Brennan Cain, Mike Kalaitzakis, MikeK4y
```
