### PR TITLE
stag_ros: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11958,6 +11958,17 @@ repositories:
       url: https://github.com/ros-planning/srdfdom.git
       version: melodic-devel
     status: maintained
+  stag_ros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/usrl-uofsc/stag_ros-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/usrl-uofsc/stag_ros.git
+      version: melodic-devel
+    status: developed
   stage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stag_ros` to `0.2.1-1`:

- upstream repository: https://github.com/usrl-uofsc/stag_ros.git
- release repository: https://github.com/usrl-uofsc/stag_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
