### PR TITLE
raptor-dbw-ros: 1.0.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9072,6 +9072,23 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raptor-dbw-ros:
+    doc:
+      type: git
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
+      version: master
+    release:
+      packages:
+      - can_dbc_parser
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/raptor-dbw-ros-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
+      version: master
+    status: maintained
   raspimouse_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor-dbw-ros` to `1.0.0-2`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
- release repository: https://github.com/nobleo/raptor-dbw-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
