### PR TITLE
sot-dynamic-pinocchio: 3.6.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11850,6 +11850,22 @@ repositories:
       url: https://github.com/stack-of-tasks/sot-core.git
       version: devel
     status: maintained
+  sot-dynamic-pinocchio:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/sot-dynamic-pinocchio.git
+      version: devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release.git
+      version: 3.6.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stack-of-tasks/sot-dynamic-pinocchio.git
+      version: devel
+    status: maintained
   sot-tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-dynamic-pinocchio` to `3.6.1-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-dynamic-pinocchio.git
- release repository: https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
