### PR TITLE
stag_ros: 0.1.1-6 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15362,6 +15362,17 @@ repositories:
       url: https://github.com/srv/srv_tools.git
       version: kinetic
     status: developed
+  stag_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/usrl-uofsc/stag_ros-release.git
+      version: 0.1.1-6
+    source:
+      type: git
+      url: https://github.com/usrl-uofsc/stag_ros.git
+      version: kinetic-devel
+    status: developed
   stage:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `stag_ros` to `0.1.1-6`:

- upstream repository: https://github.com/usrl-uofsc/stag_ros.git
- release repository: https://github.com/usrl-uofsc/stag_ros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## stag_ros

```
* Initial Release
* Contributors: Brennan Cain, Burak Benligiray, MikeK4y, bbenligiray
```
