### PR TITLE
gazebo_video_monitors: 0.6.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3322,6 +3322,25 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: melodic-devel
     status: developed
+  gazebo_video_monitors:
+    doc:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitors.git
+      version: master
+    release:
+      packages:
+      - gazebo_video_monitor_msgs
+      - gazebo_video_monitor_plugins
+      - gazebo_video_monitors
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nlamprian/gazebo_video_monitors-release.git
+      version: 0.6.0-2
+    source:
+      type: git
+      url: https://github.com/nlamprian/gazebo_video_monitors.git
+      version: master
+    status: maintained
   gencpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_video_monitors` to `0.6.0-2`:

- upstream repository: https://github.com/nlamprian/gazebo_video_monitors.git
- release repository: https://github.com/nlamprian/gazebo_video_monitors-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## gazebo_video_monitor_msgs

```
* Add metapackage
  * Move messages and services to gazebo_video_monitor_msgs
  * Update gazebo_video_monitor_plugins to use gazebo_video_monitor_msgs
  * Add gazebo_video_monitors metapackage
```

## gazebo_video_monitor_plugins

```
* Add metapackage
  * Move messages and services to gazebo_video_monitor_msgs
  * Update gazebo_video_monitor_plugins to use gazebo_video_monitor_msgs
  * Add gazebo_video_monitors metapackage
```

## gazebo_video_monitors

```
* Add metapackage
  * Move messages and services to gazebo_video_monitor_msgs
  * Update gazebo_video_monitor_plugins to use gazebo_video_monitor_msgs
  * Add gazebo_video_monitors metapackage
```
