### PR TITLE
mesh_navigation: 1.0.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5840,6 +5840,31 @@ repositories:
       url: https://github.com/ros/media_export.git
       version: indigo-devel
     status: maintained
+  mesh_navigation:
+    doc:
+      type: git
+      url: https://github.com/uos/mesh_navigation.git
+      version: tag
+    release:
+      packages:
+      - dijkstra_mesh_planner
+      - mbf_mesh_core
+      - mbf_mesh_nav
+      - mesh_client
+      - mesh_controller
+      - mesh_layers
+      - mesh_map
+      - mesh_navigation
+      - wave_front_planner
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/uos-gbp/mesh_navigation-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/uos/mesh_navigation.git
+      version: tag
+    status: developed
   mesh_tools:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5844,7 +5844,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/uos/mesh_navigation.git
-      version: tag
+      version: master
     release:
       packages:
       - dijkstra_mesh_planner
@@ -5863,7 +5863,7 @@ repositories:
     source:
       type: git
       url: https://github.com/uos/mesh_navigation.git
-      version: tag
+      version: master
     status: developed
   mesh_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `mesh_navigation` to `1.0.0-1`:

- upstream repository: https://github.com/uos/mesh_navigation.git
- release repository: https://github.com/uos-gbp/mesh_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## dijkstra_mesh_planner

```
* Initial release
```

## mbf_mesh_core

```
* Initial release
```

## mbf_mesh_nav

```
* Initial release
```

## mesh_client

```
* Initial release
```

## mesh_controller

```
* Initial release
```

## mesh_layers

```
* Initial release
```

## mesh_map

```
* Initial release
```

## mesh_navigation

```
* Initial release
```

## wave_front_planner

```
* Initial release
```
