### PR TITLE
[dep] Add python3-sh

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6765,6 +6765,11 @@ python3-sexpdata:
     xenial:
       pip:
         packages: [sexpdata]
+python3-sh:
+  debian: [python3-sh]
+  fedora: [python3-sh]
+  gentoo: [dev-python/sh]
+  ubuntu: [python3-sh]
 python3-shapely:
   arch: [python-shapely]
   debian: [python3-shapely]


### PR DESCRIPTION
- Debian https://packages.debian.org/stretch/python3-sh
- Fedora: Not sure.
   - Can't find a generic webpage on https://src.fedoraproject.org/
   - Other py3 pkg, e.g. python3-shapely, I do see py2 page https://src.fedoraproject.org/rpms/python-shapely but no py3 page found. So I assume python-sh follows the same custom? I'm not sure.
   - There's python-sh in the rosddep key already.
- Gentoo https://packages.gentoo.org/packages/dev-python/sh
- Ubuntu: https://packages.ubuntu.com/bionic/python3-sh