### PR TITLE
robot_localization: 2.6.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9565,7 +9565,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.6.7-1
+      version: 2.6.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.6.9-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.6.7-1`

## robot_localization

```
* Fix warning "Failed to meet update rate!" (#602 <https://github.com/cra-ros-pkg/robot_localization/issues/602>)
* Fix sign error in dFY_dP part of transferFunctionJacobian_ (#592 <https://github.com/cra-ros-pkg/robot_localization/issues/592>)
* Fix typo in navsat_transform_node.rst (#588 <https://github.com/cra-ros-pkg/robot_localization/issues/588>)
* fix issue caused by starting on uneven terrain (#582 <https://github.com/cra-ros-pkg/robot_localization/issues/582>)
* Local Cartesian Option (#575 <https://github.com/cra-ros-pkg/robot_localization/issues/575>)
* Fix frame id of imu in differential mode, closes #482 <https://github.com/cra-ros-pkg/robot_localization/issues/482>. (#522 <https://github.com/cra-ros-pkg/robot_localization/issues/522>)
* navsat_transform diagram to address #550 <https://github.com/cra-ros-pkg/robot_localization/issues/550> (#570 <https://github.com/cra-ros-pkg/robot_localization/issues/570>)
* Increasing the minimum CMake version (#573 <https://github.com/cra-ros-pkg/robot_localization/issues/573>)
* Contributors: Aleksander Bojda, David Jensen, James Baxter, Jeffrey Kane Johnson, Mabel Zhang, Mike, Ronald Ensing, Tom Moore
```
