### PR TITLE
Adding fcl key to solve issues with version 0.6

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -830,6 +830,8 @@ fcgi:
   fedora: [fcgi, mod_fcgid, spawn-fcgi]
   gentoo: [dev-ruby/fcgi]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
+fcl:
+  ubuntu: [libfcl0.5]
 festival:
   arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]


### PR DESCRIPTION
Fcl [in version 0.6 fcl comes with a `package.xml`](https://github.com/flexible-collision-library/fcl/blob/da07e5b4b59a99fcc45ea17a7aa786d5e077fdc9/package.xml#L2) where it declares itself as `fcl`. This creates issues like https://github.com/osrf/rmf_core/pull/234. To solve this I propose an `fcl` key that points to the corresponding OS library.