### PR TITLE
add python3-prettytable

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6282,6 +6282,11 @@ python3-pkg-resources:
   openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
+python3-prettytable:
+  debian: [python3-prettytable]
+  fedora: [python3-prettytable]
+  gentoo: [dev-python/prettytable]
+  ubuntu: [python3-prettytable]
 python3-progressbar:
   arch: [python-progressbar]
   debian: [python3-progressbar]


### PR DESCRIPTION
ubuntu: https://packages.ubuntu.com/focal/python3-prettytable
debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-prettytable
fedora: https://fedora.pkgs.org/31/fedora-x86_64/python3-prettytable-0.7.2-18.fc31.noarch.rpm.html
gentoo: https://packages.gentoo.org/packages/dev-python/prettytable