### PR TITLE
hector_models: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2167,6 +2167,22 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: master
     status: developed
+  hector_models:
+    release:
+      packages:
+      - hector_components_description
+      - hector_models
+      - hector_sensors_description
+      - hector_xacro_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
+      version: 0.5.1-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
+      version: melodic-devel
+    status: developed
   hector_slam:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.5.1-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## hector_components_description

```
* added an option to use a gpu accelerated lidar simulation
* Added tracker to vision box
* reduced collision size factor
* added collisoin geometry for table pushing person
* introduced table_link
* updated position on tbale & collision size
* used textured table
* added visionbox on table
* added standalone visionbox urdf
* added a consistent name scheme and xacro name usage
* fixed the inconsistend naming of the xm430 sensor head
* added missing include
* changed file permissions
* unified the GPU and non-GPU VLP16 xacro macro
* added meshes for the XM430 based sensor head
* cleanup
* updated the URDF of the XM430 based sensor head
* updated the URDF of the autonomy box and the VLP16
* Added more missing run dependencies.
* Added missing exec dependency.
* Switched to www.ros.org for consistency with ros wiki tutorial and publicly available URDFs.
* Merge branch 'kinetic-devel' of https://github.com/tu-darmstadt-ros-pkg/hector_models into melodic-devel
* moved t265
* Merge branch 'kinetic-devel' into realsense_t265
* added collision geom to lidar for manipulation
* added raycast geom
* added sensor head collision geometry
* added an URDF for the new XM430 based sensor head
* fixed lidar position
  realsense origin is now in mounting hole
* corrected sizes of autonomy box
* added front/back realsenses to autonomy box
* corrected sizes of autonomy box
* added front/back realsenses to autonomy box
* removed containment filter box for jasmine arm from autonomy box macro
* fixed insta360 and lidar mounting height
* moved autonomy box properties outside of macro scope again
* added parameter to add chilitags in autonomy box macro
* updated realsense t265 macro in autonomy box
* added realsense t265 tracking camera to autonomy box
* Revert "Revert "switched back to new dynamixel controller (which reports positions with an offset of pi)""
  This reverts commit c4d721c81aefe859335de7edfc01bae9bb119c27.
* Revert "switched back to new dynamixel controller (which reports positions with an offset of pi)"
  This reverts commit a9de57af00b22a533b5f1e452efc315a02ba4ca0.
* switched back to new dynamixel controller (which reports positions with an offset of pi)
* Tune mass properties of light links
* Reduce mass of headlight elements
* Modify headlight defaults
* Remove obsolete, commented out code
* Fix autonomy box material color
* Add missing chilitag include (should be removed completely in the future)
  Add imu_link as a param with default
* Fix headlight geom properly. Uses SDF, not URDF syntax
* Fix wrong box geom tag
* Update headlight to remove visuals via plugins available in subt
* Add headlight macro adapted from subt x1 model
* insta 3 exstrinsic calibration
* fixed chilitag position
* rotate the spinning lidar 180° to be compatible to the legacy dynamixel driver
* updated chilitag
* Revert "add sensor head pitch offset"
  This reverts commit 2d99e688ef22209f663ede4f6cfb81a7fc9529b3.
* add sensor head pitch offset
* Increase raycast geometry
* Update kalibr target
  Fix theta mid link to use name param
* moved chilitag
* added thickness of tags
* significatly increased collision model size of insta360
* added collision for insta360 cable
* Add kalibr calibration target
* fixed chilitag rotation
* added chilitag to autonomy box
* adjusted autonomy box sizes
* added collision model to camera360 macro
  added collision model to camera360 mount on autonomy box
* rotated lidar
* added autonomy box macro
* removed unused parts
* Add missing xacro include
* Contributors: Hectorvision, Marius Schnaubelt, Martin Oehler, Stefan Fabian, Stefan Kohlbrecher, Stefan Kohlbrecher (Tracker)
```

## hector_models

- No changes

## hector_sensors_description

```
* Merge branch 'kinetic-devel' of https://github.com/tu-darmstadt-ros-pkg/hector_models into melodic-devel
* Added missing xacro include to vlp16 macro
* Added missing xacro include to vlp16 macro
* Matching vive tracker color to gazebo color
* Replaced vive tracker collision with bounding box and added color
* Changed tracker simulation topic and color
* added 3d model
* added gazebo params
* added new urdf
* Merge pull request #8 <https://github.com/tu-darmstadt-ros-pkg/hector_models/issues/8> from TheMangalex/kinetic-devel
  Vive Tracker Urdf
* added 3d model
* added gazebo params
* added new urdf
* Set gazebo cam distortion params too
* Added parametrized camera macro
* zoom cam mesh
* flir housing mesh
* tis zoom cam
* unified the GPU and non-GPU VLP16 xacro macro
* updated the URDF of the autonomy box and the VLP16
* cleanup
* added the flir boson 640 thermal cam
* Added more missing run dependencies.
* Fixed dependencies and install rules.
* Switched to www.ros.org for consistency with ros wiki tutorial and publicly available URDFs.
* Merge branch 'kinetic-devel' of https://github.com/tu-darmstadt-ros-pkg/hector_models into melodic-devel
* use a prettier D435 model
* fixed insta360 cam size
* added high res visuals for vlp16
* added macro for realsense with mount
* added a seek thermal macro without geometry
* fixed missing arg tag
* added second tracking frame with the convention of the datasheet
* renamed camera link to camera pose frame to match rs driver names
* Revert "added t265 pose frame". Pose frame is published by driver in tf.
  This reverts commit e11f9f1f9932411b386e5cf1d749a6e92a17d46c.
* added t265 pose frame
* Merge branch 'kinetic-devel' into realsense_t265
* removed collision size prop
* added raycast geom
* added sensor head collision geometry
* added an URDF for the new XM430 based sensor head
* Merge branch 'kinetic-devel' into autonomy_box_cage_realsenses
* added new d435 macro with origin in mounting hole
* Merge branch 'kinetic-devel' into autonomy_box_cage_realsenses
* more refactoring and added option to use realsense d435 mesh
* added static publisher launch for d435 frames
* fixed visual and collision of d435
* d435 macro refactoring
* renamed realsense t265 macros
* added realsense t265 description
* fixed default topic
* Comment out custom lens due to gazebo segfaults on some machines
* Update camera360 to params we could calibrate with kalibr
* Update kalibr target
  Fix theta mid link to use name param
* fixed cam frame orientation
* Make resolution params and set defaults for thermal cam
* fixed default collision radius
* moved chilitag
* added collision for insta360 cable
* added collision model to camera360 macro
  added collision model to camera360 mount on autonomy box
* fix D435 macro
* added parameter for dist between cams to camera360 macro
* Contributors: Alberto Romay, Frederik, Frederik Bark, Marius Schnaubelt, Martin Oehler, Stefan Fabian, Stefan Kohlbrecher
```

## hector_xacro_tools

```
* Added velociy transmission
* position interface macro
* Switched to www.ros.org for consistency with ros wiki tutorial and publicly available URDFs.
* Merge pull request #6 <https://github.com/tu-darmstadt-ros-pkg/hector_models/issues/6> from mipo57/patch-1
  Fix inconsistent namespace warning
* Fix inconsistent namespace warning
  inconsistent namespace redefinitions for xmlns:xacro:
  old: http://www.ros.org/wiki/xacro
  new: http://ros.org/wiki/xacro
  Most of files define url with perciding www. Lack of it results in warning
* Contributors: Martin Oehler, Michał Pogoda, Stefan Fabian
```
