### PR TITLE
hector_gazebo: 0.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2167,6 +2167,23 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: master
     status: developed
+  hector_gazebo:
+    release:
+      packages:
+      - hector_gazebo
+      - hector_gazebo_plugins
+      - hector_gazebo_thermal_camera
+      - hector_gazebo_worlds
+      - hector_sensors_gazebo
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
+      version: 0.5.2-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
+      version: melodic-devel
+    status: maintained
   hector_slam:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.5.2-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## hector_gazebo

- No changes

## hector_gazebo_plugins

```
* Add case for rotating in place in odometry (#75 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/75>)
  * Add case for rotating in place in odometry
  Odometry calculations were not taking in account the case of the robot rotating in place. This
  would cause a division by zero and make the plugin return invalid data. This commit handles this
  case by not using the arc method if the distance traveled by the robot is close to zero.
  * Fix negative Y-axis motion bug
  Only the displacement along X and the combined displacement were used to
  calculate the angle between the X-axis and the robot drive direction.
  This resulted in a positive angle whatever if the displacement along Y
  was positive or negative. This commit addresses the issue by using both
  displacements along X and Y to calculate the angle.
* Allow publishing sensor_msgs/MagneticField (#73 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/73>)
  Add a new useMagneticFieldMsgs parameter to the magnetometer plugin, allowing the node to publish sensor_msgs/MagneticField messages instead of std_msgs/Vector3Stamped
* Add support of holonomic robot by adding missing Y component in odometry (#71 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/71>)
  * Add support of holonomic robot by adding missing Y component in odometry
  The odometry was only computed taking in account linear velocity on the x-axis and angular
  velocity around the z-axis. The code is modified to include linear velocity on the y-axis for
  support of holonomic robots. Odometry arc and radius are calculated the same way as before but
  using the combined linear velocity instead. The end position is then rotated by the angle between
  the combined velocity vector and the x-axis
  * Change variable name
  * Rename combined velocity angle variable
* Merge pull request #64 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/64> from ms-iot/upstream_windows_fix
  [Windows][melodic-devel] Follow catkin guide to update the install path
* fix install path. (#1 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/1>)
* Merge pull request #53 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/53> from enwaytech/ml/cmp0054_fix
  add CMP0045 cmake policy before gazebo include in CMakeLists.txt
* add CMP0045 cmake policy before gazebo include in CMakeLists.txt
* Contributors: Chris I-B, Johannes Meyer, Matthias Loebach, RobinB, Sean Yen, Stefan Fabian
```

## hector_gazebo_thermal_camera

```
* Merge pull request #64 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/64> from ms-iot/upstream_windows_fix
  [Windows][melodic-devel] Follow catkin guide to update the install path
* fix install path. (#1 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/1>)
* Merge pull request #53 <https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/53> from enwaytech/ml/cmp0054_fix
  add CMP0045 cmake policy before gazebo include in CMakeLists.txt
* add CMP0045 cmake policy before gazebo include in CMakeLists.txt
* Contributors: Johannes Meyer, Matthias Loebach, Sean Yen
```

## hector_gazebo_worlds

- No changes

## hector_sensors_gazebo

- No changes
