### PR TITLE
gazebo_ros_control_select_joints: 2.5.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1839,6 +1839,17 @@ repositories:
       url: https://github.com/frankaemika/franka_ros.git
       version: noetic-devel
     status: developed
+  gazebo_ros_control_select_joints:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tu-darmstadt-ros-pkg-gbp/gazebo_ros_control_select_joints-release.git
+      version: 2.5.7-1
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/gazebo_ros_control_select_joints.git
+      version: master
+    status: maintained
   gazebo_ros_pkgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_control_select_joints` to `2.5.7-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/gazebo_ros_control_select_joints.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/gazebo_ros_control_select_joints-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## gazebo_ros_control_select_joints

```
* Updated maintainer info.
* Contributors: Stefan Fabian
```
