### PR TITLE
Add RHEL rule for python3-cairo

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5561,6 +5561,7 @@ python3-cairo:
   gentoo: [dev-python/pycairo]
   openembedded: [python3-pycairo@openembedded-core]
   opensuse: [python3-cairo]
+  rhel: ['python%{python3_pkgversion}-cairo']
   slackware:
     slackpkg:
       packages: [py3cairo]


### PR DESCRIPTION
In RHEL 7, this package is provided by EPEL: https://src.fedoraproject.org/rpms/python3-cairo#bodhi_updates
In RHEL 8, this package is part of the OS AppStream repository: https://mirrors.edge.kernel.org/centos//8.3.2011/AppStream/x86_64/os/Packages/python3-cairo-1.16.3-6.el8.x86_64.rpm