### PR TITLE
mesh_tools: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3260,6 +3260,31 @@ repositories:
       url: https://github.com/ros/media_export.git
       version: indigo-devel
     status: maintained
+  mesh_tools:
+    doc:
+      type: git
+      url: https://github.com/uos/mesh_tools.git
+      version: master
+    release:
+      packages:
+      - hdf5_map_io
+      - label_manager
+      - mesh_msgs
+      - mesh_msgs_conversions
+      - mesh_msgs_hdf5
+      - mesh_msgs_transform
+      - mesh_tools
+      - rviz_map_plugin
+      - rviz_mesh_plugin
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/uos-gbp/mesh-tools.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/uos/mesh_tools.git
+      version: master
+    status: developed
   message_generation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mesh_tools` to `1.0.1-1`:

- upstream repository: https://github.com/uos/mesh_tools.git
- release repository: https://github.com/uos-gbp/mesh-tools.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## hdf5_map_io

```
* fix: find_library lvr2, since this is missing in LVR2Config.cmake
* use new hdf5 structure compatible to the datasets in https://github.com/uos/pluto_robot
* use HighFive from lvr2, add lvr2 as dependency and removed HighFive gitmodule definition
```

## label_manager

- No changes

## mesh_msgs

- No changes

## mesh_msgs_conversions

```
* fix of static-name bug in LVR2Config.cmake
* removed not implemented functions from header
* moved lvr_ros conversions to mesh_msgs_conversions
```

## mesh_msgs_hdf5

- No changes

## mesh_msgs_transform

- No changes

## mesh_tools

- No changes

## rviz_map_plugin

- No changes

## rviz_mesh_plugin

```
* Fix for memory leak in TexturedMeshVisual::addTexture()
```
