### PR TITLE
plotjuggler_ros: 1.0.1-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2116,7 +2116,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.0.0-2
+      version: 1.0.1-4
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.0.1-4`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-2`

## plotjuggler_ros

```
* Added TF messages to the parser (issue #366 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/366>)
* Update README.md
* Update README.md
* Merge pull request #1 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/1> from uhobeike/development
  Made it possible to install
* Made it possible to install
* fix includes
* Contributors: Davide Faconti, davide, uhobeike
```
