### PR TITLE
leo_common: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5287,7 +5287,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_common-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common.git
- release repository: https://github.com/fictionlab-gbp/leo_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`

## leo

- No changes

## leo_description

```
* Add macros.xacro file which contains <leo/>, <leo_gazebo/> and <leo_sim/> xacro macros
* Add simple xacro test
* Change CMakeLists formatting style
```

## leo_teleop

```
* Update package description
* Change CMakeLists formatting style
```
