### PR TITLE
leo_desktop: 0.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2942,7 +2942,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_desktop-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_desktop` to `0.2.3-1`:

- upstream repository: https://github.com/LeoRover/leo_desktop.git
- release repository: https://github.com/fictionlab-gbp/leo_desktop-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.2-1`

## leo_desktop

- No changes

## leo_viz

```
* Use relative topic names in RViz displays
* Change fixed frame to base_footprint in the default RViz config
```
