### PR TITLE
leo_simulator: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5345,7 +5345,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fictionlab-gbp/leo_simulator-release.git
-      version: 0.1.3-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `0.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator.git
- release repository: https://github.com/fictionlab-gbp/leo_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.3-1`

## leo_gazebo

```
* Specify minimum version for leo_description dependency
* Abandon usage of tf_prefix parameter since it is deprecated
* Use new URDF from the leo_description package
* Pass all args from main launch file
* Change gazebo_differential_plugin to leo_gazebo_differential_plugin
```

## leo_simulator

- No changes
