### PR TITLE
vrpn: 7.34.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6929,11 +6929,20 @@ repositories:
       version: noetic-devel
     status: maintained
   vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
     release:
       tags:
-        release: release/noetic/{package}/{version}
+        release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
       version: 7.34.0-1
+    source:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
   warehouse_ros:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6935,7 +6935,7 @@ repositories:
       version: master
     release:
       tags:
-        release: release/melodic/{package}/{version}
+        release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
       version: 7.34.0-1
     source:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6928,6 +6928,12 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: noetic-devel
     status: maintained
+  vrpn:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/vrpn-release.git
+      version: 7.34.0-1
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.34.0-1`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros-drivers-gbp/vrpn-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
