### PR TITLE
vrpn_client_ros: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6928,6 +6928,22 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: noetic-devel
     status: maintained
+  vrpn_client_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/vrpn_client_ros.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
+      version: 0.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/vrpn_client_ros.git
+      version: kinetic-devel
+    status: maintained
   warehouse_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn_client_ros` to `0.2.2-1`:

- upstream repository: https://github.com/ros-drivers/vrpn_client_ros.git
- release repository: https://github.com/ros-drivers-gbp/vrpn_client_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## vrpn_client_ros

```
* Fixup find_package
* Contributors: Paul Bovbel
```
