### PR TITLE
novatel_oem7_driver: 2.0.0-1 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8964,7 +8964,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 1.1.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git


### PR DESCRIPTION
Creating pull request manually per bloom instructions.
Bloom could not create the request due to auth token failure.