### PR TITLE
novatel_oem7_driver: 1.1.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3855,7 +3855,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `1.1.0-2`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`
