### PR TITLE
Fix laser_geometry source branch in Noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2878,7 +2878,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: indigo-devel
+      version: kinetic-devel
     status: maintained
   laser_pipeline:
     doc:


### PR DESCRIPTION
The released version, 1.6.5, is tagged out of `kinetic-devel`.
The newest version in the `indigo-devel` branch is 1.6.4.