### PR TITLE
Add rosdep rules for python3-websockets package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5225,7 +5225,7 @@ python-websocket:
   debian: [python-websocket]
   fedora: [python-websocket-client]
   gentoo: [dev-python/websocket-client]
-  openembedded: [python3-websockets@meta-python]
+  openembedded: [python3-websocket-client@meta-python]
   ubuntu:
     artful: [python-websocket]
     artful_python3: [python3-websocket]
@@ -7015,11 +7015,12 @@ python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]
   gentoo: [dev-python/websocket-client]
-  openembedded: ['python3-websockets@meta-python']
+  openembedded: [python3-websocket-client@meta-python]
   rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
 python3-websockets:
   debian: [python3-websockets]
+  openembedded: [python3-websockets@meta-python]
   ubuntu: [python3-websockets]
 python3-werkzeug:
   arch: [python-werkzeug]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5225,7 +5225,7 @@ python-websocket:
   debian: [python-websocket]
   fedora: [python-websocket-client]
   gentoo: [dev-python/websocket-client]
-  openembedded: [python3-websocket-client@meta-python]
+  openembedded: [python3-websockets@meta-python]
   ubuntu:
     artful: [python-websocket]
     artful_python3: [python3-websocket]
@@ -7015,7 +7015,7 @@ python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]
   gentoo: [dev-python/websocket-client]
-  openembedded: [python3-websocket-client@meta-python]
+  openembedded: ['python3-websockets@meta-python']
   rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
 python3-websockets:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7019,7 +7019,10 @@ python3-websocket:
   rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
 python3-websockets:
+  arch: [python-websockets]
   debian: [python3-websockets]
+  fedora: [python-websockets]
+  gentoo: [dev-python/websockets]
   openembedded: [python3-websockets@meta-python]
   ubuntu: [python3-websockets]
 python3-werkzeug:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7018,6 +7018,9 @@ python3-websocket:
   openembedded: ['python3-websockets@meta-python']
   rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
+python3-websockets:
+  debian: [python3-websockets]
+  ubuntu: [python3-websockets]
 python3-werkzeug:
   arch: [python-werkzeug]
   debian: [python3-werkzeug]


### PR DESCRIPTION
Added rules for `python3-websockets` in Debian and Ubuntu. This package provides a [library](https://websockets.readthedocs.io/en/stable/) for creating WebSocket servers and clients. Existing package `python3-websocket` is [client-only](https://packages.ubuntu.com/xenial/python3-websocket).

My particular use case involves building a web interface for controlling the robot. I need a websocket server to receive commands from user's browser.

Package listings:
- Debian: https://packages.debian.org/search?keywords=python3-websockets
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-websockets