### PR TITLE
release realsense2_camera version 3.1.2 for eloquent

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2186,7 +2186,7 @@ repositories:
       packages:
       - realsense2_camera
       - realsense2_description
-      - realsense_camera_msgs
+      - realsense2_camera_msgs
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2185,7 +2185,7 @@ repositories:
     release:
       packages:
       - realsense2_camera
-      - realsense2_node
+      - realsense2_description
       - realsense_camera_msgs
       tags:
         release: release/eloquent/{package}/{version}

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2185,8 +2185,8 @@ repositories:
     release:
       packages:
       - realsense2_camera
-      - realsense2_description
       - realsense2_camera_msgs
+      - realsense2_description
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2190,7 +2190,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Requires librealsense2 version 2.40.0 as in #27823 