### PR TITLE
rosdep: update OpenEmbedded mapping for python*-websocket and add python-pyudev

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3710,6 +3710,7 @@ python-pyudev:
   debian: [python-pyudev]
   fedora: [python-pyudev]
   gentoo: [dev-python/pyudev]
+  openembedded: ['${PYTHON_PN}-pyudev@meta-python']
   ubuntu:
     '*': [python-pyudev]
     artful_python3: [python3-pyudev]
@@ -5225,7 +5226,7 @@ python-websocket:
   debian: [python-websocket]
   fedora: [python-websocket-client]
   gentoo: [dev-python/websocket-client]
-  openembedded: [python3-websockets@meta-python]
+  openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
   ubuntu:
     artful: [python-websocket]
     artful_python3: [python3-websocket]
@@ -7021,7 +7022,7 @@ python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]
   gentoo: [dev-python/websocket-client]
-  openembedded: ['python3-websockets@meta-python']
+  openembedded: [python3-websocket-client@meta-python]
   rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
 python3-websockets:


### PR DESCRIPTION
…hon-pyudev

python-websocket-client:
https://layers.openembedded.org/layerindex/recipe/121297/
python3-websocket-client:
https://layers.openembedded.org/layerindex/recipe/97740/
python-pyudev:
https://layers.openembedded.org/layerindex/recipe/114273/
python3-pyudev:
https://layers.openembedded.org/layerindex/recipe/66922/

python3-websockets:
https://layers.openembedded.org/layerindex/recipe/82184/

Signed-off-by: Martin Jansa <martin.jansa@lge.com>