### PR TITLE
ros2_control: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2827,6 +2827,20 @@ repositories:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
       version: master
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - ros2_control
+      - ros2controlcli
+      - test_robot_hardware
+      - transmission_interface
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/bmagyar/ros2_control-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/bmagyar/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
