### PR TITLE
ergodic_exploration: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1571,6 +1571,21 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  ergodic_exploration:
+    doc:
+      type: git
+      url: https://github.com/bostoncleek/ergodic_exploration.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/bostoncleek/ergodic_exploration-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/bostoncleek/ergodic_exploration.git
+      version: noetic-devel
+    status: developed
   executive_smach:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ergodic_exploration` to `1.0.0-1`:

- upstream repository: https://github.com/bostoncleek/ergodic_exploration.git
- release repository: https://github.com/bostoncleek/ergodic_exploration-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
