### PR TITLE
ros2_controllers: 0.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2846,6 +2846,25 @@ repositories:
       url: https://github.com/ros-controls/ros2_control.git
       version: master
     status: developed
+  ros2_controllers:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    release:
+      packages:
+      - forward_command_controller
+      - joint_state_controller
+      - joint_trajectory_controller
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/bmagyar/ros2_controllers-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    status: developed
   ros2_intel_realsense:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/bmagyar/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## forward_command_controller

```
* ForwardCommandController declares parameters (#131 <https://github.com/ros-controls/ros2_controllers/issues/131>)
* Remove lifecycle node controllers (#124 <https://github.com/ros-controls/ros2_controllers/issues/124>)
* joint state controller with resource manager (#109 <https://github.com/ros-controls/ros2_controllers/issues/109>)
* forward_command_controller (#87 <https://github.com/ros-controls/ros2_controllers/issues/87>)
* Contributors: Bence Magyar, Jordan Palacios, Karsten Knese, Victor Lopez
```

## joint_state_controller

```
* Print exception msg (#130 <https://github.com/ros-controls/ros2_controllers/issues/130>)
* Remove lifecycle node controllers (#124 <https://github.com/ros-controls/ros2_controllers/issues/124>)
* joint state controller with resource manager (#109 <https://github.com/ros-controls/ros2_controllers/issues/109>)
* Use new joint handles in all controllers (#90 <https://github.com/ros-controls/ros2_controllers/issues/90>)
* Clock() defaults to RCL_SYSTEM_TIME without considering parameter use_sim_time. (#83 <https://github.com/ros-controls/ros2_controllers/issues/83>)
* Joint states are now published using the DynamicJointState message (#65 <https://github.com/ros-controls/ros2_controllers/issues/65>)
* Add on_activate to JointStateController (#43 <https://github.com/ros-controls/ros2_controllers/issues/43>)
* Contributors: Alejandro Hernández Cordero, Bence Magyar, Denis Štogl, Hang, Jordan Palacios, Karsten Knese, Victor Lopez, Yutaka Kondo
```

## joint_trajectory_controller

```
* Remove lifecycle node controllers (#124 <https://github.com/ros-controls/ros2_controllers/issues/124>)
* Use resource manager on joint trajectory controller (#112 <https://github.com/ros-controls/ros2_controllers/issues/112>)
* Use new joint handles in all controllers (#90 <https://github.com/ros-controls/ros2_controllers/issues/90>)
* More jtc tests (#75 <https://github.com/ros-controls/ros2_controllers/issues/75>)
* remove unused variables (#86 <https://github.com/ros-controls/ros2_controllers/issues/86>)
* Port over interpolation formulae, abort if goals tolerance violated (#62 <https://github.com/ros-controls/ros2_controllers/issues/62>)
* Partial joints (#68 <https://github.com/ros-controls/ros2_controllers/issues/68>)
* Use clamp function from rcppmath (#79 <https://github.com/ros-controls/ros2_controllers/issues/79>)
* Reorder incoming out of order joint_names in trajectory messages (#53 <https://github.com/ros-controls/ros2_controllers/issues/53>)
* Action server for JointTrajectoryController (#26 <https://github.com/ros-controls/ros2_controllers/issues/26>)
* Add state_publish_rate to JointTrajectoryController (#25 <https://github.com/ros-controls/ros2_controllers/issues/25>)
* Contributors: Alejandro Hernández Cordero, Anas Abou Allaban, Bence Magyar, Denis Štogl, Edwin Fan, Jordan Palacios, Karsten Knese, Victor Lopez
```
