### PR TITLE
plotjuggler: 3.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4290,7 +4290,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.0.5-2
+      version: 3.0.6-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.0.6-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.5-2`

## plotjuggler

```
* fix issue  #372 <https://github.com/PlotJuggler/PlotJuggler/issues/372> (install didn't work)
* Update rangeX during streaming
* LabStreamlayer (LSL) plugin is developed. (#355 <https://github.com/PlotJuggler/PlotJuggler/issues/355>)
* Update CMakeLists.txt (#363 <https://github.com/PlotJuggler/PlotJuggler/issues/363>)
* Contributors: Celal Savur, Davide Faconti, Tobias Fischer
```
