### PR TITLE
moveit_python: 0.3.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6288,7 +6288,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/moveit_python-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/mikeferguson/moveit_python.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.3.5-1`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.4-1`

## moveit_python

```
* use "is None"
* Fixed a comparison and logical statement order issue. (#26 <https://github.com/mikeferguson/moveit_python/issues/26>)
* fix pyassimp indices bug (#27 <https://github.com/mikeferguson/moveit_python/issues/27>)
* Contributors: Karl Kangur, Michael Ferguson, Shingo Kitagawa
```
