### PR TITLE
moveit_python: 0.3.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3550,6 +3550,21 @@ repositories:
       url: https://github.com/ros-planning/moveit_msgs.git
       version: master
     status: maintained
+  moveit_python:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/moveit_python.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mikeferguson/moveit_python-release.git
+      version: 0.3.6-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/moveit_python.git
+      version: master
+    status: maintained
   moveit_resources:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_python` to `0.3.6-1`:

- upstream repository: https://github.com/mikeferguson/moveit_python.git
- release repository: https://github.com/mikeferguson/moveit_python-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## moveit_python

```
* update package.xml for python3 support
* Contributors: Michael Ferguson
```
