### PR TITLE
ros2_tracing: 1.0.5-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2929,7 +2929,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/ros-tracing/ros2_tracing-release.git
-      version: 1.0.4-1
+      version: 1.0.5-2
     source:
       test_abi: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `1.0.5-2`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://gitlab.com/ros-tracing/ros2_tracing-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.4-1`

## tracetools

```
* Bring tracetools up to quality level 1
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Increased code coverage > 94% as part of QL1
* Contributors: Christophe Bedard, Alejandro Hernández Cordero
```
