### PR TITLE
Added 20.04 Focal version of python-setuptools.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4298,6 +4298,7 @@ python-setuptools:
   ubuntu:
     artful: [python-setuptools]
     bionic: [python-setuptools]
+    focal: [python3-setuptools]
     lucid: [python-setuptools]
     maverick: [python-setuptools]
     natty: [python-setuptools]


### PR DESCRIPTION
Added Ubuntu 20.04 Focal support for **python-setuptools** package. 