### PR TITLE
realsense2_camera version 3.1.3 for foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2556,6 +2556,26 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: foxy
     status: maintained
+  realsense2_camera:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: foxy
+    release:
+      packages:
+      - realsense2_camera
+      - realsense2_camera_msgs
+      - realsense2_node
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/IntelRealSense/realsense-ros-release.git
+      version: 3.1.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/IntelRealSense/realsense-ros.git
+      version: foxy
+    status: developed
   realtime_support:
     doc:
       type: git
@@ -2846,26 +2866,6 @@ repositories:
       url: https://github.com/ros-controls/ros2_control.git
       version: master
     status: developed
-  ros2_intel_realsense:
-    doc:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: refactor
-    release:
-      packages:
-      - realsense_examples
-      - realsense_msgs
-      - realsense_node
-      - realsense_ros
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
-      version: 2.0.8-2
-    source:
-      type: git
-      url: https://github.com/intel/ros2_intel_realsense.git
-      version: refactor
-    status: maintained
   ros2_ouster_drivers:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2866,6 +2866,26 @@ repositories:
       url: https://github.com/ros-controls/ros2_control.git
       version: master
     status: developed
+  ros2_intel_realsense:
+    doc:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: refactor
+    release:
+      packages:
+      - realsense_examples
+      - realsense_msgs
+      - realsense_node
+      - realsense_ros
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_intel_realsense-release.git
+      version: 2.0.8-2
+    source:
+      type: git
+      url: https://github.com/intel/ros2_intel_realsense.git
+      version: refactor
+    status: maintained
   ros2_ouster_drivers:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2565,7 +2565,7 @@ repositories:
       packages:
       - realsense2_camera
       - realsense2_camera_msgs
-      - realsense2_node
+      - realsense2_description
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git


### PR DESCRIPTION
Add realsense2_camera for foxy, version 3.1.3
Remove old name: ros2_intel_realsense
This PR depends on #27854 