### PR TITLE
ros2_planning_system: 1.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2907,7 +2907,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `1.0.6-1`:

- upstream repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
- release repository: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.5-1`

## plansys2_bringup

```
* Disable boost functions
* Contributors: Francisco Martin Rico
```

## plansys2_bt_actions

- No changes

## plansys2_core

- No changes

## plansys2_domain_expert

- No changes

## plansys2_executor

```
* Disable boost functions
* Contributors: Francisco Martin Rico
```

## plansys2_lifecycle_manager

- No changes

## plansys2_msgs

- No changes

## plansys2_pddl_parser

- No changes

## plansys2_planner

```
* Disable boost functions
* Contributors: Francisco Martin Rico
```

## plansys2_popf_plan_solver

```
* Disable boost functions
* Contributors: Francisco Martin Rico
```

## plansys2_problem_expert

- No changes

## plansys2_terminal

```
* Disable boost functions
* Contributors: Francisco Martin Rico
```
