### PR TITLE
jderobot_drones: 1.3.5-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4639,6 +4639,7 @@ repositories:
   jderobot_drones:
     release:
       packages:
+      - drone_assets
       - drone_wrapper
       - jderobot_drones
       - rqt_drone_teleop
@@ -4646,7 +4647,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.2-5
+      version: 1.3.5-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.5-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.3.2-5`

## drone_assets

```
* New drone_assets pkg replacing old jderobot_assets pkg.
* Fixed new iris models. Added iris base and iris dual cam.
* Added models and urdf. CMakeLists and package.xml created.
* Contributors: pariaspe
```

## drone_wrapper

```
* Removed RQT dependencies with subscribers and topics. These topics are now throttled by new drone_wrapper topics. This allows to make the RQT independent to the kind of drone connected.
* Template dependency removed from rqt_drone_teleop. The template callbacks are no longer required to send commands to the drone. The command flow goes directly from the rqt to the drone wrapper without passing through the exercise template.
* New drone_assets pkg replacing old jderobot_assets pkg.
* Removed RQT dependencies with subscribers and topics. These topics are now throttled by new drone_wrapper topics. This allows to make the RQT independent to the kind of drone connected.
* Template dependency removed from rqt_drone_teleop. The template callbacks are no longer required to send commands to the drone. The command flow goes directly from the rqt to the drone wrapper without passing through the exercise template.
* Contributors: pariaspe
```

## jderobot_drones

```
* Added drone_assets dependency
* Contributors: pariaspe
```

## rqt_drone_teleop

```
* Freeze fixed using python threadings. Might be improved using a ROS-based solution.
* Removed RQT dependencies with subscribers and topics. These topics are now throttled by new drone_wrapper topics. This allows to make the RQT independent to the kind of drone connected.
* Template dependency removed from rqt_drone_teleop. The template callbacks are no longer required to send commands to the drone. The command flow goes directly from the rqt to the drone wrapper without passing through the exercise template.
* Removed RQT dependencies with subscribers and topics. These topics are now throttled by new drone_wrapper topics. This allows to make the RQT independent to the kind of drone connected.
* Template dependency removed from rqt_drone_teleop. The template callbacks are no longer required to send commands to the drone. The command flow goes directly from the rqt to the drone wrapper without passing through the exercise template.
* Contributors: pariaspe
```

## rqt_ground_robot_teleop

- No changes
