### PR TITLE
ergodic_exploration: 1.0.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1580,7 +1580,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/bostoncleek/ergodic_exploration-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/bostoncleek/ergodic_exploration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ergodic_exploration` to `1.0.0-2`:

- upstream repository: https://github.com/bostoncleek/ergodic_exploration.git
- release repository: https://github.com/bostoncleek/ergodic_exploration-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`
