### PR TITLE
arbotix: 0.11.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -92,6 +92,28 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag_ros.git
       version: master
     status: maintained
+  arbotix:
+    doc:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: noetic-devel
+    release:
+      packages:
+      - arbotix
+      - arbotix_controllers
+      - arbotix_firmware
+      - arbotix_msgs
+      - arbotix_python
+      - arbotix_sensors
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/vanadiumlabs/arbotix_ros-release.git
+      version: 0.11.0-1
+    source:
+      type: git
+      url: https://github.com/vanadiumlabs/arbotix_ros.git
+      version: noetic-devel
+    status: maintained
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `arbotix` to `0.11.0-1`:

- upstream repository: https://github.com/vanadiumlabs/arbotix_ros.git
- release repository: https://github.com/vanadiumlabs/arbotix_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## arbotix

- No changes

## arbotix_controllers

```
* Update all python shebangs to python3 + rosdep dependency (#48 <https://github.com/vanadiumlabs/arbotix_ros/issues/48>)
  Co-authored-by: Murat Calis <mailto:mc@pirate-robotics.net>
* Merge pull request #22 <https://github.com/vanadiumlabs/arbotix_ros/issues/22> from corot/indigo-devel
  roslib.load_manifest should not be used on catkin packages
* roslib.load_manifest should not be used on catkin packages according to http://wiki.ros.org/PyStyleGuide
* Contributors: Jorge Santos, Michael Ferguson, calismurat
```

## arbotix_firmware

- No changes

## arbotix_msgs

```
* Merge pull request #25 <https://github.com/vanadiumlabs/arbotix_ros/issues/25> from corot/indigo-devel
  Implement issue https://github.com/vanadiumlabs/arbotix_ros/issues/24:
* Implement issue https://github.com/vanadiumlabs/arbotix_ros/issues/24:
  Allow 16 bit values on arbotix_msgs/Analog messages, but assume 8 bits
  by default
* Contributors: Michael Ferguson, corot
```

## arbotix_python

```
* Update all python shebangs to python3 + rosdep dependency (#48 <https://github.com/vanadiumlabs/arbotix_ros/issues/48>)
  Co-authored-by: Murat Calis <mailto:mc@pirate-robotics.net>
* arbotix_python for ROS Noetic (#46 <https://github.com/vanadiumlabs/arbotix_ros/issues/46>)
  Migrated arbotix_python to work with ROS Noetic
  Co-authored-by: Murat Calis <mailto:mc@pirate-robotics.net>
* Merge pull request #31 <https://github.com/vanadiumlabs/arbotix_ros/issues/31> from corot/serial_reconnect
  Allow runtime connection/disconnection to/from ArbotiX board
* Merge pull request #29 <https://github.com/vanadiumlabs/arbotix_ros/issues/29> from croesmann/indigo-devel
  Allow cancelling the FollowJointTrajectoryAction during execution
* Merge pull request #33 <https://github.com/vanadiumlabs/arbotix_ros/issues/33> from corot/issue_26
  Issue #26 <https://github.com/vanadiumlabs/arbotix_ros/issues/26> implementation: enable/relax services on ServoController class
* Issue #26 <https://github.com/vanadiumlabs/arbotix_ros/issues/26> implementation: enable/relax services to the ServoController
  class, so you don't need to call service on each servo
* Close serial port only if not fake
* Allow runtime connection/disconnection to/from ArbotiX board
* Minor formatting fix
* Fixed formatting issues
* the follow joint trajectory action can now be canceled during execution
* Fix syntax
* Merge pull request #25 <https://github.com/vanadiumlabs/arbotix_ros/issues/25> from corot/indigo-devel
  Implement issue https://github.com/vanadiumlabs/arbotix_ros/issues/24:
* leng -> length
* Implement issue https://github.com/vanadiumlabs/arbotix_ros/issues/24:
  Allow 16 bit values on arbotix_msgs/Analog messages, but assume 8 bits
  by default
* Contributors: Christoph Rösmann, Jorge Santos Simón, Michael Ferguson, calismurat, corot
```

## arbotix_sensors

```
* Update all python shebangs to python3 + rosdep dependency (#48 <https://github.com/vanadiumlabs/arbotix_ros/issues/48>)
  Co-authored-by: Murat Calis <mailto:mc@pirate-robotics.net>
* Merge pull request #22 <https://github.com/vanadiumlabs/arbotix_ros/issues/22> from corot/indigo-devel
  roslib.load_manifest should not be used on catkin packages
* roslib.load_manifest should not be used on catkin packages according to http://wiki.ros.org/PyStyleGuide
* Contributors: Jorge Santos, Michael Ferguson, calismurat
```
