### PR TITLE
realsense2_camera: 2.2.21-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9318,7 +9318,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.20-1
+      version: 2.2.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.21-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.2.20-1`

## realsense2_camera

```
* Publish depth confidence image for supporting devices (L515)
* fix reading json file with device other than D400 series.
* remove (temporarily) flaky IMU unit-test.
* Contributors: Isaac I.Y. Saito, doronhi
```

## realsense2_description

- No changes
