### PR TITLE
mqtt_bridge: 0.1.8-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6397,7 +6397,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/groove-x/mqtt_bridge-release.git
-      version: 0.1.7-7
+      version: 0.1.8-4
     source:
       type: git
       url: https://github.com/groove-x/mqtt_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge` to `0.1.8-4`:

- upstream repository: https://github.com/groove-x/mqtt_bridge.git
- release repository: https://github.com/groove-x/mqtt_bridge-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.7-7`

## mqtt_bridge

```
* configure rostest and run it on circleci (#41 <https://github.com/groove-x/mqtt_bridge/issues/41>)
* split requirements.txt (#38 <https://github.com/groove-x/mqtt_bridge/issues/38>)
* add unittests (#37 <https://github.com/groove-x/mqtt_bridge/issues/37>)
* Fix 'install_requires' warning when building with --install (#32 <https://github.com/groove-x/mqtt_bridge/issues/32>)
* Contributors: Jacob Seibert, Junya Hayashi
```
