### PR TITLE
mqtt_bridge: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3607,6 +3607,21 @@ repositories:
       url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
       version: noetic-devel
     status: developed
+  mqtt_bridge:
+    doc:
+      type: git
+      url: https://github.com/groove-x/mqtt_bridge.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/groove-x/mqtt_bridge-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/groove-x/mqtt_bridge.git
+      version: master
+    status: maintained
   mrpt2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge` to `0.2.1-1`:

- upstream repository: https://github.com/groove-x/mqtt_bridge.git
- release repository: https://github.com/groove-x/mqtt_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## mqtt_bridge

```
* fix build dependency (#43 <https://github.com/groove-x/mqtt_bridge/issues/43>)
* Contributors: Junya Hayashi
```
