### PR TITLE
ros2_control: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2838,7 +2838,7 @@ repositories:
       - test_robot_hardware
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_control-release
+      url: https://github.com/ros2-gbp/ros2_control-release.git
       version: 0.1.1-1
     source:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2836,11 +2836,10 @@ repositories:
       - ros2_control
       - ros2controlcli
       - test_robot_hardware
-      - transmission_interface
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/bmagyar/ros2_control-release.git
-      version: 0.1.0-1
+      url: https://github.com/ros2-gbp/ros2_control-release
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.1.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-1`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

```
* Remove transmission_interface from release, add ros2cli to ros_control (#280 <https://github.com/ros-controls/ros2_control/issues/280>)
  * Remove transmission_interface from release, add ros2cli to ros_control
  metapackage
  * patch
* Contributors: Bence Magyar
```

## ros2controlcli

- No changes

## test_robot_hardware

- No changes
