### PR TITLE
mesh_navigation: 1.0.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5903,7 +5903,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/uos-gbp/mesh_navigation-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/uos/mesh_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mesh_navigation` to `1.0.0-3`:

- upstream repository: https://github.com/uos/mesh_navigation.git
- release repository: https://github.com/uos-gbp/mesh_navigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-2`

## dijkstra_mesh_planner

```
* Initial release
```

## mbf_mesh_core

```
* Initial release
```

## mbf_mesh_nav

```
* Initial release
```

## mesh_client

```
* Initial release
```

## mesh_controller

```
* Initial release
```

## mesh_layers

```
* Initial release
```

## mesh_map

```
* Initial release
```

## mesh_navigation

```
* Initial release
```

## wave_front_planner

```
* Initial release
```
