### PR TITLE
embree_vendor: 0.0.4-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -853,6 +853,12 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  embree_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/embree_vendor-release.git
+      version: 0.0.4-4
   example_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `embree_vendor` to `0.0.4-4`:

- upstream repository: https://github.com/OUXT-Polaris/embree_vendor.git
- release repository: https://github.com/OUXT-Polaris/embree_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## embree_vendor

```
* update release workflow
* Contributors: Masaya Kataoka
```
