### PR TITLE
m_explore: 2.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5619,6 +5619,24 @@ repositories:
       url: https://github.com/uos/lvr2.git
       version: master
     status: developed
+  m_explore:
+    doc:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: melodic-devel
+    release:
+      packages:
+      - explore_lite
+      - multirobot_map_merge
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/hrnr/m-explore-release.git
+      version: 2.1.2-1
+    source:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: melodic-devel
+    status: maintained
   map_merge:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `2.1.2-1`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## explore_lite

```
* support for ROS Melodic
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* support for ROS Melodic
* bugfix: zero resolution of the merged grid for known initial posiiton
* bugfix: estimation_confidence parameter had no effect
* map_merge: set origin of merged grid in its centre
* map_merge: add new launch file
  * map_merge with 2 maps served by map_server
* bugfix: ensure that we never output map with 0 resolution
* bugfix: nullptr derefence while setting resolution of output grid
* Contributors: Jiri Horner
```
