### PR TITLE
m_explore: 2.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3119,6 +3119,24 @@ repositories:
       url: https://github.com/uos/lvr2.git
       version: master
     status: developed
+  m_explore:
+    doc:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: noetic-devel
+    release:
+      packages:
+      - explore_lite
+      - multirobot_map_merge
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/hrnr/m-explore-release.git
+      version: 2.1.3-1
+    source:
+      type: git
+      url: https://github.com/hrnr/m-explore.git
+      version: noetic-devel
+    status: developed
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `2.1.3-1`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## explore_lite

```
* add missing dependencies to catkin_package calls
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* add missing dependencies to catkin_package calls
* update map_merge for OpenCV 4
* Contributors: Jiri Horner
```
