### PR TITLE
rosfmt: 7.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5388,7 +5388,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/xqms/rosfmt-release.git
-      version: 6.2.0-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosfmt` to `7.0.0-1`:

- upstream repository: https://github.com/xqms/rosfmt.git
- release repository: https://github.com/xqms/rosfmt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `6.2.0-1`

## rosfmt

```
* rename rosfmt library to rosfmt7 to prevent ABI mismatches
* Update fmt to 7.1.2
* cmake: fix ordering of internal include paths
* add new full.h header (issue: #2)
* Contributors: Max Schwarz
```
