### PR TITLE
Rosdep rule for python3-sympy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6863,6 +6863,9 @@ python3-sphinx-rtd-theme:
 python3-sqlalchemy:
   debian: [python3-sqlalchemy]
   ubuntu: [python3-sqlalchemy]
+python3-sympy:
+  debian: [python3-sympy]
+  ubuntu: [python3-sympy]
 python3-systemd:
   debian: [python3-systemd]
   ubuntu: [python3-systemd]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6865,6 +6865,8 @@ python3-sqlalchemy:
   ubuntu: [python3-sqlalchemy]
 python3-sympy:
   debian: [python3-sympy]
+  fedora: [python3-sympy]
+  gentoo: [dev-python/sympy]
   ubuntu: [python3-sympy]
 python3-systemd:
   debian: [python3-systemd]


### PR DESCRIPTION
This is the Python 3 version of the `python-sympy` package which already exists as a rosdep rule. I don't know the equivalent packages for Gentoo or Fedora, and I don't have test systems for those, so I haven't included those rules.

Here is the Ubuntu bionic package: https://packages.ubuntu.com/bionic/python3-sympy
Here is the debian package: https://packages.debian.org/search?keywords=python3-sympy