### PR TITLE
Add CentOS/RHEL 8 for bullet

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -350,9 +350,7 @@ bullet:
   macports: [bullet]
   openembedded: [bullet@meta-ros-common]
   opensuse: [libbullet]
-  rhel:
-    '7': [bullet-devel]
-    '8': [bullet-devel]
+  rhel: [bullet-devel]
   ubuntu:
     '*': [libbullet-dev]
     trusty_python3: [libbullet-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -352,6 +352,7 @@ bullet:
   opensuse: [libbullet]
   rhel:
     '7': [bullet-devel]
+    '8': [bullet-devel]
   ubuntu:
     '*': [libbullet-dev]
     trusty_python3: [libbullet-dev]


### PR DESCRIPTION
Bullet is available as `bullet-devel` on CentOS and Red Hat Enterprise Linux 8 in the EPEL repository:

```
% dnf list bullet-devel
Last metadata expiration check: 1:46:23 ago on Mon 04 Jan 2021 14:52:16 JST.
Available Packages
bullet-devel.x86_64                                      2.87-10.el8                                      epel
```