### PR TITLE
openzen_sensor: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4156,7 +4156,7 @@ repositories:
     doc:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git
-      version: 1.2.0
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -4165,7 +4165,7 @@ repositories:
     source:
       type: git
       url: https://bitbucket.org/lpresearch/openzenros.git
-      version: 1.2.0
+      version: master
     status: developed
   oxford_gps_eth:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4152,6 +4152,21 @@ repositories:
       url: https://github.com/ros-perception/openslam_gmapping.git
       version: melodic-devel
     status: unmaintained
+  openzen_sensor:
+    doc:
+      type: git
+      url: https://bitbucket.org/lpresearch/openzenros.git
+      version: 1.2.0
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/lp-research/openzen_sensor-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://bitbucket.org/lpresearch/openzenros.git
+      version: 1.2.0
+    status: developed
   oxford_gps_eth:
     doc:
       type: git


### PR DESCRIPTION
This PR is porting the existing openzen_sensor package from ROS melodic to ROS noetic. Thanks for having a look.

Increasing version of package(s) in repository `openzen_sensor` to `1.2.0-1`:

- upstream repository: https://bitbucket.org/lpresearch/openzenros.git
- release repository: https://github.com/lp-research/openzen_sensor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## openzen_sensor

```
* fixed conditions check for build or download OpenZen options
* fixed name of primary maintainer
* added install target for openzen_node
* manually setting component ID in case a TestSensor is used
* running rostest as part of the catkin CMake file
* switched binary downloads to OpenZen 1.2.0
* updated OpenZen to version 1.2.0
* added output of GNSS measurement as ROS NavSatFix message
* Contributors:
```
