### PR TITLE
plotjuggler: 3.0.7-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8211,7 +8211,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.0.6-1
+      version: 3.0.7-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.0.7-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.6-1`

## plotjuggler

```
* Add plugin folders in the preference dialog
* fix issue #370 <https://github.com/PlotJuggler/PlotJuggler/issues/370>: libDataStreamMQTT compilation with Clang
* fix command line options
* change the way ROS path are added t othe list of plugins
* fixing windows builds, for real this time. (#379 <https://github.com/PlotJuggler/PlotJuggler/issues/379>)
* fix bug when datapoints are cleared
* remember the directory in the FunctionEditor
* moved file svg_util
* Add warning when a CSV file is malformed, and suggested in #378 <https://github.com/PlotJuggler/PlotJuggler/issues/378>
* Fixed message_parser plugin loading segfault (#376 <https://github.com/PlotJuggler/PlotJuggler/issues/376>)
* Contributors: Davide Faconti, Jordan McMichael, davide
```
