### PR TITLE
autoware_auto_msgs: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -188,6 +188,21 @@ repositories:
       url: https://github.com/AprilRobotics/apriltag.git
       version: master
     status: maintained
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    status: developed
   behaviortree_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_auto_msgs` to `1.0.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## autoware_auto_msgs

```
* Merge branch 'BoundingBoxArray-design' into 'master'
  Add design doc for bounding-box message
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!12 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/12>
* Working around https://github.com/ros-tooling/libstatistics_collector/issues/51.
* Fixing constants in AutonomyModeChange.
* Making AutonomyModeChange return empty.
* Merge branch '657-autonomy-service' into 'master'
  Adding AutonomyModeChange service definition.
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!11 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/11>
* Adding velocity_mps to VehicleControlCommand.
* Merge branch '474-add-modify-trajectory-service' into 'master'
  Adding ModifyTrajectory service definition.
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!10 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/10>
* Merge branch 'modify-plan-trajectory-action' into 'master'
  modify PlanTrajectory Action to return trajectory in Result
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!9 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/9>
* Merge branch 'fix/plan_trajectory_action' into 'master'
  fix include file and namespace of constants
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!8 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/8>
* Merge branch 'add-actions-dependency' into 'master'
  Cleaning up package.xml and adding action_msgs dependency.
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!7 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/7>
* Merge branch 'add-plan-trajectory-action' into 'master'
  add PlanTrajectory action
  See merge request autowarefoundation/autoware.auto/autoware_auto_msgs!6 <https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/merge_requests/6>
* Contributors: Frederik Beaujean, Joshua Whitley, mitsudome-r
```
