### PR TITLE
rclpy: 1.0.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2542,7 +2542,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.0.5-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.4-1`

## rclpy

```
* [documentation] Use only True to avoid confusion in autodoc config
  None and True have the same meaning:
  https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html?highlight=autoclass#confval-autodoc_default_options
* [documentation] Document QoS profile constants
* Fix Enum not being comparable with ints in get_parameter_types service (#644 <https://github.com/ros2/rclpy/issues/644>)
* Make sure to catch the ROSInterruptException when calling rate.sleep (#650 <https://github.com/ros2/rclpy/issues/650>)
* Fix memory leak (#643 <https://github.com/ros2/rclpy/issues/643>) (#646 <https://github.com/ros2/rclpy/issues/646>)
* Destroy event handlers owned by publishers/subscriptions when calling publisher.destroy()/subscription.destroy() (#603 <https://github.com/ros2/rclpy/issues/603>) (#625 <https://github.com/ros2/rclpy/issues/625>)
* Use absolute parameter events topic name (#612 <https://github.com/ros2/rclpy/issues/612>) (#614 <https://github.com/ros2/rclpy/issues/614>)
* MultiThreadedExecutor spin_until_future complete should not continue waiting when the future is done (#605 <https://github.com/ros2/rclpy/issues/605>) (#626 <https://github.com/ros2/rclpy/issues/626>)
* Contributors: Chen Lihui Chris Lalancette, Gökçe Aydos, Ivan Santiago Paunovic, Jacob Perron, Tomoya Fujita
```
