### PR TITLE
grid_map: 1.6.4-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3670,7 +3670,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/anybotics/grid_map-release.git
-      version: 1.6.2-1
+      version: 1.6.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.6.4-2`:

- upstream repository: https://github.com/anybotics/grid_map.git
- release repository: https://github.com/anybotics/grid_map-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.6.2-1`

## grid_map

- No changes

## grid_map_core

- No changes

## grid_map_costmap_2d

- No changes

## grid_map_cv

- No changes

## grid_map_demos

- No changes

## grid_map_filters

```
* Extended the ThresholdFilter:
* 
  
    * The layer parameter was replaced by condition_layer and output_layer.
  
* 
  
    * The previous behavior can be restored by setting both new parameters to the same value.
  
* Contributors: Magnus Gärtner
```

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

- No changes

## grid_map_rviz_plugin

- No changes

## grid_map_sdf

- No changes

## grid_map_visualization

- No changes
