### PR TITLE
grid_map: 1.6.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2194,6 +2194,28 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: ros1
     status: maintained
+  grid_map:
+    release:
+      packages:
+      - grid_map
+      - grid_map_core
+      - grid_map_costmap_2d
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_octomap
+      - grid_map_pcl
+      - grid_map_ros
+      - grid_map_rviz_plugin
+      - grid_map_sdf
+      - grid_map_visualization
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/anybotics/grid_map-release.git
+      version: 1.6.4-1
+    status: maintained
   haf_grasping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `1.6.4-1`:

- upstream repository: https://github.com/anybotics/grid_map.git
- release repository: https://github.com/anybotics/grid_map-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## grid_map

- No changes

## grid_map_core

- No changes

## grid_map_costmap_2d

- No changes

## grid_map_cv

- No changes

## grid_map_demos

- No changes

## grid_map_filters

```
* Extended the ThresholdFilter:
* 
  
    * The layer parameter was replaced by condition_layer and output_layer.
  
* 
  
    * The previous behavior can be restored by setting both new parameters to the same value.
  
* Contributors: Magnus Gärtner
```

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

- No changes

## grid_map_rviz_plugin

- No changes

## grid_map_sdf

- No changes

## grid_map_visualization

- No changes
