### PR TITLE
variant: 0.1.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6982,6 +6982,17 @@ repositories:
       url: https://github.com/yoshito-n-students/usb_cam_hardware.git
       version: noetic-devel
     status: maintained
+  variant:
+    release:
+      packages:
+      - variant
+      - variant_msgs
+      - variant_topic_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/anybotics/variant-release.git
+      version: 0.1.6-1
+    status: maintained
   velodyne:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variant` to `0.1.6-1`:

- upstream repository: https://github.com/anybotics/variant.git
- release repository: https://github.com/anybotics/variant-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## variant

- No changes

## variant_msgs

- No changes

## variant_topic_tools

```
* Allow 0 in message definition
* Contributors: Kenji Miyake
```
