### PR TITLE
variant: 0.1.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13343,12 +13343,12 @@ repositories:
       packages:
       - variant
       - variant_msgs
-      - variant_topic_test
       - variant_topic_tools
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/anybotics/variant-release.git
-      version: 0.1.5-0
+      version: 0.1.6-1
+    status: maintained
   velodyne:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variant` to `0.1.6-1`:

- upstream repository: https://github.com/anybotics/variant.git
- release repository: https://github.com/anybotics/variant-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.5-0`

## variant

- No changes

## variant_msgs

- No changes

## variant_topic_tools

```
* Allow 0 in message definition
* Contributors: Kenji Miyake
```
