### PR TITLE
ros2_controllers: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2879,13 +2879,18 @@ repositories:
       version: master
     release:
       packages:
+      - diff_drive_controller
+      - effort_controllers
       - forward_command_controller
       - joint_state_controller
       - joint_trajectory_controller
+      - position_controllers
+      - ros2_controllers
+      - velocity_controllers
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.1.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.0-1`

## diff_drive_controller

```
* avoid warnings (#137 <https://github.com/ros-controls/ros2_controllers/issues/137>)
* Migrate diff drive controller to resourcemanager (#128 <https://github.com/ros-controls/ros2_controllers/issues/128>)
* Contributors: Bence Magyar, Karsten Knese
```

## effort_controllers

```
* Restore forward command derivatives (#133 <https://github.com/ros-controls/ros2_controllers/issues/133>)
* Contributors: Bence Magyar
```

## forward_command_controller

```
* Restore forward command derivatives (#133 <https://github.com/ros-controls/ros2_controllers/issues/133>)
* Contributors: Bence Magyar
```

## joint_state_controller

```
* avoid warnings (#137 <https://github.com/ros-controls/ros2_controllers/issues/137>)
* Contributors: Karsten Knese
```

## joint_trajectory_controller

- No changes

## position_controllers

```
* Restore forward command derivatives (#133 <https://github.com/ros-controls/ros2_controllers/issues/133>)
* Contributors: Bence Magyar
```

## ros2_controllers

```
* Restore forward command derivatives (#133 <https://github.com/ros-controls/ros2_controllers/issues/133>)
* Migrate diff drive controller to resourcemanager (#128 <https://github.com/ros-controls/ros2_controllers/issues/128>)
* Contributors: Bence Magyar
```

## velocity_controllers

```
* Restore forward command derivatives (#133 <https://github.com/ros-controls/ros2_controllers/issues/133>)
* Contributors: Bence Magyar
```
