### PR TITLE
turtlebot3: 2.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4064,7 +4064,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `2.1.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.1.0-1`

## turtlebot3

```
* Nav2 prefix filename removed
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_bringup

```
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_cartographer

```
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_description

```
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_example

```
* Nav2 prefix filename removed
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_navigation2

```
* Nav2 prefix filename removed
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_node

```
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```

## turtlebot3_teleop

```
* turtlebot3.repos updated to target correct distro
* galactic-devel branch created
* Eloquent EOL
* Contributors: Ashe Kim, Will Son
```
