### PR TITLE
core_perception: 1.14.9-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1094,7 +1094,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/core_perception-release.git
-      version: 1.14.9-2
+      version: 1.14.9-3
     source:
       type: git
       url: https://github.com/nobleo/core_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `core_perception` to `1.14.9-3`:

- upstream repository: https://github.com/nobleo/core_perception.git
- release repository: https://github.com/nobleo/core_perception-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.14.9-2`

## points_preprocessor

```
* Remove Autoware Health Checker as dependency
* Contributors: Tim Clephas
```
