### PR TITLE
audio_common: 0.3.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -646,7 +646,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.9-1
+      version: 0.3.10-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.10-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.3.9-1`

## audio_capture

```
* add bitrate in capture launch
* [audio_capture] Publish audio info once before publishing /audio
* Contributors: Naoya Yamaguchi, Shingo Kitagawa
```

## audio_common

- No changes

## audio_common_msgs

```
* Change comment style in AudioInfo.msg
* [audio_common_msgs] AudioInfo.msg to add audio meta data
* Contributors: Naoya Yamaguchi
```

## audio_play

- No changes

## sound_play

- No changes
