### PR TITLE
agni_tf_tools: 0.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -44,6 +44,21 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: noetic-devel
     status: maintained
+  agni_tf_tools:
+    doc:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
+      version: 0.1.5-1
+    source:
+      type: git
+      url: https://github.com/ubi-agni/agni_tf_tools.git
+      version: master
+    status: maintained
   ainstein_radar:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agni_tf_tools` to `0.1.5-1`:

- upstream repository: https://github.com/ubi-agni/agni_tf_tools.git
- release repository: https://github.com/ubi-agni-gbp/agni_tf_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## agni_tf_tools

```
* Replace string-based SIGNALs with function pointers
* Always show marker type property
* EulerProperty: use QDoubleSpinBoxes (allowing animated motion)
* Display: Fix several issues with frame updates
  * Always consider return value of fillPoseStamped() and don't publish on failure
  * On failure, register to TF changes to retry later
  * Finish tf2 transition: use tf2::BufferCore instead of tf::Transformer
* Handle multiple TransformBroadcasters in the same ROS node.
* Contributors: Robert Haschke
```
