### PR TITLE
ros2_controllers: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2890,7 +2890,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
******************************************************
IMPORTANT: This is a bugfix PR for https://build.ros2.org/job/Fbin_uF64__diff_drive_controller__ubuntu_focal_amd64__binary/2/
******************************************************


Increasing version of package(s) in repository `ros2_controllers` to `0.1.2-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.1-1`

## diff_drive_controller

```
* Remove unused sensor_msgs dependency (was non-declared in package.xml) (#139 <https://github.com/ros-controls/ros2_controllers/issues/139>)
* Contributors: Bence Magyar
```

## effort_controllers

- No changes

## forward_command_controller

- No changes

## joint_state_controller

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## ros2_controllers

- No changes

## velocity_controllers

- No changes
