### PR TITLE
opw_kinematics: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4200,6 +4200,17 @@ repositories:
       url: https://bitbucket.org/lpresearch/openzenros.git
       version: master
     status: developed
+  opw_kinematics:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/opw_kinematics-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/Jmeyer1292/opw_kinematics.git
+      version: master
+    status: developed
   oxford_gps_eth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `opw_kinematics` to `0.3.1-1`:

- upstream repository: https://github.com/Jmeyer1292/opw_kinematics.git
- release repository: https://github.com/ros-industrial-release/opw_kinematics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## opw_kinematics

```
* Update to use initialize_code_coverage() macro
* Contributors: Levi Armstrong
```
