### PR TITLE
m_explore: 2.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3153,7 +3153,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/hrnr/m-explore-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       type: git
       url: https://github.com/hrnr/m-explore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `m_explore` to `2.1.4-1`:

- upstream repository: https://github.com/hrnr/m-explore.git
- release repository: https://github.com/hrnr/m-explore-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.1.3-1`

## explore_lite

```
* use C++14
* Contributors: Jiri Horner
```

## multirobot_map_merge

```
* use C++14
* support both OpenCV 3 and OpenCV 4 (support Debian Buster)
* Contributors: Jiri Horner
```
