### PR TITLE
Add python3-cffi rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5614,6 +5614,11 @@ python3-catkin-tools:
   fedora: [python3-catkin_tools]
   openembedded: [python3-catkin-tools@meta-ros-common]
   ubuntu: [python3-catkin-tools]
+python3-cffi:
+  debian: [python3-cffi]
+  fedora: [python3-cffi]
+  gentoo: [dev-python/cffi]
+  ubuntu: [python3-cffi]
 python3-cherrypy3:
   debian: [python3-cherrypy3]
   ubuntu: [python3-cherrypy3]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5618,6 +5618,7 @@ python3-cffi:
   debian: [python3-cffi]
   fedora: [python3-cffi]
   gentoo: [dev-python/cffi]
+  rhel: ['python%{python3_pkgversion}-cffi']
   ubuntu: [python3-cffi]
 python3-cherrypy3:
   debian: [python3-cherrypy3]


### PR DESCRIPTION
Used in this prototype PR here: https://github.com/ros2/rclpy/pull/656


Debian: https://packages.debian.org/buster/python3-cffi
Fedora: https://pkgs.org/download/python3-cffi
Gentoo: https://packages.gentoo.org/packages/dev-python/cffi
Ubuntu: https://packages.ubuntu.com/focal/python3-cffi

From @cottsay :
> In RHEL 7, this is supplied by EPEL: https://src.fedoraproject.org/rpms/python3-cffi#bodhi_updates
> In RHEL 8, it is supplied by BaseOS: https://mirrors.edge.kernel.org/centos/8/BaseOS/x86_64/os/Packages/python3-cffi-1.11.5-5.el8.x86_64.rpm