### PR TITLE
embree_vendor: 0.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -854,11 +854,15 @@ repositories:
       version: devel
     status: maintained
   embree_vendor:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/embree_vendor.git
+      version: master
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/OUXT-Polaris/embree_vendor-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `embree_vendor` to `0.0.6-1`:

- upstream repository: https://github.com/OUXT-Polaris/embree_vendor.git
- release repository: https://github.com/OUXT-Polaris/embree_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.5-1`

## embree_vendor

```
* Merge pull request #1 <https://github.com/OUXT-Polaris/embree_vendor/issues/1> from OUXT-Polaris/feature/add_tbb_to_depends
  update package.xml
* update package.xml
* update workflow
* rename workflow
* fix workflow
* add generate foxy dpkg workflow
* Contributors: Masaya Kataoka
```
