### PR TITLE
ueye_cam: 1.0.18-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12946,7 +12946,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.17-1
+      version: 1.0.18-1
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.18-1`:

- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.17-1`

## ueye_cam

```
* updated driver URLs for 4.94 version
* [uEye 4.94] Update Deprecated Event Handling Functions  (#97 <https://github.com/anqixu/ueye_cam/issues/97>)
  * Updated event functions to 4.94 API + Added init of event before enabling it
  * Added uEye 4.94 req
  * Changed timeout to UINT to fit 4_94 API
* Adding call of exit routine for the frame event
* Adding auto exposure reference value
* Added support for setting the software-gamma
* Package format update and code cleanup
* Contributors: Anqi Xu, Brett Newman, Nullket, jmackay2, nullket
```
