### PR TITLE
quaternion_operation: 0.0.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2339,6 +2339,22 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: foxy-devel
     status: maintained
+  quaternion_operation:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OUXT-Polaris/quaternion_operation-release.git
+      version: 0.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: ros2
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `quaternion_operation` to `0.0.4-1`:

- upstream repository: https://github.com/OUXT-Polaris/quaternion_operation.git
- release repository: https://github.com/OUXT-Polaris/quaternion_operation-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
