### PR TITLE
py_trees: 0.7.6-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4560,7 +4560,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.7.3-1
+      version: 0.7.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.7.6-2`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.3-1`

## py_trees

```
* [infra] skipping archived 0.7.4 and 0.7.5 versions that were dropped in favour of a push to 1.0.x
```
