### PR TITLE
py_trees: 0.6.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8734,7 +8734,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 0.6.8-0
+      version: 0.6.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `0.6.9-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/stonier/py_trees-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.8-0`

## py_trees

```
* [decorators] setting the child's parent as the decorator
```
