### PR TITLE
osqp: 0.6.2-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4200,6 +4200,17 @@ repositories:
       url: https://bitbucket.org/lpresearch/openzenros.git
       version: master
     status: developed
+  osqp:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/osqp-release.git
+      version: 0.6.2-3
+    source:
+      type: git
+      url: https://github.com/oxfordcontrol/osqp.git
+      version: master
+    status: developed
   oxford_gps_eth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp` to `0.6.2-3`:

- upstream repository: https://github.com/oxfordcontrol/osqp.git
- release repository: https://github.com/ros-industrial-release/osqp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
