### PR TITLE
qpoases: 3.2.1-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4634,6 +4634,17 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: melodic-devel
     status: maintained
+  qpoases:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/qpoases-release.git
+      version: 3.2.1-4
+    source:
+      type: git
+      url: https://github.com/coin-or/qpOASES.git
+      version: master
+    status: maintained
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpoases` to `3.2.1-4`:

- upstream repository: https://github.com/Levi-Armstrong/qpOASES.git
- release repository: https://github.com/ros-industrial-release/qpoases-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
