### PR TITLE
raptor-dbw-ros: 1.0.0-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9160,7 +9160,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nobleo/raptor-dbw-ros-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor-dbw-ros` to `1.0.0-3`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
- release repository: https://github.com/nobleo/raptor-dbw-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-2`
