### PR TITLE
graceful_controller: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2165,6 +2165,24 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: master
     status: maintained
+  graceful_controller:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/graceful_controller.git
+      version: ros1
+    release:
+      packages:
+      - graceful_controller
+      - graceful_controller_ros
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mikeferguson/graceful_controller-gbp.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/graceful_controller.git
+      version: ros1
+    status: developed
   graph_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.2.0-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## graceful_controller

```
* Initial release
* Contributors: Michael Ferguson
```

## graceful_controller_ros

```
* Initial release
* Contributors: Michael Ferguson
```
