### PR TITLE
common_msgs: 1.13.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -993,7 +993,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.13.0-1
+      version: 1.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.13.1-1`:

- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.13.0-1`

## actionlib_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## common_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## diagnostic_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## geometry_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## nav_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Add LoadMap service (#164 <https://github.com/ros/common_msgs/issues/164>)
* Contributors: David V. Lu!!, Michel Hidalgo
```

## sensor_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## shape_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## stereo_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## trajectory_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```

## visualization_msgs

```
* Update package maintainers (#168 <https://github.com/ros/common_msgs/issues/168>)
* Contributors: Michel Hidalgo
```
