### PR TITLE
rqt_multiplot_plugin: 0.0.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5884,6 +5884,15 @@ repositories:
       url: https://github.com/ros-visualization/rqt_msg.git
       version: master
     status: maintained
+  rqt_multiplot_plugin:
+    release:
+      packages:
+      - rqt_multiplot
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/anybotics/rqt_multiplot_plugin-release.git
+      version: 0.0.11-1
+    status: maintained
   rqt_nav_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.11-1`:

- upstream repository: https://github.com/anybotics/rqt_multiplot_plugin.git
- release repository: https://github.com/anybotics/rqt_multiplot_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rqt_multiplot

```
* update for Ros noetic
```
