### PR TITLE
jderobot_drones: 1.3.6-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4667,7 +4667,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.5-1
+      version: 1.3.6-1
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.6-1`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.3.5-1`

## drone_assets

```
* Removed duplicated jderobot logo
* Iris models updated
* Contributors: pariaspe
```

## drone_wrapper

- No changes

## jderobot_drones

```
* Fixing iris models.
* Fixing jenkins build.
* Contributors: pariaspe
```

## rqt_drone_teleop

```
* New setup.py. Fixing jenkins-build fail.
* Contributors: pariaspe
```

## rqt_ground_robot_teleop

- No changes
