### PR TITLE
raptor-dbw-ros: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4743,6 +4743,23 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raptor-dbw-ros:
+    doc:
+      type: git
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
+      version: master
+    release:
+      packages:
+      - can_dbc_parser
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/raptor-dbw-ros-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
+      version: master
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor-dbw-ros` to `1.0.0-1`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros.git
- release repository: https://github.com/nobleo/raptor-dbw-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
