### PR TITLE
async_web_server_cpp: 1.0.1-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -593,9 +593,13 @@ repositories:
     release:
       tags:
         release: release/melodic/{package}/{version}
-      url: https://github.com/gt-rail-release/async_web_server_cpp-release.git
-      version: 0.0.3-0
-    status: unmaintained
+      url: https://github.com/fkie-release/async_web_server_cpp-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: develop
+    status: maintained
   ati_force_torque:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to
`1.0.1-1`:

- upstream repository: https://github.com/fkie/async_web_server_cpp.git
- release repository:
https://github.com/gt-rail-release/async_web_server_cpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.3-0`

```
* New maintainer: Timo Röhling
* Merge outstanding pull requests
  GT-RAIL#14: Fix compatibility issue with Apache2 websocket proxy
  GT-RAIL#16: Fix C++ include path for unit tests (obsolete)
  GT-RAIL#19: Fix Python 3 compatibility for unit tests
* Modernize CMakeLists.txt
* Auto-detect MIME types from file extensions
```

**NOTE**: I have taken over the package from the original GT-RAIL
repository as it is orphaned and the original maintainer(s) are
completely unresponsive:

- https://github.com/GT-RAIL/async_web_server_cpp/issues/20
- https://discourse.ros.org/t/async-web-server-cpp-maintenance/18052