### PR TITLE
openni2_camera 1.5.0-1 in 'noetic/distribution.yaml' [non-bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4021,7 +4021,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 1.4.2-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository openni2_camera to 1.5.0-1:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros-gbp/openni2_camera-release.git
- distro file: noetic/distribution.yaml
- bloom version: 0.10.0
   - To make this PR, `bloom` failed so had to manually do it.
      ```
      ==> Checking on GitHub for a fork to make the pull request from...
      Could not find a fork of ros/rosdistro on the 130s GitHub account.
      Would you like to create one now?
      Continue [Y/n]? 
      Aborting pull request: HTTP Error 401: Unauthorized (https://api.github.com/repos/ros/rosdistro/forks)
      The release of your packages was successful, but the pull request failed.
      Please manually open a pull request by editing the file here: 'https://raw.githubusercontent.com/ros/rosdistro/master/noetic/distribution.yaml'
      <== No pull request opened.
      $ bloom-release --version
      0.10.0
      ```
- previous version for package: 1.4.2-1