### PR TITLE
async_web_server_cpp: 1.0.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -155,6 +155,17 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: master
     status: maintained
+  async_web_server_cpp:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fkie-release/async_web_server_cpp-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: develop
+    status: maintained
   audibot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `1.0.1-2`:

- upstream repository: https://github.com/fkie/async_web_server_cpp.git
- release repository: https://github.com/fkie-release/async_web_server_cpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## async_web_server_cpp

```
* New maintainer: Timo Röhling
* Merge outstanding pull requests
  GT-RAIL#14: Fix compatibility issue with Apache2 websocket proxy
  GT-RAIL#16: Fix C++ include path for unit tests (obsolete)
  GT-RAIL#19: Fix Python 3 compatibility for unit tests
* Modernize CMakeLists.txt
* Auto-detect MIME types from file extensions
```
