### PR TITLE
common_msgs: 1.12.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1731,7 +1731,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.12.7-0
+      version: 1.12.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.12.8-1`:

- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.12.7-0`

## actionlib_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## common_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## diagnostic_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## geometry_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## nav_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Add LoadMap service definition (#152 <https://github.com/ros/common_msgs/issues/152>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Jacob Perron, Michel Hidalgo, Shane Loretz
```

## sensor_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Use setuptools instead of distutils (#159 <https://github.com/ros/common_msgs/issues/159>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Fix TabError: inconsistent use of tabs and spaces in indentation (#155 <https://github.com/ros/common_msgs/issues/155>)
* Contributors: Michel Hidalgo, Ramon Wijnands, Shane Loretz
```

## shape_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## stereo_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## trajectory_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Fix EOF line break so cat output is more usable
* Contributors: Halie Murray-Davis, Michel Hidalgo, Shane Loretz
```

## visualization_msgs

```
* Update package maintainers (#170 <https://github.com/ros/common_msgs/issues/170>)
* Bump CMake version to avoid CMP0048 warning (#158 <https://github.com/ros/common_msgs/issues/158>)
* Contributors: Michel Hidalgo, Shane Loretz
```
