### PR TITLE
Add castxml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -388,6 +388,12 @@ can-utils:
   debian: [can-utils]
   fedora: [can-utils]
   ubuntu: [can-utils]
+castxml:
+  arch: [castxml]
+  debian: [castxml]
+  fedora: [castxml]
+  macports: [castxml]
+  ubuntu: [castxml]
 cccc:
   debian: [cccc]
   gentoo: [dev-util/cccc]


### PR DESCRIPTION
arch: https://aur.archlinux.org/packages/castxml/
debain: https://packages.debian.org/buster/castxml
fedora: https://fedora.pkgs.org/31/fedora-updates-x86_64/castxml-0.3.6-1.fc31.x86_64.rpm.html
gentoo: https://gpo.zugaina.org/dev-cpp/CastXML/RDep
macports: https://ports.macports.org/port/castxml/summary
ubuntu: https://packages.ubuntu.com/bionic/castxml