### PR TITLE
async_web_server_cpp: 1.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -590,11 +590,15 @@ repositories:
       version: master
     status: developed
   async_web_server_cpp:
+    doc:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: master
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fkie-release/async_web_server_cpp-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/fkie/async_web_server_cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `1.0.2-1`:

- upstream repository: https://github.com/fkie/async_web_server_cpp.git
- release repository: https://github.com/fkie-release/async_web_server_cpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-1`

## async_web_server_cpp

```
* Fix integer comparisons
* Use HTTP/1.1 reply for WebSockets protocol upgrade
* Contributors: Timo Röhling
```
