### PR TITLE
diagnostics: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -447,7 +447,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.0.2-2
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.1.0-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.2-2`

## diagnostic_aggregator

```
* Update to latest ros2 rolling. (#177 <https://github.com/ros/diagnostics/issues/177>)
* Fix installation of diagnostic aggregator example. (#159 <https://github.com/ros/diagnostics/issues/159>)
* Restore alphabetical order. (#148 <https://github.com/ros/diagnostics/issues/148>)
* Aggregator bugfix, tests, and nicer example. (#147 <https://github.com/ros/diagnostics/issues/147>)
* Contributors: Arne Nordmann, Georg Bartels, Karsten Knese
```

## diagnostic_updater

```
* Update to latest ros2 rolling. (#177 <https://github.com/ros/diagnostics/issues/177>)
* Contributors: Karsten Knese
```

## self_test

```
* Update to latest ros2 rolling. (#177 <https://github.com/ros/diagnostics/issues/177>)
* Contributors: Karsten Knese
```
