### PR TITLE
simple_grasping: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6407,6 +6407,21 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: noetic
     status: developed
+  simple_grasping:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros1
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/simple_grasping-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros1
+    status: maintained
   slam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.4.0-1`:

- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/ros-gbp/simple_grasping-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## simple_grasping

```
* add depend on grasping_msgs, fix #5 <https://github.com/mikeferguson/simple_grasping/issues/5>
* Contributors: Michael Ferguson
```
