### PR TITLE
graceful_controller: 0.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2192,7 +2192,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.2.2-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.1-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* support robot footprint (#13 <https://github.com/mikeferguson/graceful_controller/issues/13>)
* cleanup parameters (#12 <https://github.com/mikeferguson/graceful_controller/issues/12>)
  * drop unused parameters
  * manage parameters directly
* Contributors: Michael Ferguson
```
