### PR TITLE
rqt_moveit: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2240,6 +2240,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: foxy-devel
     status: maintained
+  rqt_moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_moveit-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: ros2
+    status: maintained
   rqt_msg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_moveit` to `1.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_moveit.git
- release repository: https://github.com/ros2-gbp/rqt_moveit-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rqt_moveit

```
* removed non-resolvable build_tool dependency (fix for releasing)
```
