### PR TITLE
rc_common_msgs: 0.5.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1389,6 +1389,22 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: foxy-devel
     status: maintained
+  rc_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_common_msgs_ros2-release.git
+      version: 0.5.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    status: developed
   rc_dynamics_api:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_common_msgs` to `0.5.3-1`:

- upstream repository: https://github.com/roboception/rc_common_msgs_ros2.git
- release repository: https://github.com/roboception-gbp/rc_common_msgs_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rc_common_msgs

```
* CI changes only: also build for focal/foxy
```
