### PR TITLE
rx_service_tools: 1.0.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11590,6 +11590,21 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: melodic-devel
     status: developed
+  rx_service_tools:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rx_service_tools.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/rx_service_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rx_service_tools.git
+      version: master
+    status: maintained
   rxcpp_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rx_service_tools` to `1.0.1-1`:

- upstream repository: https://github.com/nobleo/rx_service_tools.git
- release repository: https://github.com/nobleo/rx_service_tools-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rx_service_tools

```
* Roslaunch compatible by allowing unkown arguments (#1 <https://github.com/nobleo/rx_service_tools/issues/1>)
  Only parse known arguments as roslaunch tends to add arguments like __name:= and __log:=
* feat: Interactive service server GUI
  Based on the actionlib/axserver.py. Works exactly the same but for
  services instead of actions.
* Contributors: Felix Widmaier, Tim Clephas
```
