### PR TITLE
[rosdep] python3-numpy-stl

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6177,8 +6177,8 @@ python3-numpy-stl:
   debian: [python3-numpy-stl]
   fedora: [python3-numpy-stl]
   ubuntu: 
-    xenial: [null]
     '*': [python3-numpy-stl]
+    xenial: [null]
 python3-opencv:
   debian:
     buster: [python3-opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6176,7 +6176,7 @@ python3-numpy:
 python3-numpy-stl:
   debian: [python3-numpy-stl]
   fedora: [python3-numpy-stl]
-  ubuntu: 
+  ubuntu:
     '*': [python3-numpy-stl]
     xenial: null
 python3-opencv:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6173,6 +6173,10 @@ python3-numpy:
   openembedded: [python3-numpy@openembedded-core]
   rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
+python3-numpy-stl:
+  debian: [numpy-stl]
+  fedora: [python3-numpy-stl]
+  ubuntu: [python3-numpy-stl]
 python3-opencv:
   debian:
     buster: [python3-opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6178,7 +6178,7 @@ python3-numpy-stl:
   fedora: [python3-numpy-stl]
   ubuntu: 
     '*': [python3-numpy-stl]
-    xenial: [null]
+    xenial: null
 python3-opencv:
   debian:
     buster: [python3-opencv]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6174,7 +6174,7 @@ python3-numpy:
   rhel: ['python%{python3_pkgversion}-numpy']
   ubuntu: [python3-numpy]
 python3-numpy-stl:
-  debian: [numpy-stl]
+  debian: [python3-numpy-stl]
   fedora: [python3-numpy-stl]
   ubuntu: 
     xenial: [null]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6176,7 +6176,9 @@ python3-numpy:
 python3-numpy-stl:
   debian: [numpy-stl]
   fedora: [python3-numpy-stl]
-  ubuntu: [python3-numpy-stl]
+  ubuntu: 
+    xenial: [null]
+    '*': [python3-numpy-stl]
 python3-opencv:
   debian:
     buster: [python3-opencv]


### PR DESCRIPTION
Debian: https://packages.debian.org/bullseye/numpy-stl
Ubuntu: https://packages.ubuntu.com/bionic/python3-numpy-stl
Fedora: https://fedora.pkgs.org/33/fedora-x86_64/python3-numpy-stl-2.11.2-2.fc33.x86_64.rpm.html