### PR TITLE
rqt_multiplot_plugin: 0.0.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5908,7 +5908,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/anybotics/rqt_multiplot_plugin-release.git
-      version: 0.0.11-1
+      version: 0.0.12-1
     status: maintained
   rqt_nav_view:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_multiplot_plugin` to `0.0.12-1`:

- upstream repository: https://github.com/anybotics/rqt_multiplot_plugin.git
- release repository: https://github.com/anybotics/rqt_multiplot_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.11-1`

## rqt_multiplot

```
* CurveDataSequence::processMessage: Catch variant_topic_tools exception
* Mogrify all png to get rid of libpng warning
* update the readme for melodic and noetic
* Contributors: Wolfgang Merkt, tkazik, ConstGemm
```
