### PR TITLE
Adding my_repo_name to documentation index for distro

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10138,6 +10138,11 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat_eml.git
       version: melodic-devel
+  ros_factorial_isprime:
+    doc:
+      type: git
+      url: https://github.com/JudithInfineon/rosFactorial_IsPrime
+      version: 0.0.1
   ros_monitoring_msgs:
     doc:
       type: git


### PR DESCRIPTION
I'd like ros_factorial_isprime to be indexed and documented on ros.org.