### PR TITLE
rosdep: add qtpy as qtpy-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6669,6 +6669,7 @@ python3-qt5-bindings-webkit:
   openembedded: [python3-pyqt5@meta-qt5]
   ubuntu: [python3-pyqt5.qtwebkit]
 python3-qtpy:
+  arch: [python-qtpy]
   debian: [python3-qtpy]
   gentoo: [dev-python/QtPy]
   ubuntu: [python3-qtpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3862,6 +3862,11 @@ python-qt5-bindings-webkit:
     xenial: [python-pyqt5.qtwebkit]
     yakkety: [python-pyqt5.qtwebkit]
     zesty: [python-pyqt5.qtwebkit]
+python-qtpy:
+  arch: [python-qtpy]
+  debian: [python-qtpy]
+  fedora: [python-QtPy]
+  ubuntu: [python-qtpy]
 python-qwt5-qt4:
   arch: [pyqwt]
   debian: [python-qwt5-qt4]
@@ -6663,6 +6668,10 @@ python3-qt5-bindings-webkit:
   gentoo: ['dev-python/PyQt5[webkit]']
   openembedded: [python3-pyqt5@meta-qt5]
   ubuntu: [python3-pyqt5.qtwebkit]
+python3-qtpy:
+  debian: [python3-qtpy]
+  gentoo: [dev-python/QtPy]
+  ubuntu: [python3-qtpy]
 python3-rafcon-pip:
   debian:
     pip:


### PR DESCRIPTION
This PR adds rosdep key for pip package [qtpy](https://pypi.org/project/QtPy/).
This package provide abstract layer for qt APIs between pyqt4, pyqt5 and pyside.