### PR TITLE
graceful_controller: 0.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3623,7 +3623,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mikeferguson/graceful_controller-gbp.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/mikeferguson/graceful_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graceful_controller` to `0.3.0-1`:

- upstream repository: https://github.com/mikeferguson/graceful_controller.git
- release repository: https://github.com/mikeferguson/graceful_controller-gbp.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.2-1`

## graceful_controller

- No changes

## graceful_controller_ros

```
* unitialized limits causes test failures (#14 <https://github.com/mikeferguson/graceful_controller/issues/14>)
  limits does not initialize prune_plan to a value,
  causes flaky test when it ends up true (would also
  probably be bad on a real robot)
* Contributors: Michael Ferguson
```
