### PR TITLE
osqp_vendor: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4281,6 +4281,21 @@ repositories:
       url: https://github.com/Jmeyer1292/opw_kinematics.git
       version: master
     status: developed
+  osqp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tier4/osqp_vendor-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: noetic
+    status: maintained
   oxford_gps_eth:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osqp_vendor` to `0.1.2-1`:

- upstream repository: https://github.com/tier4/osqp_vendor.git
- release repository: https://github.com/tier4/osqp_vendor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
