### PR TITLE
async_web_server_cpp: 2.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -281,6 +281,21 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: master
     status: maintained
+  async_web_server_cpp:
+    doc:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: ros2-releases
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/fkie-release/async_web_server_cpp-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: ros2-develop
+    status: maintained
   automotive_autonomy_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `2.0.0-1`:

- upstream repository: https://github.com/fkie/async_web_server_cpp.git
- release repository: https://github.com/fkie-release/async_web_server_cpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## async_web_server_cpp

```
* New ROS 2 port
  - ROS 2 releases will have version numbers 2.x
  - ROS 1 releases will continue with version numbers 1.x
```
