### PR TITLE
qpoases_vendor: 3.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4715,6 +4715,21 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: melodic-devel
     status: maintained
+  qpoases_vendor:
+    doc:
+      type: git
+      url: https://github.com/autoware-ai/qpoases_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/autoware-ai/qpoases_vendor-release.git
+      version: 3.2.1-1
+    source:
+      type: git
+      url: https://github.com/autoware-ai/qpoases_vendor.git
+      version: master
+    status: maintained
   qt_gui_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qpoases_vendor` to `3.2.1-1`:

- upstream repository: https://github.com/Autoware-AI/qpoases_vendor.git
- release repository: https://github.com/autoware-ai/qpoases_vendor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## qpoases_vendor

```
* Adding missing dependency on subversion.
* Contributors: Joshua Whitley
```
