### PR TITLE
ros2_tracing: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1824,7 +1824,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/ros-tracing/ros2_tracing-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `2.1.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://gitlab.com/ros-tracing/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.0-1`

## tracetools

```
* Add instrumentation support for linking a timer to a node
* Bring tracetools up to quality level 1
* Contributors: Christophe Bedard
```

## tracetools_launch

```
* Allow configuring tracing directory through environment variables
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Allow skipping test trace cleanup by setting an environment variable
* Add test for timer-node linking instrumentation
* Increased code coverage > 94% as part of QL1
* Contributors: Christophe Bedard, Ingo Lütkebohle, Alejandro Hernández Cordero
```

## tracetools_trace

```
* Fix flake8 blind except error by using more concrete types
* Allow configuring tracing directory through environment variables
* Cleanly stop ros2trace/tracetools_trace tracing on SIGINT
* Add instrumentation support for linking a timer to a node
* Contributors: Christophe Bedard
```
