### PR TITLE
Add rules for python3-importlib-resources

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5981,6 +5981,29 @@ python3-importlib-metadata:
     xenial:
       pip:
         packages: [importlib-metadata]
+python3-importlib-resources:
+  debian:
+    '*': [python3-importlib-resources]
+    buster:
+      pip:
+        packages: [importlib-resources]
+    stretch:
+      pip:
+        packages: [importlib-resources]
+  fedora: [python3]
+  gentoo: [dev-python/importlib_resources]
+  openembedded: [python3@openembedded-core]
+  rhel:
+    '*': ['python%{python3_pkgversion}-importlib-resources']
+    '7': null
+  ubuntu:
+    '*': [libpython3.8-minimal]
+    bionic:
+      pip:
+        packages: [importlib-resources]
+    xenial:
+      pip:
+        packages: [importlib-resources]
 python3-influxdb-client-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5997,7 +5997,7 @@ python3-importlib-resources:
     '*': ['python%{python3_pkgversion}-importlib-resources']
     '7': null
   ubuntu:
-    '*': [libpython3.8-minimal]
+    '*': [python3-minimal]
     bionic:
       pip:
         packages: [importlib-resources]


### PR DESCRIPTION
The `importlib_resources` package is a backport of the `importlib.resources` package from Python 3.7. This is similar to how `importlib_metadata` is a backport of `importlib.metadata` from Python 3.8.

Platforms which package Python >= 3.8 may not package the `importlib_resources` package any more, as the functionality is built in to python. When this is the case, I listed the core Python package that should provide the dependency.