### PR TITLE
turtlebot3_simulations: 1.3.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12736,7 +12736,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
-      version: 1.2.0-0
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `1.3.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.0-0`

## turtlebot3_fake

```
* fix init() in turtlebot3_drive.cpp
* Apply low poly models
* Noetic release
* Contributors: Sean Yen, Will Son
```

## turtlebot3_gazebo

```
* fix init() in turtlebot3_drive.cpp
* Apply low poly models
* Noetic release
* Contributors: Sean Yen, Will Son
```

## turtlebot3_simulations

```
* fix init() in turtlebot3_drive.cpp
* Apply low poly models
* Noetic release
* Contributors: Sean Yen, Will Son
```
