### PR TITLE
turtlebot3_simulations: 1.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6832,6 +6832,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
       version: noetic-devel
     status: developed
+  turtlebot3_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: noetic-devel
+    release:
+      packages:
+      - turtlebot3_fake
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: noetic-devel
+    status: developed
   tuw_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `1.3.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## turtlebot3_fake

```
* fix init() in turtlebot3_drive.cpp
* Apply low poly models
* Noetic release
* Contributors: Sean Yen, Will Son
```

## turtlebot3_gazebo

```
* fix init() in turtlebot3_drive.cpp
* Apply low poly models
* Noetic release
* Contributors: Sean Yen, Will Son
```

## turtlebot3_simulations

```
* fix init() in turtlebot3_drive.cpp
* Apply low poly models
* Noetic release
* Contributors: Sean Yen, Will Son
```
