### PR TITLE
turtlebot3_simulations: 2.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3702,12 +3702,13 @@ repositories:
       version: dashing-devel
     release:
       packages:
+      - turtlebot3_fake_node
       - turtlebot3_gazebo
       - turtlebot3_simulations
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
-      version: 2.0.1-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `2.2.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.1-1`

## turtlebot3_fake_node

```
* Eloquent Elusor EOL
* Ament lint applied
* Contributors: ashe Kim, Will Son
```

## turtlebot3_gazebo

```
* Eloquent Elusor EOL
* Add missing imu joint in sdf
* Append Gazebo model path
* Portable fix, launch description revise
* Ament lint applied
* Contributors: minwoominwoominwoo7, Rayman, seanyen, ashe kim, Will Son
```

## turtlebot3_simulations

```
* Eloquent Elusor EOL
* Add missing imu joint in sdf
* Append Gazebo model path
* Portable fix, launch description revise
* Ament lint applied
* Contributors: minwoominwoominwoo7, Rayman, seanyen, ashe kim, Will Son
```
