### PR TITLE
turtlebot3: 1.2.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6811,7 +6811,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `1.2.5-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ROBOTIS-GIT-release/turtlebot3-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.4-1`

## turtlebot3

```
* Python 2/3 compatibility fix
* Rectify IMU update rate to 0 on Gazebo
* Contributors: Sean Yen, PinkDraconian
```

## turtlebot3_bringup

```
* No Changes
```

## turtlebot3_description

```
* Rectify IMU update rate to 0 on Gazebo
* Contributors: PinkDraconian
```

## turtlebot3_example

```
* No Changes
```

## turtlebot3_navigation

```
* No Changes
```

## turtlebot3_slam

```
* No Changes
```

## turtlebot3_teleop

```
* Python 2/3 compatibility fix
* Contributors: Sean Yen
```
