### PR TITLE
laser_geometry: 1.6.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3013,7 +3013,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/laser_geometry-release.git
-      version: 1.6.5-1
+      version: 1.6.6-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.6-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros-gbp/laser_geometry-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.6.5-1`

## laser_geometry

```
* Handle FindEigen3 module's differing definitions, define EIGEN3_INCLUDE_DIRS with EIGEN3_INCLUDE_DIR.
* update maintainers
* Added transformLaserScanToPointCloud() version utilizing fixed frame.
* Contributors: Jonathan Binney, Mabel Zhang, Martin Pecka, Scott K Logan
```
