### PR TITLE
map_transformer: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1604,7 +1604,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/osrf/map_transformer.git
-      version: 1.0.0
+      version: foxy
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -1613,7 +1613,7 @@ repositories:
     source:
       type: git
       url: https://github.com/osrf/map_transformer.git
-      version: 1.0.0
+      version: foxy
     status: developed
   mapviz:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1600,6 +1600,21 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: foxy
     status: maintained
+  map_transformer:
+    doc:
+      type: git
+      url: https://github.com/osrf/map_transformer.git
+      version: 1.0.0
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros-gbp/map_transformer-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/osrf/map_transformer.git
+      version: 1.0.0
+    status: developed
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `map_transformer` to `1.0.0-1`:

- upstream repository: https://github.com/osrf/map_transformer.git
- release repository: https://github.com/ros-gbp/map_transformer-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
