### PR TITLE
mcl_3dl: 0.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3380,7 +3380,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.5.2-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.1-1`

## mcl_3dl

```
* Fix potential "Time is out of dual 32-bit range" error (#367 <https://github.com/at-wat/mcl_3dl/issues/367>)
* Update assets to v0.1.4 (#365 <https://github.com/at-wat/mcl_3dl/issues/365>)
* Improve test stability (#363 <https://github.com/at-wat/mcl_3dl/issues/363>)
* Update assets to v0.1.3 (#362 <https://github.com/at-wat/mcl_3dl/issues/362>)
* Update assets to v0.1.2 (#361 <https://github.com/at-wat/mcl_3dl/issues/361>)
* Migrate to GitHub Actions (#357 <https://github.com/at-wat/mcl_3dl/issues/357>)
* Update assets to v0.0.10 (#356 <https://github.com/at-wat/mcl_3dl/issues/356>)
* Contributors: Atsushi Watanabe
```
