### PR TITLE
hector_slam: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2359,7 +2359,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_slam` to `0.5.1-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.0-1`

## hector_compressed_map_transport

- No changes

## hector_geotiff

```
* Fixed "SEVERE WARNING" by pluginloader when killing geotiff node.
  Some minor cleanup.
* Contributors: Stefan Fabian
```

## hector_geotiff_launch

- No changes

## hector_geotiff_plugins

```
* Fixed "SEVERE WARNING" by pluginloader when killing geotiff node.
  Some minor cleanup.
* Contributors: Stefan Fabian
```

## hector_imu_attitude_to_tf

- No changes

## hector_imu_tools

- No changes

## hector_map_server

- No changes

## hector_map_tools

- No changes

## hector_mapping

- No changes

## hector_marker_drawing

- No changes

## hector_nav_msgs

- No changes

## hector_slam

```
* Added hector_geotiff_launch to hector_slam metapackge.
* Contributors: Stefan Fabian
```

## hector_slam_launch

```
* Updated paths to launch files.
* Contributors: Stefan Fabian
```

## hector_trajectory_server

- No changes
