### PR TITLE
rc_reason_clients: 0.2.1-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2177,7 +2177,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/roboception-gbp/rc_reason_clients-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.2.1-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros2.git
- release repository: https://github.com/roboception-gbp/rc_reason_clients-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.0-1`

## rc_reason_clients

```
* cmake: detect if it is shallow clone on buildfarm and use version from package.xml
```

## rc_reason_msgs

```
* fix package dependencies for ROS buildfarm
```
