### PR TITLE
ueye_cam: 1.0.19-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7003,7 +7003,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.18-2
+      version: 1.0.19-1
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ueye_cam` to `1.0.19-1`:

- upstream repository: https://github.com/anqixu/ueye_cam.git
- release repository: https://github.com/anqixu/ueye_cam-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.18-2`

## ueye_cam

```
* updated MD5 hash for re-packaged unofficiall IDS drivers archives
* Contributors: Anqi Xu
```
