### PR TITLE
fkie_multimaster: 1.2.6-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1830,7 +1830,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 1.2.5-2
+      version: 1.2.6-2
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_multimaster` to `1.2.6-2`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.5-2`

## fkie_master_discovery

```
* fixed "RuntimeError: dictionary changed size during iteration", issue #150 <https://github.com/fkie/multimaster_fkie/issues/150>
* replaced Thread.isAlive() by .is_alive() according to issue #149 <https://github.com/fkie/multimaster_fkie/issues/149>
* Contributors: Alexander Tiderko
```

## fkie_master_sync

```
* replaced Thread.isAlive() by .is_alive() according to issue #149 <https://github.com/fkie/multimaster_fkie/issues/149>
* Contributors: Alexander Tiderko
```

## fkie_multimaster

```
* fixed "RuntimeError: dictionary changed size during iteration", issue #150 <https://github.com/fkie/multimaster_fkie/issues/150>
* replaced Thread.isAlive() by .is_alive() according to issue #149 <https://github.com/fkie/multimaster_fkie/issues/149>
* added imports to generated grpc init
* replace escape sequences in service responses
* Contributors: Alexander Tiderko
```

## fkie_multimaster_msgs

```
* added imports to generated grpc init
* Contributors: Alexander Tiderko
```

## fkie_node_manager

```
* replace escape sequences in service responses
* Contributors: Alexander Tiderko
```

## fkie_node_manager_daemon

- No changes
