### PR TITLE
nmea_navsat_driver: 0.6.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4028,7 +4028,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
-      version: 0.6.0-1
+      version: 0.6.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_navsat_driver` to `0.6.1-2`:

- upstream repository: https://github.com/ros-drivers/nmea_navsat_driver.git
- release repository: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.6.0-1`

## nmea_navsat_driver

```
* Decode lines from the UDP server before passing them to the driver (#122 <https://github.com/evenator/nmea_navsat_driver/issues/122>)
* Fix #115 <https://github.com/evenator/nmea_navsat_driver/issues/115> Decoding errors. (#116 <https://github.com/evenator/nmea_navsat_driver/issues/116>)
* Fix UTC time parsing #105 <https://github.com/evenator/nmea_navsat_driver/issues/105> (#106 <https://github.com/evenator/nmea_navsat_driver/issues/106>)
* Fix lint in doc config python (#117 <https://github.com/evenator/nmea_navsat_driver/issues/117>)
* Contributors: Ed Venator
```
