### PR TITLE
cob_android: 0.1.9-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1637,7 +1637,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_android-release.git
-      version: 0.1.8-1
+      version: 0.1.9-1
     source:
       type: git
       url: https://github.com/ipa320/cob_android.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_android` to `0.1.9-1`:

- upstream repository: https://github.com/ipa320/cob_android.git
- release repository: https://github.com/ipa320/cob_android-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.8-1`

## cob_android

- No changes

## cob_android_msgs

- No changes

## cob_android_resource_server

- No changes

## cob_android_script_server

```
* Merge pull request #42 <https://github.com/ipa320/cob_android/issues/42> from fmessmer/fix_noetic
  use catkin_install_python
* use catkin_install_python
* Contributors: Felix Messmer, fmessmer
```

## cob_android_settings

- No changes
