### PR TITLE
octomap_rviz_plugins: 0.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4171,6 +4171,21 @@ repositories:
       url: https://github.com/OctoMap/octomap_ros.git
       version: melodic-devel
     status: unmaintained
+  octomap_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
+      version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: kinetic-devel
+    status: maintained
   odva_ethernetip:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `0.2.3-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros-gbp/octomap_rviz_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## octomap_rviz_plugins

```
* Build plugin-lib as module (#36 <https://github.com/OctoMap/octomap_rviz_plugins/issues/36>)
* Add GitHub Actions CI, address warnings for ROS Noetic (#39 <https://github.com/OctoMap/octomap_rviz_plugins/issues/39>)
* Contributors: Sebastian Kasperski, Wolfgang Merkt
```
