### PR TITLE
cnpy: 0.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -559,7 +559,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PeterMitrano/cnpy-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/PeterMitrano/cnpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cnpy` to `0.0.6-1`:

- upstream repository: https://github.com/PeterMitrano/cnpy.git
- release repository: https://github.com/PeterMitrano/cnpy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.5-1`
