### PR TITLE
[rosdep] python3-dbus

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5691,6 +5691,10 @@ python3-datadog-pip:
   ubuntu:
     pip:
       packages: [datadog]
+python3-dbus:
+  debian: [python3-dbus]
+  fedora: [python3-dbus]
+  ubuntu: [python3-dbus]
 python3-defusedxml:
   debian: [python3-defusedxml]
   fedora: [python3-defusedxml]


### PR DESCRIPTION
Debian: https://packages.debian.org/search?keywords=python3-dbus
Fedora: https://fedora.pkgs.org/32/fedora-x86_64/python3-dbus-1.2.16-1.fc32.x86_64.rpm.html
Ubuntu: https://packages.ubuntu.com/search?keywords=python3-dbus