### PR TITLE
rc_genicam_driver: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2473,6 +2473,22 @@ repositories:
       url: https://github.com/roboception/rc_genicam_api.git
       version: master
     status: developed
+  rc_genicam_driver:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_driver_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_driver_ros2.git
+      version: master
+    status: developed
   rcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.1.1-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rc_genicam_driver

```
* fix type in package xml
```
