### PR TITLE
Add moving_average

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6414,6 +6414,12 @@ repositories:
       url: https://github.com/peci1/movie_publisher.git
       version: melodic-devel
     status: developed
+  moving_average:
+    doc:
+      type: git
+      url: https://gitlab.com/InstitutMaupertuis/moving_average.git
+      version: melodic
+    status: maintained
   mpc_local_planner:
     doc:
       type: git


### PR DESCRIPTION
Compute and publish moving average values of ROS topic values.

I don't intend to release this package, I just want it to be indexed.