### PR TITLE
rviz_satellite: 3.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11591,6 +11591,21 @@ repositories:
       url: https://github.com/ros-visualization/rviz.git
       version: melodic-devel
     status: maintained
+  rviz_satellite:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/nobleo/rviz_satellite-release.git
+      version: 3.0.3-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: master
+    status: maintained
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `3.0.3-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rviz_satellite

```
* Pragmatic URI check
* Enable catkin_lint in CI
* Enable ros industrial CI
* Update maintainer info
```
