### PR TITLE
Add RHEL rules for java and maven

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1690,6 +1690,7 @@ java:
   fedora: [java]
   freebsd: [openjdk6]
   gentoo: [virtual/jdk]
+  rhel: [java]
   ubuntu: [default-jdk]
 joystick:
   arch: [linuxconsole]
@@ -4976,6 +4977,7 @@ maven:
   debian: [maven]
   fedora: [maven]
   gentoo: [dev-java/maven-bin]
+  rhel: [maven]
   ubuntu: [maven]
 mayavi:
   debian: [mayavi2]


### PR DESCRIPTION
In RHEL 7, these packages are provided in the `base` repository:
* java: https://mirrors.edge.kernel.org/centos/7/os/x86_64/Packages/java-1.8.0-openjdk-1.8.0.262.b10-1.el7.x86_64.rpm
* maven: https://mirrors.edge.kernel.org/centos/7/os/x86_64/Packages/maven-3.0.5-17.el7.noarch.rpm

In RHEL 8, these packages are provided in the `appstream` repository:
* java: https://mirrors.edge.kernel.org/centos/8/AppStream/x86_64/os/Packages/java-1.8.0-openjdk-1.8.0.275.b01-1.el8_3.x86_64.rpm
* maven: https://mirrors.edge.kernel.org/centos/8/AppStream/x86_64/os/Packages/maven-3.6.2-5.module_el8.3.0%2B397%2Bdd71f484.noarch.rpm

Like the `java` rule for Fedora, instead of listing the name of a java package, the rule targets the virtual package named `java` which is provided by the system's default java runtime package:
```
$ yum provides java -q
1:java-1.8.0-openjdk-1.8.0.262.b10-1.el7.x86_64 : OpenJDK Runtime Environment 8
Repo        : base
Matched from:
Provides    : java = 1:1.8.0
```
```
$ dnf provides java -q
java-1.8.0-openjdk-1:1.8.0.275.b01-1.el8_3.x86_64 : OpenJDK Runtime Environment 8
Repo        : appstream
Matched from:
Provide    : java = 1:1.8.0
```