### PR TITLE
Add RHEL 7 rule for sdformat

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5906,6 +5906,8 @@ sdformat:
   debian: [libsdformat-dev]
   fedora: [sdformat-devel]
   gentoo: [dev-libs/sdformat]
+  rhel:
+    '7': [sdformat-devel]
   ubuntu:
     artful: [libsdformat6-dev]
     bionic: [libsdformat6-dev]


### PR DESCRIPTION
The sdformat package is part of the EPEL repository for RHEL 7: https://src.fedoraproject.org/rpms/sdformat#bodhi_updates

It is not currently built for RHEL 8.