### PR TITLE
async_comm: 0.2.1-3 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -711,7 +711,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/dpkoch/async_comm-release.git
-      version: 0.2.0-1
+      version: 0.2.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_comm` to `0.2.1-3`:

- upstream repository: https://github.com/dpkoch/async_comm.git
- release repository: https://github.com/dpkoch/async_comm-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.0-1`

## async_comm

```
* Add noetic to ROS prerelease test distribution list
* Fixes for compatibility with ROS2 workspaces:
  
    * cmake: Change install paths to basic lib/ and include/
    * package.xml: Remove unneeded catkin dependency
  
* Updated CMake examples in README
* Contributors: Daniel Koch, Maciej Bogusz
```
