### PR TITLE
async_comm: 0.2.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -155,6 +155,22 @@ repositories:
       url: https://github.com/astuff/astuff_sensor_msgs.git
       version: master
     status: maintained
+  async_comm:
+    doc:
+      type: git
+      url: https://github.com/dpkoch/async_comm.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/dpkoch/async_comm-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/dpkoch/async_comm.git
+      version: master
+    status: developed
   async_web_server_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_comm` to `0.2.1-1`:

- upstream repository: https://github.com/dpkoch/async_comm.git
- release repository: https://github.com/dpkoch/async_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## async_comm

```
* Add noetic to ROS prerelease test distribution list
* Fixes for compatibility with ROS2 workspaces:
  
    * cmake: Change install paths to basic lib/ and include/
    * package.xml: Remove unneeded catkin dependency
  
* Updated CMake examples in README
* Contributors: Daniel Koch, Maciej Bogusz
```
