### PR TITLE
rosdep: add python3-bitarray

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5516,6 +5516,11 @@ python3-backoff-pip:
   ubuntu:
     pip:
       packages: [backoff]
+python3-bitarray:
+  debian: [python3-bitarray]
+  fedora: [python3-bitarray]
+  gentoo: [dev-python/bitarray]
+  ubuntu: [python3-bitarray]
 python3-bokeh-pip:
   debian:
     pip:


### PR DESCRIPTION
This is the python3 version of the already existing `python-bitarray` key:

- Debian: https://packages.debian.org/search?keywords=python3-bitarray
- Fedora: https://fedora.pkgs.org/33/fedora-x86_64/python3-bitarray-1.2.2-2.fc33.x86_64.rpm.html
- Gentoo: https://packages.gentoo.org/packages/dev-python/bitarray
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-bitarray&searchon=names