### PR TITLE
ros2_control: 0.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2984,10 +2984,11 @@ repositories:
       - ros2_control
       - ros2controlcli
       - test_robot_hardware
+      - transmission_interface
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.1.3-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## controller_interface

- No changes

## controller_manager

```
* Fix building on macOS with clang (#292 <https://github.com/ros-controls/ros2_control/issues/292>)
ail.com>
* Contributors: Karsten Knese
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## ros2_control

- No changes

## ros2controlcli

- No changes

## test_robot_hardware

- No changes

## transmission_interface

```
* Remove parser from install until reworked (#301 <https://github.com/ros-controls/ros2_control/issues/301>)
* Fix building on macOS with clang (#292 <https://github.com/ros-controls/ros2_control/issues/292>)
* Add simple transmission class (#245 <https://github.com/ros-controls/ros2_control/issues/245>)
* Contributors: Bence Magyar, Karsten Knese
```
