### PR TITLE
update rosdep python-construct

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1102,8 +1102,12 @@ python-configparser:
   gentoo: [dev-python/configparser]
   ubuntu: [python-configparser]
 python-construct:
+  arch: [python-construct]
   debian: [python-construct]
-  ubuntu: [python-construct]
+  gentoo: [dev-python/construct]
+  ubuntu:
+    bionic: [python-construct]
+    xenial: [python-construct]
 python-construct-pip:
   debian:
     pip:
@@ -5699,6 +5703,11 @@ python3-connexion-pip:
   ubuntu:
     pip:
       packages: [connexion]
+python3-construct:
+  arch: [python-construct]
+  debian: [python3-construct]
+  gentoo: [dev-python/construct]
+  ubuntu: [python3-construct]
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5706,6 +5706,7 @@ python3-connexion-pip:
 python3-construct:
   arch: [python-construct]
   debian: [python3-construct]
+  fedora: [python3-construct]
   gentoo: [dev-python/construct]
   ubuntu: [python3-construct]
 python3-coverage:


### PR DESCRIPTION
this PR updates the following:
- `python-construct` is only available for ubuntu xenial and bionic - not for focal
- additional platforms for `python-construct`
- add `python3-construct`


`python-construct`:
- arch: https://archlinux.org/packages/?sort=&q=python-construct&maintainer=&flagged=
- debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python-construct
- gentoo: https://packages.gentoo.org/packages/dev-python/construct
- ubuntu: https://packages.ubuntu.com/search?keywords=python-construct
- couldn't find it for fedora

`python3-construct`:
- arch: https://archlinux.org/packages/?sort=&q=python3-construct&maintainer=&flagged=
- debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-construct
- gentoo: https://packages.gentoo.org/packages/dev-python/construct
- ubuntu: https://packages.ubuntu.com/search?keywords=python3-construct
- couldn't find it for fedora