### PR TITLE
Revert "ueye_cam: 1.0.18-1 in 'melodic/distribution.yaml' [bloom] (#2…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13009,7 +13009,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.18-1
+      version: 1.0.17-1
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
…7934)"

This reverts commit a8a6d5c9ff00d7294448d76262f1502652a1e47f.

This has been failing to build in Melodic since it was merged: https://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ueye_cam__ubuntu_bionic_amd64__binary/

@anqixu FYI