### PR TITLE
Revert "async_comm: 0.2.1-1 in 'melodic/distribution.yaml' [bloom] (#…

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -582,7 +582,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/dpkoch/async_comm-release.git
-      version: 0.2.1-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
…28051)"

This reverts commit 5c9dc11dd980752fae69752d42c1dd4fc139f693.

async_comm is failing to build with this in place: https://build.ros.org/job/Mbin_uB64__async_comm__ubuntu_bionic_amd64__binary/9/console

@dpkoch FYI