### PR TITLE
nmea_comms: 1.2.0-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4004,6 +4004,21 @@ repositories:
       url: https://github.com/nerian-vision/nerian_stereo.git
       version: master
     status: developed
+  nmea_comms:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_comms.git
+      version: jade-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/nmea_comms-release.git
+      version: 1.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_comms.git
+      version: jade-devel
+    status: maintained
   nmea_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_comms` to `1.2.0-3`:

- upstream repository: https://github.com/ros-drivers/nmea_comms.git
- release repository: https://github.com/ros-drivers-gbp/nmea_comms-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## nmea_comms

```
* Fixed boost::thread_resource_error: Resource temporarily unavailable exception that was thrown using netcat to feed socket_node.cpp with NMEA sentences. (#5 <https://github.com/ros-drivers/nmea_comms/issues/5>)
* Contributors: Avio, Mike Purvis
```
