### PR TITLE
Adding twist_stamper to src/doc index for foxy & rolling

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4313,6 +4313,16 @@ repositories:
       url: https://github.com/autowarefoundation/tvm_vendor.git
       version: main
     status: maintained
+  twist_stamper:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    status: maintained
   ublox:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2776,6 +2776,16 @@ repositories:
       url: https://github.com/ros/ros_tutorials.git
       version: galactic-devel
     status: maintained
+  twist_stamper:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    status: maintained
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Hi, I would like to add my package `twist_stamper` to the index for `foxy` and `rolling`.
No binary release yet.