### PR TITLE
add embree to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -795,6 +795,11 @@ emacs:
   gentoo: [virtual/emacs]
   openembedded: [emacs@meta-oe]
   ubuntu: [emacs]
+embree:
+  arch: [embree]
+  debian: [libembree-dev]
+  fedora: [embree]
+  ubuntu: [libembree-dev]
 enblend:
   debian: [enblend]
   fedora: [enblend]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -799,7 +799,10 @@ embree:
   arch: [embree]
   debian: [libembree-dev]
   fedora: [embree]
-  ubuntu: [libembree-dev]
+  ubuntu:
+    '*': [libembree-dev]
+    bionic: null
+    xenial: null
 enblend:
   debian: [enblend]
   fedora: [enblend]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -797,7 +797,8 @@ emacs:
   ubuntu: [emacs]
 embree:
   arch: [embree]
-  debian: [libembree-dev]
+  debian:
+    bullseye: [libembree-dev]
   fedora: [embree]
   ubuntu:
     '*': [libembree-dev]


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

I want to add embree ray tracing kernels to the rosdep.

```
Arch : https://archlinux.org/packages/community/x86_64/embree/
Debian : https://packages.debian.org/bullseye/libembree-dev
Fedora : https://src.fedoraproject.org/rpms/embree
Ubuntu : https://launchpad.net/ubuntu/+source/embree
```