### PR TITLE
fkie_multimaster: 1.2.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1830,7 +1830,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fkie-release/multimaster_fkie-release.git
-      version: 1.2.6-2
+      version: 1.2.7-1
     source:
       type: git
       url: https://github.com/fkie/multimaster_fkie.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_multimaster` to `1.2.7-1`:

- upstream repository: http://github.com/fkie/multimaster_fkie.git
- release repository: https://github.com/fkie-release/multimaster_fkie-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.6-2`

## fkie_master_discovery

- No changes

## fkie_master_sync

- No changes

## fkie_multimaster

```
* Fix install location for generated gRPC submodule
* Revert "added imports to generated grpc init"
  This reverts commit 571dd90701b4c48dcd9b5627827f7adc0ce02589.
* Contributors: Alexander Tiderko, Timo Röhling
```

## fkie_multimaster_msgs

```
* Fix install location for generated gRPC submodule
* Revert "added imports to generated grpc init"
  This reverts commit 571dd90701b4c48dcd9b5627827f7adc0ce02589.
* Contributors: Alexander Tiderko, Timo Röhling
```

## fkie_node_manager

- No changes

## fkie_node_manager_daemon

- No changes
