### PR TITLE
add python-mechanize-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2496,6 +2496,19 @@ python-mechanize:
   fedora: [python-mechanize]
   gentoo: [dev-python/mechanize]
   ubuntu: [python-mechanize]
+python-mechanize-pip:
+  debian:
+    pip:
+      packages: [mechanize]
+  fedora:
+    pip:
+      packages: [mechanize]
+  gentoo:
+    pip:
+      packages: [mechanize]
+  ubuntu:
+    pip:
+      packages: [mechanize]
 python-mock:
   alpine: [py-mock]
   arch: [python2-mock]


### PR DESCRIPTION
this adds a rosdep key for the pip version of `mechanize` (https://pypi.org/project/mechanize/)

officital `python-mechanize`/`python3-mechanize` are already available, but `python3-mechanize` is not available for `debian:buster` and thus results in problematic release of e.g. https://github.com/ipa320/cob_command_tools
(read more about it in https://github.com/ipa320/cob_command_tools/issues/289