### PR TITLE
lms1xx: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3181,6 +3181,21 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  lms1xx:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: noetic-deve;
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/clearpath-gbp/lms1xx-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/lms1xx.git
+      version: noetic-devel
+    status: maintained
   log_view:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lms1xx` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/LMS1xx.git
- release repository: https://github.com/clearpath-gbp/lms1xx-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## lms1xx

```
* Changed shebang to python3.
* Fixed typo in find_sick script.
* Update the python scripts so they'll work with python3
* Switched to industrial_ci for TravisCI.
* Contributors: Chris I-B, Tony Baltovski
```
