### PR TITLE
cob_command_tools: 0.6.20-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1679,7 +1679,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_command_tools-release.git
-      version: 0.6.19-1
+      version: 0.6.20-1
     source:
       type: git
       url: https://github.com/ipa320/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.20-1`:

- upstream repository: https://github.com/ipa320/cob_command_tools.git
- release repository: https://github.com/ipa320/cob_command_tools-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.19-1`

## cob_command_gui

```
* Merge pull request #291 <https://github.com/ipa320/cob_command_tools/issues/291> from fmessmer/fix_python3
  fix python3
* use keys vs iterkeys for python3-compatibility
* Contributors: Felix Messmer, fmessmer
```

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_interactive_teleop

- No changes

## cob_monitoring

```
* Merge pull request #295 <https://github.com/ipa320/cob_command_tools/issues/295> from fmessmer/cob_monitoring_comment_dependency_python-mechanize
  commenting dependency python3-mechanize
* commenting dependency python3-mechanize
* Contributors: Felix Messmer, fmessmer
```

## cob_script_server

```
* Merge pull request #291 <https://github.com/ipa320/cob_command_tools/issues/291> from fmessmer/fix_python3
  fix python3
* import itertools.izip as zip for python3-compatibility
* Contributors: Felix Messmer, fmessmer
```

## cob_teleop

- No changes

## generic_throttle

```
* Merge pull request #294 <https://github.com/ipa320/cob_command_tools/issues/294> from fmessmer/fix_python3
  fix python3
* fix python3
* Merge pull request #291 <https://github.com/ipa320/cob_command_tools/issues/291> from fmessmer/fix_python3
  fix python3
* Merge pull request #3 <https://github.com/ipa320/cob_command_tools/issues/3> from LoyVanBeek/fix_python3
  Get first key and value compatible with both Python 2 & 3
* Get first key and value compatible with both Python 2 & 3
* Contributors: Felix Messmer, Loy van Beek, fmessmer
```

## scenario_test_tools

- No changes

## service_tools

- No changes
