### PR TITLE
ament_package: 0.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -150,7 +150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.10.1-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.10.0-1`

## ament_package

```
* Support Python 3.8-provided importlib.metadata (#124 <https://github.com/ament/ament_package/issues/124>)
* Declare missing dependency on python3-importlib-resources (#123 <https://github.com/ament/ament_package/issues/123>)
* Contributors: Scott K Logan
```
