### PR TITLE
osrf_pycommon: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1223,7 +1223,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `0.2.1-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.0-1`

## osrf_pycommon

```
* Fix osrf.py_common.process_utils.get_loop() implementation (#70 <https://github.com/osrf/osrf_pycommon/issues/70>)
* Contributors: Michel Hidalgo
```
