### PR TITLE
rmw_cyclonedds: 0.18.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1695,7 +1695,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 0.18.3-1
+      version: 0.18.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `0.18.4-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.18.3-1`

## rmw_cyclonedds_cpp

```
* Fix use-after-free in error handling bug
* Drop compatibility with ancient cyclone versions
* Update to use Cyclone's renamed ddsi_sertype
* Use init-on-first-use for global state (#275 <https://github.com/ros2/rmw_cyclonedds/issues/275>)
* Make sure to reset the error when a typesupport can't be found.
* Switch to using the generic functions for the typesupport handles.
* Handle typesupport errors on fetch. (#271 <https://github.com/ros2/rmw_cyclonedds/issues/271>)
* Handle potential divide by 0 (#267 <https://github.com/ros2/rmw_cyclonedds/issues/267>)
* Fix incorrect log message(rmw_fastrtps_shared_cpp -> rmw_cylonedds_cpp) (#260 <https://github.com/ros2/rmw_cyclonedds/issues/260>)
* Update maintainers (#254 <https://github.com/ros2/rmw_cyclonedds/issues/254>)
* Change wrong use of %ld to print std::size_t to %zu
* Contributors: Chris Lalancette, Erik Boasson, Ivan Santiago Paunovic, Michel Hidalgo, Stephen Brawner, Sven Brinkmann, eboasson, pluris
```
