### PR TITLE
robot_state_publisher: 2.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1781,7 +1781,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `2.4.2-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.4.1-1`

## robot_state_publisher

```
* clean up license to be standard bsd 3 clause (#130 <https://github.com/ros/robot_state_publisher/issues/130>)
* Update the maintainers. (#151 <https://github.com/ros/robot_state_publisher/issues/151>)
* Contributors: Chris Lalancette, Tully Foote
```
