### PR TITLE
python_qt_binding: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1374,7 +1374,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.5-2
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.6-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.5-2`

## python_qt_binding

```
* Update maintainers (#96 <https://github.com/ros-visualization/python_qt_binding/issues/96>) (#98 <https://github.com/ros-visualization/python_qt_binding/issues/98>)
* Add pytest.ini so local tests don't display warning (#93 <https://github.com/ros-visualization/python_qt_binding/issues/93>)
* Contributors: Chris Lalancette, Shane Loretz
```
