### PR TITLE
rviz: 8.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2517,7 +2517,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.3.0-1
+      version: 8.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.3.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `8.3.0-1`

## rviz2

```
* Use "%s" as format string literal in logging macros (#633 <https://github.com/ros2/rviz/issues/633>)
* Contributors: Audrow Nash
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Check that the views_man_ and views_man_->getCurrent() are not nullptr. (#634 <https://github.com/ros2/rviz/issues/634>)
* Contributors: Chris Lalancette
```

## rviz_default_plugins

```
* Fix possible nullptr access in robot_joint.cpp. (#636 <https://github.com/ros2/rviz/issues/636>)
* Contributors: Chris Lalancette
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Revert "Support loading meshes other than .mesh and .stl with package URIs (#610 <https://github.com/ros2/rviz/issues/610>)" (#638 <https://github.com/ros2/rviz/issues/638>)
* Contributors: Shane Loretz
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
