### PR TITLE
rosidl_typesupport: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2107,7 +2107,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.1.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-2`

## rosidl_typesupport_c

```
* Typo typesupport_identidentifier (#103 <https://github.com/ros2/rosidl_typesupport/issues/103>)
* Remove type_support_dispatch.cpp files. (#101 <https://github.com/ros2/rosidl_typesupport/issues/101>)
* Defer path resolution of rosidl typesupport libraries to dynamic linker. (#98 <https://github.com/ros2/rosidl_typesupport/issues/98>)
* Ensure typesupport handle functions do not throw. (#99 <https://github.com/ros2/rosidl_typesupport/issues/99>)
* Contributors: Chris Lalancette, Michel Hidalgo, Shane Loretz
```

## rosidl_typesupport_cpp

```
* Remove type_support_dispatch.cpp files. (#101 <https://github.com/ros2/rosidl_typesupport/issues/101>)
* Defer path resolution of rosidl typesupport libraries to dynamic linker. (#98 <https://github.com/ros2/rosidl_typesupport/issues/98>)
* Ensure typesupport handle functions do not throw. (#99 <https://github.com/ros2/rosidl_typesupport/issues/99>)
* Contributors: Chris Lalancette, Michel Hidalgo
```
