### PR TITLE
rcutils: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1601,7 +1601,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.0-1`

## rcutils

```
* Add an API for directory iteration (#323 <https://github.com/ros2/rcutils/issues/323>)
* Fix a leak during error handling in dir size calculation (#324 <https://github.com/ros2/rcutils/issues/324>)
* Fix rcutils_shared_library_t path on Windows. (#322 <https://github.com/ros2/rcutils/issues/322>)
* Check linker flags instead of assuming compiler correlation. (#321 <https://github.com/ros2/rcutils/issues/321>)
* Improve shared library relative paths handling (#320 <https://github.com/ros2/rcutils/issues/320>)
* Contributors: Michel Hidalgo, Scott K Logan
```
