### PR TITLE
launch_ros: 0.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -994,7 +994,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.12.0-1
+      version: 0.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.13.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.12.0-1`

## launch_ros

```
* Make sure ParameterFile __del__ works without exception. (#212 <https://github.com/ros2/launch_ros/issues/212>)
* Contributors: Chris Lalancette
```

## launch_testing_ros

- No changes

## ros2launch

```
* Support non-interactive ros2 launch executions (#210 <https://github.com/ros2/launch_ros/issues/210>)
* Contributors: Michel Hidalgo
```
