### PR TITLE
rcpputils: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1585,7 +1585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.0.4-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.3-1`

## rcpputils

```
* Add stream operator for paths to make it easier to log (#120 <https://github.com/ros2/rcpputils/issues/120>)
* Path join operator is const (#119 <https://github.com/ros2/rcpputils/issues/119>)
* No windows.h in header files (#118 <https://github.com/ros2/rcpputils/issues/118>)
* Fix rcpputils::SharedLibrary tests. (#117 <https://github.com/ros2/rcpputils/issues/117>)
* Contributors: Emerson Knapp, Ivan Santiago Paunovic, Michel Hidalgo
```
