### PR TITLE
demos: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -426,7 +426,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.11.0-1
+      version: 0.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.11.0-1`

## action_tutorials_cpp

```
* Update logging macros (#476 <https://github.com/ros2/demos/issues/476>)
* Contributors: Audrow Nash
```

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

```
* Fix leak(#480 <https://github.com/ros2/demos/issues/480>) (#481 <https://github.com/ros2/demos/issues/481>)
* Contributors: y-okumura-isp
```

## demo_nodes_cpp

```
* Update logging macros (#476 <https://github.com/ros2/demos/issues/476>)
* Contributors: Audrow Nash
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## logging_demo

```
* Update logging macros (#476 <https://github.com/ros2/demos/issues/476>)
* Contributors: Audrow Nash
```

## pendulum_control

```
* Remove ineffective log output (#450 <https://github.com/ros2/demos/issues/450>) (#477 <https://github.com/ros2/demos/issues/477>)
* Contributors: y-okumura-isp
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Add demo of how to use qos overrides (#474 <https://github.com/ros2/demos/issues/474>)
* Contributors: Ivan Santiago Paunovic
```

## quality_of_service_demo_py

```
* QoS overrides demo in python (#479 <https://github.com/ros2/demos/issues/479>)
* Contributors: Ivan Santiago Paunovic
```

## topic_monitor

- No changes

## topic_statistics_demo

```
* Update logging macros (#476 <https://github.com/ros2/demos/issues/476>)
* Contributors: Audrow Nash
```
