### PR TITLE
launch: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -974,7 +974,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.14.0-1
+      version: 0.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.15.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.14.0-1`

## launch

```
* Support Python 3.8-provided importlib.metadata (#482 <https://github.com/ros2/launch/issues/482>)
* Workaround asyncio signal handling on Unix (#479 <https://github.com/ros2/launch/issues/479>)
* Handle signals within the asyncio loop. (#476 <https://github.com/ros2/launch/issues/476>)
* Support non-interactive launch.LaunchService runs (#475 <https://github.com/ros2/launch/issues/475>)
* Contributors: Michel Hidalgo, Scott K Logan
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
