### PR TITLE
cartographer_ros: 1.0.9003-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -397,7 +397,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 1.0.9002-1
+      version: 1.0.9003-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.9003-1`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.9002-1`

## cartographer_ros

```
* Switch to using a C-style string for RCLCPP macros.
* Cleanup the CMakeLists.txt.
* Contributors: Chris Lalancette
```

## cartographer_ros_msgs

- No changes
