### PR TITLE
mimick_vendor: 0.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1123,7 +1123,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.2.4-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.3-1`

## mimick_vendor

```
* Add missing build tool dependency on 'git' (#16 <https://github.com/ros2/mimick_vendor/issues/16>)
* Update tag for armv7l support. (#15 <https://github.com/ros2/mimick_vendor/issues/15>)
* Contributors: Michel Hidalgo, Scott K Logan
```
