### PR TITLE
libyaml_vendor: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1038,7 +1038,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.0.2-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.2-2`

## libyaml_vendor

```
* Fix target_link_directories/link_directories in cmake (#29 <https://github.com/ros2/libyaml_vendor/issues/29>)
* Included benchmark tests (#20 <https://github.com/ros2/libyaml_vendor/issues/20>)
* Update Quality Declaration (#23 <https://github.com/ros2/libyaml_vendor/issues/23>)
* Update package maintainers. (#22 <https://github.com/ros2/libyaml_vendor/issues/22>)
* Bump QD to 3 and some minor style fixes (#19 <https://github.com/ros2/libyaml_vendor/issues/19>)
* Add Security Vulnerability Policy pointing to REP-2006. (#18 <https://github.com/ros2/libyaml_vendor/issues/18>)
* Add quality declaration libyaml_vendor (#12 <https://github.com/ros2/libyaml_vendor/issues/12>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jorge Perez, Michel Hidalgo
```
