### PR TITLE
libyaml_vendor: 1.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1592,7 +1592,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.0.3-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.2-1`

## libyaml_vendor

```
* Foxy QD point to Foxy benchmark tests (#26 <https://github.com/ros2/libyaml_vendor/issues/26>)
* Update QD (#25 <https://github.com/ros2/libyaml_vendor/issues/25>)
* Included benchmark tests (#24 <https://github.com/ros2/libyaml_vendor/issues/24>)
* Add Security Vulnerability Policy pointing to REP-2006. (#18 <https://github.com/ros2/libyaml_vendor/issues/18>)
* Add quality declaration libyaml_vendor (#12 <https://github.com/ros2/libyaml_vendor/issues/12>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Jorge Perez, Louise Poubel
```
