### PR TITLE
rclpy: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1569,7 +1569,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.5.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.4.0-1`

## rclpy

```
* Fix dead stores. (#669 <https://github.com/ros2/rclpy/issues/669>)
* Fix two clang static analysis warnings. (#664 <https://github.com/ros2/rclpy/issues/664>)
* Add method to get the current logging directory (#657 <https://github.com/ros2/rclpy/issues/657>)
* Fix docstring indent error in create_node (#655 <https://github.com/ros2/rclpy/issues/655>)
* use only True to avoid confusion in autodoc config
* document QoS profile constants
* Merge pull request #649 <https://github.com/ros2/rclpy/issues/649> from ros2/clalancette/dont-except-while-sleep
* Fixes from review/CI.
* Make sure to catch the ROSInterruptException when calling rate.sleep.
* memory leak (#643 <https://github.com/ros2/rclpy/issues/643>) (#645 <https://github.com/ros2/rclpy/issues/645>)
* Don't throw an exception if timer canceled while sleeping.
* Wake executor in Node.create_subscription() (#647 <https://github.com/ros2/rclpy/issues/647>)
* Contributors: Chris Lalancette, Gökçe Aydos, Ivan Santiago Paunovic, Jacob Perron, Tully Foote, ssumoo, tomoya
```
