### PR TITLE
ros1_bridge: 0.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1797,7 +1797,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros1_bridge` to `0.10.1-1`:

- upstream repository: https://github.com/ros2/ros1_bridge.git
- release repository: https://github.com/ros2-gbp/ros1_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.10.0-1`

## ros1_bridge

```
* Fix logging for updated rclcpp interface (#303 <https://github.com/ros2/ros1_bridge/issues/303>)
* Fix typo in comments (#297 <https://github.com/ros2/ros1_bridge/issues/297>)
* Contributors: Michael Carroll, Vicidel
```
