### PR TITLE
nodelet_core: 1.10.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4104,7 +4104,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/nodelet_core-release.git
-      version: 1.10.0-1
+      version: 1.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nodelet_core` to `1.10.1-1`:

- upstream repository: https://github.com/ros/nodelet_core.git
- release repository: https://github.com/ros-gbp/nodelet_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.10.0-1`

## nodelet

```
* removed callback queue pause around onInit() (#107 <https://github.com/ros/nodelet_core/issues/107>)
* Contributors: Tomáš Báča
```

## nodelet_core

- No changes

## nodelet_topic_tools

- No changes
