### PR TITLE
map_transformer: 1.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1609,7 +1609,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/map_transformer-release.git
-      version: 1.0.0-4
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/osrf/map_transformer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `map_transformer` to `1.0.1-1`:

- upstream repository: https://github.com/osrf/map_transformer.git
- release repository: https://github.com/ros-gbp/map_transformer-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-4`
