### PR TITLE
Change Heifu branch for documentation and source

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3776,16 +3776,14 @@ repositories:
       - heifu_bringup
       - heifu_description
       - heifu_diagnostic
-      - heifu_interface
       - heifu_mavros
       - heifu_msgs
       - heifu_safety
-      - heifu_scripts_firmware
       - heifu_simple_waypoint
       - heifu_tools
-      - heifu_usb
-      - scripts
-      url: https://heifu:G2SzWMcydduaaXwttrxA@gitlab.pdmfc.com/drones/ros1/heifu.git
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/amferreiraBEV/heifu-release.git
     source:
       type: git
       url: https://heifu:G2SzWMcydduaaXwttrxA@gitlab.pdmfc.com/drones/ros1/heifu.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3766,6 +3766,31 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
       version: melodic-devel
     status: maintained
+  heifu:
+    doc:
+      type: git
+      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
+      version: debian
+    release:
+      packages:
+      - heifu_bringup
+      - heifu_description
+      - heifu_diagnostic
+      - heifu_interface
+      - heifu_mavros
+      - heifu_msgs
+      - heifu_safety
+      - heifu_scripts_firmware
+      - heifu_simple_waypoint
+      - heifu_tools
+      - heifu_usb
+      - scripts
+      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
+    source:
+      type: git
+      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
+      version: debian
+    status: maintained
   hfl_driver:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3769,7 +3769,7 @@ repositories:
   heifu:
     doc:
       type: git
-      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
+      url: https://heifu:G2SzWMcydduaaXwttrxA@gitlab.pdmfc.com/drones/ros1/heifu.git
       version: debian
     release:
       packages:
@@ -3785,10 +3785,10 @@ repositories:
       - heifu_tools
       - heifu_usb
       - scripts
-      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
+      url: https://heifu:G2SzWMcydduaaXwttrxA@gitlab.pdmfc.com/drones/ros1/heifu.git
     source:
       type: git
-      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
+      url: https://heifu:G2SzWMcydduaaXwttrxA@gitlab.pdmfc.com/drones/ros1/heifu.git
       version: debian
     status: maintained
   hfl_driver:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3784,6 +3784,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/amferreiraBEV/heifu-release.git
+      version: 0.7.1-2
     source:
       type: git
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3769,7 +3769,7 @@ repositories:
   heifu:
     doc:
       type: git
-      url: https://heifu:G2SzWMcydduaaXwttrxA@gitlab.pdmfc.com/drones/ros1/heifu.git
+      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
       version: debian
     release:
       packages:
@@ -3786,7 +3786,7 @@ repositories:
       url: https://github.com/amferreiraBEV/heifu-release.git
     source:
       type: git
-      url: https://heifu:G2SzWMcydduaaXwttrxA@gitlab.pdmfc.com/drones/ros1/heifu.git
+      url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
       version: debian
     status: maintained
   hfl_driver:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3950,7 +3950,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
-      version: debian
+      version: releasePackage
     release:
       packages:
       - heifu
@@ -3969,7 +3969,7 @@ repositories:
     source:
       type: git
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git
-      version: debian
+      version: releasePackage
     status: maintained
   heron:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3919,7 +3919,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/amferreiraBEV/heifu-release.git
-      version: 0.7.1-2
+      version: 0.7.2-1
     source:
       type: git
       url: https://gitlab.pdmfc.com/drones/ros1/heifu.git


### PR DESCRIPTION
Is it possible to change this information using the `bloom-release` command?