### PR TITLE
webots_ros: 4.0.0-1 in 'noetic/distribution.yaml' [bloom] 

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7541,7 +7541,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 2.1.1-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git


### PR DESCRIPTION
The packages in the `webots_ros` repository were released into the `noetic` distro by running `/home/lukic/.local/bin/bloom-release --rosdistro noetic --track noetic webots_ros --edit` on `Tue, 26 Jan 2021 17:00:37 -0000`

The `webots_ros` package was released.

Version of package(s) in repository `webots_ros`:

- upstream repository: https://github.com/cyberbotics/webots_ros.git
- release repository: https://github.com/cyberbotics/webots_ros-release.git
- rosdistro version: `2.1.1-1`
- old version: `2.1.1-1`
- new version: `4.0.0-1`

Versions of tools used:

- bloom version: `0.10.0`
- catkin_pkg version: `0.4.23`
- rosdep version: `0.20.0`
- rosdistro version: `0.8.3`
- vcstools version: `0.1.42`