### PR TITLE
laser_proc: 1.0.2-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -952,7 +952,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_proc-release.git
-      version: 1.0.1-2
+      version: 1.0.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `1.0.2-3`:

- upstream repository: https://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros2-gbp/laser_proc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-2`

## laser_proc

```
* Use C-style strings for RCLCPP_ macros. (#12 <https://github.com/ros-perception/laser_proc/issues/12>)
* Contributors: Chris Lalancette
```
