### PR TITLE
laser_proc: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1488,7 +1488,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/laser_proc-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_proc` to `1.0.2-1`:

- upstream repository: https://github.com/ros-perception/laser_proc.git
- release repository: https://github.com/ros2-gbp/laser_proc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.1-1`

## laser_proc

```
* Use C-style strings for RCLCPP_ macros. (#12 <https://github.com/ros-perception/laser_proc/issues/12>)
* Contributors: Chris Lalancette
```
