### PR TITLE
Switch source and doc branch of Rolling qt_gui_core to galactic-devel

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1385,7 +1385,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: foxy-devel
+      version: galactic-devel
     release:
       packages:
       - qt_dotgraph
@@ -1402,7 +1402,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: foxy-devel
+      version: galactic-devel
     status: maintained
   rc_common_msgs:
     doc:


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>