### PR TITLE
bond_core: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -250,7 +250,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 2.0.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `3.0.0-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.0.0-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* [Fixing CI] using chrono literals for durations from rclcpp API update (#69 <https://github.com/ros/bond_core/issues/69>)
* Contributors: Steve Macenski
```

## smclib

- No changes

## test_bond

```
* [Fixing CI] using chrono literals for durations from rclcpp API update (#69 <https://github.com/ros/bond_core/issues/69>)
* Contributors: Steve Macenski
```
