### PR TITLE
eigenpy: 2.6.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1617,7 +1617,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipab-slmc/eigenpy_catkin-release.git
-      version: 2.6.1-1
+      version: 2.6.1-3
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `2.6.1-3`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/ipab-slmc/eigenpy_catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.6.1-1`
