### PR TITLE
khi_robot: 1.2.0-5 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6287,6 +6287,7 @@ repositories:
       - khi_robot_bringup
       - khi_robot_control
       - khi_robot_msgs
+      - khi_robot_test
       - khi_rs007l_moveit_config
       - khi_rs007n_moveit_config
       - khi_rs080n_moveit_config
@@ -6296,7 +6297,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/Kawasaki-Robotics/khi_robot-release.git
-      version: 1.1.2-1
+      version: 1.2.0-5
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `khi_robot` to `1.2.0-5`:

- upstream repository: https://github.com/Kawasaki-Robotics/khi_robot.git
- release repository: https://github.com/Kawasaki-Robotics/khi_robot-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.2-1`

## khi_duaro_description

```
* Merge branch 'master' into refactoring
* add missing config directory in install(DIRECTORY (#34)
  * add missing config directory in install(DIRECTORY
  * add missing config directory in khi_rs_description
  Co-authored-by: Daisuke NAKAMICHI <mailto:44663870+d-nakamichi@users.noreply.github.com>
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* update duaro body from dcon to fcon (#30)
  OK, I approved.
  Now travis kinetic failed due to ros-kinetic-moveit-ros-visualization.
  I think it is OK because this PR is not related with the installation and Travis melodic passed.
* Contributors: Daisuke NAKAMICHI, Hiroki Matsui, Kei Okada, d-nakamichi
```

## khi_duaro_gazebo

```
* Add position_controllers/JointGroupPositionController (#22)
  * Add position_controllers/JointGroupPositionController
  * fixup! Add position_controllers/JointGroupPositionController
* Contributors: Daisuke NAKAMICHI
```

## khi_duaro_ikfast_plugin

- No changes

## khi_duaro_moveit_config

```
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* update duaro body from dcon to fcon (#30)
  OK, I approved.
  Now travis kinetic failed due to ros-kinetic-moveit-ros-visualization.
  I think it is OK because this PR is not related with the installation and Travis melodic passed.
* Contributors: Daisuke NAKAMICHI, Hiroki Matsui
```

## khi_robot

- No changes

## khi_robot_bringup

```
* Merge pull request #36 from d-nakamichi/refactoring
  Refactoring about khi_robot_control
* Refactoring khi_robot_controllers/JointData/KrnxRobotTable/RobotInfo/rtc to khi_robot_param/KhiRobotData/KhiRobotControllerInfo/KhiRobotKrnxRtcData
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* Add position_controllers/JointGroupPositionController (#22)
  * Add position_controllers/JointGroupPositionController
  * fixup! Add position_controllers/JointGroupPositionController
* Delete README.md in khi_robot_bringup
  This is unneeded.
* Contributors: Daisuke NAKAMICHI, Hiroki Matsui, d-nakamichi
```

## khi_robot_control

```
* Merge pull request #43 from d-nakamichi/modify_setting_home_process
  Modify setting home process
* Modify setting home process
* Merge pull request #38 from d-nakamichi/krnx_mutex_update
  Update KRNX API processing
* Update KRNX mutex functions
* Merge pull request #36 from d-nakamichi/refactoring
  Refactoring about khi_robot_control
* Remove robot_name arg
* Fix build problem
* Change args from value to reference
* Refactoring khi_robot_controllers/JointData/KrnxRobotTable/RobotInfo/rtc to khi_robot_param/KhiRobotData/KhiRobotControllerInfo/KhiRobotKrnxRtcData
* Print WARN message when krnx_ExecMon() failed by AS
* Modify switch changing process
* Simplify activate() timeout process
* Don't execute deactivete() when deleted
* Merge pull request #35 from d-nakamichi/read_velocity
  Travis test bugfix
* robot_control: correct read(..)/write(..) overrides. (#33)
  * robot_control: correct read(..)/write(..) overrides.
  Both time and period are passed as const references. Not by-value.
  * robot_control: mark read(..)/write(..) as override.
* Read joint velocities in simulation mode
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* Bugfix about getting signal status (#32)
* Merge pull request #29 from d-nakamichi/holded_state
  Holded state
* Add HOLDED state
* Rearrange state transitions
* Simplify ROS messages
* Apply AS switch setting for all robots (#23)
  * Apply AS switch setting for all robots
  * fixup! Apply AS switch setting for all robots
* Contributors: Daisuke NAKAMICHI, G.A. vd. Hoorn, Hiroki Matsui, d-nakamichi
```

## khi_robot_msgs

- No changes

## khi_robot_test

- No changes

## khi_rs007l_moveit_config

```
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* Contributors: Daisuke NAKAMICHI
```

## khi_rs007n_moveit_config

```
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* Contributors: Daisuke NAKAMICHI
```

## khi_rs080n_moveit_config

```
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* Contributors: Daisuke NAKAMICHI
```

## khi_rs_description

```
* Merge branch 'master' into refactoring
* add missing config directory in install(DIRECTORY (#34)
  * add missing config directory in install(DIRECTORY
  * add missing config directory in khi_rs_description
  Co-authored-by: Daisuke NAKAMICHI <mailto:44663870+d-nakamichi@users.noreply.github.com>
* Add joint_limits_interface (#31)
  * Add joint_limits_interface
  * Move joint_limits.yaml from moveit_config to description
  * Modify test messages and conditions in test_position_velocity
  * Change duAro's figure length
  * Move tests from khi_robot_control to khi_robot_test
* Contributors: Daisuke NAKAMICHI, Kei Okada, d-nakamichi
```

## khi_rs_gazebo

```
* Add position_controllers/JointGroupPositionController (#22)
  * Add position_controllers/JointGroupPositionController
  * fixup! Add position_controllers/JointGroupPositionController
* Contributors: Daisuke NAKAMICHI
```

## khi_rs_ikfast_plugin

- No changes
