### PR TITLE
rx_service_tools: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6429,6 +6429,21 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: noetic-devel
     status: maintained
+  rx_service_tools:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rx_service_tools.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/nobleo/rx_service_tools-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rx_service_tools.git
+      version: master
+    status: maintained
   sainsmart_relay_usb:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rx_service_tools` to `1.0.2-1`:

- upstream repository: https://github.com/nobleo/rx_service_tools.git
- release repository: https://github.com/nobleo/rx_service_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rx_service_tools

```
* Noetic migration using roscompile
```
