### PR TITLE
plotjuggler_ros: 1.0.3-8 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2193,7 +2193,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
-      version: 1.0.2-1
+      version: 1.0.3-8
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `1.0.3-8`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.2-1`

## plotjuggler_ros

```
* fix bug #387 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/387> in Plotjuggler repo
* Merge pull request #3 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/3> from kefrobotics/development
  Add diagnostic_msgs as ROS2 dependency in CMakeLists.txt files
* Add diagnostic_msgs as ROS2 dependency in CMakeLists.txt files
* Contributors: Davide Faconti, Paul Frivold
```
