### PR TITLE
behaviortree_cpp: 3.5.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -341,7 +341,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp-release.git
-      version: 3.5.3-1
+      version: 3.5.5-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `3.5.5-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/BehaviorTree/behaviortree_cpp-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.5.3-1`

## behaviortree_cpp_v3

```
* fix issue #251 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/251>
* Contributors: Davide Faconti
```
