### PR TITLE
add key for GStreamer plugins for GL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1319,6 +1319,11 @@ gstreamer1.0-alsa:
   fedora: [gstreamer1-plugins-base]
   rhel: [gstreamer1-plugins-base]
   ubuntu: [gstreamer1.0-alsa]
+gstreamer1.0-gl:
+  arch: [gst-plugins-base]
+  debian: [gstreamer1.0-gl]
+  fedora: [gstreamer1-plugins-base]
+  ubuntu: [gstreamer1.0-gl]
 gstreamer1.0-libav:
   arch: [gst-libav]
   debian: [gstreamer1.0-libav]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1321,7 +1321,9 @@ gstreamer1.0-alsa:
   ubuntu: [gstreamer1.0-alsa]
 gstreamer1.0-gl:
   arch: [gst-plugins-base]
-  debian: [gstreamer1.0-gl]
+  debian:
+    '*': [gstreamer1.0-gl]
+    stretch: null
   fedora: [gstreamer1-plugins-base]
   ubuntu:
     '*': [gstreamer1.0-gl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1323,7 +1323,9 @@ gstreamer1.0-gl:
   arch: [gst-plugins-base]
   debian: [gstreamer1.0-gl]
   fedora: [gstreamer1-plugins-base]
-  ubuntu: [gstreamer1.0-gl]
+  ubuntu:
+    '*': [gstreamer1.0-gl]
+    'xenial': null
 gstreamer1.0-libav:
   arch: [gst-libav]
   debian: [gstreamer1.0-libav]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1325,7 +1325,7 @@ gstreamer1.0-gl:
   fedora: [gstreamer1-plugins-base]
   ubuntu:
     '*': [gstreamer1.0-gl]
-    'xenial': null
+    xenial: null
 gstreamer1.0-libav:
   arch: [gst-libav]
   debian: [gstreamer1.0-libav]


### PR DESCRIPTION
Provides the library `libgstopengl.so` for gstreamer GL plugins

* Arch: https://archlinux.org/packages/extra/x86_64/gst-plugins-base/
* Debian: https://packages.debian.org/sid/gstreamer1.0-gl
* Fedora: https://src.fedoraproject.org/rpms/gstreamer1-plugins-base
* Ubuntu: https://packages.ubuntu.com/bionic/gstreamer1.0-gl