### PR TITLE
rc_genicam_driver: 0.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4959,7 +4959,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.5.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.0-1`

## rc_genicam_driver

```
* Publish images without filtering on image_rect(_color) topics
```
