### PR TITLE
adding qml-module-qtquick-window2 rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5519,6 +5519,9 @@ qml-module-qtquick-layouts:
 qml-module-qtquick-templates2:
   debian: [qml-module-qtquick-templates2]
   ubuntu: [qml-module-qtquick-templates2]
+qml-module-qtquick-window2:
+  debian: [qml-module-qtquick-window2]
+  ubuntu: [qml-module-qtquick-window2]
 qml-module-qtquick2:
   debian: [qml-module-qtquick2]
   ubuntu: [qml-module-qtquick2]


### PR DESCRIPTION
Adds the Qt 5 window 2 QML module

* Debian: https://packages.debian.org/stretch/qml-module-qtquick-window2
* Ubuntu: https://packages.ubuntu.com/bionic/qml-module-qtquick-window2