### PR TITLE
rc_genicam_camera: 1.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4950,6 +4950,22 @@ repositories:
       url: https://github.com/roboception/rc_genicam_api.git
       version: master
     status: developed
+  rc_genicam_camera:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_camera.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/roboception-gbp/rc_genicam_camera-release.git
+      version: 1.2.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_camera.git
+      version: master
+    status: developed
   rc_genicam_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_camera` to `1.2.3-1`:

- upstream repository: https://github.com/roboception/rc_genicam_camera.git
- release repository: https://github.com/roboception-gbp/rc_genicam_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## rc_genicam_camera

```
* Updated cmake and CI files
* Dropped building for trusty and added building for focal on CI
```
