### PR TITLE
Update default branch for transport_drivers

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3643,7 +3643,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: ros2
+      version: main
     release:
       packages:
       - serial_driver
@@ -3655,7 +3655,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: ros2
+      version: main
     status: developed
   tts:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4214,7 +4214,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: ros2
+      version: main
     release:
       packages:
       - serial_driver
@@ -4226,7 +4226,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: ros2
+      version: main
     status: developed
   turtlebot3:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2747,7 +2747,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: ros2
+      version: main
     release:
       packages:
       - serial_driver
@@ -2759,7 +2759,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: ros2
+      version: main
     status: developed
   turtlesim:
     doc:


### PR DESCRIPTION
To create a more famiiar branch setup for users, our default branch was changed from `ros2` to `main`. This simply updates the distribution files to reflect this change.