### PR TITLE
Update ruby rosdep key facets for Focal, and add new keys metaruby and utilrb

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -122,6 +122,6 @@ ruby1.9.3:
     precise: [ruby1.9.3]
 utilrb:
   debian:
-    gem: metaruby
+    gem: utilrb
   ubuntu:
-    gem: metaruby
+    gem: utilrb

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -12,9 +12,10 @@ facets:
   osx:
     macports: [rb-facets]
   ubuntu:
-    '*': ruby-facets
-    focal:
+    '*':
       gem: facets
+    bionic: ruby-facets
+    xenial: ruby-facets
 flexmock:
   debian: [ruby-flexmock]
   fedora: [rubygem-flexmock]
@@ -37,13 +38,7 @@ jekyll:
         depends: [ruby1.9.3]
         packages: [jekyll]
 metaruby:
-  arch:
-    gem: metaruby
   debian:
-    gem: metaruby
-  fedora:
-    gem: metaruby
-  gentoo:
     gem: metaruby
   ubuntu:
     gem: metaruby
@@ -126,13 +121,7 @@ ruby1.9.3:
   ubuntu:
     precise: [ruby1.9.3]
 utilrb:
-  arch:
-    gem: metaruby
   debian:
-    gem: metaruby
-  fedora:
-    gem: metaruby
-  gentoo:
     gem: metaruby
   ubuntu:
     gem: metaruby

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -11,7 +11,10 @@ facets:
   gentoo: [dev-ruby/facets]
   osx:
     macports: [rb-facets]
-  ubuntu: [ruby-facets]
+  ubuntu:
+    '*': ruby-facets
+    focal:
+      gem: facets
 flexmock:
   debian: [ruby-flexmock]
   fedora: [rubygem-flexmock]
@@ -33,6 +36,17 @@ jekyll:
       gem:
         depends: [ruby1.9.3]
         packages: [jekyll]
+metaruby:
+  arch:
+    gem: metaruby
+  debian:
+    gem: metaruby
+  fedora:
+    gem: metaruby
+  gentoo:
+    gem: metaruby
+  ubuntu:
+    gem: metaruby
 nokogiri:
   arch: [ruby-nokogiri]
   debian: [ruby-nokogiri]
@@ -111,3 +125,14 @@ ruby-sass:
 ruby1.9.3:
   ubuntu:
     precise: [ruby1.9.3]
+utilrb:
+  arch:
+    gem: metaruby
+  debian:
+    gem: metaruby
+  fedora:
+    gem: metaruby
+  gentoo:
+    gem: metaruby
+  ubuntu:
+    gem: metaruby

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -13,9 +13,9 @@ facets:
     macports: [rb-facets]
   ubuntu:
     '*':
-      gem: facets
-    bionic: ruby-facets
-    xenial: ruby-facets
+      gem: [facets]
+    bionic: [ruby-facets]
+    xenial: [ruby-facets]
 flexmock:
   debian: [ruby-flexmock]
   fedora: [rubygem-flexmock]
@@ -39,9 +39,9 @@ jekyll:
         packages: [jekyll]
 metaruby:
   debian:
-    gem: metaruby
+    gem: [metaruby]
   ubuntu:
-    gem: metaruby
+    gem: [metaruby]
 nokogiri:
   arch: [ruby-nokogiri]
   debian: [ruby-nokogiri]
@@ -122,6 +122,6 @@ ruby1.9.3:
     precise: [ruby1.9.3]
 utilrb:
   debian:
-    gem: utilrb
+    gem: [utilrb]
   ubuntu:
-    gem: utilrb
+    gem: [utilrb]


### PR DESCRIPTION
Those packages are dependencies of [orogen](https://github.com/orocos-toolchain/orogen). Currently it is not planned to release orogen into ROS like it was the case until [indigo](http://repositories.ros.org/status_page/compare_indigo_kinetic_lunar_melodic.html?q=orogen). But it is still possible to build from source (https://github.com/orocos-toolchain/orogen/pull/140#issuecomment-768375365), and it would be nice if `rosdep` can install its dependencies without custom rosdep files like the one we provide in [orocos-docker-images/ros2/ubuntu/prereqs.yaml](https://github.com/orocos/orocos-docker-images/blob/606e80448838fc359dbd8483cb8a1afd32b531e5/ros2/ubuntu/prereqs.yaml).

Those are [gem](https://github.com/ros-infrastructure/rosdep/issues/22) dependencies. Package [ruby-facets](https://packages.ubuntu.com/search?keywords=ruby-facets) is not available anymore for Ubuntu Focal (and newer?) and also needs to be installed as a gem now:

- [facets](http://rubyworks.github.io/facets/): https://rubygems.org/gems/facets
- [metaruby](https://github.com/rock-core/tools-metaruby): https://rubygems.org/gems/metaruby
- [utilrb](https://github.com/orocos-toolchain/utilrb): https://rubygems.org/gems/utilrb

**Questions:**

- Probably better to list keys `bionic` and `xenial` explicitly for `facets`, and use `'*'` for `focal` and newer? Likely the package won't come back.
- I did not test all distributions for the new keys, and assumed that `gem` would work the same way in all major distributions. Only Ubuntu bionic and focal have been actually tested. Do you prefer to only define the keys for Ubuntu, or even the tested versions? If not, is it possible to omit the `OS_NAME` or just write `'*':` if all resolve to the same installer and package? It is probably the same for some Python packages which are only available via pip.