### PR TITLE
neonavigation: 0.10.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3984,7 +3984,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.10.5-1
+      version: 0.10.6-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.10.6-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.10.5-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: fix condition of open queue (#576 <https://github.com/at-wat/neonavigation/issues/576>)
* planner_cspace: add debug output about cost_estim_cache update (#577 <https://github.com/at-wat/neonavigation/issues/577>)
* planner_cspace: reuse open/erase queue (#575 <https://github.com/at-wat/neonavigation/issues/575>)
* Contributors: Atsushi Watanabe, Naotaka Hatao
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
