### PR TITLE
update branch for rolling PR job

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -453,7 +453,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: foxy
+      version: ros2-devel
     release:
       packages:
       - diagnostic_aggregator
@@ -467,7 +467,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: foxy
+      version: ros2-devel
     status: maintained
   eigen3_cmake_module:
     doc:


### PR DESCRIPTION
I hope that's the change necessary to disable the rolling PR jobs for PRs opening against the foxy branch. The dev job should really only be run when opened against `ros2-devel`.