### PR TITLE
diagnostics: 2.0.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -654,7 +654,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.0.6-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.5-1`

## diagnostic_aggregator

```
* Move Aggregator publishing to timer to allow subscription callback more processing time. (#179 <https://github.com/ros/diagnostics/issues/179>)
  Co-authored-by: Chris Bierl <mailto:cbierl@moog.com>
* Contributors: cdbierl
```

## diagnostic_updater

- No changes

## self_test

- No changes
