### PR TITLE
diagnostics: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -462,7 +462,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.1.1-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.1.0-1`

## diagnostic_aggregator

```
* [ROS2] Move Aggregator publishing to timer to allow subscription callback more processing time. (#180 <https://github.com/ros/diagnostics/issues/180>)
  Co-authored-by: Chris Bierl <mailto:cbierl@moog.com>
* Contributors: cdbierl
```

## diagnostic_updater

- No changes

## self_test

- No changes
