### PR TITLE
Enable PR testing for laser_geometry

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -6573,6 +6573,7 @@ repositories:
       url: https://github.com/ros-gbp/laser_geometry-release.git
       version: 1.6.5-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
       version: kinetic-devel

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5265,6 +5265,7 @@ repositories:
       url: https://github.com/ros-gbp/laser_geometry-release.git
       version: 1.6.5-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
       version: kinetic-devel

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3056,6 +3056,7 @@ repositories:
       url: https://github.com/ros-gbp/laser_geometry-release.git
       version: 1.6.5-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
       version: kinetic-devel


### PR DESCRIPTION
Not using Bloom because build is failing on Kdev, hence enabling PR testing to check Kpr builds before releasing.

I forget whether I can approve my own PR while I'm on rosdistro duty, probably not :)