### PR TITLE
teleop_legged_robots: 1.1.2-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15877,7 +15877,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SoftServeSAG/teleop_legged_robots-release.git
-      version: 1.1.0-1
+      version: 1.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_legged_robots` to `1.1.2-2`:

- upstream repository: https://github.com/SoftServeSAG/teleop_legged_robots.git
- release repository: https://github.com/SoftServeSAG/teleop_legged_robots-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`
