### PR TITLE
teleop_legged_robots: 1.1.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12409,7 +12409,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SoftServeSAG/teleop_legged_robots-release.git
-      version: 1.1.0-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/SoftServeSAG/teleop_legged_robots.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_legged_robots` to `1.1.2-1`:

- upstream repository: https://github.com/SoftServeSAG/teleop_legged_robots.git
- release repository: https://github.com/SoftServeSAG/teleop_legged_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`
