### PR TITLE
rc_genicam_camera: 1.2.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4959,7 +4959,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_camera-release.git
-      version: 1.2.3-1
+      version: 1.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_camera` to `1.2.4-1`:

- upstream repository: https://github.com/roboception/rc_genicam_camera.git
- release repository: https://github.com/roboception-gbp/rc_genicam_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.3-1`

## rc_genicam_camera

```
* Fixed linking problems
```
