### PR TITLE
rc_genicam_driver: 0.1.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2497,7 +2497,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.1.2-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.1-1`

## rc_genicam_driver

```
* fix linking problems
```
