### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5476,6 +5476,17 @@ repositories:
       url: https://github.com/ignitionrobotics/ros_ign.git
       version: noetic
     status: developed
+  ros_industrial_cmake_boilerplate:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
+      version: 0.2.7-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+      version: master
+    status: developed
   ros_numpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.7-1`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## ros_industrial_cmake_boilerplate

```
* Add contributing file
* Add license files and update documentation
* Contributors: Levi Armstrong
```
