### PR TITLE
plotjuggler: 3.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4559,7 +4559,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.0.7-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.1.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/facontidavide/plotjuggler-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.0.7-1`

## plotjuggler

```
* fix issue #394 <https://github.com/facontidavide/PlotJuggler/issues/394>
* Update udp_server.cpp (#393 <https://github.com/facontidavide/PlotJuggler/issues/393>)
  Fixes random corruptions of UDP Json messages (garbage collector related?)
* Fix style in Windows (#390 <https://github.com/facontidavide/PlotJuggler/issues/390>)
* Fix compilation in C++17
* fix issue #389 <https://github.com/facontidavide/PlotJuggler/issues/389>
* remove qrand
* Add better help dialog to custom functions
* Allow custom function return multiple points (#386 <https://github.com/facontidavide/PlotJuggler/issues/386>)
* Apple Mac M1 build fix. (#392 <https://github.com/facontidavide/PlotJuggler/issues/392>)
  backward-cpp dependency fix for ARM 64 backport, wrong access to PC register.
* fix issue #384 <https://github.com/facontidavide/PlotJuggler/issues/384>
* temporary remove LSL
* Contributors: David CARLIER, Davide Faconti, Hugal31, alkaes
```
