### PR TITLE
ompl: 1.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4263,7 +4263,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
-      version: 1.5.1-1
+      version: 1.5.2-1
   omron_os32c_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.5.2-1`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros-gbp/ompl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.5.1-1`
