### PR TITLE
openni2_camera: 1.5.1-1 in 'noetic/distribution.yaml' [non-bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4313,7 +4313,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: noetic-devel
+      version: ros1
     release:
       packages:
       - openni2_camera
@@ -4321,11 +4321,11 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: noetic-devel
+      version: ros1
     status: maintained
   openslam_gmapping:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository openni2_camera to 1.5.1-1:

-    upstream repository: https://github.com/ros-drivers/openni2_camera.git
-    release repository: https://github.com/ros-gbp/openni2_camera-release.git
-    distro file: noetic/distribution.yaml
-    bloom version: 0.10.0
-    previous version for package: 1.5.0-1