### PR TITLE
openni2_camera: 1.5.1-1 in 'melodic/distribution.yaml' [non-bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7697,7 +7697,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: indigo-devel
+      version: ros1
     release:
       packages:
       - openni2_camera
@@ -7705,11 +7705,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/openni2_camera-release.git
-      version: 0.4.2-0
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
-      version: indigo-devel
+      version: ros1
     status: maintained
   openni_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository openni2_camera to 1.5.1-1:

-    upstream repository: https://github.com/ros-drivers/openni2_camera.git
-    release repository: https://github.com/ros-gbp/openni2_camera-release.git
-    distro file: noetic/distribution.yaml
-    bloom version: 0.10.0
-    previous version for package: 0.4.2-0