### PR TITLE
rosbag2: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1975,7 +1975,7 @@ repositories:
       - rosbag2_compression
       - rosbag2_converter_default_plugins
       - rosbag2_cpp
-      - rosbag2_performance_writer_benchmarking
+      - rosbag2_performance_benchmarking
       - rosbag2_py
       - rosbag2_storage
       - rosbag2_storage_default_plugins
@@ -1988,7 +1988,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.6.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.0-1`

## ros2bag

```
* Recorder --regex and --exclude options (#604 <https://github.com/ros2/rosbag2/issues/604>)
* Fix the tests on cyclonedds by translating qos duration values (#606 <https://github.com/ros2/rosbag2/issues/606>)
* SQLite storage optimized by default (#568 <https://github.com/ros2/rosbag2/issues/568>)
* Fix a bug on parsing wrong description in plugin xml file (#578 <https://github.com/ros2/rosbag2/issues/578>)
* Compress bag files in separate threads (#506 <https://github.com/ros2/rosbag2/issues/506>)
* Contributors: Adam Dąbrowski, Barry Xu, Emerson Knapp, P. J. Reed
```

## rosbag2

- No changes

## rosbag2_compression

```
* Make compressor implementations into a plugin via pluginlib (#624 <https://github.com/ros2/rosbag2/issues/624>)
* Use ZSTD's streaming interface for [de]compressing files (#543 <https://github.com/ros2/rosbag2/issues/543>)
* Fix build issues when rosbag2_storage is binary installed (#585 <https://github.com/ros2/rosbag2/issues/585>)
* Fix relative metadata paths in SequentialCompressionWriter (#613 <https://github.com/ros2/rosbag2/issues/613>)
* Fix deadlock race condition on compression shutdown (#616 <https://github.com/ros2/rosbag2/issues/616>)
* Deduplicate SequentialCompressionReader business logic, add fallback to find bagfiles in incorrectly-written metadata (#612 <https://github.com/ros2/rosbag2/issues/612>)
* Compress bag files in separate threads (#506 <https://github.com/ros2/rosbag2/issues/506>)
* Contributors: Emerson Knapp, P. J. Reed
```

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

```
* Fix build issues when rosbag2_storage is binary installed (#585 <https://github.com/ros2/rosbag2/issues/585>)
* Deduplicate SequentialCompressionReader business logic, add fallback to find bagfiles in incorrectly-written metadata (#612 <https://github.com/ros2/rosbag2/issues/612>)
* include what you use (#600 <https://github.com/ros2/rosbag2/issues/600>)
* Only dereference the data pointer if it is valid. (#581 <https://github.com/ros2/rosbag2/issues/581>)
* Contributors: Chris Lalancette, Emerson Knapp, Ivan Santiago Paunovic, P. J. Reed
```

## rosbag2_performance_benchmarking

```
* Performance benchmarking refactor (#594 <https://github.com/ros2/rosbag2/issues/594>)
* Contributors: Adam Dąbrowski
```

## rosbag2_py

```
* Fix build issues when rosbag2_storage is binary installed (#585 <https://github.com/ros2/rosbag2/issues/585>)
* Fix the tests on cyclonedds by translating qos duration values (#606 <https://github.com/ros2/rosbag2/issues/606>)
* Contributors: Emerson Knapp, P. J. Reed
```

## rosbag2_storage

```
* SQLite storage optimized by default (#568 <https://github.com/ros2/rosbag2/issues/568>)
  * Use optimized pragmas by default in sqlite storage. Added option to use former behavior
* Use std::filesystem compliant non-member exists function for path object (#593 <https://github.com/ros2/rosbag2/issues/593>)
* Contributors: Adam Dąbrowski, Josh Langsfeld
```

## rosbag2_storage_default_plugins

```
* Fix build issues when rosbag2_storage is binary installed (#585 <https://github.com/ros2/rosbag2/issues/585>)
* Mutex protection for db writing and stl collections in writer & storage (#603 <https://github.com/ros2/rosbag2/issues/603>)
* SQLite storage optimized by default (#568 <https://github.com/ros2/rosbag2/issues/568>)
* Contributors: Adam Dąbrowski, P. J. Reed
```

## rosbag2_test_common

```
* Stabilize test_record by reducing copies of executors and messages (#576 <https://github.com/ros2/rosbag2/issues/576>)
* Contributors: Emerson Knapp
```

## rosbag2_tests

```
* Fix relative metadata paths in SequentialCompressionWriter (#613 <https://github.com/ros2/rosbag2/issues/613>)
* Recorder --regex and --exclude options (#604 <https://github.com/ros2/rosbag2/issues/604>)
* Fix the tests on cyclonedds by translating qos duration values (#606 <https://github.com/ros2/rosbag2/issues/606>)
* Contributors: Adam Dąbrowski, Emerson Knapp
```

## rosbag2_transport

```
* Fix build issues when rosbag2_storage is binary installed (#585 <https://github.com/ros2/rosbag2/issues/585>)
* Regex and exclude fix for rosbag recorder (#620 <https://github.com/ros2/rosbag2/issues/620>)
* Recorder --regex and --exclude options (#604 <https://github.com/ros2/rosbag2/issues/604>)
* SQLite storage optimized by default (#568 <https://github.com/ros2/rosbag2/issues/568>)
* Fixed playing if unknown message types exist (#592 <https://github.com/ros2/rosbag2/issues/592>)
* Compress bag files in separate threads (#506 <https://github.com/ros2/rosbag2/issues/506>)
* Stabilize test_record by reducing copies of executors and messages (#576 <https://github.com/ros2/rosbag2/issues/576>)
* Contributors: Adam Dąbrowski, Chen Lihui, Emerson Knapp, P. J. Reed, Piotr Jaroszek
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

```
* Patch zstd 1.4.4 to include cmake_minimum_version bump to 2.8.12 (#579 <https://github.com/ros2/rosbag2/issues/579>)
* Contributors: Emerson Knapp
```
