### PR TITLE
vrpn: 7.34.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7497,7 +7497,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/vrpn-release.git
-      version: 7.34.0-1
+      version: 7.34.0-2
     source:
       type: git
       url: https://github.com/vrpn/vrpn.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.34.0-2`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros-drivers-gbp/vrpn-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `7.34.0-1`
