### PR TITLE
rosbag2_bag_v2: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2007,7 +2007,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
-      version: 0.0.10-2
+      version: 0.1.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_bag_v2` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/rosbag2_bag_v2.git
- release repository: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.10-2`

## ros1_rosbag_storage_vendor

```
* Update to the latest rosbag1. (#40 <https://github.com/ros2/rosbag2_bag_v2/issues/40>)
* Contributors: Chris Lalancette
```

## rosbag2_bag_v2_plugins

```
* Update to the latest rosbag1. (#40 <https://github.com/ros2/rosbag2_bag_v2/issues/40>)
* Fix build for latest rosbag2 StorageOptions API (#38 <https://github.com/ros2/rosbag2_bag_v2/issues/38>)
* Contributors: Chris Lalancette, Emerson Knapp
```
