### PR TITLE
async_comm: 0.2.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -582,7 +582,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/dpkoch/async_comm-release.git
-      version: 0.2.0-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_comm` to `0.2.1-2`:

- upstream repository: https://github.com/dpkoch/async_comm.git
- release repository: https://github.com/dpkoch/async_comm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.0-1`

## async_comm

```
* Add noetic to ROS prerelease test distribution list
* Fixes for compatibility with ROS2 workspaces:
  
    * cmake: Change install paths to basic lib/ and include/
    * package.xml: Remove unneeded catkin dependency
  
* Updated CMake examples in README
* Contributors: Daniel Koch, Maciej Bogusz
```
