### PR TITLE
mimick_vendor: 0.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1123,7 +1123,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.4-1`

## mimick_vendor

```
* Suppress update of pinned git repository (#17 <https://github.com/ros2/mimick_vendor/issues/17>)
* Don't overwrite -Wno-dev CMake argument (#18 <https://github.com/ros2/mimick_vendor/issues/18>)
* Contributors: Scott K Logan
```
