### PR TITLE
mavros: 1.5.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7434,7 +7434,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.5.1-1
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.5.2-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.5.1-1`

## libmavconn

- No changes

## mavros

```
* readme: add source install note for Noetic release
* Contributors: Vladimir Ermakov
```

## mavros_extras

```
* bugfix - add estimator type in odom message
  Add missing estimator_type field in  Odometry message.
  Issue #1524 <https://github.com/mavlink/mavros/issues/1524>
* Contributors: Ashwin Varghese Kuruttukulam
```

## mavros_msgs

- No changes

## test_mavros

- No changes
