### PR TITLE
gpp: 0.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2196,6 +2196,16 @@ repositories:
       type: git
       url: https://github.com/dorezyuk/gpp.git
       version: master
+    release:
+      packages:
+      - gpp_interface
+      - gpp_plugin
+      - gpp_prune_path
+      - gpp_update_map
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/dorezyuk/gpp-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/dorezyuk/gpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gpp` to `0.1.0-1`:

- upstream repository: https://github.com/dorezyuk/gpp
- release repository: https://github.com/dorezyuk/gpp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
