### PR TITLE
sick_safetyscanners: 1.0.8-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11933,7 +11933,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners` to `1.0.8-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners.git
- release repository: https://github.com/SICKAG/sick_safetyscanners-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.7-1`

## sick_safetyscanners

```
* changed to constant values for the field data
* changed uint to int for current config data
* Contributors: Lennart Puck
```
