### PR TITLE
pilz_common: 0.7.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4529,7 +4529,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_common-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_common` to `0.7.1-1`:

- upstream repository: https://github.com/PilzDE/pilz_common.git
- release repository: https://github.com/PilzDE/pilz_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.7.0-1`

## pilz_industrial_motion_testutils

```
* Fixes acceptance test utils for python 3
* Contributors: Pilz GmbH and Co. KG
* Fix acceptance-test utils (python3)
* Contributors: Pilz GmbH and Co. KG
```

## pilz_msgs

- No changes

## pilz_testutils

```
* Add missing header in service_client_mock.h
* JointStatePublisherMock stop publishing in DTOR
* Fix minor clang-tidy finding
* Omit nested namespace definitions (c++17)
* Contributors: Pilz GmbH and Co. KG
* Add unittests
* Minor fixes
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

- No changes
