### PR TITLE
robotont_nuc_description: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9932,7 +9932,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/robotont-release/robotont_nuc_description-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
   rocon_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotont_nuc_description` to `0.0.2-1`:

- upstream repository: https://github.com/robotont/robotont_nuc_description.git
- release repository: https://github.com/robotont-release/robotont_nuc_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.1-1`
