### PR TITLE
rc_genicam_driver: 0.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1461,7 +1461,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.1.3-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/roboception-gbp/rc_genicam_driver_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## rc_genicam_driver

```
* Use image_transport.hpp to get rid of a warning and hence drop eloquent support
* Use C-strings for RCLCPP macros to support rolling
```
