### PR TITLE
[rosdep] add at-spi2-core

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1823,9 +1823,6 @@ libasound2-dev:
   gentoo: [media-libs/alsa-lib]
   openembedded: [alsa-lib@openembedded-core]
   ubuntu: [libasound2-dev]
-libatspi2.0-dev:
-  debian: [libatspi2.0-dev]
-  ubuntu: [libatspi2.0-dev]
 libav:
   arch: [libav-git]
   debian: [libav-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -161,6 +161,12 @@ assimp-dev:
     maverick: [assimp-dev]
     oneiric: [assimp-dev]
     trusty_python3: [libassimp-dev]
+at-spi2-core:
+  arch: [at-spi2-core]
+  debian: [at-spi2-core]
+  fedora: [at-spi2-core]
+  gentoo: [at-spi2-core]
+  ubuntu: [at-spi2-core]
 atlas:
   arch: [atlas-lapack]
   debian: [libatlas-base-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1823,6 +1823,9 @@ libasound2-dev:
   gentoo: [media-libs/alsa-lib]
   openembedded: [alsa-lib@openembedded-core]
   ubuntu: [libasound2-dev]
+libatspi2.0-dev:
+  debian: [libatspi2.0-dev]
+  ubuntu: [libatspi2.0-dev]
 libav:
   arch: [libav-git]
   debian: [libav-tools]


### PR DESCRIPTION
ubuntu: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libatspi2.0-dev&searchon=names
debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=libatspi2.0-dev

couldn't find arch, fedora, gentoo