### PR TITLE
pybind11_vendor: 2.2.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2335,6 +2335,18 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_viewer.git
       version: devel
     status: developed
+  pybind11_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_vendor-release.git
+      version: 2.2.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/pybind11_vendor.git
+      version: master
+    status: maintained
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `2.2.6-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## pybind11_vendor

```
* Update maintainers (#7 <https://github.com/ros2/pybind11_vendor/issues/7>)
* Contributors: Shane Loretz
```
