### PR TITLE
roscompile: 1.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10489,12 +10489,13 @@ repositories:
       version: main
     release:
       packages:
+      - magical_ros2_conversion_tool
       - ros_introspection
       - roscompile
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.2.0-1`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`
