### PR TITLE
roscompile: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5615,12 +5615,13 @@ repositories:
       version: main
     release:
       packages:
+      - magical_ros2_conversion_tool
       - ros_introspection
       - roscompile
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/wu-robotics/roscompile-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `roscompile` to `1.2.0-1`:

- upstream repository: https://github.com/DLu/roscompile.git
- release repository: https://github.com/wu-robotics/roscompile-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.1-1`
