### PR TITLE
Add nlopt package to jsk_3rdparty

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2789,6 +2789,7 @@ repositories:
       - libsiftfast
       - lpg_planner
       - mini_maxwell
+      - nlopt
       - opt_camera
       - pgm_learner
       - respeaker_ros


### PR DESCRIPTION
The package is already released as name of `ros-noetic-nlopt`.

It looks the file is updated automatically. CC: @k-okada 