### PR TITLE
robotont_msgs: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9923,6 +9923,16 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/robotont-release/robotont_description-release.git
       version: 0.0.8-1
+  robotont_msgs:
+    doc:
+      type: git
+      url: https://github.com/robotont/robotont_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/robotont-release/robotont_msgs-release.git
+      version: 0.0.2-1
   robotont_nuc_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotont_msgs` to `0.0.2-1`:

- upstream repository: https://github.com/robotont/robotont_msgs.git
- release repository: https://github.com/robotont-release/robotont_msgs-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
