### PR TITLE
ros2_control: 0.1.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2994,13 +2994,13 @@ repositories:
       - controller_manager_msgs
       - hardware_interface
       - ros2_control
+      - ros2_control_test_assets
       - ros2controlcli
-      - test_robot_hardware
       - transmission_interface
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.1.4-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.3-1`

## controller_interface

- No changes

## controller_manager

```
* fix float conversion warning (#312 <https://github.com/ros-controls/ros2_control/issues/312>)
* update doxygen style according to ros2 core standard (#300 <https://github.com/ros-controls/ros2_control/issues/300>)
* Capitalized messages in controller_manager.cpp upto line669 (#285 <https://github.com/ros-controls/ros2_control/issues/285>)
* Sleep accurate duration on ros2_control_node (#302 <https://github.com/ros-controls/ros2_control/issues/302>)
* Contributors: Achinta-Choudhury, João Victor Torres Borges, Karsten Knese, Yutaka Kondo
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add test assets package (#289 <https://github.com/ros-controls/ros2_control/issues/289>)
* update doxygen style according to ros2 core standard (#300 <https://github.com/ros-controls/ros2_control/issues/300>)
* Move test_components from test_robot_hardware to hardware_interface package (#288 <https://github.com/ros-controls/ros2_control/issues/288>)
* Contributors: Denis Štogl, João Victor Torres Borges
```

## ros2_control

```
* Add test assets package (#289 <https://github.com/ros-controls/ros2_control/issues/289>)
* Contributors: Denis Štogl
```

## ros2_control_test_assets

```
* Add test assets package (#289 <https://github.com/ros-controls/ros2_control/issues/289>)
* Contributors: Denis Štogl
```

## ros2controlcli

```
* Print error messages if ros2controlcli commands fail (#309 <https://github.com/ros-controls/ros2_control/issues/309>)
* Inverse the response of cli commands to return correct exit-status. (#308 <https://github.com/ros-controls/ros2_control/issues/308>)
  * Inverse the response of cli commands to return correct exit-status.
  * list verbs return exit-status 0
* Contributors: Shota Aoki, Victor Lopez
```

## transmission_interface

```
* Add differential transmission (#303 <https://github.com/ros-controls/ros2_control/issues/303>)
* update doxygen style according to ros2 core standard (#300 <https://github.com/ros-controls/ros2_control/issues/300>)
* Add supporting images for simple transmission documentation (#304 <https://github.com/ros-controls/ros2_control/issues/304>)
* Contributors: Bence Magyar, João Victor Torres Borges
```
