### PR TITLE
hector_models: 0.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2374,7 +2374,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_models.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_models` to `0.5.2-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_models.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_models-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.1-1`

## hector_components_description

```
* Updated package format version, maintainer and CMakeLists.txt to conform to CMP0048.
* Contributors: Stefan Fabian
```

## hector_models

```
* Apparently metapackages can't have a version set.
* Updated package format version, maintainer and CMakeLists.txt to conform to CMP0048.
* Contributors: Stefan Fabian
```

## hector_sensors_description

```
* Updated package format version, maintainer and CMakeLists.txt to conform to CMP0048.
* Contributors: Stefan Fabian
```

## hector_xacro_tools

```
* Updated package format version, maintainer and CMakeLists.txt to conform to CMP0048.
* Contributors: Stefan Fabian
```
