### PR TITLE
sainsmart_relay_usb: 0.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6471,7 +6471,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sainsmart_relay_usb` to `0.0.4-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/sainsmart_relay_usb.git
- release repository: https://github.com/DataspeedInc-release/sainsmart_relay_usb-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.3-1`

## sainsmart_relay_usb

```
* Add symbolic link to serial port with udev rule
* Change ROS_INFO message on relay command to ROS_DEBUG to remove clutter in the terminal output
* Contributors: Kevin Hallenbeck
```
