### PR TITLE
hector_gazebo: 0.5.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2358,7 +2358,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hector_gazebo` to `0.5.3-1`:

- upstream repository: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo.git
- release repository: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.2-1`

## hector_gazebo

```
* Updated CMake version and fixed CMP0048 for non-metapackages.
* Updated package format and maintainer information.
* Contributors: Stefan Fabian
```

## hector_gazebo_plugins

```
* Updated CMake version and fixed CMP0048 for non-metapackages.
* Merge branch 'kinetic-devel' into melodic-devel
* Adjust licenses to be consistent with cpp files and plugins used in gazebo_ros_pkgs
* Updated package format and maintainer information.
* Contributors: Stefan Fabian, Stefan Kohlbrecher
```

## hector_gazebo_thermal_camera

```
* Updated CMake version and fixed CMP0048 for non-metapackages.
* Updated package format and maintainer information.
* Contributors: Stefan Fabian
```

## hector_gazebo_worlds

```
* Updated CMake version and fixed CMP0048 for non-metapackages.
* Updated package format and maintainer information.
* Contributors: Stefan Fabian
```

## hector_sensors_gazebo

```
* Updated CMake version and fixed CMP0048 for non-metapackages.
* Updated package format and maintainer information.
* Contributors: Stefan Fabian
```
