### PR TITLE
behaviortree_cpp: 3.5.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -229,7 +229,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.5.5-1
+      version: 3.5.6-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp` to `3.5.6-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `3.5.5-1`

## behaviortree_cpp_v3

```
* fix issue #227 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/227>
* fix issue #256 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/256>
* Merge branch 'master' of https://github.com/BehaviorTree/BehaviorTree.CPP
* fix issue #250 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/250>
* Fixed typos on SequenceNode.md (#254 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/254>)
* Contributors: Davide Faconti, LucasNolasco
```
