### PR TITLE
interactive_marker_twist_server: 1.2.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2637,7 +2637,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_marker_twist_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `1.2.2-1`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.2.1-1`

## interactive_marker_twist_server

```
* Remove the leading '/' from the default link; this causes errors in Noetic
* Bump CMake version to avoid CMP0048 warning.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```
