### PR TITLE
Adding ifxbgt60dev to documentation index for distro

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2488,11 +2488,6 @@ repositories:
       type: git
       url: https://github.com/Yang-IFX/ifxbgt60dev.git
       version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/Yang-IFX/ifxbgt60dev-release.git
-      version: 0.0.1
     source:
       test_pull_requests: true
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2483,6 +2483,22 @@ repositories:
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
     status: maintained
+  ifxbgt60dev:
+    doc:
+      type: git
+      url: https://github.com/Yang-IFX/ifxbgt60dev.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Yang-IFX/ifxbgt60dev-release.git
+      version: 0.0.1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Yang-IFX/ifxbgt60dev.git
+      version: master
+    status: maintained
   image_common:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2483,15 +2483,22 @@ repositories:
       url: https://github.com/ethz-adrl/ifopt.git
       version: master
     status: maintained
-  ifxbgt60dev:
+  ifxsensor:
     doc:
       type: git
-      url: https://github.com/Yang-IFX/ifxbgt60dev.git
+      url: https://github.com/Yang-IFX/ifxsensor.git
       version: master
+    release:
+      packages:
+      - ifx_bgt60_device
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Yang-IFX/ifxsensor-release.git
+      version: 0.0.1
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/Yang-IFX/ifxbgt60dev.git
+      url: https://github.com/Yang-IFX/ifxsensor.git
       version: master
     status: maintained
   image_common:


### PR DESCRIPTION
I'd like ifxbgt60dev to be indexed and documented on ros.org.