### PR TITLE
ros_workspace: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1957,7 +1957,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 1.0.1-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_workspace` to `1.0.2-1`:

- upstream repository: https://github.com/ros2/ros_workspace.git
- release repository: https://github.com/ros2-gbp/ros_workspace-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.1-2`

## ros_workspace

```
* Use GNUInstallDirs to determine multiarch library dir (#20 <https://github.com/ros2/ros_workspace/issues/20>)
* Contributors: Scott K Logan
```
