### PR TITLE
gazebo_ros2_control: 0.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1050,6 +1050,24 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: ros2
     status: maintained
+  gazebo_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros2_control.git
+      version: master
+    release:
+      packages:
+      - gazebo_ros2_control
+      - gazebo_ros2_control_demos
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-simulation/gazebo_ros2_control.git
+      version: master
+    status: maintained
   gazebo_ros_pkgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.0.1-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control/
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## gazebo_ros2_control

```
* Updated with ros2-control Foxy API (#44 <https://github.com/ros-simulation/gazebo_ros2_control/issues/44>)
  Co-authored-by: Karsten Knese <mailto:Karsten1987@users.noreply.github.com>
* Added initial version of gazebo_ros2_control (#1 <https://github.com/ros-simulation/gazebo_ros2_control/issues/1>)
* Contributors: Alejandro Hernández Cordero, Louise Poubel, Karsten Knese, Bence Magyar
```

## gazebo_ros2_control_demos

```
* Updated with ros2-control Foxy API (#44 <https://github.com/ros-simulation/gazebo_ros2_control/issues/44>)
  Co-authored-by: Karsten Knese <mailto:Karsten1987@users.noreply.github.com>
* Updated with recent ros2_control changes (#34 <https://github.com/ros-simulation/gazebo_ros2_control/issues/34>)
* Added initial demos in gazebo_ros2_control_demos (#2 <https://github.com/ros-simulation/gazebo_ros2_control/issues/2>)
  Co-authored-by: Louise Poubel <mailto:louise@openrobotics.org>
* Contributors: Alejandro Hernández Cordero, Louise Poubel, Karsten Knese, Bence Magyar
```
