### PR TITLE
ros2_control: 0.1.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2999,7 +2999,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.1.5-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.1.6-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.5-1`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* correct hardware interface validation in resource manager. (#317 <https://github.com/ros-controls/ros2_control/issues/317>)
* Contributors: Karsten Knese
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* correct hardware interface validation in resource manager. (#317 <https://github.com/ros-controls/ros2_control/issues/317>)
* Add missing test dep (#321 <https://github.com/ros-controls/ros2_control/issues/321>)
* Contributors: Bence Magyar, Karsten Knese
```

## ros2controlcli

- No changes

## transmission_interface

- No changes
