### PR TITLE
rcl: 2.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1482,7 +1482,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 2.5.1-1
+      version: 2.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `2.5.2-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.5.1-1`

## rcl

```
* Reference test resources directly from source tree (#554 <https://github.com/ros2/rcl/issues/554>)
* Contributors: Scott K Logan
```

## rcl_action

```
* Avoid setting error message twice. (#887 <https://github.com/ros2/rcl/issues/887>)
* Contributors: Chen Lihui
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
