### PR TITLE
rqt: 1.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2218,7 +2218,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.0.6-2
+      version: 1.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.0.7-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.6-2`

## rqt_gui

```
* getiterator() renamed to iter() in Python 3.9 (#239 <https://github.com/ros-visualization/rqt/issues/239>)
* Contributors: goekce
```

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

```
* Avoid installing test interfaces  (#228 <https://github.com/ros-visualization/rqt/issues/228>)
* Contributors: Dirk Thomas
```
