### PR TITLE
Revert "ueye_cam: 1.0.18-1 in 'kinetic/distribution.yaml' [bloom]"

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -16862,7 +16862,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/anqixu/ueye_cam-release.git
-      version: 1.0.18-1
+      version: 1.0.16-0
     source:
       type: git
       url: https://github.com/anqixu/ueye_cam.git


### PR DESCRIPTION
Reverts ros/rosdistro#27935


ueye_cam is not building after this release: https://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__ueye_cam__ubuntu_xenial_amd64__binary/11/