### PR TITLE
ros2_control: 0.1.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1820,6 +1820,30 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
+  ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - transmission_interface
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_control-release.git
+      version: 0.1.6-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.1.6-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* correct hardware interface validation in resource manager. (#317 <https://github.com/ros-controls/ros2_control/issues/317>)
* Contributors: Karsten Knese
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* correct hardware interface validation in resource manager. (#317 <https://github.com/ros-controls/ros2_control/issues/317>)
* Add missing test dep (#321 <https://github.com/ros-controls/ros2_control/issues/321>)
* Contributors: Bence Magyar, Karsten Knese
```

## ros2controlcli

- No changes

## transmission_interface

- No changes
