### PR TITLE
ros2_controllers: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3023,7 +3023,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `0.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.2-1`

## diff_drive_controller

```
* Fix diff drive twist concurrency issues (#146 <https://github.com/ros-controls/ros2_controllers/issues/146>)
  * Fix diff drive twist concurrency issues
  Before this fix, a twist message could be received and stored one
  thread, in the middle of the update() of the controller.
  This would be fixed by making a copy of the shared pointer at the
  beginning of the update() function, added realtime box to ensure safe
  concurrent access to the pointer.
  * Don't store limited command as last command
  Before these changes, the limited command overwrote the original
  command, which mean that it too much more time to reach the commanded
  speed.
  We only want this behavior when the command is too old and we replace it
  with 0 speed.
* Diff drive parameter fixes (#145 <https://github.com/ros-controls/ros2_controllers/issues/145>)
  * Recover old speed limiter behavior, if unspecified min defaults to -max
  * Change cmd_vel_timeout to seconds (double) as ROS1 instead of ms(int)
* Unstamped cmd_vel subscriber rebased (#143 <https://github.com/ros-controls/ros2_controllers/issues/143>)
* Contributors: Anas Abou Allaban, Victor Lopez
```

## effort_controllers

```
* Use ros2 contol test assets (#138 <https://github.com/ros-controls/ros2_controllers/issues/138>)
  * Add description to test trajecotry_controller
  * Use ros2_control_test_assets package
  * Delete obsolete components plugin export
* Contributors: Denis Štogl
```

## forward_command_controller

```
* Use ros2 contol test assets (#138 <https://github.com/ros-controls/ros2_controllers/issues/138>)
  * Add description to test trajecotry_controller
  * Use ros2_control_test_assets package
  * Delete obsolete components plugin export
* Contributors: Denis Štogl
```

## joint_state_controller

```
* Use ros2 contol test assets (#138 <https://github.com/ros-controls/ros2_controllers/issues/138>)
  * Add description to test trajecotry_controller
  * Use ros2_control_test_assets package
  * Delete obsolete components plugin export
* Contributors: Denis Štogl
```

## joint_trajectory_controller

```
* Use ros2 contol test assets (#138 <https://github.com/ros-controls/ros2_controllers/issues/138>)
  * Add description to test trajecotry_controller
  * Use ros2_control_test_assets package
  * Delete obsolete components plugin export
* Contributors: Denis Štogl
```

## position_controllers

```
* Use ros2 contol test assets (#138 <https://github.com/ros-controls/ros2_controllers/issues/138>)
  * Add description to test trajecotry_controller
  * Use ros2_control_test_assets package
  * Delete obsolete components plugin export
* Contributors: Denis Štogl
```

## ros2_controllers

- No changes

## velocity_controllers

```
* Use ros2 contol test assets (#138 <https://github.com/ros-controls/ros2_controllers/issues/138>)
  * Add description to test trajecotry_controller
  * Use ros2_control_test_assets package
  * Delete obsolete components plugin export
* Contributors: Denis Štogl
```
