### PR TITLE
bota_driver: 0.5.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -435,7 +435,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/botasys/bota_driver-release.git
-      version: 0.5.8-1
+      version: 0.5.9-1
     source:
       type: git
       url: https://gitlab.com/botasys/bota_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bota_driver` to `0.5.9-1`:

- upstream repository: https://gitlab.com/botasys/bota_driver.git
- release repository: https://gitlab.com/botasys/bota_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.8-1`

## bota_device_driver

```
* add url to wiki
* Feature - add firmware update
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Mike Karamousadakis
```

## bota_driver

```
* add url to wiki
* Contributors: Mike Karamousadakis
```

## bota_node

```
* add url to wiki
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Mike Karamousadakis
```

## bota_signal_handler

```
* add url to wiki
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Mike Karamousadakis
```

## bota_worker

```
* add url to wiki
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Mike Karamousadakis
```

## rokubimini

```
* add url to wiki
* Feature - add firmware update
* Feature - add unit testing of rokubimini
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Mike Karam, Mike Karamousadakis
```

## rokubimini_bus_manager

```
* add url to wiki
* Contributors: Mike Karamousadakis
```

## rokubimini_description

```
* add url to wiki
* fix old path
* Delete old urdf files.
* Added realsense urdf.
* Added rviz config.
* Added sensone ocfigurations.
* Added all the rokubi configurations in the urdf.
* Added urdf for sensone.
* Moved meshes into rokubimini_description.
* Separated adapter from urdf and changed publishing topic names in bota_driver.
* Added rokubi urdf form solidworks
* Contributors: Lefteris Kotsonis, Mike Karamousadakis
```

## rokubimini_ethercat

```
* add url to wiki
* Move soem_interface to rokubimini namespace.
* Feature - add reset services
* Feature - add firmware update
* Separated adapter from urdf and changed publishing topic names in bota_driver.
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Ilias Patsiaouras, Lefteris Kotsonis, Martin, Mike Karamousadakis
```

## rokubimini_examples

- No changes

## rokubimini_factory

```
* add url to wiki
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Mike Karamousadakis
```

## rokubimini_manager

```
* add url to wiki
* Feature - add firmware update
* fix catkin_lint warning: variable CMAKE_CXX_FLAGS is modified
* Contributors: Mike Karamousadakis
```

## rokubimini_msgs

```
* add url to wiki
* Feature - add reset services
* Feature - add firmware update
* Contributors: Mike Karamousadakis
```

## rokubimini_serial

```
* add url to wiki
* Feature - add reset services
* Feature - add firmware update
* Separated adapter from urdf and changed publishing topic names in bota_driver.
* fix bug on startup related to modeState
* Contributors: Ilias Patsiaouras, Lefteris Kotsonis, Mike Karamousadakis
```
