### PR TITLE
knowledge_representation: 0.9.3-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5109,7 +5109,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
-      version: 0.9.1-1
+      version: 0.9.3-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository knowledge_representation to 0.9.3-1:

* upstream repository: https://github.com/utexas-bwi/knowledge_representation.git
* release repository: https://github.com/utexas-bwi-gbp/knowledge_representation-release.git
* distro file: melodic/distribution.yaml
* previous version for package: 0.9.1-1

### knowledge_representation
    * Add door type
    * Add script for making a PGM that has annotated doors as obstacles
    * Update annotation loader to look for groups that look like door annotations
    * Fix "contained" queries and use in show_me
    * Minor documentation improvements
    * Support "instance_of" in knowledge loader
    * Fix API for SELECT queries on entity_attributes tables
    * Contributors: Nick Walker, Yuqian Jiang