### PR TITLE
rclcpp: 6.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1569,7 +1569,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 6.3.0-1
+      version: 6.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `6.3.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `6.3.0-1`

## rclcpp

```
* Reference test resources directly from source tree (#1543 <https://github.com/ros2/rclcpp/issues/1543>)
* clear statistics after window reset (#1531 <https://github.com/ros2/rclcpp/issues/1531>) (#1535 <https://github.com/ros2/rclcpp/issues/1535>)
* Fix a minor string error in the topic_statistics test. (#1541 <https://github.com/ros2/rclcpp/issues/1541>)
* Avoid Resource deadlock avoided if use intra_process_comms (#1530 <https://github.com/ros2/rclcpp/issues/1530>)
* Avoid an object copy in parameter_value.cpp. (#1538 <https://github.com/ros2/rclcpp/issues/1538>)
* Assert that the publisher_list size is 1. (#1537 <https://github.com/ros2/rclcpp/issues/1537>)
* Don't access objects after they have been std::move (#1536 <https://github.com/ros2/rclcpp/issues/1536>)
* Update for checking correct variable (#1534 <https://github.com/ros2/rclcpp/issues/1534>)
* Destroy msg extracted from LoanedMessage. (#1305 <https://github.com/ros2/rclcpp/issues/1305>)
* Contributors: Chen Lihui, Chris Lalancette, Ivan Santiago Paunovic, Miaofei Mei, Scott K Logan, William Woodall, hsgwa
```

## rclcpp_action

```
* Finalize rcl_handle to prevent leak (#1528 <https://github.com/ros2/rclcpp/issues/1528>) (#1529 <https://github.com/ros2/rclcpp/issues/1529>)
* Fix #1526 <https://github.com/ros2/rclcpp/issues/1526>. (#1527 <https://github.com/ros2/rclcpp/issues/1527>)
* Contributors: y-okumura-isp
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
