### PR TITLE
bno055: 0.1.1-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -347,6 +347,21 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  bno055:
+    doc:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: develop
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/flynneva/bno055-release.git
+      version: 0.1.1-3
+    source:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: develop
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bno055` to `0.1.1-3`:

- upstream repository: https://github.com/flynneva/bno055.git
- release repository: https://github.com/flynneva/bno055-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## bno055

- No changes
