### PR TITLE
bno055: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -235,6 +235,21 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  bno055:
+    doc:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/flynneva/bno055-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: develop
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bno055` to `0.1.1-1`:

- upstream repository: https://github.com/flynneva/bno055.git
- release repository: https://github.com/flynneva/bno055-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## bno055

- No changes
