### PR TITLE
rc_genicam_camera: 1.3.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9352,7 +9352,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_camera-release.git
-      version: 1.2.4-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_camera` to `1.3.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_camera.git
- release repository: https://github.com/roboception-gbp/rc_genicam_camera-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.2.4-1`

## rc_genicam_camera

```
* Make frame_id configurable and improved default.
```
