### PR TITLE
Add RHEL rule for python3-pytest-mock

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3670,6 +3670,7 @@ python-pytest-mock:
   debian: [python-pytest-mock]
   fedora: [python-pytest-mock]
   gentoo: [dev-python/pytest-mock]
+  rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python-pytest-mock]
 python-pytest-qt-pip:
   debian:


### PR DESCRIPTION
This package is supplied by EPEL for both RHEL 7 and RHEL 8: https://src.fedoraproject.org/rpms/python3-pytest-mock#bodhi_updates