### PR TITLE
Add RHEL rule for python3-requests

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6710,6 +6710,7 @@ python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]
   openembedded: [python3-requests@meta-python]
+  rhel: ['python%{python3_pkgversion}-requests']
   ubuntu: [python3-requests]
 python3-requests-oauthlib:
   debian: [python3-requests-oauthlib]


### PR DESCRIPTION
On RHEL 7, this package is supplied by EPEL: https://src.fedoraproject.org/rpms/python3-requests#bodhi_updates
On RHEL 8, this package is part of the `baseos` repository: https://mirrors.edge.kernel.org/centos/8/BaseOS/x86_64/os/Packages/python3-requests-2.20.0-2.1.el8_1.noarch.rpm