### PR TITLE
Add RHEL rules for libboost-python, libboost-python-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2042,6 +2042,9 @@ libboost-python:
   fedora: [boost-python2-devel, boost-python3-devel]
   gentoo: ['dev-libs/boost[python]']
   openembedded: [boost@openembedded-core]
+  rhel:
+    '*': [boost-python3]
+    '7': [boost-python, 'boost-python%{python3_pkgversion}']
   ubuntu:
     bionic: [libboost-python1.65.1]
     disco: [libboost-python1.67.0]
@@ -2055,6 +2058,9 @@ libboost-python-dev:
   fedora: [boost-python2-devel]
   gentoo: ['dev-libs/boost[python]']
   openembedded: [boost@openembedded-core]
+  rhel:
+    '*': [boost-python3-devel]
+    '7': [boost-devel, 'boost-python%{python3_pkgversion}-devel']
   ubuntu: [libboost-python-dev]
 libboost-random:
   debian:


### PR DESCRIPTION
In RHEL 8, there is no Python 2 boost package, and the Python 3 package is part of the `powertools` repository:
- https://mirrors.edge.kernel.org/centos/8/PowerTools/x86_64/os/Packages/boost-python3-1.66.0-10.el8.x86_64.rpm
- https://mirrors.edge.kernel.org/centos/8/PowerTools/x86_64/os/Packages/boost-python3-devel-1.66.0-10.el8.x86_64.rpm

In RHEL 7, the Python 2 boost package is supplied by the `base` repository:
- https://mirrors.edge.kernel.org/centos/7/os/x86_64/Packages/boost-python-1.53.0-28.el7.x86_64.rpm
- https://mirrors.edge.kernel.org/centos/7/os/x86_64/Packages/boost-devel-1.53.0-28.el7.x86_64.rpm

...and the Python 3 boost package is supplied by EPEL: https://src.fedoraproject.org/rpms/boost-python3#bodhi_updates