### PR TITLE
Added python packages gputil and jetson-stats

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1919,6 +1919,10 @@ python-gpiozero:
       pip:
         packages: [gpiozero]
     zesty: [python-gpiozero]
+python-gputil-pip:
+  ubuntu:
+    pip:
+      packages: [gputil]
 python-gpxpy:
   debian:
     buster: [python-gpxpy]
@@ -2221,6 +2225,10 @@ python-jasmine-pip:
   ubuntu:
     pip:
       packages: [jasmine]
+python-jetson-stats-pip:
+  ubuntu:
+    pip:
+      packages: [jetson-stats]
 python-jinja2:
   debian: [python-jinja2]
   fedora: [python-jinja2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1920,6 +1920,15 @@ python-gpiozero:
         packages: [gpiozero]
     zesty: [python-gpiozero]
 python-gputil-pip:
+  debian:
+    pip:
+      packages: [gputil]
+  fedora:
+    pip:
+      packages: [gputil]
+  osx:
+    pip:
+      packages: [gputil]
   ubuntu:
     pip:
       packages: [gputil]


### PR DESCRIPTION
There is no pip package for gputil and jetson-stats.
1) gputil: To get the gpu stats from our system. [https://pypi.org/project/GPUtil/]
2) jetson-stats: To get the stats from jetson develpoer boards. [https://pypi.org/project/jetson-stats/]
