### PR TITLE
python3-psycopg2 for ubuntu focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3238,7 +3238,7 @@ python-psycopg2:
   gentoo: [=dev-python/psycopg-2*]
   ubuntu:
     '*': [python-psycopg2]
-    focal: [python3-psycopg2]    
+    focal: [python3-psycopg2]
     trusty_python3: [python3-psycopg2]
     xenial_python3: [python3-psycopg2]
 python-pulsectl-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3240,6 +3240,7 @@ python-psycopg2:
     '*': [python-psycopg2]
     trusty_python3: [python3-psycopg2]
     xenial_python3: [python3-psycopg2]
+    focal_python3: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3238,9 +3238,9 @@ python-psycopg2:
   gentoo: [=dev-python/psycopg-2*]
   ubuntu:
     '*': [python-psycopg2]
+    focal: [python3-psycopg2]    
     trusty_python3: [python3-psycopg2]
     xenial_python3: [python3-psycopg2]
-    focal: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3240,7 +3240,7 @@ python-psycopg2:
     '*': [python-psycopg2]
     trusty_python3: [python3-psycopg2]
     xenial_python3: [python3-psycopg2]
-    focal_python3: [python3-psycopg2]
+    focal: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:


### PR DESCRIPTION
This PR is for the apt-package ``python3-psycopg2`` for Ubuntu focal. As Python2 is deprecated and psycopg2 is only available as a Python3 apt package I ommited the ``_python3`` string.