### PR TITLE
Add rosdep key for python3-ezdxf

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5813,6 +5813,16 @@ python3-events-pip:
   ubuntu:
     pip:
       packages: [Events]
+python3-ezdxf:
+  debian: [python3-ezdxf]
+  ubuntu:
+    '*': [python3-ezdxf]
+    focal:
+      pip:
+        packages: [ezdxf]
+    bionic:
+      pip:
+        packages: [ezdxf]
 python3-fastnumbers-pip:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5817,10 +5817,10 @@ python3-ezdxf:
   debian: [python3-ezdxf]
   ubuntu:
     '*': [python3-ezdxf]
-    focal:
+    bionic:
       pip:
         packages: [ezdxf]
-    bionic:
+    focal:
       pip:
         packages: [ezdxf]
 python3-fastnumbers-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5814,7 +5814,14 @@ python3-events-pip:
     pip:
       packages: [Events]
 python3-ezdxf:
-  debian: [python3-ezdxf]
+  debian:
+    '*': [python3-ezdxf]
+    buster:
+      pip:
+        packages: [ezdxf]
+    stretch:
+      pip:
+        packages: [ezdxf]
   fedora: [python3-ezdxf]
   freebsd: [py37-ezdxf]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5815,6 +5815,8 @@ python3-events-pip:
       packages: [Events]
 python3-ezdxf:
   debian: [python3-ezdxf]
+  fedora: [python3-ezdxf]
+  freebsd: [py37-ezdxf]
   ubuntu:
     '*': [python3-ezdxf]
     bionic:


### PR DESCRIPTION
Add python3-ezdxf to rosdep/python.yaml file

ezdxf is a Python package to create new DXF files and read/modify/write existing DXF files

debian: https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=python3-ezdxf
ubuntu: https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-ezdxf&searchon=names
pip: https://pypi.org/project/ezdxf/