### PR TITLE
pilz_common: 0.7.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4539,7 +4539,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PilzDE/pilz_common-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/PilzDE/pilz_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pilz_common` to `0.7.2-1`:

- upstream repository: https://github.com/PilzDE/pilz_common.git
- release repository: https://github.com/PilzDE/pilz_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.7.1-1`

## pilz_industrial_motion_testutils

```
* Make accpetance-test utils public
* Contributors: Pilz GmbH and Co. KG
```

## pilz_msgs

- No changes

## pilz_testutils

```
* Add pilz_testutils_coverage to CI job
* Add unittest for joint_state_publisher_mock
* Contributors: Pilz GmbH and Co. KG
```

## pilz_utils

- No changes
