### PR TITLE
Add libuvc-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4499,6 +4499,13 @@ libuv-dev:
     xenial: [libuv0.10-dev]
     yakkety: [libuv0.10-dev]
     zesty: [libuv0.10-dev]
+libuvc-dev:
+  debian:
+    '*': [libuvc-dev]
+    stretch: null
+  ubuntu:
+    '*': [libuvc-dev]
+    xenial: null
 libv4l-dev:
   arch: [v4l-utils]
   debian: [libv4l-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4503,6 +4503,7 @@ libuvc-dev:
   debian:
     '*': [libuvc-dev]
     stretch: null
+  gentoo: [media-libs/libuvc]
   ubuntu:
     '*': [libuvc-dev]
     xenial: null


### PR DESCRIPTION
libuvc-dev is needed to release https://github.com/ros-drivers/libuvc_ros in noetic
https://packages.debian.org/search?keywords=libuvc-dev
https://packages.ubuntu.com/search?keywords=libuvc-dev