### PR TITLE
Add RHEL rule for python3-tk

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7023,6 +7023,7 @@ python3-tk:
   debian: [python3-tk]
   fedora: [python3-tkinter]
   openembedded: [python3-tkinter@openembedded-core]
+  rhel: ['python%{python3_pkgversion}-tkinter']
   ubuntu: [python3-tk]
 python3-toml:
   debian: [python3-toml]


### PR DESCRIPTION
In RHEL 8, this package is part of the `appstream` repository: https://mirrors.edge.kernel.org/centos/8/AppStream/x86_64/os/Packages/python3-tkinter-3.6.8-31.el8.x86_64.rpm

In RHEL 7, this package is part of the `base` repository: https://mirrors.edge.kernel.org/centos/7/os/x86_64/Packages/python3-tkinter-3.6.8-17.el7.x86_64.rpm