### PR TITLE
Add RHEL rule for libjpeg

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2998,6 +2998,7 @@ libjpeg:
   macports: [jpeg]
   openembedded: [jpeg@openembedded-core]
   opensuse: [libjpeg62-devel]
+  rhel: [libjpeg-turbo-devel]
   slackware: [libjpeg-turbo]
   ubuntu:
     artful: [libjpeg-dev]


### PR DESCRIPTION
In RHEL 8, this package is part of the `appstream` repository: https://mirrors.edge.kernel.org/centos/8/AppStream/x86_64/os/Packages/libjpeg-turbo-devel-1.5.3-10.el8.x86_64.rpm

In RHEL 7, this pacakge is part of the `base` repository: https://mirrors.edge.kernel.org/centos/7/os/x86_64/Packages/libjpeg-turbo-devel-1.2.90-8.el7.x86_64.rpm