### PR TITLE
Add RHEL rule for libudev-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4382,6 +4382,7 @@ libudev-dev:
   fedora: [libudev-devel]
   gentoo: [virtual/libudev]
   openembedded: [udev@openembedded-core]
+  rhel: [libudev-devel]
   ubuntu: [libudev-dev]
 libunittest++:
   arch: [unittestpp]


### PR DESCRIPTION
In RHEL 8, this package is part of the `baseos` repository: https://mirrors.edge.kernel.org/centos/8/BaseOS/x86_64/os/Packages/systemd-devel-239-41.el8_3.1.x86_64.rpm

In RHEL 7, this package is part of the `base` repository: https://mirrors.edge.kernel.org/centos/7/os/x86_64/Packages/systemd-devel-219-78.el7.x86_64.rpm

It's tricky to demonstrate that the virtual package `libudev-devel` is provided by the `systemd-devel` package for RHEL, since there isn't a robust packaging dashboard for that platform. At least for Fedora we can link to the packaging sources, but the packaging repositories aren't public for RHEL. Best I can do is copy/paste command line output:

```
$ cat /etc/redhat-release 
CentOS Linux release 8.3.2011
$ dnf provides libudev-devel -q
systemd-devel-239-41.el8_3.1.x86_64 : Development headers for systemd
Repo        : baseos
Matched from:
Provide    : libudev-devel = 239
```

```
$ cat /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)
$ yum provides libudev-devel -q
systemd-devel-219-78.el7.x86_64 : Development headers for systemd
Repo        : base
Matched from:
Provides    : libudev-devel = 219
```