### PR TITLE
Add RHEL rule for wx-common

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6629,6 +6629,9 @@ wx-common:
   fedora: [wxGTK3-devel]
   gentoo: [x11-libs/wxGTK]
   openembedded: [wxwidgets@meta-ros-common]
+  rhel:
+    '*': [wxGTK3-devel]
+    '7': [wxGTK-devel]
   ubuntu: [wx-common]
 wxwidgets:
   arch: [wxgtk]


### PR DESCRIPTION
In RHEL, these packages are provided by the EPEL repository:
* RHEL 8: https://src.fedoraproject.org/rpms/wxGTK3#bodhi_updates
* RHEL 7: https://src.fedoraproject.org/rpms/wxGTK#bodhi_updates