### PR TITLE
Add RHEL 8 rule for python3-pandas

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6287,6 +6287,9 @@ python3-pandas:
   fedora: [python3-pandas]
   gentoo: [dev-python/pandas]
   openembedded: [python3-pandas@meta-python]
+  rhel:
+    '*': ['python%{python3_pkgversion}-pandas']
+    '7': null
   ubuntu: [python3-pandas]
 python3-papermill-pip:
   debian:


### PR DESCRIPTION
For RHEL 8, this package is provided by the EPEL repository: https://src.fedoraproject.org/rpms/python-pandas#bodhi_updates

There is no Python 3 package for EPEL 7 at this time.