### PR TITLE
Add RHEL 8 rule for python3-serial

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6849,6 +6849,9 @@ python3-serial:
   debian: [python3-serial]
   fedora: [python3-pyserial]
   openembedded: [python3-pyserial@meta-python]
+  rhel:
+    '*': ['python%{python3_pkgversion}-pyserial']
+    '7': null
   ubuntu: [python3-serial]
 python3-setuptools:
   alpine: [py3-setuptools]


### PR DESCRIPTION
In RHEL 8, this package is part of the `appstream` repository: https://mirrors.edge.kernel.org/centos/8/AppStream/x86_64/os/Packages/python3-pyserial-3.1.1-8.el8.noarch.rpm

There is no Python 3 package for RHEL 7 at this time.