### PR TITLE
Fix boost-python rules for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -323,9 +323,8 @@ boost:
     stretch: [libboost-all-dev]
     wheezy: [libboost-all-dev]
   fedora:
-    '*': [boost-devel, boost-python3-devel]
-    '30': [boost-devel, boost-python2-devel, boost-python3-devel]
-    '31': [boost-devel, boost-python2-devel, boost-python3-devel]
+    '*': [boost-devel]
+    '32': [boost-devel, boost-python3-devel]
   freebsd: [py27-boost-libs]
   gentoo: ['dev-libs/boost[python]']
   macports: [boost]
@@ -2039,7 +2038,7 @@ libboost-python:
     buster: [libboost-python1.67.0]
     jessie: [libboost-python1.55.0]
     stretch: [libboost-python1.62.0]
-  fedora: [boost-python2-devel, boost-python3-devel]
+  fedora: [boost-python3]
   gentoo: ['dev-libs/boost[python]']
   openembedded: [boost@openembedded-core]
   ubuntu:
@@ -2052,7 +2051,9 @@ libboost-python:
 libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]
-  fedora: [boost-python2-devel]
+  fedora:
+    '*': [boost-devel]
+    '32': [boost-devel, boost-python3-devel]
   gentoo: ['dev-libs/boost[python]']
   openembedded: [boost@openembedded-core]
   ubuntu: [libboost-python-dev]


### PR DESCRIPTION
No supported versions of Fedora carry a Python 2 subpackage for Boost. In Fedora 33, the boost-python3-devel subpackage was [folded into boost-devel](https://src.fedoraproject.org/rpms/boost/c/1f2e448e099a867f9da62b9da009d3dec5e1ad64).

Fedora 30 and 31 are EOL - the currently supported Fedora versions are 32 and 33.