### PR TITLE
Drop cwiid rules for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -649,14 +649,12 @@ cvs:
 cwiid:
   arch: [cwiid]
   debian: [libcwiid1]
-  fedora: [cwiid]
   gentoo: [app-misc/cwiid]
   opensuse: [libcwiid1]
   ubuntu: [libcwiid1]
 cwiid-dev:
   arch: [cwiid]
   debian: [libcwiid-dev]
-  fedora: [cwiid-devel]
   gentoo: [app-misc/cwiid]
   opensuse: [libcwiid-devel]
   ubuntu: [libcwiid-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1265,7 +1265,6 @@ python-cvxopt:
 python-cwiid:
   arch: [cwiid]
   debian: [python-cwiid]
-  fedora: [cwiid]
   gentoo: ['app-misc/cwiid[python]']
   ubuntu: [python-cwiid]
 python-cython-pip:


### PR DESCRIPTION
This package was orphaned and removed from Fedora somewhere around Fedora 30. The [upstream project](https://github.com/abstrakraft/cwiid) hasn't been active since 2010.

https://src.fedoraproject.org/rpms/cwiid#bodhi_updates