### PR TITLE
Drop python3-requests-oauthlib from RHEL 7

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6718,7 +6718,9 @@ python3-requests-oauthlib:
   fedora: [python3-requests-oauthlib]
   gentoo: [dev-python/requests-oauthlib]
   openembedded: [python3-requests-oauthlib@meta-python]
-  rhel: ['python%{python3_pkgversion}-requests-oauthlib']
+  rhel:
+    '*': ['python%{python3_pkgversion}-requests-oauthlib']
+    '7': null
   ubuntu: [python3-requests-oauthlib]
 python3-retrying:
   arch: [python-retrying]


### PR DESCRIPTION
It looks like this package is only available as part of RHEL 8.

The Fedora package has an EPEL 7 branch, which [contains a message](https://src.fedoraproject.org/rpms/python-requests-oauthlib/blob/epel7/f/dead.package) stating that RHEL 7 has a python package for requests-oauthlib so EPEL cannot provide it. The system package only provides for Python 2, and there is no Python 3 package.