### PR TITLE
Add rosdep rules for python decorator

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1328,6 +1328,9 @@ python-debian:
 python-decorator:
   debian: [python-decorator]
   fedora: [python2-decorator]
+  gentoo: [dev-python/decorator]
+  osx:
+    pip: [decorator]
   ubuntu: [python-decorator]
 python-deepdiff-pip:
   debian:
@@ -5734,6 +5737,9 @@ python3-dbus:
 python3-decorator:
   debian: [python3-decorator]
   fedora: [python3-decorator]
+  gentoo: [dev-python/decorator]
+  osx:
+    pip: [decorator]
   ubuntu: [python3-decorator]
 python3-defusedxml:
   debian: [python3-defusedxml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1325,6 +1325,10 @@ python-debian:
     yakkety_python3: [python3-debian]
     zesty: [python-debian]
     zesty_python3: [python3-debian]
+python-decorator:
+  debian: [python-decorator]
+  fedora: [python-decorator]
+  ubuntu: [python-decorator]
 python-deepdiff-pip:
   debian:
     pip: [deepdiff]
@@ -5727,6 +5731,10 @@ python3-dbus:
   debian: [python3-dbus]
   fedora: [python3-dbus]
   ubuntu: [python3-dbus]
+python3-decorator:
+  debian: [python3-decorator]
+  fedora: [python3-decorator]
+  ubuntu: [python3-decorator]
 python3-defusedxml:
   debian: [python3-defusedxml]
   fedora: [python3-defusedxml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1327,7 +1327,7 @@ python-debian:
     zesty_python3: [python3-debian]
 python-decorator:
   debian: [python-decorator]
-  fedora: [python-decorator]
+  fedora: [python2-decorator]
   ubuntu: [python-decorator]
 python-deepdiff-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1327,7 +1327,6 @@ python-debian:
     zesty_python3: [python3-debian]
 python-decorator:
   debian: [python-decorator]
-  fedora: [python2-decorator]
   gentoo: [dev-python/decorator]
   osx:
     pip: [decorator]


### PR DESCRIPTION
Adds https://pypi.org/project/decorator/ to rosdep/python.yaml.

The goal of the decorator module is to make it easy to define signature-preserving function decorators and decorator factories. It also includes an implementation of multiple dispatch and other niceties (please check the docs). It is released under a two-clauses BSD license.