### PR TITLE
disable ros2_control for rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1835,30 +1835,6 @@ repositories:
       url: https://github.com/ros2/ros1_bridge.git
       version: master
     status: maintained
-  ros2_control:
-    doc:
-      type: git
-      url: https://github.com/ros-controls/ros2_control.git
-      version: master
-    release:
-      packages:
-      - controller_interface
-      - controller_manager
-      - controller_manager_msgs
-      - hardware_interface
-      - ros2_control
-      - ros2_control_test_assets
-      - ros2controlcli
-      - transmission_interface
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.1.6-1
-    source:
-      type: git
-      url: https://github.com/ros-controls/ros2_control.git
-      version: master
-    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
The rolling release was made my mistake. The current master branches are not compliant with the rest of the ROS2 rolling stack and for API/ABI conserving reasons, we'd not like branch at this point.

cc/ @bmagyar I couldn't find an entry for ros2_controllers. I assume you didn't release that repo for rolling then?