### PR TITLE
mir_robot: 1.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3623,7 +3623,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.1-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.1.0-1`

## mir_actions

```
* Contributors: Martin Günther
```

## mir_description

```
* Add prepend_prefix_to_laser_frame to URDF and launch files
  Fixes #65 <https://github.com/dfki-ric/mir_robot/issues/65>.
* Add tf_prefix to URDF and launch files
* Fix typo in robot_namespace
* Add missing 'xacro:' xml namespace prefixes
  Macro calls without 'xacro:' prefix are deprecated in Melodic and will
  be forbidden in Noetic.
* Contributors: Martin Günther
```

## mir_driver

```
* Fix subscribing twice to same topic (TF etc)
  There was a flaw in the subscriber logic that caused the mir_bridge to
  subscribe multiple times to the same topic from the MiR, especially for
  latched topics. This can be seen by repeated lines in the output:
  starting to stream messages on topic 'tf'
  starting to stream messages on topic 'tf'
  starting to stream messages on topic 'tf'
  Probably related to #64 <https://github.com/dfki-ric/mir_robot/issues/64>.
* Contributors: Martin Günther
```

## mir_dwb_critics

```
* Fix bug in path_dist_pruned
  With some paths, the previous code crashed with "terminate called after throwing an instance
  of 'std::bad_alloc'".
* Contributors: Martin Günther
```

## mir_gazebo

```
* mir_gazebo: Add model_name arg
* Move joint_state_publisher to mir_gazebo_common.launch
* Add optional namespace to launch files
* Add prepend_prefix_to_laser_frame to URDF and launch files
  Fixes #65 <https://github.com/dfki-ric/mir_robot/issues/65>.
* Add tf_prefix to URDF and launch files
* Contributors: Martin Günther
```

## mir_msgs

```
* Contributors: Martin Günther
```

## mir_navigation

```
* Add optional namespace to launch files
* Add prefix to start_planner.launch (#67 <https://github.com/dfki-ric/mir_robot/issues/67>)
* Update scripts to Python3 (Noetic)
* Contributors: Martin Günther
```

## mir_robot

```
* Contributors: Martin Günther
```

## sdc21x0

```
* Contributors: Martin Günther
```
