### PR TITLE
toposens: 2.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6972,7 +6972,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toposens` to `2.2.0-1`:

- upstream repository: https://gitlab.com/toposens/public/ros-packages.git
- release repository: https://gitlab.com/toposens/public/toposens-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.1.0-1`

## toposens

- No changes

## toposens_bringup

```
* Optimize launch file structure
* Contributors: Dennis Maier
```

## toposens_description

```
* Optimize launch file structure
* Contributors: Dennis Maier
```

## toposens_driver

```
* Optimize launch file structure
* Add .clang-format file and auto-format files (including XML-style files)
* Remove reconfig unit/integration tests from packages toposens_driver and
  toposens_markers
* Bugfix: Install param/ folder
* Contributors: Dennis Maier, Tobias Roth
```

## toposens_markers

```
* Optimize launch file structure
* Add .clang-format file and auto-format files (including XML-style files)
* Remove reconfig unit/integration tests
* Bugfix: Install param/ folder
* Contributors: Dennis Maier, Tobias Roth
```

## toposens_msgs

- No changes

## toposens_pointcloud

```
* Optimize launch file structure
* Add .clang-format file and auto-format files (including XML-style files)
* Contributors: Dennis Maier, Tobias Roth
```

## toposens_sync

```
* Optimize launch file structure
* Add .clang-format file and auto-format files (including XML-style files)
* Contributors: Dennis Maier, Tobias Roth
```
