### PR TITLE
Target RHEL 7 in ROS 2 Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
+  rhel:
+  - '7'
   ubuntu:
   - focal
 repositories:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5970,9 +5970,7 @@ python3-importlib-metadata:
     '31': [python3-importlib-metadata]
   gentoo: [dev-python/importlib_metadata]
   openembedded: [python3-importlib-metadata@openembedded-core]
-  rhel:
-    '*': ['python%{python3_pkgversion}-importlib-metadata']
-    '7': null
+  rhel: ['python%{python3_pkgversion}-importlib-metadata']
   ubuntu:
     '*': [python3-importlib-metadata]
     bionic:
@@ -5993,9 +5991,7 @@ python3-importlib-resources:
   fedora: [python3]
   gentoo: [dev-python/importlib_resources]
   openembedded: [python3@openembedded-core]
-  rhel:
-    '*': ['python%{python3_pkgversion}-importlib-resources']
-    '7': null
+  rhel: ['python%{python3_pkgversion}-importlib-resources']
   ubuntu:
     '*': [python3-minimal]
     bionic:


### PR DESCRIPTION
I've bloomed nearly all of the ROS 2 Rolling repositories in ros2-gbp and updated their action lists. We're currently able to build ~87% of the packages, and I believe that when the dust settles, we'll be in the mid 90's.

For the most part, when a Python package is not available for RHEL 7, I've been dropping the dependency in Bloom just to move things forward. However, the importlib_* backport packages are actually needed for downstream builds to work, so adding bootstrap packages seems like the only option. Therefore I'm adding rules here, just like we do for the bootstrap packages for Ubuntu.

Even though we don't have packages building on build.ros2.org at the moment, I'd really like to stop performing out-of-band Bloom generation on the packages, so I'd like to merge this while I'm caught up. 