### PR TITLE
add flask socketio

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1642,6 +1642,19 @@ python-flask-restful:
         packages: [flask-restful]
     xenial: [python-flask-restful]
     yakkety: [python-flask-restful]
+python-flask-socketio:
+   debian:
+     pip:
+       packages: [flask-socketio]
+   fedora:
+     pip:
+       packages: [flask-socketio]
+   osx:
+     pip:
+       packages: [flask-socketio]
+   ubuntu:
+     pip:
+       packages: [flask-socketio]
 python-flatdict-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1642,7 +1642,7 @@ python-flask-restful:
         packages: [flask-restful]
     xenial: [python-flask-restful]
     yakkety: [python-flask-restful]
-python-flask-socketio:
+python3-flask-socketio-pip:
    debian:
      pip:
        packages: [flask-socketio]


### PR DESCRIPTION
Hi, 

For a project I'm working on, we would like to do bidirectional streaming of information over the web for which we need WebSockets. 

We tried using python web sockets, but it was too low level for our purposes. Also we are using Flask, so we want to use the Flask framework. 

https://pypi.org/project/Flask-SocketIO/

https://flask-socketio.readthedocs.io/en/latest/