### PR TITLE
contracts_lite_vendor: 0.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -541,7 +541,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-safety/contracts_lite_vendor-release.git
-      version: 0.4.1-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-safety/contracts_lite_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `contracts_lite_vendor` to `0.5.0-1`:

- upstream repository: https://github.com/ros-safety/contracts_lite_vendor.git
- release repository: https://github.com/ros-safety/contracts_lite_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.4.1-1`

## contracts_lite_vendor

```
* Library update: Add contract types (#14 <https://github.com/ros-safety/contracts_lite/pull/14>)
  
    * rename contract_types.hpp to operators.hpp
    * edit testing instructions in readme
    * add helper types and tests
    * update documentation
    * add requirements docs
    * remove assertions.hpp and scalar_flicker.hpp; too specific for this library
  
```
