### PR TITLE
Fix RHEL rule for python3-pytest-mock

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3688,7 +3688,6 @@ python-pytest-mock:
   debian: [python-pytest-mock]
   fedora: [python-pytest-mock]
   gentoo: [dev-python/pytest-mock]
-  rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python-pytest-mock]
 python-pytest-qt-pip:
   debian:
@@ -6651,9 +6650,7 @@ python3-pytest-mock:
   fedora: [python3-pytest-mock]
   gentoo: [dev-python/pytest-mock]
   openembedded: [python3-pytest-mock@meta-ros-common]
-  rhel:
-    '*': ['python%{python3_pkgversion}-pytest-mock']
-    '7': null
+  rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-pytest-timeout:
   debian: [python3-pytest-timeout]


### PR DESCRIPTION
This rule was added to python-pytest-mock by mistake in #28275.