### PR TITLE
heron_simulator: 0.3.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4875,7 +4875,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_simulator-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/heron/heron_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_simulator` to `0.3.1-1`:

- upstream repository: https://github.com/heron/heron_simulator.git
- release repository: https://github.com/clearpath-gbp/heron_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.0-1`

## heron_gazebo

```
* Merge pull request #11 <https://github.com/heron/heron_simulator/issues/11> from heron/thruster-fix
  Enable thruster joints in simulation
* Enable the simulation argument so the thrusters are mobile & allow the robot to move
* Merge pull request #10 <https://github.com/heron/heron_simulator/issues/10> from heron/namespace-fix
  Fix namespace preventing the EKF node from working
* Use remap instead of rosparams to set the topics for the mag topic translator. This allows the node to work correctly when the namespace argument is set.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## heron_simulator

- No changes
