### PR TITLE
heron: 0.3.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3984,7 +3984,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/heron/heron.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron` to `0.3.4-1`:

- upstream repository: https://github.com/heron/heron
- release repository: https://github.com/clearpath-gbp/heron-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.3-1`

## heron_control

- No changes

## heron_description

```
* Fix disconnected thruster joints (#12 <https://github.com/heron/heron/issues/12>)
  * Use a fixed joint for the thrusters unless we're in simulation; these joints are purely decorative outside gazebo, and the tf is not published except in simulation anyway
  * Remove superfluous .py; they were a copy & paste error
* Merge pull request #11 <https://github.com/heron/heron/issues/11> from heron/no-um6
  Rename UM6 env vars to be generic IMU
* Rename the UM6 IMU env vars to remove the reference to UM6; make them generic IMU vars instead
* [heron_description] Dropped --in-order arg from xacro since it is default in Melodic.
* [heron_description] Added xacro xml namespace prefix.
* [heron_description] Dropped .py on xacro since it is deprecated.
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## heron_msgs

- No changes
