### PR TITLE
Add rosdep rules for python3-yappi

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7194,6 +7194,13 @@ python3-yaml:
       packages: [pyyaml]
   rhel: ['python%{python3_pkgversion}-PyYAML']
   ubuntu: [python3-yaml]
+python3-yappi:
+  debian: [python3-yappi]
+  fedora: [python3-yappi]
+  gentoo: [dev-python/yappi]
+  osx:
+    pip: [yappi]
+  ubuntu: [python3-yappi]
 python3-zmq:
   arch: [python-pyzmq]
   debian: [python3-zmq]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7195,12 +7195,18 @@ python3-yaml:
   rhel: ['python%{python3_pkgversion}-PyYAML']
   ubuntu: [python3-yaml]
 python3-yappi:
-  debian: [python3-yappi]
+  debian:
+    '*': [python3-yappi]
+    buster: null
+    stretch: null
   fedora: [python3-yappi]
   gentoo: [dev-python/yappi]
   osx:
     pip: [yappi]
-  ubuntu: [python3-yappi]
+  ubuntu:
+    '*': [python3-yappi]
+    bionic: null
+    xenial: null
 python3-zmq:
   arch: [python-pyzmq]
   debian: [python3-zmq]


### PR DESCRIPTION
Adds rosdep rules for python3-yappi

PyPi: https://pypi.org/project/yappi/
Debian: https://packages.debian.org/sid/arm64/python3-yappi / 
Ubuntu: https://packages.ubuntu.com/source/focal/python-yappi
Fedora: https://src.fedoraproject.org/rpms/python-yappi/blob/rawhide/f/python-yappi.spec
Gentoo: https://packages.gentoo.org/packages/dev-python/yappi