### PR TITLE
Added rosdep key for python3-nose-parameterized

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6230,6 +6230,9 @@ python3-nose:
   openembedded: [python3-nose@openembedded-core]
   rhel: ['python%{python3_pkgversion}-nose']
   ubuntu: [python3-nose]
+python3-nose-parameterized:
+  debian: [python3-nose-parameterized]
+  ubuntu: [python3-nose-parameterized]
 python3-nose-yanc:
   debian: [python3-nose-yanc]
   openembedded: [python3-nose-yanc@meta-ros-common]


### PR DESCRIPTION
Adds python3-nose-parameterized rosdep key

python3-nose-parameterized is deprecated in Fedora and Gentoo.

Debian: https://packages.debian.org/buster/python3-nose-parameterized
Ubuntu: https://packages.ubuntu.com/xenial/python3-nose-parameterized