### PR TITLE
Adds rosdep definition for python3-contextlib2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5704,6 +5704,13 @@ python3-construct:
   fedora: [python3-construct]
   gentoo: [dev-python/construct]
   ubuntu: [python3-construct]
+python3-contextlib2:
+  debian: [python3-contextlib2]
+  fedora: [python3-contextlib2]
+  gentoo: [dev-python/contextlib2]
+  osx:
+    pip: [contextlib2]
+  ubuntu: [python3-contextlib2]
 python3-coverage:
   debian: [python3-coverage]
   fedora: [python3-coverage]


### PR DESCRIPTION
Debian: https://packages.debian.org/stretch/python3-contextlib2
Ubuntu: https://packages.ubuntu.com/xenial/python3-contextlib2
Fedora: https://fedora.pkgs.org/33/fedora-x86_64/python3-contextlib2-0.5.5-15.fc33.noarch.rpm.html
Gentoo: https://packages.gentoo.org/packages/dev-python/contextlib2
Pip: https://pypi.org/project/contextlib2/