### PR TITLE
async_web_server_cpp: 1.0.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -593,7 +593,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fkie/async_web_server_cpp.git
-      version: master
+      version: ros1-releases
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -602,7 +602,7 @@ repositories:
     source:
       type: git
       url: https://github.com/fkie/async_web_server_cpp.git
-      version: develop
+      version: ros1-develop
     status: maintained
   ati_force_torque:
     doc:

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -598,7 +598,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fkie-release/async_web_server_cpp-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/fkie/async_web_server_cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `1.0.3-1`:

- upstream repository: https://github.com/fkie/async_web_server_cpp.git
- release repository: https://github.com/fkie-release/async_web_server_cpp-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.2-1`

## async_web_server_cpp

```
* Add Windows 10 compatibility (#1 <https://github.com/fkie/async_web_server_cpp/issues/1>)
* Contributors: Pranav Dhulipala, Timo Röhling
```
