### PR TITLE
ros_led: 0.0.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10250,6 +10250,24 @@ repositories:
       type: git
       url: https://github.com/shadow-robot/ros_ethercat_eml.git
       version: melodic-devel
+  ros_led:
+    doc:
+      type: git
+      url: https://github.com/CopterExpress/ros_led.git
+      version: master
+    release:
+      packages:
+      - led_msgs
+      - ws281x
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CopterExpress/ros_led-release.git
+      version: 0.0.9-1
+    source:
+      type: git
+      url: https://github.com/CopterExpress/ros_led.git
+      version: master
+    status: maintained
   ros_monitoring_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_led` to `0.0.9-1`:

- upstream repository: https://github.com/CopterExpress/ros_led.git
- release repository: https://github.com/CopterExpress/ros_led-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## led_msgs

```
* Version bump
```

## ws281x

```
* Restore lost rpi_ws281x library files
```
