### PR TITLE
scan_tools: 0.3.3-1 in 'melodic/distribution.yaml' [non-bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12029,6 +12029,30 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/sbpl-release.git
       version: 1.3.1-0
+  scan_tools:
+    doc:
+      type: git
+      url: https://github.com/ccny-ros-pkg/scan_tools.git
+      version: ros1
+    release:
+      packages:
+      - laser_ortho_projector
+      - laser_scan_matcher
+      - laser_scan_sparsifier
+      - laser_scan_splitter
+      - ncd_parser
+      - polar_scan_matcher
+      - scan_to_cloud_converter
+      - scan_tools
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-gbp/scan_tools-release.git
+      version: 0.3.3-2
+    source:
+      type: git
+      url: https://github.com/ccny-ros-pkg/scan_tools.git
+      version: ros1
+    status: unmaintained
   schunk_modular_robotics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository ros_led to 0.3.3-1:
-    upstream repository: https://github.com/ros-gbp/scan_tools-release.git
-    release repository: https://github.com/ros-gbp/scan_tools-release.git
-    distro file: melodic/distribution.yaml
-    bloom version: 0.10.1
-    previous version for package: null

NOTE: PR is made manually due to the issue [answers.ros.org#371864](https://answers.ros.org/question/371864/bloom-release-fais-aborting-pull-request-http-error-401-unauthorized/).