### PR TITLE
rosbag2: 0.3.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3318,7 +3318,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.3.6-1
+      version: 0.3.7-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.3.7-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.6-1`

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_converter_default_plugins

- No changes

## rosbag2_cpp

```
* [foxy backport] Fix --topics flag for ros2 bag play being ignored for all bags after the first one (#619 <https://github.com/ros2/rosbag2/issues/619>) (#654 <https://github.com/ros2/rosbag2/issues/654>)
* Contributors: Aleksandr Rozhdestvenskii
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* [foxy backport] Fix --topics flag for ros2 bag play being ignored for all bags after the first one (#619 <https://github.com/ros2/rosbag2/issues/619>) (#654 <https://github.com/ros2/rosbag2/issues/654>)
* Contributors: Aleksandr Rozhdestvenskii
```

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

```
* [foxy backport] Zstd should not install internal headers (#631 <https://github.com/ros2/rosbag2/issues/631>) (#653 <https://github.com/ros2/rosbag2/issues/653>)
* Contributors: Emerson Knapp
```
