### PR TITLE
t_mapping: 0.1.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -15759,6 +15759,20 @@ repositories:
       url: https://github.com/NicksSimulationsROS/sync_params.git
       version: ros-kinetic
     status: developed
+  t_mapping:
+    doc:
+      type: git
+      url: https://github.com/mitre/t_mapping.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/tbostic32/t_mapping-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/mitre/t_mapping.git
+      version: kinetic-devel
   talos_robot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `t_mapping` to `0.1.2-1`:

- upstream repository: https://github.com/mitre/t_mapping.git
- release repository: https://github.com/tbostic32/t_mapping-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
