### PR TITLE
Add rosdep rules for python-crcmod and python3-crcmod

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1222,8 +1222,8 @@ python-crcmod:
     pip:
       packages: [crcmod]
   ubuntu:
-    xenial: [python-crcmod]
     bionic: [python-crcmod]
+    xenial: [python-crcmod]
 python-crypto:
   alpine: [py-crypto]
   arch: [python2-crypto]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1213,6 +1213,17 @@ python-crccheck-pip:
   ubuntu:
     pip:
       packages: [crccheck]
+python-crcmod:
+  debian: [python-crcmod]
+  fedora:
+    pip:
+      packages: [crcmod]
+  osx:
+    pip:
+      packages: [crcmod]
+  ubuntu:
+    '*': [python-crcmod]
+    focal: null
 python-crypto:
   alpine: [py-crypto]
   arch: [python2-crypto]
@@ -5734,6 +5745,15 @@ python3-coverage:
   openembedded: [python3-coverage@meta-python]
   rhel: ['python%{python3_pkgversion}-coverage']
   ubuntu: [python3-coverage]
+python3-crcmod:
+  debian: [python3-crcmod]
+  fedora:
+    pip:
+      packages: [crcmod]
+  osx:
+    pip:
+      packages: [crcmod]
+  ubuntu: [python3-crcmod]
 python3-cryptography:
   alpine: [py3-cryptography]
   debian: [python3-cryptography]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1222,8 +1222,8 @@ python-crcmod:
     pip:
       packages: [crcmod]
   ubuntu:
-    '*': [python-crcmod]
-    focal: null
+    xenial: [python-crcmod]
+    bionic: [python-crcmod]
 python-crypto:
   alpine: [py-crypto]
   arch: [python2-crypto]


### PR DESCRIPTION
Add rosdep rules for `python-crcmod` and `python3-crcmod`.

### python-crcmod:
**Debian Jessie, Stretch, Buster:** https://packages.debian.org/search?keywords=python-crcmod
**Ubuntu Xenial and Bionic:** https://packages.ubuntu.com/search?keywords=python-crcmod
**Fedora:** https://apps.fedoraproject.org/packages is down :disappointed: There's a `python-crcmod`[here](https://src.fedoraproject.org/rpms/python-crcmod), it has no releases. So I stuck with [pip](https://pypi.org/project/crcmod/)
**OSX:** Pip https://pypi.org/project/crcmod/

### python3-crcmod:
**Debian Jessie, Stretch, Buster:** https://packages.debian.org/search?keywords=python3-crcmod
**Ubuntu Xenial, Bionic, and Focal:** https://packages.ubuntu.com/search?keywords=python3-crcmod
**Fedora:** There doesn't appear to be a `python3-crcmod`. So I stuck with [pip](https://pypi.org/project/crcmod/)
**OSX:** Pip https://pypi.org/project/crcmod/