### PR TITLE
Add rosdep rules for python-pyqtgraph

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3586,8 +3586,8 @@ python-pyqtgraph:
     pip:
       packages: [pyqtgraph]
   ubuntu:
-    '*': [python-pyqtgraph]
-    focal: null
+    xenial: [python-pyqtgraph]
+    bionic: [python-pyqtgraph]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3586,8 +3586,8 @@ python-pyqtgraph:
     pip:
       packages: [pyqtgraph]
   ubuntu:
-    xenial: [python-pyqtgraph]
     bionic: [python-pyqtgraph]
+    xenial: [python-pyqtgraph]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3577,6 +3577,17 @@ python-pyqrcode:
     xenial:
       pip:
         packages: [PyQRCode]
+python-pyqtgraph:
+  debian: [python-pyqtgraph]
+  fedora:
+    pip:
+      packages: [pyqtgraph]
+  gentoo:
+    pip:
+      packages: [pyqtgraph]
+  ubuntu:
+    '*': [python-pyqtgraph]
+    focal: null
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]


### PR DESCRIPTION
Mimics the `python3-pyqtgraph` rules for py2.

### python-pyqtgraph:
**Debian Jessie, Stretch, Buster:** https://packages.debian.org/search?keywords=python-pyqtgraph
**Ubuntu Xenial and Bionic:** https://packages.ubuntu.com/search?keywords=python-pyqtgraph
**Fedora:** No py2 version released, falling back on pip (https://pypi.org/project/pyqtgraph/)
**Gentoo:** No py2 version released, falling back on pip (https://pypi.org/project/pyqtgraph/)