### PR TITLE
Added focal key for python-serial

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4285,6 +4285,7 @@ python-serial:
     artful_python3: [python3-serial]
     bionic: [python-serial]
     bionic_python3: [python3-serial]
+    focal: [python3-serial]
     lucid: [python-serial]
     maverick: [python-serial]
     natty: [python-serial]


### PR DESCRIPTION
I need to have a ROS package depend on python-serial and also be compatible with both melodic and noetic. 

https://packages.ubuntu.com/focal/python3-serial

(Tested locally by changing /opt/ros/rosdep/sources.list.d)