### PR TITLE
realsense2_camera: 3.1.4-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2741,7 +2741,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.1.3-1
+      version: 3.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `3.1.4-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `3.1.3-1`

## realsense2_camera

```
* fix reading json file with device other than D400 series.
* Publish depth confidence image for supporting devices (L515)
* Add selecting QoS option
* Import unit-tests
* fix timestamp domain issues
  - Add offset to ros_time only if device uses hardware-clock. Otherwise use device time - either system_time or global_time.
  - Warn of a hardware timestamp possible loop.
* Choose the default profile in case of an invalid request.
* Avoid aligning confidence image.
* Add an option for an Ordered PointCloud.
* Contributors: Gabriel Urbain, Isaac I.Y. Saito, Itamar Eliakim, Marc Alban, doronhi
```

## realsense2_camera_msgs

- No changes

## realsense2_description

```
* d415 add plug
* fix d415 mass in _d415.urdf.xacro.
  import tests for xacro files.
* Contributors: Manuel Stahl, Tim Übelhör, doronhi
```
