### PR TITLE
libuvc: 0.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3218,6 +3218,21 @@ repositories:
       type: git
       url: https://github.com/SICKAG/libsick_ldmrs.git
       version: master
+  libuvc:
+    doc:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/libuvc-release.git
+      version: 0.0.6-1
+    source:
+      type: git
+      url: https://github.com/ktossell/libuvc.git
+      version: master
+    status: unmaintained
   lms1xx:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libuvc` to `0.0.6-1`:

- upstream repository: https://github.com/ktossell/libuvc.git
- release repository: https://github.com/ros-drivers-gbp/libuvc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
