### PR TITLE
Adding z_laser_projector repository for noetic indexing

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7765,5 +7765,15 @@ repositories:
       url: https://github.com/openspur/ypspur_ros.git
       version: master
     status: developed
+  z_laser_projector:
+    doc:
+      type: git
+      url: https://github.com/fada-catec/z_laser_projector.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/fada-catec/z_laser_projector.git
+      version: noetic
+    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
Request to add z_laser_projector repository for noetic index.

The z_laser_projector package is a ROS wrapper for ZLP1 Z-LASER Projector, developed under the Focused Technical Project (FTP) grant instrument within the ROSIN (ROS-Industrial) EU project. This package provides libraries that allow the user to operate the device.

Thank you very much.