### PR TITLE
heron_simulator: 0.3.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -4875,7 +4875,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_simulator-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/heron/heron_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_simulator` to `0.3.2-1`:

- upstream repository: https://github.com/heron/heron_simulator.git
- release repository: https://github.com/clearpath-gbp/heron_simulator-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.1-1`

## heron_gazebo

```
* Bumped CMake version to avoid author warning.
* Add the config, launch, and worlds folders to the install target
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## heron_simulator

```
* Bumped CMake version to avoid author warning.
* Contributors: Tony Baltovski
```
