### PR TITLE
heron_simulator: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4002,7 +4002,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron_simulator-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/heron/heron_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_simulator` to `0.3.2-1`:

- upstream repository: https://github.com/heron/heron_simulator.git
- release repository: https://github.com/clearpath-gbp/heron_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.1-1`

## heron_gazebo

```
* Bumped CMake version to avoid author warning.
* Add the config, launch, and worlds folders to the install target
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```

## heron_simulator

```
* Bumped CMake version to avoid author warning.
* Contributors: Tony Baltovski
```
