### PR TITLE
opw_kinematics: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4368,11 +4368,15 @@ repositories:
       version: master
     status: developed
   opw_kinematics:
+    doc:
+      type: git
+      url: https://github.com/Jmeyer1292/opw_kinematics.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/opw_kinematics-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/Jmeyer1292/opw_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opw_kinematics` to `0.4.0-1`:

- upstream repository: https://github.com/Jmeyer1292/opw_kinematics.git
- release repository: https://github.com/ros-industrial-release/opw_kinematics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.1-1`

## opw_kinematics

```
* Vectorize using Eigen::Array and Eigen::Map
* Add code coverage CI build
* Clean CMakeLists.txt
* Switch to using std::array versus raw pointer to array
* Contributors: Levi Armstrong
```
