### PR TITLE
people: 1.4.0-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8047,7 +8047,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/OSUrobotics/people-release.git
-      version: 1.2.0-1
+      version: 1.4.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `people` to `1.4.0-4`:

- upstream repository: https://github.com/wg-perception/people.git
- release repository: https://github.com/OSUrobotics/people-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.2.0-1`
