### PR TITLE
move_base_sequence: 0.0.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6296,6 +6296,22 @@ repositories:
       url: https://github.com/magazino/move_base_flex.git
       version: melodic
     status: developed
+  move_base_sequence:
+    doc:
+      type: git
+      url: https://github.com/MarkNaeem/move_base_sequence.git
+      version: main
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/MarkNaeem/move_base_sequence-release.git
+      version: 0.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MarkNaeem/move_base_sequence.git
+      version: main
+    status: maintained
   moveit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_sequence` to `0.0.1-2`:

- upstream repository: git@github.com:MarkNaeem/move_base_sequence.git
- release repository: https://github.com/MarkNaeem/move_base_sequence-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## move_base_sequence

```
* added a gif to readme
* edit2
* edit
* edited readme
* Edited Readme
* adjusted class, rosparams, ros topics names
* upload the package files
* Initial commit
* Contributors: Mark Naeem, MarkNaeem
```
