### PR TITLE
rospilot: 1.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5821,7 +5821,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/rospilot/rospilot-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/rospilot/rospilot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospilot` to `1.6.1-1`:

- upstream repository: https://github.com/rospilot/rospilot.git
- release repository: https://github.com/rospilot/rospilot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.6.0-1`

## rospilot

```
* Fix systemd service to use noetic
* Remove map server
  Tilestache is no longer supported on modern Ubuntu
* Remove firmware directory
* Switch to Github Actions for CI
* Remove calls to deprecated ffmpeg functions
* Contributors: Christopher Berner
```
