### PR TITLE
fetch_msgs: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1773,6 +1773,20 @@ repositories:
         release: release/noetic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
       version: 0.6.1-1
+  fetch_msgs:
+    release:
+      packages:
+      - fetch_auto_dock_msgs
+      - fetch_driver_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_msgs.git
+      version: ros1
+    status: maintained
   fetch_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/fetchrobotics/fetch_msgs.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## fetch_auto_dock_msgs

```
* Noetic updates and update maintainers
* Contributors: Eric Relson
```

## fetch_driver_msgs

```
* Noetic updates
* Add bool field if charger is detected or not
* Use std_msgs/Header for broader compatibility
  Some ROS APIs may not accept the short version ("Header")
  of the std_msgs/Header type.
* updates maintainers
  Listed multiple individual maintainers and also included the internal
  mailing list to ensure the load is distributed in the event of build
  failures.
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```
