### PR TITLE
fetch_open_auto_dock: 0.1.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1794,6 +1794,17 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_msgs.git
       version: ros1
     status: maintained
+  fetch_open_auto_dock:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/fetchrobotics/fetch_open_auto_dock.git
+      version: ros1
+    status: maintained
   fetch_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_open_auto_dock` to `0.1.3-1`:

- upstream repository: https://github.com/fetchrobotics/fetch_open_auto_dock.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## fetch_open_auto_dock

```
* First Noetic release of auto dock
* Minor python3 updates to scripts (#5 <https://github.com/fetchrobotics/fetch_open_auto_dock/issues/5>)
* Contributors: Eric Relson
```
