### PR TITLE
eml: 1.8.15-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1639,6 +1639,13 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  eml:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/eml-release.git
+      version: 1.8.15-3
+    status: unmaintained
   ergodic_exploration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eml` to `1.8.15-3`:

- upstream repository: https://www.cse.unr.edu/~dave/eml/eml-r36.tar.gz
- release repository: https://github.com/ros-gbp/eml-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
