### PR TITLE
dynamic-graph: 4.3.3-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1421,7 +1421,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
-      version: 4.3.3-1
+      version: 4.3.3-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph` to `4.3.3-4`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `4.3.3-1`
