### PR TITLE
dynamic-graph-tutorial: 1.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1453,7 +1453,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
-      version: 1.2.2-1
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic-graph-tutorial` to `1.3.2-1`:

- upstream repository: https://github.com/stack-of-tasks/dynamic-graph-tutorial.git
- release repository: https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.2.2-1`
