### PR TITLE
robot_controllers: 0.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5133,6 +5133,22 @@ repositories:
       url: https://github.com/mikeferguson/robot_calibration.git
       version: ros1
     status: developed
+  robot_controllers:
+    release:
+      packages:
+      - robot_controllers
+      - robot_controllers_interface
+      - robot_controllers_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/fetchrobotics/robot_controllers.git
+      version: ros1
+    status: maintained
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.7.0-1`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## robot_controllers

```
* Add support for 4wd bases (#69 <https://github.com/fetchrobotics/robot_controllers/issues/69>)
* Build fixes for noetic
* Add time_from_start information to feedback topic (#38 <https://github.com/fetchrobotics/robot_controllers/issues/38>)
* [GCC][Warnings] SYSTEM includes and catch ref (#36 <https://github.com/fetchrobotics/robot_controllers/issues/36>)
* Updates maintainers
* Add init trajectory for future start time (#40 <https://github.com/fetchrobotics/robot_controllers/issues/40>)
* Contributors: Alex Moriarty, Michael Ferguson, Naoya Yamaguchi, Russell Toris, Shingo Kitagawa, root
```

## robot_controllers_interface

```
* Added gyro interface to robot controllers (#43 <https://github.com/fetchrobotics/robot_controllers/issues/43>)
* [GCC][Warnings] SYSTEM includes and catch ref (#36 <https://github.com/fetchrobotics/robot_controllers/issues/36>)
* Updates maintainers
* Contributors: Alex Moriarty, Carl Saldanha, Russell Toris
```

## robot_controllers_msgs

```
* Updates maintainers
* Contributors: Alex Moriarty, Russell Toris
```
