### PR TITLE
ros_control_boilerplate: 0.5.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10168,7 +10168,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.5.1-1`:

- upstream repository: https://github.com/PickNikRobotics/ros_control_boilerplate.git
- release repository: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.0-1`

## ros_control_boilerplate

```
* Replaced boost with std shared_ptr
* Make NodeHandle a const reference
* test_trajectory:  Read joints list from trajectory controller params
* Generalize GenericHWControlLoop to all types of RobotHW (#38 <https://github.com/PickNikRobotics/ros_control_boilerplate/issues/38>)
* Increase num AsyncSpinners where control loops are instantiated
* Contributors: AndyZe, Dave Coleman, Jafar Abdi, John Morris, Ramon Wijnands, Robert Wilbrandt, RobertWilbrandt, Tim Übelhör
```
