### PR TITLE
ros_control_boilerplate: 0.6.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5400,7 +5400,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.6.1-1`:

- upstream repository: https://github.com/PickNikRobotics/ros_control_boilerplate.git
- release repository: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.6.0-1`

## ros_control_boilerplate

```
* Increase required cmake version to fix CMake CMP0048 warning
* Replaced boost with std shared_ptr
* Make NodeHandle a const reference
* test_trajectory:  Read joints list from trajectory controller params
* Increase num AsyncSpinners where control loops are instantiated
* Contributors: AndyZe, Dave Coleman, John Morris, Ramon Wijnands, Robert Wilbrandt, Tim Übelhör
```
