### PR TITLE
sot-tools: 2.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6774,6 +6774,21 @@ repositories:
       url: https://github.com/stack-of-tasks/sot-core.git
       version: devel
     status: maintained
+  sot-tools:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/sot-tools.git
+      version: devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stack-of-tasks/sot-tools-ros-release.git
+      version: 2.3.3-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/sot-tools.git
+      version: devel
+    status: maintained
   sparse_bundle_adjustment:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-tools` to `2.3.3-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-tools.git
- release repository: https://github.com/stack-of-tasks/sot-tools-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
