### PR TITLE
velodyne_simulator: 1.0.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7446,7 +7446,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 1.0.10-1
+      version: 1.0.11-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.11-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.10-1`

## velodyne_description

```
* Add organize_cloud parameter to match velodyne_pointcloud
* Contributors: Kevin Hallenbeck
```

## velodyne_gazebo_plugins

```
* Remove support for end-of-life ROS distributions
* Add organize_cloud parameter to match velodyne_pointcloud
* Contributors: Kevin Hallenbeck
```

## velodyne_simulator

- No changes
