### PR TITLE
rqt_plot: 0.4.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6177,7 +6177,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_plot-release.git
-      version: 0.4.12-1
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `0.4.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros-gbp/rqt_plot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.4.12-1`

## rqt_plot

```
* Fix resize bug. Set minimum size of MatDataPlot's Canvas (#69 <https://github.com/ros-visualization/rqt_plot/issues/69>)
* Update maintainers
* Replace string.atoi with int() (#57 <https://github.com/ros-visualization/rqt_plot/issues/57>)
* Contributors: Felix Exner, Mabel Zhang, Robert Haschke
```
