### PR TITLE
ntpd_driver: 2.0.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2003,6 +2003,21 @@ repositories:
       url: https://github.com/swri-robotics/novatel_gps_driver.git
       version: dashing-devel
     status: developed
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/vooon/ntpd_driver-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    status: maintained
   object_recognition_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `2.0.1-1`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## ntpd_driver

```
* disable depend on launch_xml, rosdep can't find it
* Contributors: Vladimir Ermakov
```
