### PR TITLE
foxy: Add mavros docs entry

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1738,6 +1738,17 @@ repositories:
       url: https://github.com/mavlink/mavlink-gbp-release.git
       version: release/foxy/mavlink
     status: maintained
+  mavros:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    status: developed
   message_filters:
     doc:
       type: git


### PR DESCRIPTION
That commit adds doc entry for ROS2 port of Mavros.

Now it's only provide messages package with definitions for ros1_bridge.
But my intention to port all functionalities of mavros 1, but it is slow: https://github.com/mavlink/mavros/issues/1369 .