### PR TITLE
turtlebot3_simulations: 2.2.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4351,7 +4351,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `2.2.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3_simulations-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.2.1-1`

## turtlebot3_fake_node

```
* none
```

## turtlebot3_gazebo

```
* Remove shared objects built in older version
* Contributors: Will Son
```

## turtlebot3_simulations

```
* Remove shared objects built in older version
* Contributors: Will Son
```
