### PR TITLE
fetch_open_auto_dock: 0.1.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1799,7 +1799,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp.git
-      version: 0.1.3-1
+      version: 0.1.3-2
     source:
       type: git
       url: https://github.com/fetchrobotics/fetch_open_auto_dock.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_open_auto_dock` to `0.1.3-2`:

- upstream repository: https://github.com/fetchrobotics/fetch_open_auto_dock.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.3-1`

## fetch_open_auto_dock

```
* First Noetic release of auto dock
* Minor python3 updates to scripts (#5 <https://github.com/fetchrobotics/fetch_open_auto_dock/issues/5>)
* Contributors: Eric Relson
```
