### PR TITLE
rmw: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1691,7 +1691,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `3.0.0-1`

## rmw

```
* Add declaration for function to check QoS profile compatibility (#299 <https://github.com/ros2/rmw/issues/299>)
* Update the rmw_take_sequence documentation. (#297 <https://github.com/ros2/rmw/issues/297>)
* Contributors: Chris Lalancette, Jacob Perron
```

## rmw_implementation_cmake

```
* Shorten some excessively long lines of CMake (#300 <https://github.com/ros2/rmw/issues/300>)
* Contributors: Scott K Logan
```
