### PR TITLE
Disable Python 2.7 tests.

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 jobs:
   nosetests:
     name: Nosetests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.8]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -30,7 +30,7 @@ jobs:
       run: nosetests -s
   yamllint:
     name: Yaml Linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.8]


### PR DESCRIPTION
There is no need to run them anymore; Python 2.7 is out of
support for over a year now.  While we are in here, also
upgrade our runners to use Ubuntu 20.04

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>