### PR TITLE
ament_acado: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -21,6 +21,17 @@ repositories:
       url: https://github.com/ros-drivers/ackermann_msgs.git
       version: ros2
     status: maintained
+  ament_acado:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado.git
+      version: main
+    status: maintained
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_acado` to `1.0.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## ament_acado

```
* Initial port from Autoware.Auto
* Contributors: Joshua Whitley
```
