### PR TITLE
ament_acado: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8,6 +8,17 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  ament_acado:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado.git
+      version: main
+    status: maintained
   ament_cmake:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_acado` to `1.0.0-1`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## ament_acado

```
* Initial port from Autoware.Auto
* Contributors: Joshua Whitley
```
