### PR TITLE
Add python-opencv for Ubuntu focal (20.04)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2873,6 +2873,9 @@ python-opencv:
     '7': [opencv-python]
   slackware: [opencv]
   ubuntu: [python-opencv]
+python3-opencv:
+  ubuntu:
+    focal: [python3-opencv]
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]


### PR DESCRIPTION
As of 20.04, python-opencv is no longer present in the APT repositories, and was superseded by python3-opencv. 

This is also coherent with the switch from python2 to python3 that happened between ROS Melodic and Noetic.

Solves https://github.com/IFL-CAMP/easy_handeye/issues/74