### PR TITLE
fastrtps: 1.8.4-3 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -924,7 +924,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 1.8.4-1
+      version: 1.8.4-3
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `1.8.4-3`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.8.4-1`
