### PR TITLE
ros2_control: 0.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3069,7 +3069,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.1.6-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.6-1`

## controller_interface

- No changes

## controller_manager

```
* Add "Fake" components for simple integration of framework (#323 <https://github.com/ros-controls/ros2_control/issues/323>)
* Contributors: Denis Štogl
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add "Fake" components for simple integration of framework (#323 <https://github.com/ros-controls/ros2_control/issues/323>)
* Contributors: Denis Štogl
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Add "Fake" components for simple integration of framework (#323 <https://github.com/ros-controls/ros2_control/issues/323>)
* Moved example URDFs for parser/scenario tests to assets package (#316 <https://github.com/ros-controls/ros2_control/issues/316>)
* Contributors: Denis Štogl
```

## ros2controlcli

```
* Increase service call timeout, often services take longer than 0.2s (#324 <https://github.com/ros-controls/ros2_control/issues/324>)
* Contributors: Victor Lopez
```

## transmission_interface

```
* Add four bar linkage transmission (#307 <https://github.com/ros-controls/ros2_control/issues/307>)
* Contributors: Bence Magyar
```
