### PR TITLE
Replace ament_acado with acado_vendor

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -6,6 +6,17 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
+  acado_vendor:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
+      version: main
+    status: maintained
   ackermann_msgs:
     doc:
       type: git
@@ -20,17 +31,6 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/ackermann_msgs.git
       version: ros2
-    status: maintained
-  ament_acado:
-    release:
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado-release.git
-      version: 1.0.0-1
-    source:
-      type: git
-      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado.git
-      version: main
     status: maintained
   ament_cmake:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6,6 +6,17 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  acado_vendor:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
+      version: main
+    status: maintained
   ackermann_msgs:
     doc:
       type: git
@@ -20,17 +31,6 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/ackermann_msgs.git
       version: ros2
-    status: maintained
-  ament_acado:
-    release:
-      tags:
-        release: release/foxy/{package}/{version}
-      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado-release.git
-      version: 1.0.0-1
-    source:
-      type: git
-      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado.git
-      version: main
     status: maintained
   ament_cmake:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8,15 +8,15 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
-  ament_acado:
+  acado_vendor:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado-release.git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor-release.git
       version: 1.0.0-1
     source:
       type: git
-      url: https://gitlab.com/autowarefoundation/autoware.auto/ament_acado.git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
       version: main
     status: maintained
   ament_cmake:


### PR DESCRIPTION
`ament_acado` does not match the naming conventions of other vendor wrapper packages. Additionally, `ament_` makes it sound like this package is part of `ament` rather than being `ament`-ified. The source and release repositories have already been renamed and these changes reflect those naming changes.