### PR TITLE
rmw_dds_common: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1755,7 +1755,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.1.1-1`

## rmw_dds_common

```
* Add function for checking QoS profile compatibility (#45 <https://github.com/ros2/rmw_dds_common/issues/45>)
* Shorten some excessively long lines of CMake (#44 <https://github.com/ros2/rmw_dds_common/issues/44>)
* Fix test_graph_cache ASAN errors (#41 <https://github.com/ros2/rmw_dds_common/issues/41>) (#42 <https://github.com/ros2/rmw_dds_common/issues/42>)
* Contributors: Jacob Perron, Scott K Logan, y-okumura-isp
```
