### PR TITLE
fetch_ros: 0.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1805,6 +1805,28 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_open_auto_dock.git
       version: ros1
     status: maintained
+  fetch_ros:
+    release:
+      packages:
+      - fetch_calibration
+      - fetch_depth_layer
+      - fetch_description
+      - fetch_ikfast_plugin
+      - fetch_maps
+      - fetch_moveit_config
+      - fetch_navigation
+      - fetch_ros
+      - fetch_teleop
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
+      version: 0.9.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/fetchrobotics/fetch_ros.git
+      version: ros1
+    status: maintained
   fetch_tools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.9.0-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## fetch_calibration

```
* Initial noetic release
* Update yaml parsing to avoid warnings
* Updates for python3 and ROS Noetic
* add velocity-factor in calibrate_robot (#133 <https://github.com/fetchrobotics/fetch_ros/issues/133>)
  Limit velocity factor so that it only can slow down calibration.
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris, Shingo Kitagawa
```

## fetch_depth_layer

```
* Initial noetic release
* Update OpenCV version for fetch_depth_layer
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```

## fetch_description

```
* Initial noetic release
* Manually revert textures on URDF models
  See fetch_ros/issues/#138 <https://github.com/fetchrobotics/fetch_ros/issues/138>
* Updates for python3 and ROS Noetic
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```

## fetch_ikfast_plugin

```
* Initial noetic release
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```

## fetch_maps

```
* Initial noetic release
* updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```

## fetch_moveit_config

```
* Initial noetic release
* Updates maintainers
* Contributors: Eric Relson
```

## fetch_navigation

```
* Initial noetic release
* Updates for python3 and ROS Noetic
* Add use_map_topic arg in fetch_nav.launch (#145 <https://github.com/fetchrobotics/fetch_ros/issues/145>)
* Update bias/scale params (#141 <https://github.com/fetchrobotics/fetch_ros/issues/141>)
  bias params are limited to 5.0, divided them all by 16
  so that our bias distances are close to the defaults
* Add topicname args to navigation launch (#136 <https://github.com/fetchrobotics/fetch_ros/issues/136>)
  * add topic args for navigation launch files
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Koki Shinjo, Michael Ferguson, Russell Toris, Shingo Kitagawa
```

## fetch_ros

```
* Initial noetic release
* Updates for python3 and ROS Noetic
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```

## fetch_teleop

```
* Initial noetic release
* Update maintainers
* Use mesh for tuck arm collision
* Move collision objects to avoid collision
* Fix tuck_arm.py moveit check
* Updates for python3 and ROS Noetic
* Tuck arm script: Add ground collision for melodic (#130 <https://github.com/fetchrobotics/fetch_ros/issues/130>)
  * add ground as collision object
  * make robot base keepout larger
* Contributors: Alex Moriarty, Eric Relson, Russell Toris, Shingo Kitagawa
```
