### PR TITLE
core_perception: 1.14.11-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1140,7 +1140,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/nobleo/core_perception-release.git
-      version: 1.14.10-1
+      version: 1.14.11-2
     source:
       type: git
       url: https://github.com/nobleo/core_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `core_perception` to `1.14.11-2`:

- upstream repository: https://github.com/nobleo/core_perception.git
- release repository: https://github.com/nobleo/core_perception-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.14.10-1`

## points_preprocessor

```
* Fix zero-division error on empty clouds
* Contributors: Tim Clephas
```
