### PR TITLE
rospy_message_converter: 0.5.6-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -13687,7 +13687,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/uos-gbp/rospy_message_converter-release.git
-      version: 0.5.5-1
+      version: 0.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `0.5.6-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/uos-gbp/rospy_message_converter-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.5.5-1`

## rospy_message_converter

```
* Propagate strict_mode, check_missing_fields in _convert_to_ros_type
  Previously, _convert_to_ros_type dropped strict_mode and
  check_missing_fields in nested messages.
* Add NestedUint8ArrayTestService tests
* propagate check_types in _convert_to_ros_type (#51 <https://github.com/uos/rospy_message_converter/issues/51>)
  Co-authored-by: Martin Günther <mailto:martin.guenther@dfki.de>
* Fix binary_array_as_bytes=False with nested msgs
* Add param binary_array_as_bytes
  Closes #45 <https://github.com/uos/rospy_message_converter/issues/45>.
* Contributors: Marc Bosch-Jorge, Martin Günther, Otacon5555
```
