### PR TITLE
jderobot_drones: 1.3.7-3 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4675,7 +4675,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/JdeRobot/drones-release.git
-      version: 1.3.6-1
+      version: 1.3.7-3
     source:
       type: git
       url: https://github.com/JdeRobot/drones.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jderobot_drones` to `1.3.7-3`:

- upstream repository: https://github.com/JdeRobot/drones.git
- release repository: https://github.com/JdeRobot/drones-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.3.6-1`

## drone_assets

- No changes

## drone_wrapper

```
* Added namespace to topics and services
* Contributors: pariaspe
```

## jderobot_drones

```
* New version of drone_wrapper compatible with web templates.
* Contributors: pariaspe
```

## rqt_drone_teleop

- No changes

## rqt_ground_robot_teleop

- No changes
