### PR TITLE
rmw_fastrtps: 4.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1775,7 +1775,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 4.3.0-1
+      version: 4.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `4.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `4.3.0-1`

## rmw_fastrtps_cpp

```
* Add RMW function to check QoS compatibility (#511 <https://github.com/ros2/rmw_fastrtps/issues/511>)
* Capture cdr exceptions (#505 <https://github.com/ros2/rmw_fastrtps/issues/505>)
* Contributors: Jacob Perron, Miguel Company
```

## rmw_fastrtps_dynamic_cpp

```
* Add RMW function to check QoS compatibility (#511 <https://github.com/ros2/rmw_fastrtps/issues/511>)
* Capture cdr exceptions (#505 <https://github.com/ros2/rmw_fastrtps/issues/505>)
* Load profiles based on topic names in rmw_fastrtps_dynamic_cpp (#497 <https://github.com/ros2/rmw_fastrtps/issues/497>)
* Contributors: Eduardo Ponz Segrelles, Jacob Perron, Miguel Company
```

## rmw_fastrtps_shared_cpp

```
* Add RMW function to check QoS compatibility (#511 <https://github.com/ros2/rmw_fastrtps/issues/511>)
* Capture cdr exceptions (#505 <https://github.com/ros2/rmw_fastrtps/issues/505>)
* Contributors: Jacob Perron, Miguel Company
```
