### PR TITLE
rcpputils: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1629,7 +1629,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.0.4-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.0.4-1`

## rcpputils

```
* Add path equality operators (#127 <https://github.com/ros2/rcpputils/issues/127>)
* Add create_temp_directory filesystem helper (#126 <https://github.com/ros2/rcpputils/issues/126>)
* Use new noexcept specifier. (#123 <https://github.com/ros2/rcpputils/issues/123>)
* Contributors: Chen Lihui, Emerson Knapp
```
