### PR TITLE
rmw_connext: 3.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1721,7 +1721,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 3.5.1-1
+      version: 3.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connext` to `3.6.0-1`:

- upstream repository: https://github.com/ros2/rmw_connext.git
- release repository: https://github.com/ros2-gbp/rmw_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `3.5.1-1`

## rmw_connext_cpp

```
* Add RMW function to check QoS compatibility (#488 <https://github.com/ros2/rmw_connext/issues/488>)
* Shorten some excessively long lines of CMake (#486 <https://github.com/ros2/rmw_connext/issues/486>)
* Contributors: Jacob Perron, Scott K Logan
```

## rmw_connext_shared_cpp

```
* Add RMW function to check QoS compatibility (#488 <https://github.com/ros2/rmw_connext/issues/488>)
* Contributors: Jacob Perron
```
