### PR TITLE
Updated python-can rosdep rules for Ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -818,49 +818,8 @@ python-can:
     pip:
       packages: [python-can]
   ubuntu:
-    '*': [python-can]
-    lucid:
-      pip:
-        packages: [python-can]
-    maverick:
-      pip:
-        packages: [python-can]
-    natty:
-      pip:
-        packages: [python-can]
-    oneiric:
-      pip:
-        packages: [python-can]
-    precise:
-      pip:
-        packages: [python-can]
-    quantal:
-      pip:
-        packages: [python-can]
-    raring:
-      pip:
-        packages: [python-can]
-    saucy:
-      pip:
-        packages: [python-can]
-    trusty:
-      pip:
-        packages: [python-can]
-    utopic:
-      pip:
-        packages: [python-can]
-    vivid:
-      pip:
-        packages: [python-can]
-    wily:
-      pip:
-        packages: [python-can]
-    xenial:
-      pip:
-        packages: [python-can]
-    yakkety:
-      pip:
-        packages: [python-can]
+    pip:
+      packages: [python-can]
 python-cantools-pip:
   debian:
     pip:


### PR DESCRIPTION
The Ubuntu package is out of date and no longer the recommended way to install.

PyPi: https://pypi.org/project/python-can/

This is my first open source contribution, I apologize if this doesn't meet all the rules (I did run unit tests). 