### PR TITLE
acado_vendor: 1.0.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -11,7 +11,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `acado_vendor` to `1.0.0-2`:

- upstream repository: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
- release repository: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.0-1`

## acado_vendor

```
* Initial port from Autoware.Auto
* Contributors: Joshua Whitley
```
