### PR TITLE
robot_upstart: 0.3.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9939,7 +9939,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 0.3.0-0
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `0.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.3.0-0`

## robot_upstart

```
* Using setpriv (#101 <https://github.com/clearpathrobotics/robot_upstart/issues/101>)
  * Try replacing setuidgid with setpriv to see if this is a viable solution to the group permission issues
  * Fix a typo
  * Set the real and effective user and group IDs, not just the real ones
  * Add a missing "roslaunch" argument to the actual launch. Whoops :/
* Contributors: Chris I-B
```
