### PR TITLE
log_view: 0.1.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5677,7 +5677,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/hatchbed/log_view-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.1.3-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.2-1`

## log_view

```
* Prevent help screen text from wrapping.
* Make help screen modal.
* Add keybindings for selecting all nodes and inverting the node selection.
* Update README.
* Fix compiler warnings.
* Contributors: Marc Alban
```
