### PR TITLE
robot_pose_ekf: 1.15.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5387,6 +5387,21 @@ repositories:
       url: https://github.com/locusrobotics/robot_navigation.git
       version: noetic
     status: developed
+  robot_pose_ekf:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/robot_pose_ekf.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/robot_pose_ekf-release.git
+      version: 1.15.0-2
+    source:
+      type: git
+      url: https://github.com/ros-planning/robot_pose_ekf.git
+      version: master
+    status: unmaintained
   robot_self_filter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_ekf` to `1.15.0-2`:

- upstream repository: https://github.com/ros-planning/robot_pose_ekf.git
- release repository: https://github.com/ros-gbp/robot_pose_ekf-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## robot_pose_ekf

```
* Merge pull request #13 <https://github.com/ros-planning/robot_pose_ekf/issues/13> from k-okada/add_travis_noetic
  Close #12 <https://github.com/ros-planning/robot_pose_ekf/issues/12>
* use format3 to support both nfl and liborocos-blf-dev
* fixed bfl dependency to be liborocos-bfl-dev
* fixed bfl dependency to be liborocos-bfl
* updated wtf.py to be python3 compatible
* fixed travis.yml for build checks
* Merge pull request #8 <https://github.com/ros-planning/robot_pose_ekf/issues/8> from contradict/patch-1
  Remove email from package.xml
* Remove email from package.xml
  I did work on the package several years ago (a port to a new version of ROS), but I am not the author and also not the person named here. Would you mind removing my email from the package?
* Contributors: Dave Feil-Seifer, Kei Okada, Michael Ferguson, contradict
```
