### PR TITLE
xacro: 1.14.6-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7903,7 +7903,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.5-1
+      version: 1.14.6-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.6-2`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.14.5-1`

## xacro

```
* [fix] Report correct filename for XML errors (#268 <https://github.com/ros/xacro/issues/268>)
* [fix] Python3-compatible property Table (#266 <https://github.com/ros/xacro/issues/266>)
* [fix] Use outer-scope symbols to resolve include filename in xacro:include (#264 <https://github.com/ros/xacro/issues/264>)
* Contributors: Robert Haschke
```