### PR TITLE
xacro: 2.0.5-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -4040,7 +4040,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.5-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.0.4-1`

## xacro

```
* [fix]     Report correct filename for XML errors (#268 <https://github.com/ros/xacro/issues/268>)
* [fix]     Python3-compatible property Table (#266 <https://github.com/ros/xacro/issues/266>)
* [fix]     Use outer-scope symbols to resolve include filename in xacro:include (#264 <https://github.com/ros/xacro/issues/264>)
* [fix]     Append test directory to existing AMENT_PREFIX_PATH (#260 <https://github.com/ros/xacro/issues/260>)
* [fix]     yaml loading: recursively wrap lists and dicts for dotted dict access (#258 <https://github.com/ros/xacro/issues/258>)
* [feature] Provide support for yaml constructors !degrees and !radians (#252 <https://github.com/ros/xacro/issues/252>)
* Contributors: Chen Bainian, Robert Haschke, G.A. vd. Hoorn
```
