### PR TITLE
eml: 1.8.15-7 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1644,7 +1644,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/eml-release.git
-      version: 1.8.15-3
+      version: 1.8.15-7
     status: unmaintained
   ergodic_exploration:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `eml` to `1.8.15-7`:

- upstream repository: https://www.cse.unr.edu/~dave/eml/eml-r36.tar.gz
- release repository: https://github.com/ros-gbp/eml-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.8.15-3`
