### PR TITLE
rosdep: add support for python*-semantic-version

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4292,6 +4292,12 @@ python-selenium-pip:
   ubuntu:
     pip:
       packages: [selenium]
+python-semantic-version:
+  debian: [python-semantic-version]
+  fedora: [python2-semantic_version]
+  ubuntu:
+    bionic: [python-semantic-version]
+    xenial: [python-semantic-version]
 python-semver:
   debian: [python-semver]
   fedora: [python-semver]
@@ -6940,6 +6946,10 @@ python3-selenium:
     pip:
       packages: [selenium]
   ubuntu: [python3-selenium]
+python3-semantic-version:
+  debian: [python3-semantic-version]
+  fedora: [python3-semantic_version]
+  ubuntu: [python3-semantic-version]
 python3-sense-emu-pip:
   debian:
     pip:


### PR DESCRIPTION
OS Package Links:

<!-- Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-semantic-version
python3-semantic-version

## Package Upstream Source:

https://github.com/rbarrois/python-semanticversion

## Purpose of using this:

This library is useful for validating and comparing semantic versions.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - REQUIRED
  - https://packages.debian.org/stretch/python-semantic-version
  - https://packages.debian.org/stretch/python3-semantic-version
- Ubuntu: https://packages.ubuntu.com/
   - REQUIRED
   - https://packages.ubuntu.com/xenial/python-semantic-version
   - https://packages.ubuntu.com/focal/python3-semantic-version
- Fedora: https://apps.fedoraproject.org/packages/
  - IF AVAILABLE
  - https://fedora.pkgs.org/32/fedora-x86_64/python3-semantic_version-2.8.4-3.fc32.noarch.rpm.html
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
