### PR TITLE
pr2_ethercat_drivers: 1.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4863,6 +4863,25 @@ repositories:
       url: https://github.com/pr2/pr2_common.git
       version: melodic-devel
     status: unmaintained
+  pr2_ethercat_drivers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_ethercat_drivers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ethercat_hardware
+      - fingertip_pressure
+      - pr2_ethercat_drivers
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
+      version: 1.9.0-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_ethercat_drivers.git
+      version: kinetic-devel
+    status: unmaintained
   pr2_mechanism:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_ethercat_drivers` to `1.9.0-1`:

- upstream repository: https://github.com/pr2/pr2_ethercat_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_ethercat_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## ethercat_hardware

- No changes

## fingertip_pressure

```
* Merge pull request #79 <https://github.com/pr2/pr2_ethercat_drivers/issues/79> from k-okada/add_noetic_travis
* add queue_size=1000 and use int for list, https://github.com/PR2/pr2_ethercat_drivers/pull/78/commits/aa6f87a6191ee816c181b1548464b9e8b7a060a1 except explicit python3 shban, which catkin_instal_python deal with
* use catkin_install_python for python script install
* fix for python3/python2 using '2to3 -w -f print .; 2to3 -w -f except .
* Contributors: Kei Okada
```

## pr2_ethercat_drivers

- No changes
