### PR TITLE
diagnostics: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -490,7 +490,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.1.2-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.1.1-1`

## diagnostic_aggregator

```
* Adapt new launch file syntax. (#190 <https://github.com/ros/diagnostics/issues/190>)
* Introduce history depth parameter for subscription. (#168 <https://github.com/ros/diagnostics/issues/168>)
* Contributors: Karsten Knese, Ryohsuke Mitsudome
```

## diagnostic_updater

```
* Replace every byte creation instance. (#184 <https://github.com/ros/diagnostics/issues/184>)
* Enable multiple tasks publishing for diagnostic updater. (#182 <https://github.com/ros/diagnostics/issues/182>)
* Contributors: BasVolkers
```

## self_test

- No changes
