### PR TITLE
Update Dashing branch for transport_drivers

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3654,7 +3654,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: main
+      version: dashing
     release:
       packages:
       - serial_driver
@@ -3666,7 +3666,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: main
+      version: dashing
     status: developed
   tts:
     doc:


### PR DESCRIPTION
`main` fails to compile in Dashing because we've added Foxy-only changes. This updates the branches for Dashing so it will build again.