### PR TITLE
Use apt packages for python-more-itertools

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6285,7 +6285,7 @@ python3-more-itertools:
   debian: [python3-more-itertools]
   fedora: [python3-more-itertools]
   gentoo: [dev-python/more-itertools]
-  rhel: [python3-more-itertools]
+  rhel: ['python%{python3_pkgversion}-more-itertools']
   ubuntu: [python3-more-itertools]
 python3-msgpack:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2569,10 +2569,27 @@ python-more-itertools:
   debian: [python-more-itertools]
   fedora: [python-more-itertools]
   ubuntu:
-    bionic: [python-more-itertools]
+    '*': [python-more-itertools]
+    xenial: null
+python-more-itertools-pip:
+  arch:
+    pip:
+      packages: [more-itertools]
+  debian:
+    pip:
+      packages: [more-itertools]
+  fedora:
+    pip:
+      packages: [more-itertools]
+  ubuntu:
+    bionic:
+      pip: [more-itertools]
+    focal:
+      pip: [more-itertools]
+    groovy:
+      pip: [more-itertools]
     xenial:
-      pip:
-        packages: [more-itertools]
+      pip: [more-itertools]
 python-moviepy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2564,19 +2564,15 @@ python-mock:
     xenial_python3: [python3-mock]
     yakkety: [python-mock]
     zesty: [python-mock]
-python-more-itertools-pip:
-  arch:
-    pip:
-      packages: [more-itertools]
-  debian:
-    pip:
-      packages: [more-itertools]
-  fedora:
-    pip:
-      packages: [more-itertools]
+python-more-itertools:
+  arch: [python-more-itertools]
+  debian: [python-more-itertools]
+  fedora: [python-more-itertools]
   ubuntu:
-    pip:
-      packages: [more-itertools]
+    xenial:
+      pip:
+        packages: [more-itertools]
+    bionic: [python-more-itertools]
 python-moviepy-pip:
   debian:
     pip:
@@ -6273,6 +6269,9 @@ python3-mock:
   openembedded: [python3-mock@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
+python3-more-itertools:
+  debian: [python3-more-itertools]
+  ubuntu: [python3-more-itertools]
 python3-msgpack:
   debian:
     '*': [python3-msgpack]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2582,12 +2582,6 @@ python-more-itertools-pip:
     pip:
       packages: [more-itertools]
   ubuntu:
-    bionic:
-      pip: [more-itertools]
-    focal:
-      pip: [more-itertools]
-    groovy:
-      pip: [more-itertools]
     xenial:
       pip: [more-itertools]
 python-moviepy-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2569,10 +2569,10 @@ python-more-itertools:
   debian: [python-more-itertools]
   fedora: [python-more-itertools]
   ubuntu:
+    bionic: [python-more-itertools]
     xenial:
       pip:
         packages: [more-itertools]
-    bionic: [python-more-itertools]
 python-moviepy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6281,7 +6281,11 @@ python3-mock:
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-more-itertools:
+  arch: [python-more-itertools]
   debian: [python3-more-itertools]
+  fedora: [python3-more-itertools]
+  gentoo: [dev-python/more-itertools]
+  rhel: [python3-more-itertools]
   ubuntu: [python3-more-itertools]
 python3-msgpack:
   debian:


### PR DESCRIPTION
In follow-up of the discussion here: https://github.com/ros/rosdistro/pull/19058