### PR TITLE
rc_genicam_api: 2.5.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2562,7 +2562,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.4.4-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.5.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/roboception-gbp/rc_genicam_api-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.4.4-1`

## rc_genicam_api

```
* Upgrading GenICam reference implementation to version 3.3
* Added support for storing images of format RGB8 and BayerXX8
* Increasing discover timeout from 100 ms to 1 s, which is necessary for some cameras
* Resetting chunk adapter in gc_stream if user explicitely disables chunk data
* Added tool gc_file for reading / writing user data from / to a GenICam device
* Integrated attaching buffers to nodemap into stream and buffer classes
* Added support for handling payload type chunk data for supporting Basler ace cameras
* Updated handling of PTP in gc_config tool using the new feature names
* Correct exception message if png can't be stored
* Rename adaptive_out1_reduction to out1_reduction in stored parameter file
```
