### PR TITLE
network_interface: 3.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4204,6 +4204,21 @@ repositories:
       url: https://github.com/nerian-vision/nerian_stereo.git
       version: master
     status: developed
+  network_interface:
+    doc:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: 3.0.0
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/astuff/network_interface-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/astuff/network_interface.git
+      version: 3.0.0
+    status: maintained
   nmea_comms:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4208,7 +4208,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/network_interface.git
-      version: 3.0.0
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -4217,7 +4217,7 @@ repositories:
     source:
       type: git
       url: https://github.com/astuff/network_interface.git
-      version: 3.0.0
+      version: master
     status: maintained
   nmea_comms:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `network_interface` to `3.0.0-1`:

- upstream repository: https://github.com/astuff/network_interface.git
- release repository: https://github.com/astuff/network_interface-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## network_interface

```
* Add noetic CI builds (#31 <https://github.com/astuff/network_interface/issues/31>)
* Disable docker layer caching (#30 <https://github.com/astuff/network_interface/issues/30>)
* Merge pull request #26 <https://github.com/astuff/network_interface/issues/26> from astuff/fix/memory_allocation
  Fix memory initialization of buffer vector.
* Apply same buffer allocation fix to UDP interface.
* Fix memory initialization of buffer vector.
* Adding copyright to utils.cpp.
* Moving definition of return_status_desc to fix linking bug.
* Merge pull request #25 <https://github.com/astuff/network_interface/issues/25> from astuff/maint/cpp_11_cleanup
  Maint/cpp 11 cleanup
* Had to add offset to parse_tuple.
* Moving parse_tuple from ibeo_core.
* Allowing read functions to take multiple containers.
* Commenting code.
* New implementation of write_le and write_be. Tests for both.
* Changing valueOffset to float and casting in util functions.
* Replacing unsigned int with uint32_t.
* Used wrong type-trait qualifier.
* CI: Adding Melodic armhf build.
* CI: Machine executors require sudo.
* CI: Add first run at armhf build.
* Changing to reinterpret_cast instead of non-portable solution.
* Removing async calls from TCP. Allocating buffers with reserve.
* Removing apparently useless check in write_le.
* Consistent braced initializers.
* -DBUILD_ROS is no longer a thing.
* Reserving requested space in read_exactly.
* Making ByteOrder enum scoped too.
* Switching back to memcpy.
* Moving common enums into common.h.
* Scoped enum for return statuses.
* Using vectors and type traits.
* CI: Making roslint run in run_tests.
* Merge pull request #20 <https://github.com/astuff/network_interface/issues/20> from astuff/maint/ci_add_lint
  Maint/ci add lint
* CI: Adding catkin_test_results the right way.
* CI: Adding catkin_test_results.
* Making lint cover all files and adding copyright.
* CI: Need --no-deps for lint.
* CI: Oops.
* CI: Adding roslint to build tests.
* Removing unused gitlabci file.
* CI: Removing Indigo build.
* Merge pull request #19 <https://github.com/astuff/network_interface/issues/19> from astuff/maint/add_urls
  Adding website URL to package.xml.
* Adding website URL to package.xml.
* Merge pull request #18 <https://github.com/astuff/network_interface/issues/18> from astuff/maint/ci_new_docker_images
  CI: Using AS Docker images.
* CI: Using AS Docker images.
* Contributors: Ian Colwell, Joshua Whitley, Rinda Gunjala, Sam Rustan, Zach Oakes
```
