### PR TITLE
rviz: 1.13.16-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11754,7 +11754,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.13.15-1
+      version: 1.13.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.13.16-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.13.15-1`

## rviz

```
* [fix]     Enforce GLSL 1.4 on more Mesa systems (#1588 <https://github.com/ros-visualization/rviz/issues/1588>)
* [fix]     PointStampedDisplay: show points from the very beginning (#1586 <https://github.com/ros-visualization/rviz/issues/1586>)
* [maint]   Augment system info at startup with used OpenGL device
* [maint]   Remove warnings about ignored marker scale
* [feature] Tool: Propagate name change to VisualizationFrame (#1570 <https://github.com/ros-visualization/rviz/issues/1570>)
* Contributors: João C. Monteiro, Robert Haschke
```
