### PR TITLE
rclc: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2686,7 +2686,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 0.1.7-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.1.7-1`

## rclc

```
* service callbacks with context
* fixed minor issues unit tests
* upgraded setup_ros action (ci jobs)
* removed Eloquent from ci jobs
```

## rclc_examples

```
* Updated version
```

## rclc_lifecycle

```
* Updated version
```
