### PR TITLE
rviz: 1.14.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6692,7 +6692,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.4-1
+      version: 1.14.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.5-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.14.4-1`

## rviz

```
* [fix]     IntensityPCTransformer: make min/max values read-only
* [fix]     Fix ScrewDisplays (#1593 <https://github.com/ros-visualization/rviz/issues/1593>)
* [fix]     Enforce GLSL 1.4 on more Mesa systems (#1588 <https://github.com/ros-visualization/rviz/issues/1588>)
* [fix]     PointStampedDisplay: show points from the very beginning (#1586 <https://github.com/ros-visualization/rviz/issues/1586>)
* [fix]     Fix segfault in PathDisplay (#1583 <https://github.com/ros-visualization/rviz/issues/1583>)
* [fix]     Fix OGRE_INCLUDE_DIRS (#1574 <https://github.com/ros-visualization/rviz/issues/1574>)
* [fix]     Fix Windows compilation (#1568 <https://github.com/ros-visualization/rviz/issues/1568>)
* [fix]     Remove duplicate plugin description for AccelStamped
* [maint]   Augment system info at startup with used OpenGL device
* [maint]   Remove warnings about ignored marker scale
* [feature] Tool: Propagate name change to VisualizationFrame (#1570 <https://github.com/ros-visualization/rviz/issues/1570>)
* Contributors: João C. Monteiro, Robert Haschke, Tobias Fischer
```
