### PR TITLE
diagnostics: 2.0.7-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -680,7 +680,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 2.0.6-1
+      version: 2.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `2.0.7-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.6-1`

## diagnostic_aggregator

- No changes

## diagnostic_updater

```
* Enable multiple tasks publishing for diagnostic updater (#182 <https://github.com/ros/diagnostics/issues/182>) (#192 <https://github.com/ros/diagnostics/issues/192>)
* Replace every byte creation instance (#184 <https://github.com/ros/diagnostics/issues/184>) (#191 <https://github.com/ros/diagnostics/issues/191>)
* Contributors: BasVolkers
```

## self_test

- No changes
