### PR TITLE
bloom-rclc-18 correction

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2769,7 +2769,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: foxy
     release:
       packages:
       - rclc

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2783,7 +2783,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: foxy
     status: developed
   rclcpp:
     doc:


### PR DESCRIPTION
there is now a 'foxy' branch in ros2/rclc repository. I updated the version with the bloom-release tool, however, the version was not updated in `foxy/distribution.yaml`. Therefore this manual PR.

see previous PR: https://github.com/ros/rosdistro/pull/28481