### PR TITLE
sick_safetyscanners2: 1.0.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3970,7 +3970,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners2-release.git
-      version: 1.0.0-2
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2` to `1.0.1-2`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2.git
- release repository: https://github.com/SICKAG/sick_safetyscanners2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.0-2`

## sick_safetyscanners2

```
* changed the parameter callback interface so its only triggered
  when the parameters of this node are called
* Contributors: Lennart Puck
```
