### PR TITLE
raptor_dbw_ros2: 1.0.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2109,6 +2109,24 @@ repositories:
       url: https://github.com/ros-visualization/qt_gui_core.git
       version: crystal-devel
     status: maintained
+  raptor_dbw_ros2:
+    release:
+      packages:
+      - raptor_can_dbc_parser
+      - raptor_dbw_can
+      - raptor_dbw_joystick
+      - raptor_dbw_msgs
+      - raptor_pdu
+      - raptor_pdu_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
+      version: 1.0.0
+    status: developed
   raspimouse2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor_dbw_ros2` to `1.0.0-2`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
- release repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## raptor_can_dbc_parser

```
* Initial Release
* Contributors: Joshua Whitley, New Eagle, neweagleraptor
```

## raptor_dbw_can

```
* Initial Release
* Contributors: Joshua Whitley, New Eagle, neweagleraptor
```

## raptor_dbw_joystick

```
* Initial Release
* Contributors: Joshua Whitley, neweagleraptor
```

## raptor_dbw_msgs

```
* Initial Release
* Contributors: New Eagle, neweagleraptor
```

## raptor_pdu

```
* Initial Release
* Contributors: Joshua Whitley, New Eagle, neweagleraptor
```

## raptor_pdu_msgs

```
* Initial Release
* Contributors: New Eagle, neweagleraptor
```
