### PR TITLE
rqt_plot: 1.0.9-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2387,7 +2387,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.0.8-2
+      version: 1.0.9-3
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2382,7 +2382,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: crystal-devel
+      version: foxy-devel
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2391,7 +2391,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: crystal-devel
+      version: foxy-devel
     status: maintained
   rqt_publisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.0.9-3`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.8-2`

## rqt_plot

```
* Fix plots of array items (#71 <https://github.com/ros-visualization/rqt_plot/issues/71>)
* Update maintainers
* Contributors: Ivan Santiago Paunovic, Mabel Zhang
```
