### PR TITLE
rqt_plot: 1.0.9-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3743,7 +3743,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: crystal-devel
+      version: foxy-devel
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -3752,7 +3752,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: crystal-devel
+      version: foxy-devel
     status: maintained
   rqt_publisher:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3748,7 +3748,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.0.9-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.8-1`

## rqt_plot

```
* Fix plots of array items (#71 <https://github.com/ros-visualization/rqt_plot/issues/71>)
* Update maintainers
* Contributors: Ivan Santiago Paunovic, Mabel Zhang
```
