### PR TITLE
fetch_ros: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1835,7 +1835,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.9.1-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.9.0-1`

## fetch_calibration

- No changes

## fetch_depth_layer

```
* Fixup: Remove version specification for OpenCV
  Debian Buster only has 3.x available, while Ubuntu 20.04 has 4.x available.
  This package works with either.
* Contributors: Eric Relson
```

## fetch_description

- No changes

## fetch_ikfast_plugin

- No changes

## fetch_maps

- No changes

## fetch_moveit_config

- No changes

## fetch_navigation

- No changes

## fetch_ros

- No changes

## fetch_teleop

- No changes
