### PR TITLE
fetch_robots: 0.9.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1820,6 +1820,22 @@ repositories:
       url: https://github.com/fetchrobotics/fetch_open_auto_dock.git
       version: ros1
     status: maintained
+  fetch_robots:
+    release:
+      packages:
+      - fetch_bringup
+      - fetch_drivers
+      - freight_bringup
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
+      version: 0.9.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/fetchrobotics/fetch_robots.git
+      version: ros1
+    status: maintained
   fetch_ros:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.9.1-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## fetch_bringup

```
* Changes for Noetic/Py3 (#61 <https://github.com/fetchrobotics/fetch_robots/issues/61>)
  
    * Remove some ps3 controller references (no longer supported)
    * Update state_publisher -> robot_state_publisher
    * Changes for compatibility with new drivers:
      Drivers primarily load some params from a json file which
      end-users shouldn't need to modify. This file will live in
      /opt/ros/noetic or the catkin workspace for 99% of usecases.
    * Add explicit setting for fetch teleop param.
    * Point to a new drivers binary release (0.9.0)
    * Respawn tuck_arm node on shutdown [OPEN-48]
  
* Add soundplay ROS node as systemd service (#53 <https://github.com/fetchrobotics/fetch_robots/issues/53>)
  Functionality existed in 14.04/indigo, and was initially left out.
* Contributors: Eric Relson
```

## fetch_drivers

```
* Initial Noetic release
* Point to a new drivers binary release (0.9.0)
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```

## freight_bringup

```
* Changes for Noetic/Py3 (#61 <https://github.com/fetchrobotics/fetch_robots/issues/61>)
  
    * Remove some ps3 controller references (no longer supported)
    * Update state_publisher -> robot_state_publisher
    * Changes for compatibility with new drivers:
      Drivers primarily load some params from a json file which
      end-users shouldn't need to modify. This file will live in
      /opt/ros/noetic or the catkin workspace for 99% of usecases.
    * Add explicit setting for fetch teleop param.
  
* Add soundplay ROS node as systemd service (#53 <https://github.com/fetchrobotics/fetch_robots/issues/53>)
  Functionality existed in 14.04/indigo, and was initially left out.
* Contributors: Eric Relson
```
