### PR TITLE
prosilica_gige_sdk: 1.26.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4948,6 +4948,20 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: unmaintained
+  prosilica_gige_sdk:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
+      version: 1.26.3-2
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+      version: hydro-devel
   psen_scan_v2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_gige_sdk` to `1.26.3-2`:

- upstream repository: https://github.com/ros-drivers/prosilica_gige_sdk.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
