### PR TITLE
add python3-bluez rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5579,6 +5579,11 @@ python3-bitarray:
   fedora: [python3-bitarray]
   gentoo: [dev-python/bitarray]
   ubuntu: [python3-bitarray]
+python3-bluez:
+  debian: [python3-bluez]
+  fedora: [python3-bluez]
+  gentoo: [dev-python/pybluez]
+  ubuntu: [python3-bluez]
 python3-bokeh-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5583,7 +5583,10 @@ python3-bluez:
   debian: [python3-bluez]
   fedora: [python3-bluez]
   gentoo: [dev-python/pybluez]
-  ubuntu: [python3-bluez]
+  ubuntu:
+    '*': [python3-bluez]
+    'bionic': null
+    'xenial': null
 python3-bokeh-pip:
   debian:
     pip:


### PR DESCRIPTION
Debian: https://packages.debian.org/buster/python3-bluez
Fedora: https://fedora.pkgs.org/32/fedora-x86_64/python3-bluez-0.22-18.fc32.x86_64.rpm.html
Gentoo: https://packages.gentoo.org/packages/dev-python/pybluez
Ubuntu: https://packages.ubuntu.com/focal/python3-bluez

Some widely used packages like [ps3joy](https://github.com/ros-drivers/joystick_drivers/blob/0eb32c2eebb68a7a0066ef288f1a1aa793d08650/ps3joy/package.xml#L33) rely on pybluez