### PR TITLE
fetch_ros: 0.8.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3020,7 +3020,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_ros` to `0.8.3-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_ros.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.8.2-1`

## fetch_calibration

```
* Initial noetic release
* Add velocity-factor in calibrate_robot (#133 <https://github.com/fetchrobotics/fetch_ros/issues/133>)
  Limit velocity factor so that it can only be used to slow down calibration.
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris, Shingo Kitagawa
```

## fetch_depth_layer

```
* Initial noetic release
* Updates maintainers
* Contributors: Alex Moriarty, Russell Toris
```

## fetch_description

```
* Initial noetic release
* Manually revert textures on URDF models (#154 <https://github.com/fetchrobotics/fetch_ros/issues/154>)
* Updates maintainers
* Contributors: Alex Moriarty, Eric Relson, Russell Toris
```

## fetch_ikfast_plugin

```
* Initial noetic release
* Updates maintainers
* Contributors: Alex Moriarty, Russell Toris
```

## fetch_maps

```
* Initial noetic release
* Updates maintainers
* Contributors: Alex Moriarty, Russell Toris
```

## fetch_moveit_config

```
* Initial noetic release
* Add srdf file path argument to move_group.launch
* Use xacro to load fetch.srdf
* Add srdf file path argument to move_group.launch
* Updates maintainers
* Contributors: Alex Moriarty, Carl Saldanha, Naoya Yamaguchi, Russell Toris
```

## fetch_navigation

```
* Initial noetic release
* Add launch_map_server argument in fetch_nav.launch (#147 <https://github.com/fetchrobotics/fetch_ros/issues/147>)
* Add use_map_topic arg in fetch_nav.launch (#145 <https://github.com/fetchrobotics/fetch_ros/issues/145>)
* Update bias/scale params (#141 <https://github.com/fetchrobotics/fetch_ros/issues/141>)
* Add topicname args to navigation launch (#136 <https://github.com/fetchrobotics/fetch_ros/issues/136>)
* Updates maintainers
* Contributors: Alex Moriarty, Koki Shinjo, Michael Ferguson, Russell Toris, Shingo Kitagawa
```

## fetch_ros

```
* Initial noetic release
* Updates maintainers
* Contributors: Alex Moriarty, Russell Toris
```

## fetch_teleop

```
* Initial noetic release
* Fix tuck arm moveit check [OPEN-48] (#150 <https://github.com/fetchrobotics/fetch_ros/issues/150>)
* Tuck arm script: Add ground collision for melodic (#130 <https://github.com/fetchrobotics/fetch_ros/issues/130>)
* Updates maintainers
* Contributors: Alex Moriarty, Jeff Wilson, Russell Toris, Shingo Kitagawa
```
