### PR TITLE
fetch_robots: 0.8.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2994,7 +2994,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.8.8-1
+      version: 0.8.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.8.9-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.8.8-1`

## fetch_bringup

```
* Initial Noetic release
* Respawn tuck_arm node on shutdown [OPEN-48] (#59 <https://github.com/fetchrobotics/fetch_robots/issues/59>)
* Add soundplay ROS node as systemd service (#53 <https://github.com/fetchrobotics/fetch_robots/issues/53>)
* Updates maintainers
* Contributors: Eric Relson, Jeff Wilson
```

## fetch_drivers

```
* Initial Noetic release
* Updates maintainers
* Contributors: Alex Moriarty, Russell Toris
```

## freight_bringup

```
* Initial Noetic release
* Add soundplay ROS node as systemd service (#53 <https://github.com/fetchrobotics/fetch_robots/issues/53>)
* Updates maintainers
* Contributors: Eric Relson
```
