### PR TITLE
neonavigation: 0.10.7-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -8790,7 +8790,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.10.6-1
+      version: 0.10.7-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.10.7-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.10.6-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: improve performance of hysteresis clearing (#586 <https://github.com/at-wat/neonavigation/issues/586>)
* Contributors: Naotaka Hatao
```

## safety_limiter

```
* safety_limiter: add a max_linear_vel and max_angular_vel (#581 <https://github.com/at-wat/neonavigation/issues/581>)
* Contributors: Teo Cardoso
```

## track_odometry

- No changes

## trajectory_tracker

- No changes
