### PR TITLE
mcl_3dl: 0.5.4-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7449,7 +7449,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mcl_3dl` to `0.5.4-1`:

- upstream repository: https://github.com/at-wat/mcl_3dl.git
- release repository: https://github.com/at-wat/mcl_3dl-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.5.3-1`

## mcl_3dl

```
* Add odom/imu/cloud_queue_size params (#375 <https://github.com/at-wat/mcl_3dl/issues/375>)
* Fix flaky tests (#376 <https://github.com/at-wat/mcl_3dl/issues/376>)
* Contributors: Atsushi Watanabe
```
