### PR TITLE
mitre_fast_layered_map: 0.1.4-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7701,6 +7701,21 @@ repositories:
       url: https://github.com/dfki-ric/mir_robot.git
       version: kinetic
     status: developed
+  mitre_fast_layered_map:
+    doc:
+      type: git
+      url: https://github.com/mitre/mitre_fast_layered_map.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/mitre/mitre_fast_layered_map-release.git
+      version: 0.1.4-2
+    source:
+      type: git
+      url: https://github.com/mitre/mitre_fast_layered_map.git
+      version: kinetic-devel
+    status: maintained
   ml_classifiers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mitre_fast_layered_map` to `0.1.4-2`:

- upstream repository: https://github.com/mitre/mitre_fast_layered_map.git
- release repository: https://github.com/mitre/mitre_fast_layered_map-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
