### PR TITLE
jackal: 0.7.3-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4579,7 +4579,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.7.3-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.7.2-1`

## jackal_control

- No changes

## jackal_description

```
* Add VLP16 support, refactor main/secondary laser envar support (#79)
* Contributors: Chris I-B
```

## jackal_msgs

- No changes

## jackal_navigation

- No changes
