### PR TITLE
mocap_optitrack: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7747,7 +7747,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/mocap_optitrack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_optitrack` to `0.1.1-1`:

- upstream repository: https://github.com/ros-drivers/mocap_optitrack.git
- release repository: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.0-1`

## mocap_optitrack

```
* Fix/coordinate system motive 2.0 (#56 <https://github.com/ros-drivers/mocap_optitrack/issues/56>)
  * fix: coordinate system for motive 2.0+
  * typo
  * fix: coordiante system for versions > motive 2.0
  Co-authored-by: jad <mailto:jad.hajmustafa@eurogroep.com>
* Feat: add enable disable tf publisher param (#55 <https://github.com/ros-drivers/mocap_optitrack/issues/55>)
  * feat: enable tf publisher param
  * fix: default value of enable_tf_publisher
  * feat: add-enable-disable param for tf publisher
  * feat: add tf topic to enable/disable tf publisher
  * remove unnecessary changes
  * fix: lint
  Co-authored-by: jad <mailto:jad.hajmustafa@eurogroep.com>
* Added Noetic to CI.
* Contributors: Tony Baltovski, jadhm
```
