### PR TITLE
Add RHEL 7 rule for 'benchmark'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -268,9 +268,7 @@ benchmark:
     stretch: null
   fedora: [google-benchmark-devel]
   openembedded: [google-benchmark@meta-ros2]
-  rhel:
-    '*': [google-benchmark-devel]
-    '7': null
+  rhel: [google-benchmark-devel]
   ubuntu:
     '*': [libbenchmark-dev]
     xenial: null


### PR DESCRIPTION
This package is now available for all supported RHEL releases (7 and 8).

It is supplied by the EPEL repository: https://src.fedoraproject.org/rpms/google-benchmark#build_status