### PR TITLE
Switch to RHEL 8 in ROS 2 Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4,7 +4,7 @@
 ---
 release_platforms:
   rhel:
-  - '7'
+  - '8'
   ubuntu:
   - focal
 repositories:


### PR DESCRIPTION
We've reached a point in EPEL 8 where there are sufficient dependencies to build a large portion of ROS 2 Rolling. This means that RHEL 8 will be a better candidate for building ROS 2 moving forward.