### PR TITLE
phidgets_drivers: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4703,7 +4703,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.2-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.1-1`

## libphidget22

- No changes

## phidgets_accelerometer

```
* Don't publish messages that jumped back in time. (#85 <https://github.com/ros-drivers/phidgets_drivers/issues/85>)
* Log synchronization window details at DEBUG level. (#82 <https://github.com/ros-drivers/phidgets_drivers/issues/82>)
* Contributors: Michael Grupp
```

## phidgets_analog_inputs

- No changes

## phidgets_api

- No changes

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

```
* Don't publish messages that jumped back in time. (#85 <https://github.com/ros-drivers/phidgets_drivers/issues/85>)
* Log synchronization window details at DEBUG level. (#82 <https://github.com/ros-drivers/phidgets_drivers/issues/82>)
* Contributors: Michael Grupp
```

## phidgets_high_speed_encoder

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Don't publish messages that jumped back in time. (#85 <https://github.com/ros-drivers/phidgets_drivers/issues/85>)
* Log synchronization window details at DEBUG level. (#82 <https://github.com/ros-drivers/phidgets_drivers/issues/82>)
* Contributors: Michael Grupp
```

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Don't publish messages that jumped back in time. (#85 <https://github.com/ros-drivers/phidgets_drivers/issues/85>)
* Log synchronization window details at DEBUG level. (#82 <https://github.com/ros-drivers/phidgets_drivers/issues/82>)
* Contributors: Michael Grupp
```

## phidgets_temperature

- No changes
