### PR TITLE
moose: 0.1.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7816,7 +7816,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/moose-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/moose-cpr/moose.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moose` to `0.1.1-1`:

- upstream repository: https://github.com/moose-cpr/moose.git
- release repository: https://github.com/clearpath-gbp/moose-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.0-1`

## moose_control

```
* Expose MOOSE_JOY_DEV and MOOSE_JOY_TELEOP environment variables.  Enable the joy node's messages to be received by twist_mux with the same priority as Warthog.
* Contributors: Chris Iverach-Brereton
```

## moose_description

```
* Add the legacy mode NS flag to the gazebo file. This gets rid of a warning when launching gazebo
* Contributors: Chris I-B
```

## moose_msgs

- No changes
