### PR TITLE
radar_msgs: 0.1.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5130,6 +5130,22 @@ repositories:
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
+  radar_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/radar_msgs.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/radar_msgs-release.git
+      version: 0.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/radar_msgs.git
+      version: noetic
+    status: maintained
   radar_pa:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `radar_msgs` to `0.1.0-2`:

- upstream repository: https://github.com/ros-perception/radar_msgs.git
- release repository: https://github.com/ros2-gbp/radar_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
