### PR TITLE
rosidl: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2050,6 +2050,7 @@ repositories:
     release:
       packages:
       - rosidl_adapter
+      - rosidl_cli
       - rosidl_cmake
       - rosidl_generator_c
       - rosidl_generator_cpp
@@ -2062,7 +2063,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.0.3-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.0.3-1`

## rosidl_adapter

```
* Support hex constants in msg files (#559 <https://github.com/ros2/rosidl/issues/559>)
* Contributors: Dereck Wonnacott
```

## rosidl_cli

```
* Align rosidl_cli package version with the rest of the repo. (#579 <https://github.com/ros2/rosidl/issues/579>)
* Expose an API for each rosidl CLI command.  (#577 <https://github.com/ros2/rosidl/issues/577>)
* Add rosidl translate CLI. (#575 <https://github.com/ros2/rosidl/issues/575>)
* Add rosidl generate CLI. (#567 <https://github.com/ros2/rosidl/issues/567>)
* Contributors: Michel Hidalgo, Shane Loretz
```

## rosidl_cmake

```
* Shorten some excessively long lines of CMake (#571 <https://github.com/ros2/rosidl/issues/571>)
* Contributors: Scott K Logan
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

```
* Switch to std::allocator_traits. (#564 <https://github.com/ros2/rosidl/issues/564>)
* Contributors: Chris Lalancette
```

## rosidl_parser

- No changes

## rosidl_runtime_c

```
* Shorten some excessively long lines of CMake (#571 <https://github.com/ros2/rosidl/issues/571>)
* Contributors: Scott K Logan
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
