### PR TITLE
Revert "Provide python3-importlib-{metadata,resources} in bootstrap"

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6110,7 +6110,9 @@ python3-importlib-metadata:
     '31': [python3-importlib-metadata]
   gentoo: [dev-python/importlib_metadata]
   openembedded: [python3-importlib-metadata@openembedded-core]
-  rhel: ['python%{python3_pkgversion}-importlib-metadata']
+  rhel:
+    '*': ['python%{python3_pkgversion}-importlib-metadata']
+    '7': null
   ubuntu:
     '*': [python3-importlib-metadata]
     bionic:
@@ -6131,7 +6133,9 @@ python3-importlib-resources:
   fedora: [python3]
   gentoo: [dev-python/importlib_resources]
   openembedded: [python3@openembedded-core]
-  rhel: ['python%{python3_pkgversion}-importlib-resources']
+  rhel:
+    '*': ['python%{python3_pkgversion}-importlib-resources']
+    '7': null
   ubuntu:
     '*': [python3-minimal]
     bionic:


### PR DESCRIPTION
This reverts commit 09a719f446d95d0805adde496fa28c41f012509f.

We're no longer targeting RHEL 7 in Rolling, so we will no longer be providing these packages from the bootstrap repository.