### PR TITLE
pal_gazebo_worlds: 3.0.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2159,11 +2159,19 @@ repositories:
       version: foxy
     status: maintained
   pal_gazebo_worlds:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_gazebo_worlds.git
+      version: foxy-devel
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
       version: 3.0.1-2
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_gazebo_worlds.git
+      version: foxy-devel
     status: developed
   pcl_msgs:
     release:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2158,6 +2158,13 @@ repositories:
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: foxy
     status: maintained
+  pal_gazebo_worlds:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
+      version: 3.0.1-2
+    status: developed
   pcl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gazebo_worlds` to `3.0.1-2`:

- upstream repository: https://github.com/pal-robotics/pal_gazebo_worlds.git
- release repository: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.9.8`
- previous version for package: `null`

## pal_gazebo_worlds

```
* Remove ROS1 dependencies
* Contributors: Victor Lopez
```
