### PR TITLE
yp-spur: 1.20.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -18331,7 +18331,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.20.0-1
+      version: 1.20.1-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.20.1-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.20.0-1`

## ypspur

```
* Fix timestamp estimation (#169 <https://github.com/openspur/yp-spur/issues/169>)
* Update assets to v0.1.4 (#164 <https://github.com/openspur/yp-spur/issues/164>)
* Migrate to GitHub Actions (#166 <https://github.com/openspur/yp-spur/issues/166>)
* Update static_assert availability check (#163 <https://github.com/openspur/yp-spur/issues/163>)
* Add static_assert to enum value overlap (#162 <https://github.com/openspur/yp-spur/issues/162>)
* Fix version in CMakeLists (#161 <https://github.com/openspur/yp-spur/issues/161>)
* Fix git directory on release-candidate (#159 <https://github.com/openspur/yp-spur/issues/159>)
* Automatically update version in CMakeLists (#157 <https://github.com/openspur/yp-spur/issues/157>)
* Update assets to v0.1.2 (#156 <https://github.com/openspur/yp-spur/issues/156>)
* Update assets to v0.0.10 (#154 <https://github.com/openspur/yp-spur/issues/154>)
* Contributors: Atsushi Watanabe
```
