### PR TITLE
psen_scan_v2: 0.1.5-1 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8886,7 +8886,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.1.5-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.4-1`

## psen_scan_v2

```
* Make specifying host ip optional
* Reorder Readme sections
* API change: A scan is published only if it contains measurement data
* Make tests build in standalone with or without ROS installed
* Document key components in a meaningful expressive way
* Enable building the standalone lib using MSVC
* Enable separate building of cpp-lib; extract sources into subproject psen_scan_v2_standalone
* Renames ScanRange and DefaultScanRange to improve usability
* Improve namespace hierarchy and move files to respective subfolders
* Use defaults ports in ScannerConfiguration
* Contributors: Pilz GmbH and Co. KG
```