### PR TITLE
urg_stamped: 0.0.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13457,7 +13457,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.7-1
+      version: 0.0.9-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.9-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.0.7-1`

## urg_stamped

```
* Release 0.0.8 (#84 <https://github.com/seqsense/urg_stamped/issues/84>)
* Fix token name for releasing (#86 <https://github.com/seqsense/urg_stamped/issues/86>)
* Fix prerelease test (#85 <https://github.com/seqsense/urg_stamped/issues/85>)
* Remove unnecessary newline from log (#82 <https://github.com/seqsense/urg_stamped/issues/82>)
* Migrate to GitHub Actions (#81 <https://github.com/seqsense/urg_stamped/issues/81>)
* Contributors: Atsushi Watanabe, github-actions[bot]
```
