### PR TITLE
visp: 3.4.0-4 in 'melodic/distribution.yaml'

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13773,7 +13773,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.3.0-3
+      version: 3.4.0-4
     status: maintained
   visualization_osg:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository visp to 3.4.0-4:

    upstream repository: https://github.com/lagadic/visp.git
    release repository: https://github.com/lagadc/visp-release.git
    distro file: melodic/distribution.yaml
    bloom version: 0.10.1
    previous version for package: 3.3.0-3
