### PR TITLE
visp: 3.4.0-3 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17570,7 +17570,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.3.0-3
+      version: 3.4.0-3
     status: maintained
   visp_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository visp to 3.4.0-3:

    upstream repository: https://github.com/lagadic/visp.git
    release repository: https://github.com/lagadc/visp-release.git
    distro file: melodic/distribution.yaml
    bloom version: 0.10.1
    previous version for package: 3.3.0-3
