### PR TITLE
visp: 3.4.0-2 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7832,6 +7832,13 @@ repositories:
       url: https://github.com/ros-perception/vision_opencv.git
       version: noetic
     status: maintained
+  visp:
+     release:
+       tags:
+         release: release/noetic/{package}/{version}
+       url: https://github.com/lagadic/visp-release.git
+       version: 3.4.0-2
+     status: maintained
   visualization_tutorials:
     doc:
       type: git


### PR DESCRIPTION
New version of package(s) in repository visp to 3.4.0-2:

    upstream repository: https://github.com/lagadic/visp.git
    release repository: https://github.com/lagadc/visp-release.git
    distro file: noetic/distribution.yaml
    bloom version: 0.10.1

