### PR TITLE
rmw_implementation: 2.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1809,7 +1809,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.2.0-2`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.2.0-1`

## rmw_implementation

```
* Add function for checking QoS profile compatibility (#180 <https://github.com/ros2/rmw_implementation/issues/180>)
* Shorten some excessively long lines of CMake (#179 <https://github.com/ros2/rmw_implementation/issues/179>)
* Add rmw_fastrtps_dynamic_cpp to the explicit group deps (#177 <https://github.com/ros2/rmw_implementation/issues/177>)
* Contributors: Jacob Perron, Scott K Logan
```
