### PR TITLE
Require libXext-devel for sip on RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6795,7 +6795,7 @@ python3-qt5-bindings:
   gentoo: [dev-python/PyQt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
-  rhel: ['python%{python3_pkgversion}-qt5-devel']
+  rhel: ['python%{python3_pkgversion}-qt5-devel', libXext-devel]
   slackware: [python3-PyQt5]
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]


### PR DESCRIPTION
This extra dependency is already present for Fedora (#25891), but it looks like RHEL 8 will need it too. The dependency seems to be otherwise handled on RHEL 7, but including it explicitly shouldn't hurt.

This package is part of `base` on RHEL 7: https://mirrors.edge.kernel.org/centos/7.9.2009/os/x86_64/Packages/libXext-devel-1.3.3-3.el7.x86_64.rpm
This package is part of `appstream` on RHEL 8: https://mirrors.edge.kernel.org/centos/8.3.2011/AppStream/x86_64/os/Packages/libXext-devel-1.3.4-1.el8.x86_64.rpm