### PR TITLE
libyaml_vendor: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1066,7 +1066,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.1.1-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.1.0-1`

## libyaml_vendor

```
* Fix linker flags for tests when CMake < 3.13 (#35 <https://github.com/ros2/libyaml_vendor/issues/35>)
* Always preserve source permissions in vendor packages (#31 <https://github.com/ros2/libyaml_vendor/issues/31>)
* Contributors: Scott K Logan
```
