### PR TITLE
Add python3-pyside2.qtopengl for Ubuntu focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6719,6 +6719,9 @@ python3-pyrr-pip:
   ubuntu:
     pip:
       packages: [pyrr]
+python3-pyside2.qtopengl:
+  ubuntu:
+    noetic: [python3-pyside2.qtopengl]
 python3-pystemd:
   debian:
     bullseye: [python3-pystemd]
@@ -6730,9 +6733,6 @@ python3-pystemd:
     xenial:
       pip:
         packages: [pystemd]
-python3-pyside2.qtopengl:
-  ubuntu:
-    noetic: [python3-pyside2.qtopengl]
 python3-pyswarms-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6720,6 +6720,9 @@ python3-pyrr-pip:
     pip:
       packages: [pyrr]
 python3-pyside2.qtopengl:
+  debian: [python3-pyside2.qtopengl]
+  fedora: [python3-pyside2]
+  gentoo: [dev-python/pyside2]
   ubuntu:
     '*': [python3-pyside2.qtopengl]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6892,7 +6892,7 @@ python3-rosdistro-modules:
   rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
 python3-rosinstall-generator:
-  ubuntu: [python3-rosinstall-generator]raultron:patch-1
+  ubuntu: [python3-rosinstall-generator]
 python3-rospkg:
   alpine: [py3-rospkg]
   debian: [python3-rospkg]
@@ -6901,7 +6901,7 @@ python3-rospkg:
     pip:
       packages: [rospkg]
   gentoo: [dev-python/rospkg]
-  openembedded: [python3-rospkg@meta-ros-common]raultron:patch-1
+  openembedded: [python3-rospkg@meta-ros-common]
   opensuse: [python3-rospkg]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6721,7 +6721,7 @@ python3-pyrr-pip:
       packages: [pyrr]
 python3-pyside2.qtopengl:
   ubuntu:
-    noetic: [python3-pyside2.qtopengl]
+    focal: [python3-pyside2.qtopengl]
 python3-pystemd:
   debian:
     bullseye: [python3-pystemd]
@@ -6892,7 +6892,7 @@ python3-rosdistro-modules:
   rhel: ['python%{python3_pkgversion}-rosdistro']
   ubuntu: [python3-rosdistro-modules]
 python3-rosinstall-generator:
-  ubuntu: [python3-rosinstall-generator]
+  ubuntu: [python3-rosinstall-generator]raultron:patch-1
 python3-rospkg:
   alpine: [py3-rospkg]
   debian: [python3-rospkg]
@@ -6901,7 +6901,7 @@ python3-rospkg:
     pip:
       packages: [rospkg]
   gentoo: [dev-python/rospkg]
-  openembedded: [python3-rospkg@meta-ros-common]
+  openembedded: [python3-rospkg@meta-ros-common]raultron:patch-1
   opensuse: [python3-rospkg]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6730,6 +6730,9 @@ python3-pystemd:
     xenial:
       pip:
         packages: [pystemd]
+python3-pyside2.qtopengl:
+  ubuntu:
+    noetic: [python3-pyside2.qtopengl]
 python3-pyswarms-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6720,6 +6720,7 @@ python3-pyrr-pip:
     pip:
       packages: [pyrr]
 python3-pyside2.qtopengl:
+  arch: [pyside2]
   debian: [python3-pyside2.qtopengl]
   fedora: [python3-pyside2]
   gentoo: [dev-python/pyside2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6721,7 +6721,9 @@ python3-pyrr-pip:
       packages: [pyrr]
 python3-pyside2.qtopengl:
   ubuntu:
-    focal: [python3-pyside2.qtopengl]
+    '*': [python3-pyside2.qtopengl]
+    bionic: null
+    xenial: null
 python3-pystemd:
   debian:
     bullseye: [python3-pystemd]


### PR DESCRIPTION
Package in Noetic: 
https://packages.ubuntu.com/focal/python/python3-pyside2.qtopengl

This package allows the creation of an opengl widget in rqt when using the pyside backend.