### PR TITLE
vision_visp: 0.12.0-1 in 'kinetic/distribution.yaml'

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17559,7 +17559,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/vision_visp-release.git
-      version: 0.11.1-1
+      version: 0.12.0-1
     source:
       type: git
       url: https://github.com/lagadic/vision_visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository vision_visp to 0.12.0-1:

    upstream repository: https://github.com/lagadic/vision_visp.git
    release repository: https://github.com/lagadic/vision_visp-release.git
    distro file: kinetic/distribution.yaml
    bloom version: 0.10.1
    previous version for package: 0.11.1-1