### PR TITLE
sot-tools: 2.3.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7082,7 +7082,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/sot-tools-ros-release.git
-      version: 2.3.3-1
+      version: 2.3.4-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/sot-tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-tools` to `2.3.4-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-tools.git
- release repository: https://github.com/stack-of-tasks/sot-tools-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `2.3.3-1`
