### PR TITLE
rmw_connextdds: 0.2.1-1 in 'rolling/distribution.yaml' [non-bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1728,6 +1728,26 @@ repositories:
       url: https://github.com/ros2/rmw_connext.git
       version: master
     status: maintained
+  rmw_connextdds:
+    doc:
+      type: git
+      url: https://github.com/rticommunity/rmw_connextdds.git
+      version: master
+    release:
+      packages:
+      - rmw_connextdds
+      - rmw_connextdds_common
+      - rmw_connextddsmicro
+      - rti_connext_dds_cmake_module
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_connextdds-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/rticommunity/rmw_connextdds.git
+      version: master
+    status: developed
   rmw_cyclonedds:
     doc:
       type: git


### PR DESCRIPTION
Follow up to #28559 using release repository [ros2-gbp/rmw_connextdds-release](https://github.com/ros2-gbp/rmw_connextdds-release).

I'm creating the PR by hand because I wasn't able to create an OAuth token with bloom, even though I used the correct password (I had received the same error several times while preparing for #28559).

```
Would you like to create an OAuth token now [Y/n]? 
GitHub username [asorbini]: 
GitHub password (never stored): 
HTTP Error 404: Not Found (https://api.github.com/authorizations): None

This sometimes fails when the username or password are incorrect, try again?
Continue [Y/n]? n
```
