### PR TITLE
rmw: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1702,7 +1702,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `3.1.0-1`

## rmw

```
* Introduce RMW_DURATION_INFINITE constant and API return value promise (#301 <https://github.com/ros2/rmw/issues/301>)
* Contributors: Emerson Knapp
```

## rmw_implementation_cmake

- No changes
