### PR TITLE
rmw_connextdds: 0.2.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1742,7 +1742,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.2.1-1
+      version: 0.2.1-3
     source:
       type: git
       url: https://github.com/rticommunity/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.2.1-3`:

- upstream repository: https://github.com/rticommunity/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.2.1-1`

## rmw_connextdds

```
* Renamed environment variables (``RMW_CONNEXT_USE_DEFAULT_PUBLISH_MODE``,
  ``RMW_CONNEXT_LEGACY_RMW_COMPATIBILITY_MODE``).
* Support a list of initial peers via ``RMW_CONNEXT_INITIAL_PEERS``.
```

## rmw_connextdds_common

- No changes

## rmw_connextddsmicro

- No changes

## rti_connext_dds_cmake_module

- No changes
