### PR TITLE
pcl_msgs: 1.0.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1281,7 +1281,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pcl_msgs-release.git
-      version: 1.0.0-3
+      version: 1.0.0-4
     status: maintained
   perception_pcl:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_msgs` to `1.0.0-4`:

- upstream repository: https://github.com/ros-perception/pcl_msgs
- release repository: https://github.com/ros2-gbp/pcl_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-3`

## pcl_msgs

```
* Trim README
* ros2 port of pcl_msgs (#11 <https://github.com/ros-perception/pcl_msgs/issues/11>)
  * Migrated From ROS1 to ROS2
  * Update CHANGELOG.rst
  * Migrated pcl_msgs from ROS1 to ROS2
  * Updated Readme.md
  Added Migration changes information and How to build and test information.
  * Update README.md
  * Update README.md
  * Update README.md
* Migrated From ROS1 to ROS2 (#10 <https://github.com/ros-perception/pcl_msgs/issues/10>)
  * Migrated From ROS1 to ROS2
  * Update CHANGELOG.rst
  * Migrated pcl_msgs from ROS1 to ROS2
* Add service file to update filename
* Contributors: Kentaro Wada, Paul Bovbel, Sandip Rakhasiya
```
