### PR TITLE
rosidl_python: 0.9.4-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2138,7 +2138,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.9.4-2
+      version: 0.9.4-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.9.4-3`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.9.4-2`

## rosidl_generator_py

```
* Update maintainers (#119 <https://github.com/ros2/rosidl_python/issues/119>)
* Fix too early decref of WString when converting from Python to C (#117 <https://github.com/ros2/rosidl_python/issues/117>)
* Add pytest.ini so tests succeed locally. (#116 <https://github.com/ros2/rosidl_python/issues/116>)
* Contributors: Chris Lalancette, Claire Wang, Dirk Thomas
```
