### PR TITLE
fastrtps: 2.0.0-6 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -596,7 +596,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.0.0-4
+      version: 2.0.0-6
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastrtps` to `2.0.0-6`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.0.0-4`
