### PR TITLE
cascade_lifecycle: 0.0.7-4 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -457,7 +457,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/fmrico/cascade_lifecycle-release.git
-      version: 0.0.6-1
+      version: 0.0.7-4
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `0.0.7-4`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/fmrico/cascade_lifecycle-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.0.6-1`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Dynamic add/remove deps
* Contributors: Francisco Martin Rico, Francisco Martín Rico
```
