### PR TITLE
Adding ROSXBee to documentation index for foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3612,6 +3612,12 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: foxy
     status: developed
+  rosxbee:
+    doc:
+      type: git
+      url: https://github.com/Sudharsan10/ROSXBee.git
+      version: foxy
+    status: developed
   roverrobotics_ros2:
     doc:
       type: git


### PR DESCRIPTION
I'd like my repo to be indexed and documented on ros.org