### PR TITLE
Adding ROSXBee to documentation index for foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3617,6 +3617,18 @@ repositories:
       type: git
       url: https://github.com/Sudharsan10/ROSXBee.git
       version: foxy
+    release:
+      packages:
+      - rosxbeepy
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/Sudharsan10/ROSXBee-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/Sudharsan10/ROSXBee.git
+      version: foxy
+    status: developed
   roverrobotics_ros2:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3612,6 +3612,11 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: foxy
     status: developed
+  rosxbee:
+    doc:
+      type: git
+      url: https://github.com/Sudharsan10/ROSXBee.git
+      version: foxy
   roverrobotics_ros2:
     doc:
       type: git


### PR DESCRIPTION
I'd like ROSXBee to be indexed and documented on the ros.org