### PR TITLE
rosxbee: 0.0.1-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3612,6 +3612,24 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
       version: foxy
     status: developed
+  rosxbee:
+    doc:
+      type: git
+      url: https://github.com/Sudharsan10/ROSXBee.git
+      version: 0.0.1
+    release:
+      packages:
+      - rosxbeepy
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/Sudharsan10/ROSXBee-release.git
+      version: 0.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Sudharsan10/ROSXBee.git
+      version: 0.0.1
+    status: developed
   roverrobotics_ros2:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3616,7 +3616,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Sudharsan10/ROSXBee.git
-      version: 0.0.1
+      version: foxy
     release:
       packages:
       - rosxbeepy
@@ -3628,7 +3628,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/Sudharsan10/ROSXBee.git
-      version: 0.0.1
+      version: foxy
     status: developed
   roverrobotics_ros2:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosxbee` to `0.0.1-2`:

- upstream repository: https://github.com/Sudharsan10/ROSXBee.git
- release repository: https://github.com/Sudharsan10/ROSXBee-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## rosxbeepy

```
* Merge pull request #1 <https://github.com/Sudharsan10/ROSXBee/issues/1> from Sudharsan10/development
  Interfacing an XBee module
* Interfacing an XBee module
* base commit
* Contributors: Sudharsan
```
