### PR TITLE
sot-dynamic-pinocchio: 3.6.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -12200,7 +12200,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release.git
-      version: 3.6.1-1
+      version: 3.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-dynamic-pinocchio` to `3.6.2-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-dynamic-pinocchio.git
- release repository: https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `3.6.1-1`
