### PR TITLE
sot-dynamic-pinocchio: 3.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7073,6 +7073,21 @@ repositories:
       url: https://github.com/stack-of-tasks/sot-core.git
       version: devel
     status: maintained
+  sot-dynamic-pinocchio:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/sot-dynamic-pinocchio.git
+      version: devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release.git
+      version: 3.6.2-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/sot-dynamic-pinocchio.git
+      version: devel
+    status: maintained
   sot-tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sot-dynamic-pinocchio` to `3.6.2-1`:

- upstream repository: https://github.com/stack-of-tasks/sot-dynamic-pinocchio.git
- release repository: https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
