### PR TITLE
astuff_sensor_msgs: 3.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -151,7 +151,6 @@ repositories:
       version: master
     release:
       packages:
-      - astuff_sensor_msgs
       - delphi_esr_msgs
       - delphi_mrr_msgs
       - delphi_srr_msgs
@@ -164,7 +163,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `astuff_sensor_msgs` to `3.2.0-1`:

- upstream repository: https://github.com/astuff/astuff_sensor_msgs.git
- release repository: https://github.com/astuff/astuff_sensor_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `3.1.0-1`

## delphi_esr_msgs

```
* Bag migration rules cleanup (#76 <https://github.com/astuff/astuff_sensor_msgs/issues/76>)
  * delphi_esr_msgs: Consolidate bag migration rules
* Update delphi_esr_msgs (#69 <https://github.com/astuff/astuff_sensor_msgs/issues/69>)
  * Update delphi_esr_msgs to closer match documentation and fix typos
  * Update delphi_esr_msgs CMakeLists.txt
  * Change from EsrTrackMotionPower to EsrTrackMotionPowerTrack
  * Add migration file for changes to delphi_esr_msgs
  * Fix up old migration rules, order was wrong, remove duplication
  * Factor out install directive for migration folder
  * Fix CATKIN_PACKAGE_SHARE_DESTINATION for ROS2
* Contributors: icolwell-as
```

## delphi_mrr_msgs

- No changes

## delphi_srr_msgs

```
* Bag migration rules cleanup (#76 <https://github.com/astuff/astuff_sensor_msgs/issues/76>)
  * delphi_srr_msgs: Cleanup and consolidate bag migration rules, add install directive to CMakeLists.txt
* Contributors: icolwell-as
```

## derived_object_msgs

- No changes

## ibeo_msgs

- No changes

## kartech_linear_actuator_msgs

- No changes

## mobileye_560_660_msgs

- No changes

## neobotix_usboard_msgs

- No changes

## pacmod_msgs

```
* Bag migration rules cleanup (#76 <https://github.com/astuff/astuff_sensor_msgs/issues/76>)
  * pacmod_msgs: Consolidate bag migration rules, add install directive to CMakeLists.txt
* Contributors: icolwell-as
```
