### PR TITLE
fetch_robots: 0.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1829,7 +1829,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fetch_robots` to `0.9.2-1`:

- upstream repository: git@github.com:fetchrobotics/fetch_robots.git
- release repository: https://github.com/fetchrobotics-gbp/fetch_robots-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.9.1-1`

## fetch_bringup

- No changes

## fetch_drivers

```
* Update md5sum file
* Contributors: Eric Relson
```

## freight_bringup

- No changes
