### PR TITLE
heron_controller: 0.2.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3994,6 +3994,21 @@ repositories:
       url: https://github.com/heron/heron.git
       version: kinetic-devel
     status: maintained
+  heron_controller:
+    doc:
+      type: git
+      url: https://github.com/heron/heron_controller.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/heron_controller-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/heron/heron_controller.git
+      version: kinetic-devel
+    status: maintained
   heron_desktop:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `heron_controller` to `0.2.0-1`:

- upstream repository: https://github.com/heron/heron_controller.git
- release repository: https://github.com/clearpath-gbp/heron_controller-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## heron_controller

```
* Bumped CMake version to avoid author warning.
* Minor linting changes.
* Switched to BSD licence.
* Removed message generation.
* Added GitHub CI, codeowners and issue template.
* Removed launch folder to be installed because it doesn't exist
* Switched to std_srvs/SetBool.
* Fixing dependencies
* Removed unnecessary includes
* Updated package.xml to format 2
* Deleted unnecessary log command
* Updated C++ version
* Updated Heron parameters
* Deleted unused files
* Updated PID params
* Last update to the default velocity covariance setting
* Making time-out the default option
* New control parameters for debugging
* Initialized output force to zero and changed default velocity covariance limit
* Added deadzone in motor control algorithms so motor's aren't always on
* Fixes to new command-switching system
* Added service to allow for disabling heron_controller
* Changed command timeout system
* Velocity timeout was checking the wrong covariance entry in the odom twist
* max_fwd_force already accounts for two thrusters
* Parameterized covariance check on sensor data
* Changed controll to only depend on odometry/filtered topic
* Added fwd vel PID control
* Contributors: Guy Stoppi, Tony Baltovski
```
