### PR TITLE
Add RHEL rules for libspnav-dev and spacenavd

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4178,6 +4178,7 @@ libspnav-dev:
   debian: [libspnav-dev]
   fedora: [libspnav-devel]
   gentoo: [dev-libs/libspnav]
+  rhel: [libspnav-devel]
   ubuntu: [libspnav-dev]
 libsqlite3-dev:
   alpine: [sqlite-dev]
@@ -6097,6 +6098,7 @@ spacenavd:
   debian: [spacenavd]
   fedora: [spacenavd]
   gentoo: [app-misc/spacenavd]
+  rhel: [spacenavd]
   ubuntu: [spacenavd]
 sparsehash:
   debian: [libsparsehash-dev]


### PR DESCRIPTION
Both of these packages are provided by the EPEL repository, and both are available for RHEL 7 and RHEL 8.
https://src.fedoraproject.org/rpms/libspnav#bodhi_updates
https://src.fedoraproject.org/rpms/spacenavd#bodhi_updates