### PR TITLE
cartographer_ros: 1.0.9003-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -313,7 +313,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 1.0.9003-1
+      version: 1.0.9003-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer_ros` to `1.0.9003-2`:

- upstream repository: https://github.com/ros2/cartographer_ros.git
- release repository: https://github.com/ros2-gbp/cartographer_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.9003-1`

## cartographer_ros

```
* Switch to using a C-style string for RCLCPP macros.
* Cleanup the CMakeLists.txt.
* Contributors: Chris Lalancette
```

## cartographer_ros_msgs

- No changes
