### PR TITLE
control_msgs: 2.5.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -407,7 +407,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 2.5.0-1
+      version: 2.5.0-2
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `2.5.0-2`:

- upstream repository: git://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.5.0-1`

## control_msgs

```
* Extend QueryTrajectoryState to allow to report errors
* Contributors: Victor Lopez
```
