### PR TITLE
image_transport_plugins: 2.3.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -877,7 +877,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.3.0-2
+      version: 2.3.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.3.0-3`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.3.0-2`

## compressed_depth_image_transport

```
* Use non-deprecated image_transport headers (#59 <https://github.com/ros-perception/image_transport_plugins/issues/59>)
* Contributors: Michael Carroll
```

## compressed_image_transport

```
* Use non-deprecated image_transport headers (#59 <https://github.com/ros-perception/image_transport_plugins/issues/59>)
* Add parameter declarations (#52 <https://github.com/ros-perception/image_transport_plugins/issues/52>)
* Contributors: Michael Carroll, Łukasz Mitka
```

## image_transport_plugins

- No changes

## theora_image_transport

- No changes
