### PR TITLE
joystick_drivers: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -929,10 +929,13 @@ repositories:
       - joy
       - joy_linux
       - sdl2_vendor
+      - spacenav
+      - wiimote
+      - wiimote_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 2.4.1-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joystick_drivers` to `3.0.0-1`:

- upstream repository: https://github.com/ros-drivers/joystick_drivers.git
- release repository: https://github.com/ros2-gbp/joystick_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.4.1-2`

## joy

```
* Fix SDL2 include path (#196 <https://github.com/ros-drivers/joystick_drivers/issues/196>)
* Contributors: Scott K Logan
```

## joy_linux

```
* Update joy_linux_node.cpp (#189 <https://github.com/ros-drivers/joystick_drivers/issues/189>)
* Reenable diagnostics (#181 <https://github.com/ros-drivers/joystick_drivers/issues/181>)
* Contributors: Vitaliy Bondar, aaronaaronson98
```

## sdl2_vendor

```
* Use INTERFACE_LINK_OPTIONS in sdl2_vendor (#195 <https://github.com/ros-drivers/joystick_drivers/issues/195>)
* Contributors: Scott K Logan
```

## spacenav

```
* spacenav node changed for ros2 (#194 <https://github.com/ros-drivers/joystick_drivers/issues/194>)
* Contributors: Nils Schulte
```

## wiimote

```
* Fix a warning while building wiimote_controller.cpp (#201 <https://github.com/ros-drivers/joystick_drivers/issues/201>)
* fix compile error caused by missing include (#197 <https://github.com/ros-drivers/joystick_drivers/issues/197>)
* Port over Wiimote to ROS2 Foxy (#175 <https://github.com/ros-drivers/joystick_drivers/issues/175>)
* Contributors: Chris Lalancette, Kuni Natsuki, Kurt Wilson
```

## wiimote_msgs

```
* Port over Wiimote to ROS2 Foxy (#175 <https://github.com/ros-drivers/joystick_drivers/issues/175>)
* Contributors: Kuni Natsuki
```
