### PR TITLE
Add libbluetooth rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1884,6 +1884,7 @@ libbluetooth:
   debian: [libbluetooth3]
   fedora: [bluez-libs]
   gentoo: [net-wireless/bluez-libs]
+  rhel: [bluez-libs]
   ubuntu: [libbluetooth3]
 libbluetooth-dev:
   arch: [bluez]


### PR DESCRIPTION
In RHEL 7, this package is part of the `base` repository: https://mirrors.edge.kernel.org/centos/7.9.2009/os/x86_64/Packages/bluez-libs-5.44-7.el7.x86_64.rpm

In RHEL 8, this package is part of the `BaseOS` repository: https://mirrors.edge.kernel.org/centos/8.3.2011/BaseOS/x86_64/os/Packages/bluez-libs-5.52-1.el8.x86_64.rpm