### PR TITLE
Make the libspnav-dev key depend on libx11-dev.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4175,11 +4175,11 @@ libspatialite:
     trusty: [libspatialite5]
 libspnav-dev:
   arch: [libspnav]
-  debian: [libspnav-dev]
+  debian: [libspnav-dev, libx11-dev]
   fedora: [libspnav-devel]
   gentoo: [dev-libs/libspnav]
   rhel: [libspnav-devel]
-  ubuntu: [libspnav-dev]
+  ubuntu: [libspnav-dev, libx11-dev]
 libsqlite3-dev:
   alpine: [sqlite-dev]
   arch: [sqlite]


### PR DESCRIPTION
The header files depend on it, but it is missing an explicit
dependency on it.  Add that into the rosdep database.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix the build of spacenav in Rolling that is currently failing: https://build.ros2.org/job/Rbin_uF64__spacenav__ubuntu_focal_amd64__binary/1/