### PR TITLE
zbar_ros: 0.3.0-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14371,6 +14371,21 @@ repositories:
       url: https://github.com/fada-catec/z_laser_projector.git
       version: melodic
     status: maintained
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/zbar_ros-release.git
+      version: 0.3.0-2
+    source:
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: melodic-devel
+    status: maintained
   zeroconf_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.3.0-2`:

- upstream repository: https://github.com/ros-drivers/zbar_ros.git
- release repository: https://github.com/ros-drivers-gbp/zbar_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## zbar_ros

```
* Lint and close #6 <https://github.com/ros-drivers/zbar_ros/issues/6>
* Contributors: Paul Bovbel
```
