### PR TITLE
Add qtpositioning5-dev rosdep rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5852,6 +5852,9 @@ qtmultimedia5-dev:
   gentoo: ['dev-qt/qtmultimedia:5']
   openembedded: [qtmultimedia@meta-qt5]
   ubuntu: [qtmultimedia5-dev]
+qtpositioning5-dev:
+  debian: [qtpositioning5-dev]
+  ubuntu: [qtpositioning5-dev]
 qttools5-dev:
   debian: [qttools5-dev]
   fedora: [qt5-qttools-devel]


### PR DESCRIPTION
https://packages.ubuntu.com/focal/qtpositioning5-dev
https://packages.debian.org/buster/qtpositioning5-dev

This is a dependency of the CCOM Autonomous Mission Planner found here: https://github.com/CCOMJHC/AutonomousMissionPlanner