### PR TITLE
Work around missing libspnav-devel dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4176,9 +4176,9 @@ libspatialite:
 libspnav-dev:
   arch: [libspnav]
   debian: [libspnav-dev, libx11-dev]
-  fedora: [libspnav-devel]
+  fedora: [libspnav-devel, libX11-devel]
   gentoo: [dev-libs/libspnav]
-  rhel: [libspnav-devel]
+  rhel: [libspnav-devel, libX11-devel]
   ubuntu: [libspnav-dev, libx11-dev]
 libsqlite3-dev:
   alpine: [sqlite-dev]


### PR DESCRIPTION
It appears that the RPM package for `libspnav-devel` is missing a dependency on libX11-devel for Fedora and EPEL. This same issue seems to be a problem on Ubuntu as well.

Upstream issue: https://bugzilla.redhat.com/show_bug.cgi?id=1938491
Same change for Ubuntu: #28620