### PR TITLE
diagnostics: 1.10.4-1 in 'noetic/distribution.yaml' [non-bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1395,7 +1395,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.10.3-1
+      version: 1.10.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Given a token issue during the last PR opening step with bloom, I am opening this PR manually

Increasing version of package(s) in repository `diagnostics` to `1.10.4-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros-gbp/diagnostics-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.10.3-1`

## diagnostic_aggregator

```
* Improve messages of GenericAnalyzer when items are stale. (#187 <https://github.com/ros/diagnostics/issues/187>)
* Contributors: Michael Grupp
```

## diagnostic_analysis

- No changes

## diagnostic_common_diagnostics

```
* Port diagnostic common diagnostics to python 3
* fix(cpu_monitor): Exception on shutdown (#186 <https://github.com/ros/diagnostics/issues/186>)
  Catch sigint properly
* Contributors: Rein Appeldoorn, gemignani
```

## diagnostic_updater

```
* Fix some doc typos and remove travis config (#173 <https://github.com/ros/diagnostics/issues/173>)
  * cleate -> create
  * single single -> single
  * remove travis config
* Contributors: Mikael Arguedas
```

## diagnostics

- No changes

## rosdiagnostic

- No changes

## self_test

- No changes

## test_diagnostic_aggregator

- No changes
