### PR TITLE
denso_robot_ros: 3.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2138,6 +2138,33 @@ repositories:
         release: release/melodic/{package}/{version}
       url: https://github.com/pal-gbp/ddynamic_reconfigure_python-release.git
       version: 0.0.1-0
+  denso_robot_ros:
+    doc:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: melodic-devel
+    release:
+      packages:
+      - bcap_core
+      - bcap_service
+      - bcap_service_test
+      - denso_robot_bringup
+      - denso_robot_control
+      - denso_robot_core
+      - denso_robot_core_test
+      - denso_robot_descriptions
+      - denso_robot_gazebo
+      - denso_robot_moveit_config
+      - denso_robot_ros
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/DENSORobot/denso_robot_ros-release.git
+      version: 3.1.1-1
+    source:
+      type: git
+      url: https://github.com/DENSORobot/denso_robot_ros.git
+      version: melodic-devel
+    status: developed
   depthcloud_encoder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso_robot_ros` to `3.1.1-1`:

- upstream repository: https://github.com/DENSORobot/denso_robot_ros.git
- release repository: https://github.com/DENSORobot/denso_robot_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## bcap_core

```
* Change the symbolic link to the directory of include/bcap_core
```

## bcap_service

- No changes

## bcap_service_test

- No changes

## denso_robot_bringup

- No changes

## denso_robot_control

```
* Add ros::spinOnce() for the callbacks.
```

## denso_robot_core

- No changes

## denso_robot_core_test

- No changes

## denso_robot_descriptions

```
* Fix Controller ABORTED ([#5](https://github.com/DENSORobot/denso_robot_ros/issues/5))
```

## denso_robot_gazebo

- No changes

## denso_robot_moveit_config

- No changes

## denso_robot_ros

- No changes
