### PR TITLE
sick_safetyscanners2: 1.0.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4027,7 +4027,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners2-release.git
-      version: 1.0.1-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2` to `1.0.2-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2.git
- release repository: https://github.com/SICKAG/sick_safetyscanners2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.1-2`

## sick_safetyscanners2

```
* added missing dependencies to package xml
* Contributors: Lennart Puck
```
