### PR TITLE
Add pydantic pip package to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6592,6 +6592,15 @@ python3-pycryptodome:
       packages: [pycryptodome]
   rhel: ['python%{python3_pkgversion}-pycryptodomex']
   ubuntu: [python3-pycryptodome]
+python3-pydantic:
+  arch: [python-pydantic]
+  debian: null
+  fedora: [python3-pydantic]
+  gentoo: [dev-python/pydantic]
+  ubuntu:
+    '*': [python3-pydantic]
+    bionic: null
+    xenial: null
 python3-pydot:
   alpine: [py3-pydot]
   arch: [python-pydot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6596,15 +6596,20 @@ python3-pydantic:
   arch: [python-pydantic]
   debian:
     '*': [python3-pydantic]
-    buster: null
-    jessie: null
-    stretch: null
+    buster:
+      pip: [pydantic]
+    jessie:
+      pip: [pydantic]
+    stretch:
+      pip: [pydantic]
   fedora: [python3-pydantic]
   gentoo: [dev-python/pydantic]
   ubuntu:
     '*': [python3-pydantic]
-    bionic: null
-    xenial: null
+    bionic:
+      pip: [pydantic]
+    xenial:
+      pip: [pydantic]
 python3-pydot:
   alpine: [py3-pydot]
   arch: [python-pydot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6594,7 +6594,11 @@ python3-pycryptodome:
   ubuntu: [python3-pycryptodome]
 python3-pydantic:
   arch: [python-pydantic]
-  debian: null
+  debian:
+    '*': [python3-pydantic]
+    buster: null
+    jessie: null
+    stretch: null
   fedora: [python3-pydantic]
   gentoo: [dev-python/pydantic]
   ubuntu:


### PR DESCRIPTION
We're using pydantic (https://pydantic-docs.helpmanual.io/) to generate json schemata.

On focal, there's a python3-pydantic package available, but previous versions don't seem to have one yet, so I specified pip instead.