### PR TITLE
pr2_power_drivers: 1.1.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4963,6 +4963,26 @@ repositories:
       url: https://github.com/pr2/pr2_mechanism_msgs.git
       version: master
     status: unmaintained
+  pr2_power_drivers:
+    doc:
+      type: git
+      url: https://github.com/pr2/pr2_power_drivers.git
+      version: kinetic-devel
+    release:
+      packages:
+      - ocean_battery_driver
+      - power_monitor
+      - pr2_power_board
+      - pr2_power_drivers
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/pr2-gbp/pr2_power_drivers-release.git
+      version: 1.1.8-1
+    source:
+      type: git
+      url: https://github.com/pr2/pr2_power_drivers.git
+      version: kinetic-devel
+    status: unmaintained
   prosilica_gige_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pr2_power_drivers` to `1.1.8-1`:

- upstream repository: https://github.com/pr2/pr2_power_drivers.git
- release repository: https://github.com/pr2-gbp/pr2_power_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`

## ocean_battery_driver

- No changes

## power_monitor

- No changes

## pr2_power_board

```
* fix for python3 (#73 <https://github.com/pr2/pr2_power_drivers/issues/73>)
  * fix by 2to3 -w -f except .
  * fix by 2to3 -w -f print .
* Contributors: Kei Okada
```

## pr2_power_drivers

- No changes
