### PR TITLE
Change the Foxy branch for udf_parser_py development.

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4551,7 +4551,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf_parser_py.git
-      version: ros2
+      version: foxy-devel
     release:
       packages:
       - urdfdom_py
@@ -4563,7 +4563,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/urdf_parser_py.git
-      version: ros2
+      version: foxy-devel
     status: maintained
   urdfdom:
     doc:


### PR DESCRIPTION
Make it foxy-devel so we can land some potentially breaking
changes.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>