### PR TITLE
urdf_parser_py: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2948,7 +2948,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
-      version: 1.0.0-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_parser_py` to `1.1.0-1`:

- upstream repository: https://github.com/ros/urdf_parser_py.git
- release repository: https://github.com/ros2-gbp/urdfdom_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-2`

## urdfdom_py

```
* Use a Python entry point for 'display_urdf' (#64 <https://github.com/ros/urdf_parser_py/issues/64>)
* Move the 'display_urdf' script into the Python module (#64 <https://github.com/ros/urdf_parser_py/issues/64>)
* Make 'file' argument to display_urdf required (#64 <https://github.com/ros/urdf_parser_py/issues/64>)
* Make sure to add the version when creating a new URDF. (#62 <https://github.com/ros/urdf_parser_py/issues/62>)
* Remove the from_parameter_server method from urdf.py for ROS 2. (#63 <https://github.com/ros/urdf_parser_py/issues/63>)
* Silence pytest warnings when running locally. (#61 <https://github.com/ros/urdf_parser_py/issues/61>)
* Contributors: Chris Lalancette, Scott K Logan
```
