### PR TITLE
Add libceres-dev rule for RHEL 8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2252,8 +2252,7 @@ libceres-dev:
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   openembedded: [ceres-solver@meta-oe]
-  rhel:
-    '7': [ceres-solver-devel]
+  rhel: [ceres-solver-devel]
   ubuntu: [libceres-dev]
 libcgroup-dev:
   debian: [libcgroup-dev]


### PR DESCRIPTION
This package recently became available for RHEL 8: https://src.fedoraproject.org/rpms/ceres-solver#bodhi_updates