### PR TITLE
openvslam: 0.2.0-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2094,6 +2094,21 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros-gbp/ompl-release.git
       version: 1.5.0-1
+  openvslam:
+    doc:
+      type: git
+      url: https://github.com/OpenVSLAM-Community/openvslam.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/OpenVSLAM-Community/openvslam-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/OpenVSLAM-Community/openvslam.git
+      version: foxy-devel
+    status: developed
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openvslam` to `0.2.0-2`:

- upstream repository: https://github.com/OpenVSLAM-Community/openvslam.git
- release repository: https://github.com/OpenVSLAM-Community/openvslam-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`
