### PR TITLE
rmw_connextdds: 0.3.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1740,12 +1740,11 @@ repositories:
       packages:
       - rmw_connextdds
       - rmw_connextdds_common
-      - rmw_connextddsmicro
       - rti_connext_dds_cmake_module
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       type: git
       url: https://github.com/rticommunity/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.3.1-2`:

- upstream repository: https://github.com/rticommunity/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.3.1-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

- No changes

## rti_connext_dds_cmake_module

```
* Pass ``-Wl,--no-as-needed`` for system dependencies of Connext 5.3.1.
* Set ``IMPORTED_NO_SONAME true`` for Connext 5.3.1 imported library target.
```
