### PR TITLE
rosidl_typesupport_gurumdds: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2233,7 +2233,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
-      version: 1.0.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_gurumdds` to `2.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_gurumdds.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.2-1`

## gurumdds_cmake_module

```
* Update packages to use gurumdds-2.7
* Change maintainer
* Contributors: Youngjin Yun
```
