### PR TITLE
neonavigation: 0.10.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -7107,7 +7107,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.10.8-1
+      version: 0.10.9-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.10.9-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.10.8-1`

## costmap_cspace

- No changes

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

```
* neonavigation_launch: add isolated room to demo map (#591 <https://github.com/at-wat/neonavigation/issues/591>)
* Contributors: Atsushi Watanabe
```

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: abort A* search on continuous timeout (#592 <https://github.com/at-wat/neonavigation/issues/592>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
