### PR TITLE
launch_pal: 0.0.2-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1564,6 +1564,12 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: foxy
     status: developed
+  launch_pal:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/pal-gbp/launch_pal-release.git
+      version: 0.0.2-3
   launch_ros:
     doc:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1565,11 +1565,20 @@ repositories:
       version: foxy
     status: developed
   launch_pal:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: foxy-devel
     release:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
       version: 0.0.2-3
+    source:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: foxy-devel
+    status: developed
   launch_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.0.2-3`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## launch_pal

```
* Added missing dependencies
* Contributors: Jordan Palacios
```
