### PR TITLE
Add Ada toolchain: gnat, gprbuild

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1214,6 +1214,9 @@ glut:
   openembedded: [freeglut@meta-oe]
   rhel: [freeglut-devel]
   ubuntu: [freeglut3-dev]
+gnat:
+  debian: [gnat]
+  ubuntu: [gnat]
 gnuplot:
   arch: [gnuplot]
   debian: [gnuplot]
@@ -1274,6 +1277,9 @@ gphoto2:
   fedora: [gphoto2]
   gentoo: [media-gfx/gphoto2]
   ubuntu: [gphoto2]
+gprbuild:
+  debian: [gprbuild]
+  ubuntu: [gprbuild]
 gpsd:
   debian: [gpsd]
   fedora: [gpsd]


### PR DESCRIPTION
These are the system packages required by the ROS2 Ada client library packages: https://github.com/ada-ros/ada4ros2

gnat@debian: https://packages.debian.org/buster/gnat
gnat@ubuntu: https://packages.ubuntu.com/focal/gnat
gprbuild@debian: https://packages.debian.org/buster/gprbuild
gprbuild@ubuntu: https://packages.ubuntu.com/focal/gprbuild

- **gnat**: this is the Ada frontend of gcc. It compiles individual Ada units.
- **gprbuild**: this is a build tool that ensures that the whole build is consistent, per Ada rules; e.g., a touched file causes the recompilation of all dependents; it also binds the resulting objects and ensures a proper order of initialization ("elaboration" in the Ada lexicon). It can also be used to build mixed-language projects. (Ada/C/C++/etc.)