### PR TITLE
gazebo_ros_pkgs: 3.5.2-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -675,7 +675,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.5.1-1
+      version: 3.5.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.5.2-3`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `3.5.1-1`

## gazebo_dev

- No changes

## gazebo_msgs

- No changes

## gazebo_plugins

```
* gazebo_ros_camera: Added accessor methods for camera properties (#1246 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1246>)
  * Added accessor methods to gazebo_ros_camera for subclass access to camera properties.
  * Removed ros node accessor; no longer needed
  * Removed const return types and added vector include to header
  Co-authored-by: kbjeppes <mailto:kaden.b.jeppesen@nasa.gov>
* Fix tests for cyclonedds (#1228 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1228>) The
  default RMW implementation changed recently and some tests are now failing.
  This fixes the tests.  * Use KeepLast(1) with transient_local in tests There
  are some QoS incompatibilities in some tests that use SystemDefaultsQoS, so
  this changes them to use KeepLast(1) with transient_local instead. This fixes
  some of the test failures but not all.  * test_sim_time: allow more startup
  messages * Fix QoS and initialization of joint state pub test
* Make p3d offset element names singular (#1210 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1210>)
  * Make p3d offset element names singular
  - <xyz_offsets> is renamed to <xyz_offset>
  - <rpy_offsets> is renamed to <rpy_offsets>
  The old names can still be used, but are deprecated.
  This is more consistent with the naming convention used in ROS 1 versions.
  * Add test for deprecated functionality
* Contributors: Jacob Perron, Steve Peters, kjeppesen1
```

## gazebo_ros

```
* Remove slash from gazebo_ros scripts Python package name (#1251 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1251>)
* Fix line length in gazebo_ros/test/CMakeLists.txt (#1249 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1249>)
* gazebo_ros: use lxml in spawn_entity.py (#1221 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1221>)
  The python xml.etree.ElementTree library does not handle xml namespaces well,
  replacing namespaces of prefixed elements with ns0, ns1, etc. This switches
  to using lxml instead, which has the same syntax and is already used by other
  ros2 packages.  * Add a test
* Fix tests for cyclonedds (#1228 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1228>)
  The default RMW implementation changed recently and some tests are now
  failing. This fixes the tests.  * Use KeepLast(1) with transient_local in
  tests There are some QoS incompatibilities in some tests that use
  SystemDefaultsQoS, so this changes them to use KeepLast(1) with
  transient_local instead. This fixes some of the test failures but not all.
  * test_sim_time: allow more startup messages
  * Fix QoS and initialization of joint state pub test
* Fix executor to avoid random exceptions when shutting down (#1212 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1212>)
  * Fix executor to avoid random exceptions when shutting down
  * Add link to related issue in rclcpp
* ros2: Only subscribe to /gazebo/performance_metrics when necessary (#1205 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1205>)
  We are currently subscribing to the /gazebo/performance_metrics topic
  even if there are no subscribers to the ROS topic forwarding this data.
  This changes gazebo_ros_init to only subscribe to the gazebo topic
  if there are any subscribers to the corresponding ROS topic.
  While advertiser callbacks are used in ROS 1 but are not yet in ROS2,
  here we use polling in the GazeboRosInitPrivate::PublishSimTime
  callback to check for subscribers since it is called for each Gazebo
  time step.
  This also helps workaround the deadlock documented in #1175 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1175> and
  osrf/gazebo#2902 <https://github.com/osrf/gazebo/issues/2902>.
  This also adds a macro to reduce duplication of the version checking
  logic.
* Contributors: Ivan Santiago Paunovic, Michel Hidalgo, Steve Peters
```

## gazebo_ros_pkgs

- No changes
