### PR TITLE
ros_control_boilerplate: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -10264,7 +10264,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros_control_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_control_boilerplate` to `0.5.2-1`:

- upstream repository: https://github.com/PickNikRobotics/ros_control_boilerplate.git
- release repository: https://github.com/PickNikRobotics/ros_control_boilerplate-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.5.1-1`

## ros_control_boilerplate

```
* Revert "Replaced boost with std shared_ptr"
  This reverts commit 9fa14cd3d00328efa3d44d7bf4d849ce909310f0.
* Contributors: JafarAbdi
```
