### PR TITLE
ethercat_grant: 0.2.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1675,6 +1675,21 @@ repositories:
       url: https://github.com/bostoncleek/ergodic_exploration.git
       version: noetic-devel
     status: developed
+  ethercat_grant:
+    doc:
+      type: git
+      url: https://github.com/shadow-robot/ethercat_grant.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/shadow-robot/ethercat_grant-release.git
+      version: 0.2.5-1
+    source:
+      type: git
+      url: https://github.com/shadow-robot/ethercat_grant.git
+      version: noetic-devel
+    status: maintained
   executive_smach:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ethercat_grant` to `0.2.5-1`:

- upstream repository: https://github.com/shadow-robot/ethercat_grant.git
- release repository: https://github.com/shadow-robot/ethercat_grant-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`
