### PR TITLE
yp-spur: 1.20.2-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -18346,7 +18346,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.20.1-1
+      version: 1.20.2-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.20.2-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.20.1-1`

## ypspur

```
* Revert "Fix timestamp estimation (#169 <https://github.com/openspur/yp-spur/issues/169>)" (#172 <https://github.com/openspur/yp-spur/issues/172>)
* Contributors: Atsushi Watanabe
```
