### PR TITLE
yp-spur: 1.20.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8134,7 +8134,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.20.1-1
+      version: 1.20.2-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.20.2-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.20.1-1`

## ypspur

```
* Revert "Fix timestamp estimation (#169 <https://github.com/openspur/yp-spur/issues/169>)" (#172 <https://github.com/openspur/yp-spur/issues/172>)
* Contributors: Atsushi Watanabe
```
