### PR TITLE
rqt_publisher: 1.1.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2425,7 +2425,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.1.0-2
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.1.1-2`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.0-2`

## rqt_publisher

```
* Use rosidl_runtime_py instead of rqt_py_common where possible (#24 <https://github.com/ros-visualization/rqt_publisher/issues/24>)
* Add now() to evaluation (#22 <https://github.com/ros-visualization/rqt_publisher/issues/22>)
* Contributors: Ivan Santiago Paunovic, Yossi Ovcharik
```
