### PR TITLE
rqt_publisher: 1.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3820,7 +3820,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.0-1`

## rqt_publisher

```
* Use rosidl_runtime_py instead of rqt_py_common where possible (#24 <https://github.com/ros-visualization/rqt_publisher/issues/24>)
* Add now() to evaluation (#22 <https://github.com/ros-visualization/rqt_publisher/issues/22>)
* Contributors: Ivan Santiago Paunovic, Yossi Ovcharik
```
