### PR TITLE
trac_ik: 1.6.1-6 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7386,7 +7386,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.6.1-1
+      version: 1.6.1-6
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.6.1-6`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.6.1-1`
