### PR TITLE
Add python3-semver

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6972,6 +6972,11 @@ python3-semantic-version:
   debian: [python3-semantic-version]
   fedora: [python3-semantic_version]
   ubuntu: [python3-semantic-version]
+python3-semver:
+  debian: [python3-semver]
+  fedora: [python3-semver]
+  freebsd: [py36-semver]
+  ubuntu: [python3-semver]
 python3-sense-emu-pip:
   debian:
     pip:


### PR DESCRIPTION
PyPi: https://pypi.org/project/semver/

Supported [linux distributions](https://python-semver.readthedocs.io/en/latest/install.html#linux-distributions)

Packages Lists:
[Ubuntu](https://packages.ubuntu.com/search?keywords=python3-semver&searchon=names&suite=all&section=all)
[Debian](https://packages.debian.org/search?keywords=python3-semver&searchon=names&suite=all&section=all)


