### PR TITLE
rmw_gurumdds: 0.8.8-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2329,6 +2329,24 @@ repositories:
       url: https://github.com/ros2/rmw_fastrtps.git
       version: eloquent
     status: maintained
+  rmw_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: eloquent
+    release:
+      packages:
+      - rmw_gurumdds_cpp
+      - rmw_gurumdds_shared_cpp
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+      version: 0.8.8-1
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: eloquent
+    status: maintained
   rmw_implementation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `0.8.8-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## rmw_gurumdds_cpp

```
* Use DataReader listener for taking data samples
* Change maintainer
* Update packages to use gurumdds-2.7
* Contributors: youngjin
```

## rmw_gurumdds_shared_cpp

```
* Use DataReader listener for taking data samples
* Delete contained entities before deleting domain participant
* Change maintainer
* Update packages to use gurumdds-2.7
* Contributors: youngjin
```
