### PR TITLE
rosidl_typesupport_gurumdds: 0.8.6-1 in 'eloquent/distribution.yaml' [bloom]

### DIFF
--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -2775,6 +2775,23 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: eloquent
     status: maintained
+  rosidl_typesupport_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
+      version: eloquent
+    release:
+      packages:
+      - gurumdds_cmake_module
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
+      version: 0.8.6-1
+    source:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_gurumdds.git
+      version: eloquent
+    status: maintained
   rosidl_typesupport_opensplice:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_gurumdds` to `0.8.6-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_gurumdds.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_gurumdds-release.git
- distro file: `eloquent/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## gurumdds_cmake_module

```
* Update packages to use gurumdds-2.7
* Change maintainer
* Contributors: Youngjin Yun
```
