### PR TITLE
tsid: 1.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7401,7 +7401,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/tsid-ros-release.git
-      version: 1.4.2-1
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tsid` to `1.6.0-1`:

- upstream repository: https://github.com/stack-of-tasks/tsid.git
- release repository: https://github.com/stack-of-tasks/tsid-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.4.2-1`
