### PR TITLE
ament_package: 0.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -163,7 +163,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.10.1-1
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.11.0-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.10.1-1`

## ament_package

```
* Generate Setuptools Dict Helper Method (#126 <https://github.com/ament/ament_package/issues/126>)
* Add Audrow as a maintainer (#127 <https://github.com/ament/ament_package/issues/127>)
* Contributors: Audrow Nash, David V. Lu!!
```
