### PR TITLE
interactive_markers: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -893,7 +893,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.1.3-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.2.0-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.1.3-1`

## interactive_markers

```
* Cleanup bsd 3 clause license usage (#61 <https://github.com/ros-visualization/interactive_markers/issues/61>)
* Add missing includes (#81 <https://github.com/ros-visualization/interactive_markers/issues/81>)
* Contributors: Bjar Ne, Tully Foote
```
