### PR TITLE
class_loader: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -329,7 +329,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.0.1-2
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.1.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.0.1-2`

## class_loader

```
* Fix ternary null check found by clang static analysis (#176 <https://github.com/ros/class_loader/issues/176>)
* Update QD to QL 1 (#177 <https://github.com/ros/class_loader/issues/177>)
* Updated console_bridge QL in QD
* Update package maintainers. (#169 <https://github.com/ros/class_loader/issues/169>)
* enable building a static library (#163 <https://github.com/ros/class_loader/issues/163>)
* Update Quality Declaration to reflect QL 2 (#160 <https://github.com/ros/class_loader/issues/160>).
* Increase coverage with a graveyard behavior test and unmanaged instance test (#159 <https://github.com/ros/class_loader/issues/159>)
* Add Security Vulnerability Policy pointing to REP-2006. (#157 <https://github.com/ros/class_loader/issues/157>)
* Clean up and improve documentation (#156 <https://github.com/ros/class_loader/issues/156>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Dirk Thomas, Michel Hidalgo, Stephen Brawner, ahcorde, brawner
```
