### PR TITLE
Update rqt_publisher source and doc branches for foxy and rolling

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3830,7 +3830,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: dashing-devel
+      version: foxy-devel
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -3839,7 +3839,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: dashing-devel
+      version: foxy-devel
     status: maintained
   rqt_py_console:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2420,7 +2420,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: dashing-devel
+      version: foxy-devel
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2429,7 +2429,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: dashing-devel
+      version: foxy-devel
     status: maintained
   rqt_py_console:
     doc:


### PR DESCRIPTION
Modifying rqt_publisher foxy and rolling branches to https://github.com/ros-visualization/rqt_publisher/tree/foxy-devel.