### PR TITLE
teleop_twist_joy: 2.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2709,7 +2709,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.4.2-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.4.1-1`

## teleop_twist_joy

```
* Update README to reflect changes to config parameters. (fixes #23 <https://github.com/ros2/teleop_twist_joy/issues/23>) (#24 <https://github.com/ros2/teleop_twist_joy/issues/24>)
* Contributors: Josh Newans
```
