### PR TITLE
tlsf: 0.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2785,7 +2785,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tlsf-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tlsf` to `0.5.2-1`:

- upstream repository: https://github.com/ros2/tlsf.git
- release repository: https://github.com/ros2-gbp/tlsf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.5.1-1`

## tlsf

```
* Switch to standard __VA_ARGS__. (#9 <https://github.com/ros2/tlsf/issues/9>)
* Contributors: Chris Lalancette
```
