### PR TITLE
tinyxml_vendor: 0.8.2-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4323,7 +4323,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
-      version: 0.8.0-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml_vendor` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/tinyxml_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.8.0-1`
