### PR TITLE
test_interface_files: 0.8.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4295,7 +4295,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.8.1-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.8.0-1`

## test_interface_files

```
* Update maintainer (#13 <https://github.com/ros2/test_interface_files/issues/13>)
* Contributors: Jacob Perron
```
