### PR TITLE
realtime_support: 0.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1667,7 +1667,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.10.1-1
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.10.1-1`

## rttest

```
* Fix up nonsensical handling of NULL in rttest_get_{params,statistics} (#107 <https://github.com/ros2/realtime_support/issues/107>)
* Contributors: Chris Lalancette
```

## tlsf_cpp

```
* Add in the Apache license to tlsf_cpp. (#108 <https://github.com/ros2/realtime_support/issues/108>)
* Contributors: Chris Lalancette
```
