### PR TITLE
spdlog_vendor: 1.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2616,7 +2616,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.2.2-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.2.1-1`

## spdlog_vendor

```
* Remove a stale TODO (#22 <https://github.com/ros2/spdlog_vendor/issues/22>)
* Always preserve source permissions in vendor packages (#20 <https://github.com/ros2/spdlog_vendor/issues/20>)
* Contributors: Scott K Logan
```
