### PR TITLE
ros2cli_common_extensions: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3292,7 +3292,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.1.1-1`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.1.0-1`

## ros2cli_common_extensions

```
* remove maintainer (#5 <https://github.com/ros2/ros2cli_common_extensions/issues/5>)
* update maintainer (#4 <https://github.com/ros2/ros2cli_common_extensions/issues/4>)
* Contributors: Claire Wang
```
