### PR TITLE
rosidl_typesupport: 1.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2175,7 +2175,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.1.1-3
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.1.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.1-3`

## rosidl_typesupport_c

```
* Expose C typesupport generation via rosidl generate CLI (#105 <https://github.com/ros2/rosidl_typesupport/issues/105>)
* Contributors: Michel Hidalgo
```

## rosidl_typesupport_cpp

```
* Expose C++ typesupport generation via rosidl generate CLI (#104 <https://github.com/ros2/rosidl_typesupport/issues/104>)
* Contributors: Michel Hidalgo
```
