### PR TITLE
rosidl: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2085,7 +2085,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.1.0-1`

## rosidl_adapter

```
* Expose .msg/.srv/.action to .idl conversion via rosidl translate CLI (#576 <https://github.com/ros2/rosidl/issues/576>)
* Contributors: Michel Hidalgo
```

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Expose C code generation via rosidl generate CLI (#569 <https://github.com/ros2/rosidl/issues/569>)
* Contributors: Michel Hidalgo
```

## rosidl_generator_cpp

```
* Expose C++ code generation via rosidl generate CLI (#570 <https://github.com/ros2/rosidl/issues/570>)
* Contributors: Michel Hidalgo
```

## rosidl_parser

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Expose C introspection typesupport generation via rosidl generate CLI (#572 <https://github.com/ros2/rosidl/issues/572>)
* Contributors: Michel Hidalgo
```

## rosidl_typesupport_introspection_cpp

```
* Expose C++ introspection typesupport generation via rosidl generate CLI  (#573 <https://github.com/ros2/rosidl/issues/573>)
* Contributors: Michel Hidalgo
```
