### PR TITLE
rqt_bag: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2303,7 +2303,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-1`

## rqt_bag

```
* Reset timeline zoom after loading a new bag. (#98 <https://github.com/ros-visualization/rqt_bag/issues/98>)
* Refactor the Rosbag2 class (#91 <https://github.com/ros-visualization/rqt_bag/issues/91>)
* Contributors: Michael Grupp, Michael Jeronimo
```

## rqt_bag_plugins

```
* Refactor the Rosbag2 class (#91 <https://github.com/ros-visualization/rqt_bag/issues/91>)
* Contributors: Michael Jeronimo
```
