### PR TITLE
yaml_cpp_vendor: 7.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3136,7 +3136,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 7.0.2-2
+      version: 7.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `7.1.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `7.0.2-2`

## yaml_cpp_vendor

```
* Always preserve source permissions in vendor packages (#22 <https://github.com/ros2/yaml_cpp_vendor/issues/22>)
* Add an override flag to force vendored build (#21 <https://github.com/ros2/yaml_cpp_vendor/issues/21>)
* Reapply "Use system installed yaml-cpp 0.6 if available (#8 <https://github.com/ros2/yaml_cpp_vendor/issues/8>)" (#16 <https://github.com/ros2/yaml_cpp_vendor/issues/16>)
* Revert "Use system installed yaml-cpp 0.6 if available (#8 <https://github.com/ros2/yaml_cpp_vendor/issues/8>)" (#15 <https://github.com/ros2/yaml_cpp_vendor/issues/15>)
* Use system installed yaml-cpp 0.6 if available (#8 <https://github.com/ros2/yaml_cpp_vendor/issues/8>)
* Contributors: Ivan Santiago Paunovic, Scott K Logan, Sean Yen
```
