### PR TITLE
rcutils: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1648,7 +1648,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 3.1.0-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `3.1.0-1`

## rcutils

```
* Quiet down a warning in release mode. (#334 <https://github.com/ros2/rcutils/issues/334>)
* Make the logging separate char an implementation detail. (#332 <https://github.com/ros2/rcutils/issues/332>)
* Performance tests demo (#288 <https://github.com/ros2/rcutils/issues/288>)
* Remove references of __xstat (#330 <https://github.com/ros2/rcutils/issues/330>)
* Update the documentation to be more consistent. (#331 <https://github.com/ros2/rcutils/issues/331>)
* Shorten some excessively long lines of CMake (#328 <https://github.com/ros2/rcutils/issues/328>)
* qnx-support: include sys/link.h & avoid using dlinfo (#327 <https://github.com/ros2/rcutils/issues/327>)
* QNX uses XSI-compliant (#326 <https://github.com/ros2/rcutils/issues/326>)
* Contributors: Ahmed Sobhy, Chris Lalancette, Homalozoa X, Jorge Perez, Scott K Logan
```
