### PR TITLE
rosidl_defaults: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2122,7 +2122,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.0.0-2
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-2`

## rosidl_default_generators

```
* Update maintainers (#13 <https://github.com/ros2/rosidl_defaults/issues/13>)
* Contributors: Shane Loretz
```

## rosidl_default_runtime

```
* Update QD to QL 1 (#15 <https://github.com/ros2/rosidl_defaults/issues/15>)
* Update maintainers (#13 <https://github.com/ros2/rosidl_defaults/issues/13>)
* Updated QD to 2 in README.md (#12 <https://github.com/ros2/rosidl_defaults/issues/12>)
* Update rosidl_default_runtime QD to QL2. (#11 <https://github.com/ros2/rosidl_defaults/issues/11>)
* Bump the QUALITY_DECLARATION to level 3. (#10 <https://github.com/ros2/rosidl_defaults/issues/10>)
* Add Security Vulnerability Policy pointing to REP-2006. (#9 <https://github.com/ros2/rosidl_defaults/issues/9>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Michel Hidalgo, Shane Loretz, Stephen Brawner
```
