### PR TITLE
rosidl_typesupport_fastrtps: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2214,7 +2214,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.0-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Expose FastRTPS C typesupport generation via rosidl generate CLI (#65 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/65>)
* Contributors: Michel Hidalgo
```

## rosidl_typesupport_fastrtps_cpp

```
* Expose FastRTPS C++ typesupport generation via rosidl generate CLI (#66 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/66>)
* Contributors: Michel Hidalgo
```
