### PR TITLE
rosidl_typesupport_connext: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2195,7 +2195,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 1.0.2-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_connext.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_connext` to `1.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_connext.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.2-2`

## connext_cmake_module

```
* Shorten some excessively long lines of CMake (#66 <https://github.com/ros2/rosidl_typesupport_connext/issues/66>)
* Update maintainers (#64 <https://github.com/ros2/rosidl_typesupport_connext/issues/64>)
* Contributors: Jacob Perron, Scott K Logan
```

## rosidl_typesupport_connext_c

```
* Expose Connext C typesupport generation via rosidl generate CLI (#67 <https://github.com/ros2/rosidl_typesupport_connext/issues/67>)
* Update maintainers (#64 <https://github.com/ros2/rosidl_typesupport_connext/issues/64>)
* Contributors: Jacob Perron, Michel Hidalgo
```

## rosidl_typesupport_connext_cpp

```
* Expose Connext C++ typesupport generation via rosidl generate CLI (#68 <https://github.com/ros2/rosidl_typesupport_connext/issues/68>)
* Update maintainers (#64 <https://github.com/ros2/rosidl_typesupport_connext/issues/64>)
* Contributors: Jacob Perron, Michel Hidalgo
```
