### PR TITLE
rcl: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1513,7 +1513,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 2.5.2-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `2.6.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.5.2-1`

## rcl

```
* Add support for rmw_connextdds (#895 <https://github.com/ros2/rcl/issues/895>)
* Put an argument list of 'void' where no arguments are expected. (#899 <https://github.com/ros2/rcl/issues/899>)
* Cleanup documentation for doxygen. (#896 <https://github.com/ros2/rcl/issues/896>)
* Contributors: Andrea Sorbini, Chris Lalancette
```

## rcl_action

```
* Don't expect RCL_RET_TIMEOUT to set an error string (#900 <https://github.com/ros2/rcl/issues/900>)
* Add support for rmw_connextdds (#895 <https://github.com/ros2/rcl/issues/895>)
* Contributors: Andrea Sorbini
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
