### PR TITLE
ros_comm: 1.15.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5653,7 +5653,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.9-1
+      version: 1.15.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.10-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.15.9-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* Add missing Boost (#2108 <https://github.com/ros/ros_comm/issues/2108>)
* Start player in paused state (#2086 <https://github.com/ros/ros_comm/issues/2086>)
* Contributors: Francisco Vina, Timo Röhling
```

## rosbag_storage

- No changes

## roscpp

```
* Fix for deadlock issue related to timers (#2121 <https://github.com/ros/ros_comm/issues/2121>)
* Fix getNumPublishers() to only count fully connected (#2107 <https://github.com/ros/ros_comm/issues/2107>)
* Replace message assertion with logging in order to have release modes to fail in compilation when msg type mismatches occur (#2096 <https://github.com/ros/ros_comm/issues/2096>)
* Contributors: C. Andy Martin, Ivor Wanders, Tahsincan Köse
```

## rosgraph

```
* Fix HTTP for kernel < 4.16 (#2132 <https://github.com/ros/ros_comm/issues/2132>)
* Contributors: Jesse Ikawa
```

## roslaunch

```
* Fix AttributeError isAlive (#2092 <https://github.com/ros/ros_comm/issues/2092>)
* Contributors: Brutus The Tschiepel
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

```
* Clean up test dependencies (#2103 <https://github.com/ros/ros_comm/issues/2103>)
* Contributors: Kyle Fazzari
```

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* Fix "TypeError: not enough arguments for format string" (#2127 <https://github.com/ros/ros_comm/issues/2127>)
* Use Logger.warning() instead of the deprecated warn() (#2120 <https://github.com/ros/ros_comm/issues/2120>)
* Fix AttributeError isAlive (#2092 <https://github.com/ros/ros_comm/issues/2092>)
* Contributors: Brutus The Tschiepel, mikolajz, 金梦磊
```

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

```
* Fix /use_sim_time parameter typo in roswtf error (#2102 <https://github.com/ros/ros_comm/issues/2102>)
* Contributors: Nicholas Paul
```

## topic_tools

- No changes

## xmlrpcpp

```
* Portable fix to recent Windows build breaks (#2110 <https://github.com/ros/ros_comm/issues/2110>)
* Contributors: Sean Yen
```
