### PR TITLE
rclcpp: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1600,7 +1600,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 6.3.1-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `7.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `6.3.1-1`

## rclcpp

```
* Document design decisions that were made for statically typed parameters (#1568 <https://github.com/ros2/rclcpp/issues/1568>)
* Fix doc typo in CallbackGroup constructor (#1582 <https://github.com/ros2/rclcpp/issues/1582>)
* Enable qos parameter overrides for the /parameter_events topic  (#1532 <https://github.com/ros2/rclcpp/issues/1532>)
* Add support for rmw_connextdds (#1574 <https://github.com/ros2/rclcpp/issues/1574>)
* Remove 'struct' from the rcl_time_jump_t. (#1577 <https://github.com/ros2/rclcpp/issues/1577>)
* Add tests for declaring statically typed parameters when undeclared parameters are allowed (#1575 <https://github.com/ros2/rclcpp/issues/1575>)
* Quiet clang memory leak warning on "DoNotOptimize". (#1571 <https://github.com/ros2/rclcpp/issues/1571>)
* Add ParameterEventsSubscriber class (#829 <https://github.com/ros2/rclcpp/issues/829>)
* When a parameter change is rejected, the parameters map shouldn't be updated. (#1567 <https://github.com/ros2/rclcpp/pull/1567>)
* Fix when to throw the NoParameterOverrideProvided exception. (#1567 <https://github.com/ros2/rclcpp/pull/1567>)
* Fix SEGV caused by order of destruction of Node sub-interfaces (#1469 <https://github.com/ros2/rclcpp/issues/1469>)
* Fix benchmark test failure introduced in #1522 <https://github.com/ros2/rclcpp/issues/1522> (#1564 <https://github.com/ros2/rclcpp/issues/1564>)
* Fix documented example in create_publisher (#1558 <https://github.com/ros2/rclcpp/issues/1558>)
* Enforce static parameter types (#1522 <https://github.com/ros2/rclcpp/issues/1522>)
* Allow timers to keep up the intended rate in MultiThreadedExecutor (#1516 <https://github.com/ros2/rclcpp/issues/1516>)
* Fix UBSAN warnings in any_subscription_callback. (#1551 <https://github.com/ros2/rclcpp/issues/1551>)
* Fix runtime error: reference binding to null pointer of type (#1547 <https://github.com/ros2/rclcpp/issues/1547>)
* Contributors: Andrea Sorbini, Chris Lalancette, Colin MacKenzie, Ivan Santiago Paunovic, Jacob Perron, Steven! Ragnarök, bpwilcox, tomoya
```

## rclcpp_action

```
* Add support for rmw_connextdds (#1574 <https://github.com/ros2/rclcpp/issues/1574>)
* node_handle must be destroyed after client_handle to prevent memory leak (#1562 <https://github.com/ros2/rclcpp/issues/1562>)
* Contributors: Andrea Sorbini, Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Add support for rmw_connextdds (#1574 <https://github.com/ros2/rclcpp/issues/1574>)
* Fix SEGV caused by order of destruction of Node sub-interfaces (#1469 <https://github.com/ros2/rclcpp/issues/1469>)
* Enforce static parameter types (#1522 <https://github.com/ros2/rclcpp/issues/1522>)
* Contributors: Andrea Sorbini, Colin MacKenzie, Ivan Santiago Paunovic
```
