### PR TITLE
rclpy: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1616,7 +1616,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 1.5.0-1
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `1.6.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.5.0-1`

## rclpy

```
* Convert serialize/deserialize to pybind11 (#712 <https://github.com/ros2/rclpy/issues/712>)
* Convert names_and_types graph APIs to pybind11 (#717 <https://github.com/ros2/rclpy/issues/717>)
* Use Pybind11 for name functions (#709 <https://github.com/ros2/rclpy/issues/709>)
* Better checks for valid msg and srv types (#714 <https://github.com/ros2/rclpy/issues/714>)
* Convert duration to pybind11 (#716 <https://github.com/ros2/rclpy/issues/716>)
* Convert wait_set functions to pybind11 (#706 <https://github.com/ros2/rclpy/issues/706>)
* Explicitly populate tuple with None (#711 <https://github.com/ros2/rclpy/issues/711>)
* Change the time jump time type to just rcl_time_jump_t. (#707 <https://github.com/ros2/rclpy/issues/707>)
* Convert rclpy service functions to pybind11 (#703 <https://github.com/ros2/rclpy/issues/703>)
* Bump the cppcheck timeout by 2 minutes (#705 <https://github.com/ros2/rclpy/issues/705>)
* Convert subscription functions to pybind11 (#696 <https://github.com/ros2/rclpy/issues/696>)
* Convert rclpy client functions to pybind11 (#701 <https://github.com/ros2/rclpy/issues/701>)
* Fix static typing when allow undeclared (#702 <https://github.com/ros2/rclpy/issues/702>)
* Convert publisher functions to pybind11 (#695 <https://github.com/ros2/rclpy/issues/695>)
* Convert clock and time functions to pybind11 (#699 <https://github.com/ros2/rclpy/issues/699>)
* Set destructor on QoS Profile struct (#700 <https://github.com/ros2/rclpy/issues/700>)
* Convert timer functions to pybind11 (#693 <https://github.com/ros2/rclpy/issues/693>)
* Convert guard conditions functions to pybind11 (#692 <https://github.com/ros2/rclpy/issues/692>)
* Convert service info functions to pybind11 (#694 <https://github.com/ros2/rclpy/issues/694>)
* Enforce static parameter types when dynamic typing is not specified (#683 <https://github.com/ros2/rclpy/issues/683>)
* rclpy_ok and rclpy_create_context to pybind11 (#691 <https://github.com/ros2/rclpy/issues/691>)
* Include Pybind11 before Python.h (#690 <https://github.com/ros2/rclpy/issues/690>)
* Clean up exceptions in _rclpy_action (#685 <https://github.com/ros2/rclpy/issues/685>)
* Clean windows flags on _rclpy_pybind11 and _rclpy_action (#688 <https://github.com/ros2/rclpy/issues/688>)
* Use pybind11 for _rclpy_handle (#668 <https://github.com/ros2/rclpy/issues/668>)
* Split rclpy module for easier porting to pybind11 (#675 <https://github.com/ros2/rclpy/issues/675>)
* Use Pybind11 to generate _rclpy_logging (#659 <https://github.com/ros2/rclpy/issues/659>)
* Copy windows debug fixes for pybind11 (#681 <https://github.com/ros2/rclpy/issues/681>)
* Use pybind11 for _rclpy_action (#678 <https://github.com/ros2/rclpy/issues/678>)
* Update just pycapsule lib to use pybind11 (#652 <https://github.com/ros2/rclpy/issues/652>)
* remove maintainer (#682 <https://github.com/ros2/rclpy/issues/682>)
* Use Pybind11's CMake code (#667 <https://github.com/ros2/rclpy/issues/667>)
* Don't call destroy_node while spinning (#674 <https://github.com/ros2/rclpy/issues/674>)
* Check the rcl_action return value on cleanup. (#672 <https://github.com/ros2/rclpy/issues/672>)
* Fix the NULL check for destroy_ros_message. (#677 <https://github.com/ros2/rclpy/issues/677>)
* Use Py_XDECREF for pynode_names_and_namespaces (#673 <https://github.com/ros2/rclpy/issues/673>)
* Use Py_XDECREF for pyresult_list. (#670 <https://github.com/ros2/rclpy/issues/670>)
* Contributors: Chris Lalancette, Claire Wang, Ivan Santiago Paunovic, Michel Hidalgo, Scott K Logan, Shane Loretz
```
