### PR TITLE
python_qt_binding: 1.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1405,7 +1405,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.0.6-2
+      version: 1.0.7-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1400,7 +1400,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: crystal-devel
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1410,7 +1410,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: crystal-devel
+      version: main
     status: maintained
   qt_gui_core:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.0.7-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.6-2`

## python_qt_binding

```
* Add repo README
* Shorten some long lines of CMake (#99 <https://github.com/ros-visualization/python_qt_binding/issues/99>)
* Contributors: Scott K Logan, Shane Loretz
```
