### PR TITLE
rqt_common_plugins: 1.0.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2318,7 +2318,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `1.0.0-3`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros2-gbp/rqt_common_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-2`

## rqt_common_plugins

```
* ROS 2 port, commenting out unavailable plugins (#457 <https://github.com/ros-visualization/rqt_common_plugins/issues/457>)
* convert to package format 2 (#455 <https://github.com/ros-visualization/rqt_common_plugins/issues/455>)
```
