### PR TITLE
rosbag2: 0.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2023,7 +2023,7 @@ repositories:
       - ros2bag
       - rosbag2
       - rosbag2_compression
-      - rosbag2_converter_default_plugins
+      - rosbag2_compression_zstd
       - rosbag2_cpp
       - rosbag2_performance_benchmarking
       - rosbag2_py
@@ -2038,7 +2038,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.6.0-1
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.6.0-1`

## ros2bag

```
* use rosbag2_py for ros2 bag info (#673 <https://github.com/ros2/rosbag2/issues/673>)
* CLI query rosbag2_py for available storage implementations (#659 <https://github.com/ros2/rosbag2/issues/659>)
* Contributors: Emerson Knapp, Karsten Knese
```

## rosbag2

```
* RMW-implementation-searcher converter in rosbag2_cpp (#670 <https://github.com/ros2/rosbag2/issues/670>)
* Move zstd compressor to its own package (#636 <https://github.com/ros2/rosbag2/issues/636>)
* Contributors: Emerson Knapp
```

## rosbag2_compression

```
* CLI query rosbag2_py for available storage implementations (#659 <https://github.com/ros2/rosbag2/issues/659>)
* Move zstd compressor to its own package (#636 <https://github.com/ros2/rosbag2/issues/636>)
* Remove rosbag2_compression test dependencies on zstd implementation in prep for moving it into a separate package (#637 <https://github.com/ros2/rosbag2/issues/637>)
* Contributors: Emerson Knapp
```

## rosbag2_compression_zstd

```
* Add test_depend ament_cmake_gmock (#639 <https://github.com/ros2/rosbag2/issues/639>)
* Move zstd compressor to its own package (#636 <https://github.com/ros2/rosbag2/issues/636>)
* Contributors: Emerson Knapp, Shane Loretz
```

## rosbag2_cpp

```
* alternative write api (#676 <https://github.com/ros2/rosbag2/issues/676>)
* RMW-implementation-searcher converter in rosbag2_cpp (#670 <https://github.com/ros2/rosbag2/issues/670>)
* CLI query rosbag2_py for available storage implementations (#659 <https://github.com/ros2/rosbag2/issues/659>)
* Fix --topics flag for ros2 bag play being ignored for all bags after the first one. (#619 <https://github.com/ros2/rosbag2/issues/619>)
* Fix a crash in test_message_cache. (#635 <https://github.com/ros2/rosbag2/issues/635>)
* Contributors: Alexander, Chris Lalancette, Emerson Knapp, Karsten Knese
```

## rosbag2_performance_benchmarking

```
* fixed a memory leak in no-transport benchmark (#674 <https://github.com/ros2/rosbag2/issues/674>)
* report of performance improvements in rosbag2 (roughly since Foxy) (#651 <https://github.com/ros2/rosbag2/issues/651>)
* Performance benchmarking improvements (#634 <https://github.com/ros2/rosbag2/issues/634>)
  * Performance benchmarking improvements
  * fixed durability qos in config
  * Benchmark db files information in one file
  Co-authored-by: Adam Dabrowski <mailto:adam.dabrowski@robotec.ai>
* Contributors: Adam Dąbrowski, Piotr Jaroszek
```

## rosbag2_py

```
* RMW-implementation-searcher converter in rosbag2_cpp (#670 <https://github.com/ros2/rosbag2/issues/670>)
* use rosbag2_py for ros2 bag info (#673 <https://github.com/ros2/rosbag2/issues/673>)
* CLI query rosbag2_py for available storage implementations (#659 <https://github.com/ros2/rosbag2/issues/659>)
* Contributors: Emerson Knapp, Karsten Knese
```

## rosbag2_storage

```
* Remove outdated pluginlib cmake script from rosbag2_storage (#661 <https://github.com/ros2/rosbag2/issues/661>)
* CLI query rosbag2_py for available storage implementations (#659 <https://github.com/ros2/rosbag2/issues/659>)
* Shorten some excessively long lines of CMake (#648 <https://github.com/ros2/rosbag2/issues/648>)
* Contributors: Emerson Knapp, Scott K Logan
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_test_common

```
* Remove temporary directory platform-specific logic from test fixture (#660 <https://github.com/ros2/rosbag2/issues/660>)
* Contributors: Emerson Knapp
```

## rosbag2_tests

```
* Alternative write api (#676 <https://github.com/ros2/rosbag2/issues/676>)
* RMW-implementation-searcher converter in rosbag2_cpp (#670 <https://github.com/ros2/rosbag2/issues/670>)
* Use rosbag2_py for ros2 bag info (#673 <https://github.com/ros2/rosbag2/issues/673>)
* Remove temporary directory platform-specific logic from test fixture (#660 <https://github.com/ros2/rosbag2/issues/660>)
* Fix --topics flag for ros2 bag play being ignored for all bags after the first one. (#619 <https://github.com/ros2/rosbag2/issues/619>)
* Move zstd compressor to its own package (#636 <https://github.com/ros2/rosbag2/issues/636>)
* Contributors: Alexander, Emerson Knapp, Karsten Knese
```

## rosbag2_transport

```
* Add support for rmw_connextdds (#671 <https://github.com/ros2/rosbag2/issues/671>)
* Use rosbag2_py for ros2 bag info (#673 <https://github.com/ros2/rosbag2/issues/673>)
* Contributors: Andrea Sorbini, Karsten Knese
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

```
* Always preserve source permissions in vendor packages (#645 <https://github.com/ros2/rosbag2/issues/645>)
* Contributors: Scott K Logan
```

## zstd_vendor

```
* Always preserve source permissions in vendor packages (#645 <https://github.com/ros2/rosbag2/issues/645>)
* Zstd should not install internal headers - some of them try include others that aren't installed. We don't use them. Avoid the situation (#631 <https://github.com/ros2/rosbag2/issues/631>)
* Contributors: Emerson Knapp, Scott K Logan
```
