### PR TITLE
rqt_console: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2333,7 +2333,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 1.1.1-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2328,7 +2328,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: dashing-devel
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2337,7 +2337,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: dashing-devel
+      version: ros2
     status: maintained
   rqt_graph:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.1-2`
