### PR TITLE
rqt_action: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2285,7 +2285,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 1.0.1-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2280,7 +2280,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: crystal-devel
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2289,7 +2289,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: crystal-devel
+      version: ros2
     status: maintained
   rqt_bag:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.1-2`
