### PR TITLE
Tag package rosidl_generator_ada as actively developed

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3520,6 +3520,7 @@ repositories:
       type: git
       url: https://github.com/ada-ros/rosidl_generator_ada.git
       version: foxy
+    status: developed
   rosidl_python:
     doc:
       type: git


### PR DESCRIPTION
This was mistakenly omitted in the initial PR (https://github.com/ros/rosdistro/pull/28532).