### PR TITLE
Add space to please yamllint

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5628,7 +5628,7 @@ postgresql-postgis:
     jessie: [postgresql-9.4-postgis-2.1, postgresql-contrib, postgresql-server-dev-all]
     stretch: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
   fedora: [postgis]
-  gentoo: [dev-db/postgis,'=dev-db/postgresql-9*']
+  gentoo: [dev-db/postgis, '=dev-db/postgresql-9*']
   ubuntu:
     artful: [postgresql-9.6-postgis-2.3, postgresql-contrib, postgresql-server-dev-all]
     bionic: [postgresql-10-postgis-2.4, postgresql-contrib, postgresql-server-dev-all]


### PR DESCRIPTION
We vendor this file into our internal rosdistro repo, and yamllint there complains about the missing space:

```
./rosdep/upstream.yaml
  5563:27   warning  too few spaces after comma  (commas)
```