### PR TITLE
rqt_reconfigure: 0.5.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11391,7 +11391,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.5.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.5.3-1`

## rqt_reconfigure

```
* Replace deprecated isAlive with is_alive (#102 <https://github.com/ros-visualization/rqt_reconfigure/issues/102>)
* Update param_groups.py (#101 <https://github.com/ros-visualization/rqt_reconfigure/issues/101>)
* Address rqt_reconfigure crashing with IndexError (#93 <https://github.com/ros-visualization/rqt_reconfigure/issues/93>)
* Update the package.xml files with the latest Open Robotics maintainers (#94 <https://github.com/ros-visualization/rqt_reconfigure/issues/94>)
* Contributors: Michael Jeronimo, Rafael Olaechea, Timon Engelke, augustinmanecy
```
