### PR TITLE
rqt_image_view: 1.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2366,7 +2366,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `1.1.0-2`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.0-1`

## rqt_image_view

```
* fix segfault on topic change (#40 <https://github.com/ros-visualization/rqt_image_view/issues/40>)
* fix ImportError in image_publisher script (#39 <https://github.com/ros-visualization/rqt_image_view/issues/39>)
* update include directives for image_transport to avoid deprecation warning (#34 <https://github.com/ros-visualization/rqt_image_view/issues/34>)
```
