### PR TITLE
rqt_common_plugins: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2320,7 +2320,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
-      version: 1.0.0-3
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2315,7 +2315,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: dashing-devel
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2324,7 +2324,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: dashing-devel
+      version: ros2
     status: maintained
   rqt_console:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros2-gbp/rqt_common_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-3`

## rqt_common_plugins

```
* Add ``rqt_bag`` to the ``rqt_common_plugins`` metapackage (#463 <https://github.com/ros-visualization/rqt_common_plugins/issues/463>)
* Contributors: Michael Jeronimo
```
