### PR TITLE
launch: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1007,7 +1007,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.15.0-1
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.15.0-1`

## launch

```
* Add arg_choice arg to DeclareLaunchArguments (#483 <https://github.com/ros2/launch/issues/483>)
* Contributors: Victor Lopez
```

## launch_testing

```
* Use unittest.mock instead of mock (#487 <https://github.com/ros2/launch/issues/487>)
* Contributors: Michel Hidalgo
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
