### PR TITLE
ros_testing: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1997,7 +1997,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
-      version: 0.2.1-2
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_testing` to `0.3.0-1`:

- upstream repository: https://github.com/ros2/ros_testing.git
- release repository: https://github.com/ros2-gbp/ros_testing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.2.1-2`

## ros2test

```
* Add pytest.ini so local tests don't display warning (#8 <https://github.com/ros2/ros_testing/issues/8>)
* Contributors: Chris Lalancette
```

## ros_testing

```
* Use rostest CMake target as output file basename. (#9 <https://github.com/ros2/ros_testing/issues/9>)
* Contributors: Michel Hidalgo
```
