### PR TITLE
rqt_topic: 1.2.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4005,7 +4005,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.2.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.0-1`

## rqt_topic

```
* Created an entry-point for rqt_topic in setup.py (#16 <https://github.com/ros-visualization/rqt_topic/issues/16>)
* Fix flake8 errors and add linter tests (#28 <https://github.com/ros-visualization/rqt_topic/issues/28>)
* Update Open Robotics Maintainer (#26 <https://github.com/ros-visualization/rqt_topic/issues/26>)
* Use raw / non-string value for ordering (#23 <https://github.com/ros-visualization/rqt_topic/issues/23>)
* Support order fields as defined in message (#22 <https://github.com/ros-visualization/rqt_topic/issues/22>)
* Fix the type cell value for sequence items (#21 <https://github.com/ros-visualization/rqt_topic/issues/21>)
* Updated version package and license in setup.py (#17 <https://github.com/ros-visualization/rqt_topic/issues/17>)
* Contributors: Alejandro Hernández Cordero, Dirk Thomas, Scott K Logan
```
