### PR TITLE
optic: 0.0.1-6 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2124,6 +2124,20 @@ repositories:
       url: https://github.com/OpenVSLAM-Community/openvslam.git
       version: foxy-devel
     status: developed
+  optic:
+    doc:
+      type: git
+      url: https://github.com/alvaro0308/optic.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/alvaro0308/optic-release.git
+      version: 0.0.1-6
+    source:
+      type: git
+      url: https://github.com/alvaro0308/optic.git
+      version: foxy-devel
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `optic` to `0.0.1-6`:

- upstream repository: https://github.com/alvaro0308/optic.git
- release repository: https://github.com/alvaro0308/optic-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`
