### PR TITLE
ros2_control: 0.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3147,7 +3147,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.1-1`

## controller_interface

- No changes

## controller_manager

```
* release_interfaces when stopping controller (#343 <https://github.com/ros-controls/ros2_control/issues/343>)
  * release_interfaces when stopping controller
  * Moved release_interfaces after deactivate
  * First attempt at test_release_interfaces
  * Switched to std::async with cm_->update
* Capatalized error message and put the controllers name and resource name inside quote (#338 <https://github.com/ros-controls/ros2_control/issues/338>)
* Contributors: mahaarbo, suab321321
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Capatalized error message and put the controllers name and resource name inside quote (#338 <https://github.com/ros-controls/ros2_control/issues/338>)
* Parse True and true in fakesystem, touch up variable name
* Contributors: Denis Štogl, suab321321
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## transmission_interface

- No changes
