### PR TITLE
launchfile_switcher: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -5337,6 +5337,22 @@ repositories:
       url: https://github.com/ros-perception/laser_proc.git
       version: melodic-devel
     status: maintained
+  launchfile_switcher:
+    doc:
+      type: git
+      url: https://github.com/rb-sapiens/launchfile_switcher.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rb-sapiens/launchfile_switcher-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rb-sapiens/launchfile_switcher.git
+      version: melodic-devel
+    status: maintained
   lauv_gazebo:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launchfile_switcher` to `0.1.0-1`:

- upstream repository: https://github.com/rb-sapiens/launchfile_switcher.git
- release repository: https://github.com/rb-sapiens/launchfile_switcher-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`
