### PR TITLE
xacro_live: 0.1.0-1 in 'foxy/distribution.yaml' [manual]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4858,6 +4858,21 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: dashing-devel
     status: maintained
+  xacro_live:
+    doc:
+      type: git
+      url: https://github.com/orise-robotics/xacro_live.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/orise-robotics/xacro_live-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/orise-robotics/xacro_live.git
+      version: main
+    status: maintained
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
The xacro_live package was released.

upstream repository: https://github.com/orise-robotics/xacro_live
release repository: https://github.com/orise-robotics/xacro_live-release.git
distro file: foxy/distribution.yaml
bloom version: 0.10.2
previous version for package: null

I got problems with bloom on creating an OAuth token, so I'm following its recommendation of making a manual PR. I hope everything is correct.