### PR TITLE
rmw_gurumdds: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1818,7 +1818,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `2.1.2-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.1.1-1`

## rmw_gurumdds_cpp

```
* Update code about build error on windows
* Add RMW function to check QoS compatibility
* 2.1.1
* Update packages to use gurumdds-2.7
* Contributors: Youngjin Yun, youngjin
```

## rmw_gurumdds_shared_cpp

```
* Update code about build error on windows
* Add RMW function to check QoS compatibility
* 2.1.1
* Update packages to use gurumdds-2.7
* fix typo
* Contributors: Youngjin Yun, youngjin
```
