### PR TITLE
volta_simulation: 1.0.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -17685,7 +17685,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/botsync-gbp/volta_simulation-release.git
-      version: 1.0.0-3
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `volta_simulation` to `1.0.1-1`:

- upstream repository: https://github.com/botsync/volta_simulation.git
- release repository: https://github.com/botsync-gbp/volta_simulation-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-3`

## volta_simulation

```
* Fixed versions
* Added gazebo models and updated launch files.
* Kinetic devel r2 update to Kinetic (#3 <https://github.com/botsync/volta_simulation/issues/3>)
  * Merged volta_development.
  * Changed maintainer name.
* Contributors: Toship
```
