### PR TITLE
volta_simulation: 1.1.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13939,7 +13939,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/botsync-gbp/volta_simulation-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/botsync/volta_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `volta_simulation` to `1.1.1-1`:

- upstream repository: https://github.com/botsync/volta_simulation.git
- release repository: https://github.com/botsync-gbp/volta_simulation-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.1.0-2`

## volta_simulation

```
* Added gazebo models and updated launch files.
* Kinetic devel r2 update to melodic (#4 <https://github.com/botsync/volta_simulation/issues/4>)
  * Updated Version, license
  * Merged volta_development.
  * Changed maintainer name.
  Co-authored-by: Mahendra-botsync <mailto:mahendra.l@botsync.co>
  Co-authored-by: nikhil-botsync <mailto:64353067+nikhil-botsync@users.noreply.github.com>
* Contributors: Toship
```
