### PR TITLE
fmi_adapter: 1.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1991,7 +1991,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: melodic_and_noetic
     release:
       packages:
       - fmi_adapter
@@ -2003,7 +2003,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: melodic_and_noetic
     status: maintained
   four_wheel_steering_msgs:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1999,7 +1999,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `1.0.4-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/boschresearch/fmi_adapter-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.3-1`

## fmi_adapter

```
* Updated to version 2.2.3 of FMILibrary.
```

## fmi_adapter_examples

```
* Ensured same relative location for sample FMUs in devel and install layout.
```
