### PR TITLE
Added python package smbus2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1919,6 +1919,10 @@ python-gpiozero:
       pip:
         packages: [gpiozero]
     zesty: [python-gpiozero]
+python-gputil-pip:
+  ubuntu:
+    pip:
+      packages: [gputil]
 python-gpxpy:
   debian:
     buster: [python-gpxpy]
@@ -2221,6 +2225,10 @@ python-jasmine-pip:
   ubuntu:
     pip:
       packages: [jasmine]
+python-jetson-stats-pip:
+  ubuntu:
+    pip:
+      packages: [jetson-stats]
 python-jinja2:
   debian: [python-jinja2]
   fedora: [python-jinja2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1920,6 +1920,15 @@ python-gpiozero:
         packages: [gpiozero]
     zesty: [python-gpiozero]
 python-gputil-pip:
+  debian:
+    pip:
+      packages: [gputil]
+  fedora:
+    pip:
+      packages: [gputil]
+  osx:
+    pip:
+      packages: [gputil]
   ubuntu:
     pip:
       packages: [gputil]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2234,10 +2234,6 @@ python-jasmine-pip:
   ubuntu:
     pip:
       packages: [jasmine]
-python-jetson-stats-pip:
-  ubuntu:
-    pip:
-      packages: [jetson-stats]
 python-jinja2:
   debian: [python-jinja2]
   fedora: [python-jinja2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4500,6 +4500,19 @@ python-slycot-pip:
 python-smbus:
   debian: [python-smbus]
   ubuntu: [python-smbus]
+python-smbus2-pip:
+  debian:
+    pip:
+      packages: [smbus2]
+  fedora:
+    pip:
+      packages: [smbus2]
+  osx:
+    pip:
+      packages: [smbus2]
+  ubuntu:
+    pip:
+      packages: [smbus2]
 python-sortedcontainers-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
1) I have added the rules for smbus2 package in python.yaml file. [https://pypi.org/project/smbus2/].

2) Earlier I added jetson-stats package [https://pypi.org/project/jetson-stats/] but found that it is not working with rosdep. Also to install the package manually "pip install jetson-stats" does not work but "sudo -H pip install -U jetson-stats" works. So, how should I define it in the python.yaml file?

@cottsay @hidmic 