### PR TITLE
fmi_adapter: 1.0.4-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3208,7 +3208,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3200,7 +3200,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: 1.0.2
+      version: melodic_and_noetic
     release:
       packages:
       - fmi_adapter
@@ -3212,7 +3212,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: melodic_and_noetic
     status: maintained
   force_torque_sensor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `1.0.4-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/boschresearch/fmi_adapter-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.3-1`

## fmi_adapter

```
* Updated to version 2.2.3 of FMILibrary.
```

## fmi_adapter_examples

```
* Ensured same relative location for sample FMUs in devel and install layout.
```
