### PR TITLE
fmilibrary_vendor: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1043,8 +1043,8 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/boschresearch/fmilibrary_vendor-release.git
-      version: 0.2.0-1
+      url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1048,7 +1048,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: master
+      version: foxy
     status: maintained
   foonathan_memory_vendor:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.2.0-1`

## fmilibrary_vendor

```
* Updated to version 2.2.3 of FMILibrary.
```
