### PR TITLE
fmilibrary_vendor: 1.0.0-1 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -959,7 +959,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: master
+      version: dashing
     status: maintained
   foonathan_memory_vendor:
     release:

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -954,8 +954,8 @@ repositories:
     release:
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/boschresearch/fmilibrary_vendor-release.git
-      version: 0.2.0-1
+      url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.2.0-1`

## fmilibrary_vendor

```
* Updated to version 2.2.3 of FMILibrary.
```
