### PR TITLE
rclcpp: 7.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 7.0.0-1
+      version: 7.0.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `7.0.1-2`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `7.0.0-1`

## rclcpp

```
* get_parameters service should return empty if undeclared parameters are allowed (#1514 <https://github.com/ros2/rclcpp/issues/1514>)
* Made 'Context::shutdown_reason' function a const function (#1578 <https://github.com/ros2/rclcpp/issues/1578>)
* Contributors: Tomoya Fujita, suab321321
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
