### PR TITLE
carla_msgs: 1.3.0-1 in 'melodic/distribution.yaml' [non-bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1058,7 +1058,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/carla-simulator/ros-carla-msgs-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git


### PR DESCRIPTION
Opening this PR manually due to an authentication issue during the last step with bloom.

Increasing version of package(s) in repository `carla_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/carla-simulator/ros-carla-msgs.git
- release repository: https://github.com/carla-simulator/ros-carla-msgs-release.git
- rosdistro version: `1.2.0-1`
- old version: `1.2.0-1`
- new version: `1.3.0-1`

