### PR TITLE
carla_msgs: 1.3.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -399,7 +399,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git
-      version: release
+      version: master
     release:
       tags:
         release: release/foxy/{package}/{version}
@@ -408,7 +408,7 @@ repositories:
     source:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git
-      version: release
+      version: master
     status: developed
   cartographer:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -395,6 +395,21 @@ repositories:
       url: https://github.com/ros/bond_core.git
       version: dashing-devel
     status: maintained
+  carla_msgs:
+    doc:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/carla-simulator/ros-carla-msgs-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    status: developed
   cartographer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `carla_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/carla-simulator/ros-carla-msgs.git
- release repository: https://github.com/carla-simulator/ros-carla-msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `null`
