### PR TITLE
hfl_driver: 0.1.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -4054,7 +4054,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/flynneva/hfl_driver-release.git
-      version: 0.0.20-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/continental/hfl_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hfl_driver` to `0.1.0-1`:

- upstream repository: https://github.com/continental/hfl_driver.git
- release repository: https://github.com/flynneva/hfl_driver-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.0.20-1`

## hfl_driver

```
* remove kinetic from CI due to EOL
* rotation fix, pointcloud size fix, telemetry parsing
* bump ros actions
* fixed documentation
* removed include tof
* removed msg gen
* removed legacy code & clean up cmakelist
* fix some links in readme
* add link to continentals website
* add note to readme
* update readme
* Contributors: Evan Flynn, flynneva
```
