### PR TITLE
Adding python3-evdev rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1505,6 +1505,7 @@ python-espeak:
     trusty: [python-espeak]
     trusty_python3: [python3-espeak]
 python-evdev:
+  gentoo: [dev-python/python-evdev]
   ubuntu: [python-evdev]
 python-expiringdict:
   debian: [python-expiringdict]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5906,6 +5906,7 @@ python3-evdev:
     jessie: null
     stretch: null
   fedora: [python3-evdev]
+  gentoo: [dev-python/python-evdev]
   osx:
     pip:
       packages: [evdev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5900,7 +5900,10 @@ python3-empy:
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-evdev:
-  debian: [python3-evdev]
+  debian:
+    '*': [python3-evdev]
+    jessie: null
+    stretch: null
   fedora: [python3-evdev]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5900,6 +5900,7 @@ python3-empy:
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-evdev:
+  arch: [python-evdev]
   debian:
     '*': [python3-evdev]
     jessie: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1510,10 +1510,10 @@ python-evdev:
 python3-evdev:
   debian: [python3-evdev]
   fedora: [python3-evdev]
-  ubuntu: [python3-evdev]
   osx:
     pip:
       packages: [evdev]
+  ubuntu: [python3-evdev]
 python-expiringdict:
   debian: [python-expiringdict]
   fedora:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1507,6 +1507,13 @@ python-espeak:
 python-evdev:
   gentoo: [dev-python/python-evdev]
   ubuntu: [python-evdev]
+python3-evdev:
+  debian: [python3-evdev]
+  fedora: [python3-evdev]
+  ubuntu: [python3-evdev]
+  osx:
+    pip:
+      packages: [evdev]
 python-expiringdict:
   debian: [python-expiringdict]
   fedora:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1505,7 +1505,6 @@ python-espeak:
     trusty: [python-espeak]
     trusty_python3: [python3-espeak]
 python-evdev:
-  gentoo: [dev-python/python-evdev]
   ubuntu: [python-evdev]
 python-expiringdict:
   debian: [python-expiringdict]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1507,13 +1507,6 @@ python-espeak:
 python-evdev:
   gentoo: [dev-python/python-evdev]
   ubuntu: [python-evdev]
-python3-evdev:
-  debian: [python3-evdev]
-  fedora: [python3-evdev]
-  osx:
-    pip:
-      packages: [evdev]
-  ubuntu: [python3-evdev]
 python-expiringdict:
   debian: [python-expiringdict]
   fedora:
@@ -5906,6 +5899,13 @@ python3-empy:
   openembedded: [python3-empy@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
+python3-evdev:
+  debian: [python3-evdev]
+  fedora: [python3-evdev]
+  osx:
+    pip:
+      packages: [evdev]
+  ubuntu: [python3-evdev]
 python3-events-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-evdev

## Package Upstream Source:

https://github.com/gvalkov/python-evdev

## Purpose of using this:

Adding the Python 3 version of evdev to rosdep. The package provides bindings to the generic input event interface in Linux. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=python3-evdev
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-evdev&searchon=names
- Fedora: https://apps.fedoraproject.org/packages/
  - Service Unavailable
- Arch: https://www.archlinux.org/packages/
  - Python3 package not available
- Gentoo: https://packages.gentoo.org/packages/
  - Python3 package not available
- macOS: https://formulae.brew.sh/
  - added pip

