### PR TITLE
carla_msgs: 1.3.0-1 in 'noetic/distribution.yaml' [non-bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -480,7 +480,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/carla-simulator/ros-carla-msgs-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/carla-simulator/ros-carla-msgs.git


### PR DESCRIPTION
Opening this PR manually due to an authentication issue during the last step with bloom.

Increasing version of package(s) in repository `carla_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/carla-simulator/ros-carla-msgs.git
- release repository: https://github.com/carla-simulator/ros-carla-msgs-release.git
- rosdistro version: `1.2.0-1`
- old version: `1.2.0-1`
- new version: `1.3.0-1`