### PR TITLE
raptor_dbw_ros2: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2566,7 +2566,7 @@ repositories:
     source:
       type: git
       url: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
-      version: foxy-1.0.0
+      version: foxy
     status: developed
   raspimouse2:
     doc:

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2550,6 +2550,24 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: ros2
     status: maintained
+  raptor_dbw_ros2:
+    release:
+      packages:
+      - raptor_can_dbc_parser
+      - raptor_dbw_can
+      - raptor_dbw_joystick
+      - raptor_dbw_msgs
+      - raptor_pdu
+      - raptor_pdu_msgs
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
+      version: foxy-1.0.0
+    status: developed
   raspimouse2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raptor_dbw_ros2` to `1.0.0-1`:

- upstream repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2.git
- release repository: https://github.com/NewEagleRaptor/raptor-dbw-ros2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## raptor_can_dbc_parser

```
* Initial release
* Contributors: Joshua Whitley, neweagleraptor
```

## raptor_dbw_can

```
* Initial release
* Contributors: Joshua Whitley, New Eagle, dev, neweagleraptor
```

## raptor_dbw_joystick

```
* Initial release
* Contributors: Joshua Whitley, neweagleraptor
```

## raptor_dbw_msgs

```
* Initial release
* Contributors: New Eagle, neweagleraptor
```

## raptor_pdu

```
* Initial release
* Contributors: Joshua Whitley, neweagleraptor
```

## raptor_pdu_msgs

```
* Initial release
* Contributors: neweagleraptor
```
