### PR TITLE
driver_common: 1.6.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1412,6 +1412,24 @@ repositories:
       url: https://github.com/UbiquityRobotics-release/dnn_detect-release.git
       version: 0.1.0-1
     status: maintained
+  driver_common:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/driver_common.git
+      version: indigo-devel
+    release:
+      packages:
+      - driver_base
+      - driver_common
+      - timestamp_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/driver_common-release.git
+      version: 1.6.9-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/driver_common.git
+      version: indigo-devel
   dual_quaternions:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `driver_common` to `1.6.9-1`:

- upstream repository: https://github.com/ros-drivers/driver_common.git
- release repository: https://github.com/ros-gbp/driver_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## driver_base

- No changes

## driver_common

- No changes

## timestamp_tools

```
* Merge pull request #11 <https://github.com/ros-drivers/driver_common/issues/11> from PR2-prime/indigo-devel
  updates for compile on focal/noetic
* Merge pull request #1 <https://github.com/ros-drivers/driver_common/issues/1> from PR2-prime/noetic-devel
  Noetic devel
* Merge branch 'indigo-devel' into noetic-devel
* fix to make tests compile under focal/noetic
* fixed boost time duration error with doubles no longer being supported
* fixed dependency issue in timestamp_tools
* updated header due to boost changes in focal/noetic
* Merge pull request #7 <https://github.com/ros-drivers/driver_common/issues/7> from AurelienBallier/indigo-devel
  Fix CATKIN_ENABLE_TESTING set to False issue.
* Fix CATKIN_ENABLE_TESTING set to False issue.
* Contributors: Aurélien Ballier, Chad Rockey, Dave Feil-Seifer
```
