### PR TITLE
willow_maps: 1.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8082,6 +8082,20 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros.git
       version: master
     status: maintained
+  willow_maps:
+    doc:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/willow_maps-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/pr2/willow_maps.git
+      version: kinetic-devel
   wireless:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `willow_maps` to `1.0.3-1`:

- upstream repository: https://github.com/pr2/willow_maps.git
- release repository: https://github.com/ros-gbp/willow_maps-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## willow_maps

```
* Merge pull request #2 <https://github.com/pr2/willow_maps/issues/2> from k-okada/fix_cmake
  Fix cmake
* Merge pull request #1 <https://github.com/pr2/willow_maps/issues/1> from k-okada/orph
  change maintainer to ROS orphaned package maintainer
* update CMake files
  use download.ros.org instead of code.ros.org/svn
  remove willow-2010-02-18-0.025.pgm and willow-sans-whitelab-2010-02-18-0.025.pgm, whcih are not found in download.ros.org
  add code to install .xml and .pgm files
* change maintainer to ROS orphaned package maintainer
* Changed willow maps names
* Contributors: Kei Okada, TheDash
```
