### PR TITLE
Update libcoin80-dev system dependency for noetic

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2285,7 +2285,11 @@ libcoin80-dev:
     jessie: [libcoin80-dev]
     stretch: [libcoin80-dev]
   fedora: [Coin2-devel]
-  ubuntu: [libcoin80-dev]
+  ubuntu:
+    xenial: [libcoin80-dev]
+    bionic: [libcoin80-dev]
+    focal: [libcoin-dev]
+    groovy: [libcoin-dev]
 libconfig++-dev:
   debian: [libconfig++-dev]
   gentoo: ['dev-libs/libconfig[cxx]']

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2286,10 +2286,9 @@ libcoin80-dev:
     stretch: [libcoin80-dev]
   fedora: [Coin2-devel]
   ubuntu:
-    xenial: [libcoin80-dev]
+    '*': [libcoin-dev]
     bionic: [libcoin80-dev]
-    focal: [libcoin-dev]
-    groovy: [libcoin-dev]
+    xenial: [libcoin80-dev]
 libconfig++-dev:
   debian: [libconfig++-dev]
   gentoo: ['dev-libs/libconfig[cxx]']


### PR DESCRIPTION
Since Ubuntu focal, `libcoin80-dev` package was renamed in `libcoin-dev`

See: https://packages.ubuntu.com/search?keywords=libcoin-dev
