### PR TITLE
rcl: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1515,7 +1515,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 2.6.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.6.0-1`

## rcl

- No changes

## rcl_action

- No changes

## rcl_lifecycle

```
* make rcl_lifecycle_com_interface optional in lifecycle nodes (#882 <https://github.com/ros2/rcl/issues/882>)
* Contributors: Karsten Knese
```

## rcl_yaml_param_parser

- No changes
