### PR TITLE
rclcpp: 8.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 7.0.1-2
+      version: 8.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `8.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `7.0.1-2`

## rclcpp

```
* Guard against integer overflow in duration conversion (#1584 <https://github.com/ros2/rclcpp/issues/1584>)
* Contributors: Jacob Perron
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* make rcl_lifecyle_com_interface optional in lifecycle nodes (#1507 <https://github.com/ros2/rclcpp/issues/1507>)
* Contributors: Karsten Knese
```
