### PR TITLE
wge100_driver: 1.8.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8106,6 +8106,24 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros.git
       version: master
     status: maintained
+  wge100_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: noetic-devel
+    release:
+      packages:
+      - wge100_camera
+      - wge100_camera_firmware
+      - wge100_driver
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/wge100_driver-release.git
+      version: 1.8.5-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/wge100_driver.git
+      version: noetic-devel
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wge100_driver` to `1.8.5-1`:

- upstream repository: https://github.com/ros-drivers/wge100_driver.git
- release repository: https://github.com/ros-drivers-gbp/wge100_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## wge100_camera

- No changes

## wge100_camera_firmware

- No changes

## wge100_driver

- No changes
