### PR TITLE
prosilica_driver: 1.9.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5022,6 +5022,22 @@ repositories:
       url: https://github.com/pr2/pr2_power_drivers.git
       version: kinetic-devel
     status: unmaintained
+  prosilica_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: noetic-devel
+    release:
+      packages:
+      - prosilica_camera
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
+      version: 1.9.5-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/prosilica_driver.git
+      version: noetic-devel
   prosilica_gige_sdk:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prosilica_driver` to `1.9.5-1`:

- upstream repository: https://github.com/ros-drivers/prosilica_driver.git
- release repository: https://github.com/ros-drivers-gbp/prosilica_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## prosilica_camera

```
* Merge pull request #19 <https://github.com/ros-drivers/prosilica_driver/issues/19> from PR2-prime/noetic-devel
  updated settings for noetic compile
* updated settings for noetic compile
* Merge pull request #15 <https://github.com/ros-drivers/prosilica_driver/issues/15> from jnmacdnld/kinetic-devel
  Remove driver_base dependency as this package is deprecated
* Remove driver_base dependency as this package is deprecated
  Only the SensorLevels message is needed from this package, which is now
  provided by dynamic_reconfigure
* Merge pull request #11 <https://github.com/ros-drivers/prosilica_driver/issues/11> from athackst/nodelet
  updated prosilica driver to be a nodelet
* returned guard on frameDone in prosilica.cpp
* fixed install in CMakeLists.txt
* Update prosilica_nodelet.cpp
  updated comments
* updated prosilica driver to be a nodelet, added diagnostic messages, and autoadjust streambytespersecond when multiple cameras are connected (can be overwritten by reconfigure)
* Contributors: Allison Thackston, Austin, Dave Feil-Seifer, John Macdonald, athackst
```
