### PR TITLE
fmi_adapter: 2.0.0-1 in 'dashing/distribution.yaml'

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -932,24 +932,24 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 6a6f79c4256a00fc13834a2aaa3c60a0aaac5e76
     status: developed
-  fmi_adapter_ros2:
+  fmi_adapter:
     doc:
       type: git
-      url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: master
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: dashing
     release:
       packages:
       - fmi_adapter
       - fmi_adapter_examples
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
-      version: 0.1.7-1
+      url: https://github.com/ros2-gbp/fmi_adapter-release.git
+      version: 2.0.0-1
     source:
       type: git
-      url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: master
-    status: developed
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: dashing
+    status: maintained
   fmilibrary_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `2.0.0-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/ros2-gbp/fmi_adapter-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.1.7-1`

... and removed suffix `_ros2` from upstream repository and release repository.

## fmi_adapter

```
* Added function 'getValue' to return value of any given variable name
  Co-authored-by: Sebastian Zarnack <sebastian.zarnack@eas.iis.fraunhofer.de>
* Improved readability of unit tests by chrono literals.
* Replaced use of deprecated Duration ctor.
* Added virtual to lifecycle callbacks, as in interface.
```

## fmi_adapter_examples

```
* .
```

