### PR TITLE
realsense2_camera: 3.1.5-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2870,7 +2870,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 3.1.4-1
+      version: 3.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `3.1.5-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `3.1.4-1`

## realsense2_camera

```
* Support Eloquent and Dashing.
* Add filter: HDR_merge
* fix initialization of colorizer image if user specified negative image size (as is in default launch file)
* Remove the following tests for known playback issue with librealsense2 version 2.43.0: align_depth_color_1, align_depth_ir1_1, align_depth_ir1_decimation_1.
* Remove wrong dependency
* changed default image QOS to SYSTEM_DEFAULT
* Add missing librealsense2 dependency from package.xml
* fix bug: selection of profile disregarded stream index.
* Contributors: changseung.yu, doronhi
```

## realsense2_camera_msgs

- No changes

## realsense2_description

- No changes
