### PR TITLE
fmi_adapter: 2.1.0-1 in 'foxy/distribution.yaml'

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1021,24 +1021,24 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
-  fmi_adapter_ros2:
+  fmi_adapter:
     doc:
       type: git
-      url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: master
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: foxy
     release:
       packages:
       - fmi_adapter
       - fmi_adapter_examples
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
-      version: 0.1.8-1
+      url: https://github.com/ros2-gbp/fmi_adapter-release.git
+      version: 2.1.0-1
     source:
       type: git
-      url: https://github.com/boschresearch/fmi_adapter_ros2.git
-      version: master
-    status: developed
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: foxy
+    status: maintained
   fmilibrary_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `2.1.0-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/ros2-gbp/fmi_adapter-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.0.0-1`

... and removed suffix `_ros2` from upstream repository and release repository.

## fmi_adapter

```
* Adapted launch files to API changes.
```

## fmi_adapter_examples

```
* Adapted launch files to API changes.
```
