### PR TITLE
realsense2_camera: 2.2.23-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -9590,7 +9590,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.22-1
+      version: 2.2.23-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `2.2.23-1`:

- upstream repository: https://github.com/IntelRealSense/realsense-ros.git
- release repository: https://github.com/IntelRealSense/realsense-ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.2.22-1`

## realsense2_camera

```
* Remove the following tests for known playback issue with librealsense2 version 2.43.0: points_cloud_1, align_depth_color_1, align_depth_ir1_1, align_depth_ir1_decimation_1.
* Add filter: HDR_merge
* add default values to infra stream in rs_camera.launch as non are defined in librealsense2.
* fix bug: selection of profile disregarded stream index.
* fix initialization of colorizer inner image
* Contributors: doronhi
```

## realsense2_description

- No changes
