### PR TITLE
fmi_adapter: 2.1.0-1 in 'rolling/distribution.yaml'

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -622,10 +622,10 @@ repositories:
       url: https://github.com/ros/filters.git
       version: ros2
     status: maintained
-  fmi_adapter_ros2:
+  fmi_adapter:
     doc:
       type: git
-      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      url: https://github.com/boschresearch/fmi_adapter.git
       version: master
     release:
       packages:
@@ -633,13 +633,13 @@ repositories:
       - fmi_adapter_examples
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/fmi_adapter_ros2-release.git
-      version: 0.1.8-1
+      url: https://github.com/ros2-gbp/fmi_adapter-release.git
+      version: 2.1.0-1
     source:
       type: git
-      url: https://github.com/boschresearch/fmi_adapter_ros2.git
+      url: https://github.com/boschresearch/fmi_adapter.git
       version: master
-    status: developed
+    status: maintained
   fmilibrary_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fmi_adapter` to `2.1.0-1`:

- upstream repository: https://github.com/boschresearch/fmi_adapter.git
- release repository: https://github.com/ros2-gbp/fmi_adapter-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.0.0-1`

... and removed suffix `_ros2` from upstream repository and release repository.

## fmi_adapter

```
* Adapted launch files to API changes.
```

## fmi_adapter_examples

```
* Adapted launch files to API changes.
```
