### PR TITLE
Adding python3-seaborn for Ubuntu focal

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4270,7 +4270,6 @@ python-seaborn:
   gentoo: [dev-python/seaborn]
   ubuntu:
     '*': [python-seaborn]
-    focal_python3: [python3-seaborn]
     trusty:
       pip:
         packages: [seaborn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4270,6 +4270,7 @@ python-seaborn:
   gentoo: [dev-python/seaborn]
   ubuntu:
     '*': [python-seaborn]
+    focal: [python3-seaborn]
     trusty:
       pip:
         packages: [seaborn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4262,7 +4262,7 @@ python-scp:
   fedora: [python-scp]
   ubuntu: [python-scp]
 python-seaborn:
-  arch: [python2-seaborn]
+  arch: [python-seaborn]
   debian: [python-seaborn]
   fedora:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6994,8 +6994,7 @@ python3-seaborn:
   debian: [python3-seaborn]
   fedora: [python3-seaborn]
   gentoo: [dev-python/seaborn]
-  ubuntu:
-    '*': [python3-seaborn]
+  ubuntu: [python3-seaborn]
 python3-selenium:
   arch: [python-selenium]
   debian: [python3-selenium]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4273,6 +4273,13 @@ python-seaborn:
     trusty:
       pip:
         packages: [seaborn]
+python3-seaborn:
+  arch: [python-seaborn]
+  debian: [python3-seaborn]
+  fedora: [python3-seaborn]
+  gentoo: [dev-python/seaborn]
+  ubuntu:
+    '*': [python3-seaborn]
 python-selectors2-pip:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4273,13 +4273,6 @@ python-seaborn:
     trusty:
       pip:
         packages: [seaborn]
-python3-seaborn:
-  arch: [python-seaborn]
-  debian: [python3-seaborn]
-  fedora: [python3-seaborn]
-  gentoo: [dev-python/seaborn]
-  ubuntu:
-    '*': [python3-seaborn]
 python-selectors2-pip:
   arch:
     pip:
@@ -6996,6 +6989,13 @@ python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
   ubuntu: [python3-scp]
+python3-seaborn:
+  arch: [python-seaborn]
+  debian: [python3-seaborn]
+  fedora: [python3-seaborn]
+  gentoo: [dev-python/seaborn]
+  ubuntu:
+    '*': [python3-seaborn]
 python3-selenium:
   arch: [python-selenium]
   debian: [python3-selenium]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4270,7 +4270,7 @@ python-seaborn:
   gentoo: [dev-python/seaborn]
   ubuntu:
     '*': [python-seaborn]
-    focal: [python3-seaborn]
+    focal_python3: [python3-seaborn]
     trusty:
       pip:
         packages: [seaborn]


### PR DESCRIPTION
Please add the following dependency for python3-seaborn for Ubuntu Focal 20.04 to the rosdep database.

## Package name:

python3-seaborn

## Package Upstream Source:

https://github.com/mwaskom/seaborn

## Purpose of using this:

This dependency is being used in a www.dlr.de research project. 

Distro packaging links:

## Links to Distribution Package

- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-seaborn

