### PR TITLE
move_basic: 0.4.1-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -7953,7 +7953,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/UbiquityRobotics-release/move_basic-release.git
-      version: 0.3.2-0
+      version: 0.4.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_basic` to `0.4.1-2`:

- upstream repository: https://github.com/UbiquityRobotics/move_basic.git
- release repository: https://github.com/UbiquityRobotics-release/move_basic-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.3.2-0`

## move_basic

```
* Removed backward drive
* Cosine Runaway safety abort
* Minimum velocity parameters
* Stop service
* Contributors: Janez Cimerman, Jim Vaughan, Mark Johnston, MoffKalast, Rohan Agrawal, Teodor Janez Podobnik
```
