### PR TITLE
mocap_optitrack: 0.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3815,7 +3815,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/mocap_optitrack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_optitrack` to `0.1.2-1`:

- upstream repository: https://github.com/ros-drivers/mocap_optitrack.git
- release repository: https://github.com/ros-drivers-gbp/mocap_optitrack-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.1.1-1`

## mocap_optitrack

```
* Fix/infinit fast reconnect loop (#58 <https://github.com/ros-drivers/mocap_optitrack/issues/58>)
  * fix: infinit fast loop
  * fix: infinit-reconnect-loop
  * fix: lint
  * fix: styling
  Co-authored-by: jad <mailto:jad.hajmustafa@eurogroep.com>
* Contributors: Jad Haj Mustafa
```
