### PR TITLE
xacro_live: 0.1.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4881,7 +4881,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/orise-robotics/xacro_live-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/orise-robotics/xacro_live.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro_live` to `0.1.1-1`:

- upstream repository: https://github.com/orise-robotics/xacro_live
- release repository: https://github.com/orise-robotics/xacro_live-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.1.0-1`

## xacro_live

```
* Comment exit-code check test (temporary fix to error in buildfarm)
```
