### PR TITLE
Add a RHEL rule for 'bison'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -286,6 +286,7 @@ bison:
   gentoo: [sys-devel/bison]
   macports: [bison]
   openembedded: [bison@openembedded-core]
+  rhel: [bison]
   ubuntu: [bison]
 blender:
   arch: [blender]


### PR DESCRIPTION
RHEL 7: https://mirrors.edge.kernel.org/centos/7.9.2009/os/x86_64/Packages/bison-3.0.4-2.el7.x86_64.rpm
RHEL 8: https://mirrors.edge.kernel.org/centos/8.3.2011/AppStream/x86_64/os/Packages/bison-3.0.4-10.el8.x86_64.rpm