### PR TITLE
Move rmw_connextdds to ros2 organization

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1736,7 +1736,7 @@ repositories:
   rmw_connextdds:
     doc:
       type: git
-      url: https://github.com/rticommunity/rmw_connextdds.git
+      url: https://github.com/ros2/rmw_connextdds.git
       version: master
     release:
       packages:
@@ -1749,7 +1749,7 @@ repositories:
       version: 0.3.1-2
     source:
       type: git
-      url: https://github.com/rticommunity/rmw_connextdds.git
+      url: https://github.com/ros2/rmw_connextdds.git
       version: master
     status: developed
   rmw_cyclonedds:


### PR DESCRIPTION
This PR updates the URL for `rmw_connextdds` now that the repository was transfered to the `ros2` GitHub organization.