### PR TITLE
rviz: 8.4.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2588,7 +2588,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 8.4.0-1
+      version: 8.4.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `8.4.0-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `8.4.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Always preserve source permissions in vendor packages (#647 <https://github.com/ros2/rviz/issues/647>)
* Add an override flag to force vendored build (#642 <https://github.com/ros2/rviz/issues/642>)
* Contributors: Scott K Logan
```

## rviz_common

```
* Add ViewPicker::get3DPatch to the public API (#657 <https://github.com/ros2/rviz/issues/657>)
* Fix byte indexing for depth patch pixels (#661 <https://github.com/ros2/rviz/issues/661>)
* fix toolbar vanishing when pressing escape (#656 <https://github.com/ros2/rviz/issues/656>)
* Expose VisualizationManager and YamlConfigReader to the public API (#649 <https://github.com/ros2/rviz/issues/649>)
* Use the stack for the classes in the property test. (#644 <https://github.com/ros2/rviz/issues/644>)
* Contributors: Chris Lalancette, Joseph Schornak, ipa-fez
```

## rviz_default_plugins

```
* Add ViewPicker::get3DPatch to the public API (#657 <https://github.com/ros2/rviz/issues/657>)
* Allow to zoom more with orbit controller (#654 <https://github.com/ros2/rviz/issues/654>)
* Contributors: Joseph Schornak, Victor Lamoine
```

## rviz_ogre_vendor

```
* Always preserve source permissions in vendor packages (#647 <https://github.com/ros2/rviz/issues/647>)
* Contributors: Scott K Logan
```

## rviz_rendering

```
* reset current line width when calculating text width (#655 <https://github.com/ros2/rviz/issues/655>)
* Silence a dead store warning. (#643 <https://github.com/ros2/rviz/issues/643>)
* Fix a memory leak when using the ResourceIOSystem. (#641 <https://github.com/ros2/rviz/issues/641>)
* Contributors: Chris Lalancette, ipa-fez
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

```
* Quiet a clang warning about a Qt memory leak. (#651 <https://github.com/ros2/rviz/issues/651>)
* Contributors: Chris Lalancette
```
