### PR TITLE
added smbus2 python key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4554,7 +4554,7 @@ python-smbus2-pip:
       packages: [smbus2]
   ubuntu:
     pip:
-      packages: [smbus2]  
+      packages: [smbus2]
 python-sortedcontainers-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4542,6 +4542,19 @@ python-slycot-pip:
 python-smbus:
   debian: [python-smbus]
   ubuntu: [python-smbus]
+python-smbus2-pip:
+  debian:
+    pip:
+      packages: [smbus2]
+  fedora:
+    pip:
+      packages: [smbus2]
+  osx:
+    pip:
+      packages: [smbus2]
+  ubuntu:
+    pip:
+      packages: [smbus2]  
 python-sortedcontainers-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4542,19 +4542,6 @@ python-slycot-pip:
 python-smbus:
   debian: [python-smbus]
   ubuntu: [python-smbus]
-python-smbus2-pip:
-  debian:
-    pip:
-      packages: [smbus2]
-  fedora:
-    pip:
-      packages: [smbus2]
-  osx:
-    pip:
-      packages: [smbus2]
-  ubuntu:
-    pip:
-      packages: [smbus2]
 python-sortedcontainers-pip:
   ubuntu:
     pip:
@@ -7168,6 +7155,19 @@ python3-sklearn:
     pip:
       packages: [scikit-learn]
   ubuntu: [python3-sklearn]
+python3-smbus2-pip:
+  debian:
+    pip:
+      packages: [smbus2]
+  fedora:
+    pip:
+      packages: [smbus2]
+  osx:
+    pip:
+      packages: [smbus2]
+  ubuntu:
+    pip:
+      packages: [smbus2]
 python3-sphinx:
   debian: [python3-sphinx]
   fedora: [python3-sphinx]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

Package name:
smbus2

Package Upstream Source:
`https://pypi.org/project/smbus2/`

Purpose of using this:
Our current robot stack is working on smbus2 for i2c communication to peripheral boards, earlier we faced problems with smbus and they still not resolved but using smbus2 worked for our stack. 

Please Add This Package to be indexed in the rosdistro.
Melodic

@mabelzhang @cottsay @hidmic 
