### PR TITLE
unique_identifier_msgs: 2.2.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2913,7 +2913,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.2.0-2
+      version: 2.2.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.2.0-3`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.2.0-2`

## unique_identifier_msgs

```
* Update QD to QL 1 (#17 <https://github.com/ros2/unique_identifier_msgs/issues/17>)
* Update Quality Declaration to QL2. (#15 <https://github.com/ros2/unique_identifier_msgs/issues/15>)
* Update Quality level to level 3 (#13 <https://github.com/ros2/unique_identifier_msgs/issues/13>)
* Add Security Vulnerability Policy pointing to REP-2006. (#11 <https://github.com/ros2/unique_identifier_msgs/issues/11>)
* Contributors: Chris Lalancette, Michel Hidalgo, Stephen Brawner, brawner
```
