### PR TITLE
rmw_connextdds: 0.3.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1746,7 +1746,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.3.1-2
+      version: 0.3.1-3
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.3.1-3`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.3.1-2`

## rmw_connextdds

- No changes

## rmw_connextdds_common

- No changes

## rti_connext_dds_cmake_module

```
* Pass ``-Wl,--no-as-needed`` for system dependencies of Connext 5.3.1.
* Set ``IMPORTED_NO_SONAME true`` for Connext 5.3.1 imported library target.
```
