### PR TITLE
ros2cli: 0.12.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1938,7 +1938,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.12.0-2
+      version: 0.12.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.12.0-3`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.12.0-2`
