### PR TITLE
rosidl_python: 0.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2142,7 +2142,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.10.0-1
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.10.0-1`

## rosidl_generator_py

```
* Remove dependency from rosidl_typesupport_connext_c (#127 <https://github.com/ros2/rosidl_python/issues/127>)
* Contributors: Andrea Sorbini
```
