### PR TITLE
rosidl_typesupport: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2177,7 +2177,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 1.1.2-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `1.2.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.1.2-1`

## rosidl_typesupport_c

```
* Remove dependencies from Connext type support (#106 <https://github.com/ros2/rosidl_typesupport/issues/106>)
* Contributors: Andrea Sorbini
```

## rosidl_typesupport_cpp

```
* Remove dependencies from Connext type support (#106 <https://github.com/ros2/rosidl_typesupport/issues/106>)
* Contributors: Andrea Sorbini
```
