### PR TITLE
rclcpp: 8.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 8.0.0-1
+      version: 8.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `8.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `8.0.0-1`

## rclcpp

```
* Remove rmw_connext_cpp references. (#1595 <https://github.com/ros2/rclcpp/issues/1595>)
* Add API for checking QoS profile compatibility (#1554 <https://github.com/ros2/rclcpp/issues/1554>)
* Document misuse of parameters callback (#1590 <https://github.com/ros2/rclcpp/issues/1590>)
* use const auto & to iterate over parameters (#1593 <https://github.com/ros2/rclcpp/issues/1593>)
* Contributors: Chris Lalancette, Jacob Perron, Karsten Knese
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
