### PR TITLE
panda_moveit_config: 0.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4657,6 +4657,21 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: main
     status: maintained
+  panda_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/panda_moveit_config.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/panda_moveit_config-release.git
+      version: 0.7.5-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/panda_moveit_config.git
+      version: melodic-devel
+    status: maintained
   parameter_pa:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `panda_moveit_config` to `0.7.5-1`:

- upstream repository: https://github.com/ros-planning/panda_moveit_config.git
- release repository: https://github.com/ros-gbp/panda_moveit_config-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## panda_moveit_config

```
* Update SRDF for collision model (#35 <https://github.com/ros-planning/panda_moveit_config/issues/35>)
  franka_description got updated with a more coarse collision model [1] matching the internal
  self-collision detection, so the SRDF needs to be adapted.
  Disable collision checking between panda_link6 and panda_link8 which collide in the default pose.
  Tested with example controllers.
  Closes #18 <https://github.com/ros-planning/panda_moveit_config/issues/18>. Resolves ros-planning/moveit#1210 <https://github.com/ros-planning/moveit/issues/1210>, resolves frankaemika/franka_ros#39 <https://github.com/frankaemika/franka_ros/issues/39>.
  [1] https://github.com/frankaemika/franka_ros/commit/e52c03a23aa18c6532e40f9bf4927dedfc0c596a
* Fix ordering of planning adapters (#69 <https://github.com/ros-planning/panda_moveit_config/issues/69>)
  As explained in https://github.com/ros-planning/moveit/pull/2053
  AddTimeParameterization should be at the begining of the list.
* Add tranposrt joint state (#67 <https://github.com/ros-planning/panda_moveit_config/issues/67>)
  Co-authored-by: Libor Wagner <mailto:libor.wagner@cvut.cz>
* Bump required cmake version (#61 <https://github.com/ros-planning/panda_moveit_config/issues/61>)
* Contributors: Florian Walch, Libor Wagner, Michael Görner, tnaka
```
