### PR TITLE
ntpd_driver: 2.1.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2052,7 +2052,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/vooon/ntpd_driver-release.git
-      version: 2.0.2-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ntpd_driver` to `2.1.0-1`:

- upstream repository: https://github.com/vooon/ntpd_driver.git
- release repository: https://github.com/vooon/ntpd_driver-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.0.2-1`

## ntpd_driver

```
* make linker happy
* fix loading as a component
* Contributors: Vladimir Ermakov
```
