### PR TITLE
rmw_implementation: 2.3.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1832,7 +1832,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.3.0-2`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `2.3.0-1`

## rmw_implementation

```
* Remove rmw_connext_cpp. (#183 <https://github.com/ros2/rmw_implementation/issues/183>)
* Add support for rmw_connextdds (#182 <https://github.com/ros2/rmw_implementation/issues/182>)
* Contributors: Andrea Sorbini, Chris Lalancette
```
