### PR TITLE
Adding meshio to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6294,6 +6294,7 @@ python3-mechanize:
 python3-meshio:
   debian: [python3-meshio]
   ubuntu: [python3-meshio]
+  arch: [python-meshio]
 python3-mock:
   alpine: [py3-mock]
   debian: [python3-mock]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6291,6 +6291,9 @@ python3-mechanize:
     '*': [python3-mechanize]
     bionic: null
     xenial: null
+python3-meshio:
+  debian: [python3-meshio]
+  ubuntu: [python3-meshio]
 python3-mock:
   alpine: [py3-mock]
   debian: [python3-mock]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6292,9 +6292,9 @@ python3-mechanize:
     bionic: null
     xenial: null
 python3-meshio:
+  arch: [python-meshio]
   debian: [python3-meshio]
   ubuntu: [python3-meshio]
-  arch: [python-meshio]
 python3-mock:
   alpine: [py3-mock]
   debian: [python3-mock]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-meshio

## Package Upstream Source:

https://github.com/nschloe/meshio

## Purpose of using this:

We are using meshio to load some meshes into our MoveIt planning scene via Python.

Meshio can read and write most commonly used mesh formats for representing unstructured meshes, and smoothly converts between them.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/buster/python3-meshio
- Ubuntu: https://packages.ubuntu.com/focal/python3-meshio
- Fedora: https://apps.fedoraproject.org/packages/
  - "Service Unavailable" (couldn't find any matches for meshio on [https://src.fedoraproject.org/](https://src.fedoraproject.org/) either)
- Arch: https://aur.archlinux.org/packages/python-meshio
- Gentoo: https://packages.gentoo.org/packages/
  - not available
- macOS: https://formulae.brew.sh/
  - not available (see comment below)

I found something for macOS here, but not sure if I would go about adding it to rosdep: https://github.com/macports/macports-ports/blob/master/python/py-meshio/Portfile

It's also on pip: https://pypi.org/project/meshio/