### PR TITLE
Updating source branch of rclc-repo for Dashing

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2298,7 +2298,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: foxy
     release:
       packages:
       - rclc
@@ -2312,7 +2312,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclc.git
-      version: master
+      version: foxy
     status: developed
   rclcpp:
     doc:


### PR DESCRIPTION
Signed-off-by: Jan Staschulat <jan.staschulat@de.bosch.com>

updating the source branch for dashing release of ros2/rclc repository to 'foxy' branch.