### PR TITLE
bond_core: 3.0.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -278,7 +278,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 3.0.1-2
+      version: 3.0.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `3.0.1-3`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `3.0.1-2`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Fix cpplint/uncrustify errors.
* Add build dependencies on pkg-config.
* Contributors: Chris Lalancette
```

## smclib

```
* Fix cpplint/uncrustify errors.
* Contributors: Chris Lalancette
```

## test_bond

```
* Add build dependencies on pkg-config.
* Contributors: Chris Lalancette
```
