### PR TITLE
geographic_info: 1.0.4-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -697,7 +697,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
-      version: 1.0.4-3
+      version: 1.0.4-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `1.0.4-4`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros2-gbp/geographic_info-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.0.4-3`
