### PR TITLE
gps_umd: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -775,7 +775,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 1.0.3-2
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `1.0.4-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.0.3-2`

## gps_msgs

```
* Add support for ros1 bridge (#32 <https://github.com/swri-robotics/gps_umd/issues/32>)
* Contributors: Andrew Palmer
```

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

- No changes
