### PR TITLE
lgsvl_msgs: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1039,7 +1039,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/lgsvl_msgs-release.git
-      version: 0.0.3-2
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lgsvl_msgs` to `0.0.4-1`:

- upstream repository: https://github.com/lgsvl/lgsvl_msgs.git
- release repository: https://github.com/ros2-gbp/lgsvl_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.0.3-2`

## lgsvl_msgs

```
* Add VehicleOdometry.msg to README
* Adding VehicleOdometry.
* Update README and LICENSE
* Update package description and maintainers
* Add ultrasonic message.
* Contributors: Guodong Rong, Hadi Tabatabaee, Piotr Jaroszek
```
