### PR TITLE
nmea_msgs: 2.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1204,7 +1204,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_msgs-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nmea_msgs` to `2.0.0-2`:

- upstream repository: https://github.com/ros-drivers/nmea_msgs.git
- release repository: https://github.com/ros2-gbp/nmea_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.0.0-1`

## nmea_msgs

```
* Initial release for ROS 2
* Contributors: Andreas Klintberg, Edward Venator
```
