### PR TITLE
add python3-pqdict-pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6515,6 +6515,19 @@ python3-pkg-resources:
   openembedded: [python3-setuptools@openembedded-core]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
+python3-pqdict-pip:
+  debian:
+    pip:
+      packages: [pqdict]
+  fedora:
+    pip:
+      packages: [pqdict]
+  osx:
+    pip:
+      packages: [pqdict]
+  ubuntu:
+    pip:
+      packages: [pqdict]
 python3-prettytable:
   debian: [python3-prettytable]
   fedora: [python3-prettytable]


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name:

pqdict for python3 (follow up of #21557)

## Package Upstream Source:

https://github.com/nvictus/priority-queue-dictionary

## Purpose of using this:

It provides a pythonic priority queue, which can be used, for instance, for A* implementations.

## Links to Distribution Packages

pip only: 
https://pypi.org/project/pqdict/

