### PR TITLE
Make the python3-lark-parser key forwards compatible.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6223,8 +6223,8 @@ python3-lark-parser:
   openembedded: [python3-lark-parser@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-lark-parser']
   ubuntu:
+    '*': [python3-lark]
     bionic: [python3-lark-parser]
-    focal: [python3-lark]
     xenial: [python3-lark-parser]
 python3-lttng:
   alpine: [py3-lttng]


### PR DESCRIPTION
That is, on Focal and later we use the python3-lark key.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Here's the link to the package on Ubuntu: https://packages.ubuntu.com/search?keywords=python3-lark&searchon=names&suite=all&section=all .

Note that prior to Focal, we hosted our own version of lark parser from the bootstrap repository: http://repos.ros.org/repos/ros_bootstrap/pool/main/l/lark-parser/ .  That's why the key changed names.