### PR TITLE
ros_canopen: 2.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1962,7 +1962,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_canopen-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git


### PR DESCRIPTION
closes https://github.com/ros-industrial/ros_canopen/issues/424

Increasing version of package(s) in repository `ros_canopen` to `2.0.0-2`:

- upstream repository: https://github.com/ros-industrial/ros_canopen.git
- release repository: https://github.com/ros-industrial-release/ros_canopen-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.0.0-1`

## can_msgs

```
* port can_msgs to ROS2
* Contributors: Joshua Whitley, Mathias Lüdtke
```
