### PR TITLE
rc_common_msgs: 0.5.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1445,7 +1445,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/roboception-gbp/rc_common_msgs_ros2-release.git
-      version: 0.5.3-1
+      version: 0.5.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_common_msgs` to `0.5.3-2`:

- upstream repository: https://github.com/roboception/rc_common_msgs_ros2.git
- release repository: https://github.com/roboception-gbp/rc_common_msgs_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.5.3-1`

## rc_common_msgs

```
* CI changes only: also build for focal/foxy
```
