### PR TITLE
clover: 0.21.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -1259,6 +1259,28 @@ repositories:
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git
       version: master
     status: maintained
+  clover:
+    doc:
+      type: git
+      url: https://github.com/CopterExpress/clover.git
+      version: melodic-devel
+    release:
+      packages:
+      - aruco_pose
+      - clover
+      - clover_blocks
+      - clover_description
+      - clover_simulation
+      - roswww_static
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/CopterExpress/clover-release.git
+      version: 0.21.2-1
+    source:
+      type: git
+      url: https://github.com/CopterExpress/clover.git
+      version: melodic-devel
+    status: developed
   cmake_modules:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clover` to `0.21.2-1`:

- upstream repository: https://github.com/CopterExpress/clover.git
- release repository: https://github.com/CopterExpress/clover-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`
