### PR TITLE
flir_ptu: 0.2.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3784,7 +3784,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
-      version: 0.2.0-0
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_ptu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.2.1-1`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/ros-drivers-gbp/flir_ptu-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.2.0-0`

## flir_ptu_description

```
* Fix missing xacro namespace prefixes
* Updated PTU mesh geometry (#40 <https://github.com/ros-drivers/flir_ptu/issues/40>)
* Contributors: Dave Niewinski, Robert Haschke
```

## flir_ptu_driver

```
* Don't load the description & start the robot_state_publisher by default
* Contributors: Chris Iverach-Brereton
```

## flir_ptu_viz

- No changes
