### PR TITLE
flir_ptu: 0.2.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3223,6 +3223,25 @@ repositories:
       url: https://github.com/astuff/flir_boson_usb.git
       version: master
     status: developed
+  flir_ptu:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: master
+    release:
+      packages:
+      - flir_ptu_description
+      - flir_ptu_driver
+      - flir_ptu_viz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_ptu.git
+      version: master
+    status: maintained
   fmi_adapter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `0.2.1-1`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/ros-drivers-gbp/flir_ptu-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## flir_ptu_description

```
* Fix missing xacro namespace prefixes
* Updated PTU mesh geometry (#40 <https://github.com/ros-drivers/flir_ptu/issues/40>)
* Contributors: Dave Niewinski, Robert Haschke
```

## flir_ptu_driver

```
* Don't load the description & start the robot_state_publisher by default
* Contributors: Chris Iverach-Brereton
```

## flir_ptu_viz

- No changes
