### PR TITLE
Add several rules for Debian Bullseye

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -448,6 +448,7 @@ clang:
 clang-format:
   alpine: [clang]
   debian:
+    bullseye: [clang-format]
     buster: [clang-format]
     stretch: [clang-format]
   fedora: [clang]
@@ -460,6 +461,7 @@ clang-format:
 clang-tidy:
   alpine: [clang-extra-tools]
   debian:
+    bullseye: [clang-tidy]
     buster: [clang-tidy]
     stretch: [clang-tidy]
   fedora: [clang-tools-extra]
@@ -764,6 +766,7 @@ eigen:
   alpine: [eigen-dev]
   arch: [eigen3]
   debian:
+    bullseye: [libeigen3-dev]
     buster: [libeigen3-dev]
     jessie: [libeigen3-dev]
     stretch: [libeigen3-dev]
@@ -4958,6 +4961,7 @@ log4cxx:
   arch: [log4cxx]
   cygwin: [liblog4cxx-devel]
   debian:
+    bullseye: [liblog4cxx-dev]
     buster: [liblog4cxx-dev]
     jessie: [liblog4cxx10-dev]
     squeeze: [liblog4cxx10-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -272,6 +272,7 @@ pika:
 pydocstyle:
   alpine: [py3-pydocstyle]
   debian:
+    bullseye: [pydocstyle]
     buster: [pydocstyle]
     stretch: [pydocstyle]
   fedora: [python3-pydocstyle]
@@ -5898,6 +5899,7 @@ python3-docutils:
 python3-empy:
   alpine: [py3-empy]
   debian:
+    bullseye: [python3-empy]
     buster: [python3-empy]
     jessie: [python3-empy]
     stretch: [python3-empy]
@@ -5967,6 +5969,7 @@ python3-filterpy-pip:
 python3-flake8:
   alpine: [py3-flake8]
   debian:
+    bullseye: [python3-flake8]
     buster: [python3-flake8]
     jessie: [python3-flake8]
     stretch: [python3-flake8]
@@ -6216,6 +6219,7 @@ python3-kitchen:
 python3-lark-parser:
   alpine: [py3-lark-parser]
   debian:
+    bullseye: [python3-lark]
     buster: [python3-lark-parser]
     stretch: [python3-lark-parser]
   fedora: [python3-lark-parser]
@@ -6316,6 +6320,7 @@ python3-mypy:
   alpine: [py3-mypy]
   arch: [mypy]
   debian:
+    bullseye: [python3-mypy]
     buster: [python3-mypy]
     stretch: [mypy]
   fedora: [python3-mypy]


### PR DESCRIPTION
These rules are needed for building ROS 2.

clang-format: https://packages.debian.org/bullseye/clang-format
clang-tidy: https://packages.debian.org/bullseye/clang-tidy
libeigen3-dev: https://packages.debian.org/bullseye/libeigen3-dev
liblog4cxx-dev: https://packages.debian.org/bullseye/liblog4cxx-dev
pydocstyle: https://packages.debian.org/bullseye/pydocstyle
python3-empy: https://packages.debian.org/bullseye/python3-empy
python3-flake8: https://packages.debian.org/bullseye/python3-flake8
python3-lark: https://packages.debian.org/bullseye/python3-lark
python3-mypy: https://packages.debian.org/bullseye/python3-mypy