### PR TITLE
grbl_msgs: 0.0.2-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -791,7 +791,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/flynneva/grbl_msgs-release.git
-      version: 0.0.2-1
+      version: 0.0.2-4
     source:
       type: git
       url: https://github.com/flynneva/grbl_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grbl_msgs` to `0.0.2-4`:

- upstream repository: https://github.com/flynneva/grbl_msgs.git
- release repository: https://github.com/flynneva/grbl_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.0.2-1`

## grbl_msgs

```
* Merge pull request #6 <https://github.com/flynneva/grbl_msgs/issues/6> from flynneva/main
* add release gh action
* removed exec depend
* missing std_msgs dependency
* Contributors: Evan Flynn
```
