### PR TITLE
Require redhat-rpm-config for Python Qt bindings on RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6848,7 +6848,7 @@ python3-qt5-bindings:
   gentoo: [dev-python/PyQt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
-  rhel: ['python%{python3_pkgversion}-qt5-devel', libXext-devel]
+  rhel: ['python%{python3_pkgversion}-qt5-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]


### PR DESCRIPTION
This one is a little bit tricky.

It seems that the compiler flags used during the RPM build process for sip are getting carried forward into the `Makefile` it is generating. This package provides some compiler spec files that appear to be necessary for the bindings to build. Conveniently, the RPM builds are passing because this package is already part of the RPM buildroot. I hit this error building from source in a container with a minimal set of dependencies installed.

Here's the error I'm seeing while building `qt_gui_cpp` without this package installed:
```
g++: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
gmake[3]: *** [Makefile:18: siplibqt_gui_cpp_sipcmodule.o] Error 1
gmake[2]: *** [src/qt_gui_cpp_sip/CMakeFiles/libqt_gui_cpp_sip.dir/build.make:61: src/qt_gui_cpp_sip/libqt_gui_cpp_sip.so] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:316: src/qt_gui_cpp_sip/CMakeFiles/libqt_gui_cpp_sip.dir/all] Error 2
gmake: *** [Makefile:141: all] Error 2
```

RHEL 7: https://mirrors.edge.kernel.org/centos/7.9.2009/os/x86_64/Packages/redhat-rpm-config-9.1.0-88.el7.centos.noarch.rpm
RHEL 8: https://mirrors.edge.kernel.org/centos/8.3.2011/AppStream/x86_64/os/Packages/redhat-rpm-config-123-1.el8.noarch.rpm