### PR TITLE
pincher_arm: 0.1.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -8371,6 +8371,28 @@ repositories:
       url: https://github.com/PilzDE/pilz_robots.git
       version: melodic-devel
     status: developed
+  pincher_arm:
+    doc:
+      type: git
+      url: https://github.com/fictionlab/pincher_arm.git
+      version: master
+    release:
+      packages:
+      - pincher_arm
+      - pincher_arm_bringup
+      - pincher_arm_description
+      - pincher_arm_ikfast_plugin
+      - pincher_arm_moveit_config
+      - pincher_arm_moveit_demos
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/fictionlab-gbp/pincher_arm-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/fictionlab/pincher_arm.git
+      version: master
+    status: maintained
   ping360_sonar:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pincher_arm` to `0.1.1-2`:

- upstream repository: https://github.com/fictionlab/pincher_arm.git
- release repository: https://github.com/fictionlab-gbp/pincher_arm-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `null`

## pincher_arm

```
* Update metapackage dependencies
```

## pincher_arm_bringup

```
* Update dependencies
```

## pincher_arm_description

- No changes

## pincher_arm_ikfast_plugin

- No changes

## pincher_arm_moveit_config

- No changes

## pincher_arm_moveit_demos

- No changes
