### PR TITLE
rtabmap/rtabmap_ros: 0.20.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6830,7 +6830,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.7-2
+      version: 0.20.9-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -6845,7 +6845,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.7-1
+      version: 0.20.9-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository rtabmap/rtabmap_ros to 0.20.9-1:

  * upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
  * release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
  * distro file: noetic/distribution.yaml
  * bloom version: 0.10.2
  * previous version for package: 0.20.7-1
