### PR TITLE
rtabmap/rtabmap_ros: 0.20.9-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11704,7 +11704,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.20.7-1
+      version: 0.20.9-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -11719,7 +11719,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.20.7-1
+      version: 0.20.9-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository rtabmap/rtabmap_ros to 0.20.9-1:

  * upstream repository: https://github.com/introlab/rtabmap.git, https://github.com/introlab/rtabmap_ros.git
  * release repository: https://github.com/introlab/rtabmap-release.git, https://github.com/introlab/rtabmap_ros-release.git
  * distro file: melodic/distribution.yaml
  * bloom version: 0.10.2
  * previous version for package: 0.20.7-1

