### PR TITLE
rclc: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1580,7 +1580,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## rclc

```
* Windows port
* Compatibility sleep function (Windows, POSIX-OS)
* Fixed RCL lifecycle API change for Rolling
```

## rclc_examples

```
* Windows port
* Compatibility sleep function (Windows, POSIX-OS)
* Fixed RCL lifecycle API change for Rolling
```

## rclc_lifecycle

```
* Windows port
* Compatibility sleep function (Windows, POSIX-OS)
* Fixed RCL lifecycle API change for Rolling
```
