### PR TITLE
xacro: 1.13.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -14286,7 +14286,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.13.9-1
+      version: 1.13.10-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.13.10-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.13.9-1`

## xacro

```
* Use outer-scope symbols to resolve include filename in xacro:include (#264 <https://github.com/ros/xacro/issues/264>)
* Contributors: Robert Haschke
```
