### PR TITLE
Remove rmw_connext_cpp and rosidl_typesupport_connext.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1713,25 +1713,6 @@ repositories:
       url: https://github.com/ros2/rmw.git
       version: master
     status: maintained
-  rmw_connext:
-    doc:
-      type: git
-      url: https://github.com/ros2/rmw_connext.git
-      version: master
-    release:
-      packages:
-      - rmw_connext_cpp
-      - rmw_connext_shared_cpp
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rmw_connext-release.git
-      version: 3.6.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros2/rmw_connext.git
-      version: master
-    status: maintained
   rmw_connextdds:
     doc:
       type: git
@@ -2181,25 +2162,6 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: master
-    status: maintained
-  rosidl_typesupport_connext:
-    doc:
-      type: git
-      url: https://github.com/ros2/rosidl_typesupport_connext.git
-      version: master
-    release:
-      packages:
-      - connext_cmake_module
-      - rosidl_typesupport_connext_c
-      - rosidl_typesupport_connext_cpp
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rosidl_typesupport_connext-release.git
-      version: 1.1.0-1
-    source:
-      type: git
-      url: https://github.com/ros2/rosidl_typesupport_connext.git
       version: master
     status: maintained
   rosidl_typesupport_fastrtps:


### PR DESCRIPTION
Rolling no longer needs these as we've switched to
rmw_connextdds.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>