### PR TITLE
phidgets_drivers: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1343,7 +1343,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.0.2-3
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.1.0-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.0.2-3`

## libphidget22

```
* Compile libphidget22 with -fPIC (#88 <https://github.com/ros-drivers/phidgets_drivers/issues/88>)
* Update to libphidget22 from 2020.
* Contributors: Chris Lalancette, Scott K Logan
```

## phidgets_accelerometer

```
* Don't publish messages that jumped back in time. (#86 <https://github.com/ros-drivers/phidgets_drivers/issues/86>)
* Log synchronization window details at DEBUG level (#84 <https://github.com/ros-drivers/phidgets_drivers/issues/84>)
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette, Martin Günther, Michael Grupp
```

## phidgets_analog_inputs

```
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette
```

## phidgets_api

```
* Switch header guards to _HPP SUFFIX.
* Remove unnecessary cstddef.
* Contributors: Chris Lalancette
```

## phidgets_digital_inputs

```
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette
```

## phidgets_digital_outputs

```
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

```
* Don't publish messages that jumped back in time. (#86 <https://github.com/ros-drivers/phidgets_drivers/issues/86>)
* Log synchronization window details at DEBUG level (#84 <https://github.com/ros-drivers/phidgets_drivers/issues/84>)
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette, Martin Günther, Michael Grupp
```

## phidgets_high_speed_encoder

```
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette
```

## phidgets_ik

```
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
  Foxy deprecated some of the names we use in the launch files.
  Switch to the new supported names here.
* Contributors: Chris Lalancette
```

## phidgets_magnetometer

```
* Don't publish messages that jumped back in time. (#86 <https://github.com/ros-drivers/phidgets_drivers/issues/86>)
* Log synchronization window details at DEBUG level (#84 <https://github.com/ros-drivers/phidgets_drivers/issues/84>)
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette, Martin Günther, Michael Grupp
```

## phidgets_motors

```
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette
```

## phidgets_msgs

- No changes

## phidgets_spatial

```
* Don't publish messages that jumped back in time. (#86 <https://github.com/ros-drivers/phidgets_drivers/issues/86>)
* Log synchronization window details at DEBUG level (#84 <https://github.com/ros-drivers/phidgets_drivers/issues/84>)
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette, Martin Günther, Michael Grupp
```

## phidgets_temperature

```
* Get rid of deprecation warnings in Foxy. (#75 <https://github.com/ros-drivers/phidgets_drivers/issues/75>)
* Switch header guards to _HPP SUFFIX.
* Contributors: Chris Lalancette
```
