### PR TITLE
ros2_tracing: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1906,7 +1906,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/ros-tracing/ros2_tracing-release.git
-      version: 2.1.0-3
+      version: 2.2.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `2.2.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://gitlab.com/ros-tracing/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.1.0-3`

## tracetools

```
* Add support for rcl_publish and rclcpp_publish tracepoints
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Add tests for rcl_publish and rclcpp_publish tracepoints
* Allow asserting order of list of events
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Add support for rcl_publish and rclcpp_publish tracepoints
* Contributors: Christophe Bedard
```
