### PR TITLE
fmilibrary_vendor: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -645,7 +645,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fmilibrary_vendor` to `1.0.1-1`:

- upstream repository: https://github.com/boschresearch/fmilibrary_vendor.git
- release repository: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.0.0-1`

## fmilibrary_vendor

```
* Suppressing update step so that CMake doesn't attempt to re-build the
  external project during the installation phase.
* Contributors: Scott K Logan
```
