### PR TITLE
velodyne_simulator: 1.0.12-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13751,7 +13751,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
-      version: 1.0.11-1
+      version: 1.0.12-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator` to `1.0.12-1`:

- upstream repository: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
- release repository: https://github.com/DataspeedInc-release/velodyne_simulator-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.0.11-1`

## velodyne_description

- No changes

## velodyne_gazebo_plugins

```
* Fix swapped PointCloud2 width/height
  Bug introduced in recent commit adding organize_cloud option
* Contributors: Kevin Hallenbeck
```

## velodyne_simulator

- No changes
