### PR TITLE
Mechanism to check rosdep rules against package repositories

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -10,6 +10,8 @@ jobs:
         python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -18,6 +20,7 @@ jobs:
       run: |
         git remote add unittest_upstream_comparision https://github.com/ros/rosdistro.git || git remote set-url unittest_upstream_comparision https://github.com/ros/rosdistro.git
         git fetch --no-tags --depth=1 unittest_upstream_comparision master
+        git fetch --no-tags --depth=1 origin $GITHUB_BASE_REF
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/test/rosdep_repo_check/README.md
+++ b/test/rosdep_repo_check/README.md
@@ -1,0 +1,17 @@
+ a system for checking rosdep rules against the current package repositories for supported platforms
+
+## Running on rosdep PRs
+
+This test package is configured to run during pull request checks on changed rosdep key entries.
+
+If a package can't be found in the repositories, a failing test is registered notifying the contributor.
+Links to package web indexes/dashboards is also printed in the action logs.
+
+
+## Running locally on the entire rosdep database
+
+To review the entire rosdep database and not only the rules that were changed in the most recent commit, it is also possible to invoke the test as a python module. For example:
+```
+
+PYTHONPATH=test python3 -m rosdep_repo_check
+```

--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from gzip import GzipFile
+import socket
+import sys
+import time
+try:
+    from urllib.error import HTTPError
+    from urllib.error import URLError
+    from urllib.request import Request
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import HTTPError
+    from urllib2 import Request
+    from urllib2 import URLError
+    from urllib2 import urlopen
+
+
+def is_probably_gzip(response):
+    return (response.url.endswith('.gz') or
+            response.getheader('Content-Encoding') == 'gzip' or
+            response.getheader('Content-Type') == 'application/x-gzip')
+
+
+def open_gz_url(url, retry=2, retry_period=1, timeout=10):
+    request = Request(url, headers={'Accept-Encoding': 'gzip'})
+    try:
+        f = urlopen(request, timeout=timeout)
+    except HTTPError as e:
+        if e.code == 503 and retry:
+            time.sleep(retry_period)
+            return open_gz_url(
+                url, retry=retry - 1, retry_period=retry_period,
+                timeout=timeout)
+        e.msg += ' (%s)' % url
+        raise
+    except URLError as e:
+        if isinstance(e.reason, socket.timeout) and retry:
+            time.sleep(retry_period)
+            return open_gz_url(
+                url, retry=retry - 1, retry_period=retry_period,
+                timeout=timeout)
+        raise URLError(str(e) + ' (%s)' % url)
+    return GzipFile(fileobj=f, mode='rb') if is_probably_gzip(f) else f
+
+
+class PackageEntry(str):
+
+    def __new__(cls, name, version, source_name=None, binary_name=None):
+        obj = str.__new__(cls, name)
+        obj.name = obj
+        obj.version = version
+        obj.source_name = obj if source_name is None else source_name
+        obj.binary_name = obj if binary_name is None else binary_name
+        return obj
+
+
+class RepositoryCache:
+
+    def __init__(self, iterator):
+        self._cache = set()
+        self._source_iterator = iterator
+
+    def __iter__(self):
+        return self._enumerate_packages()
+
+    def __contains__(self, needle):
+        if needle in self._cache:
+            return True
+        for pkg in self._enumerate_from_source():
+            if pkg == needle:
+                return True
+
+        return False
+
+    def _enumerate_from_source(self):
+        while self._source_iterator:
+            try:
+                val = next(self._source_iterator)
+                self._cache.add(val)
+                yield val
+            except StopIteration:
+                self._source_iterator = None
+
+    def _enumerate_packages(self):
+        yield from self._cache
+        yield from self._enumerate_from_source()
+
+
+class RepositoryCacheCollection:
+
+    def __init__(self, iterator):
+        self._cache = {}
+        self._iterator = iterator
+
+    def enumerate_packages(self, os_name, os_code_name, os_arch):
+        cache = self._cache.get((os_name, os_code_name, os_arch))
+        if not cache:
+            cache = RepositoryCache(self._iterator(os_name, os_code_name, os_arch))
+            self._cache[(os_name, os_code_name, os_arch)] = cache
+        return cache
+
+
+def summarize_broken_packages(broken):
+    # Group and sort by os, version, arch, key
+    grouped = {}
+
+    for os_name, os_ver, os_arch, key, package in broken:
+        platform = '%s %s on %s' % (os_name, os_ver, os_arch)
+        if platform not in grouped:
+            grouped[platform] = set()
+        grouped[platform].add('- Package %s for rosdep key %s' % (package, key))
+
+    return '\n\n'.join(
+        '* The following %d packages were not found for %s:\n%s' % (
+            len(pkg_msgs), platform, '\n'.join(sorted(pkg_msgs)))
+        for platform, pkg_msgs in sorted(grouped.items()))
+
+
+def find_package(config, pkg_name, os_name, os_code_name, os_arch):
+    if os_name not in config['package_sources']:
+        return
+
+    for os_sources in config['package_sources'][os_name]:
+        if isinstance(os_sources, dict):
+            sources = os_sources.get(os_code_name, [])
+        else:
+            sources = [os_sources]
+        if not sources:
+            print('WARNING: No sources for %s %s' % (os_name, os_code_name), file=sys.stderr)
+        for source in sources:
+            for p in [
+                    p for p in source.enumerate_packages(os_name, os_code_name, os_arch)
+                    if p == pkg_name]:
+                return p

--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -133,7 +133,7 @@ def summarize_broken_packages(broken):
     # Group and sort by os, version, arch, key
     grouped = {}
 
-    for os_name, os_ver, os_arch, key, package in broken:
+    for os_name, os_ver, os_arch, key, package, _ in broken:
         platform = '%s %s on %s' % (os_name, os_ver, os_arch)
         if platform not in grouped:
             grouped[platform] = set()

--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -230,10 +230,9 @@ def find_package(config, pkg_name, os_name, os_code_name, os_arch):
         if not sources:
             print('WARNING: No sources for %s %s' % (os_name, os_code_name), file=sys.stderr)
         for source in sources:
-            for p in [
-                    p for p in source.enumerate_packages(os_name, os_code_name, os_arch)
-                    if p == pkg_name]:
-                return p
+            for p in source.enumerate_packages(os_name, os_code_name, os_arch:
+                if p == pkg_name:
+                    return p
 
 
 def get_package_link(config, pkg, os_name, os_code_name, os_arch):

--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -42,12 +42,27 @@ except ImportError:
 
 
 def is_probably_gzip(response):
+    """
+    Determine if a urllib response is likely gzip'd.
+
+    :param response: the urllib response
+    """
     return (response.url.endswith('.gz') or
             response.getheader('Content-Encoding') == 'gzip' or
             response.getheader('Content-Type') == 'application/x-gzip')
 
 
 def open_gz_url(url, retry=2, retry_period=1, timeout=10):
+    """
+    Open a URL to a possibly gzip'd file.
+
+    :param url: URL to the file.
+    :param retry: number of times to re-attempt the download.
+    :param retry_period: number of seconds to wait between retry attempts.
+    :param timeout: number of seconds to wait for the remote host to respond.
+
+    :returns: file-like object for streaming file data.
+    """
     request = Request(url, headers={'Accept-Encoding': 'gzip'})
     try:
         f = urlopen(request, timeout=timeout)
@@ -70,6 +85,7 @@ def open_gz_url(url, retry=2, retry_period=1, timeout=10):
 
 
 class PackageEntry(str):
+    """Lightweight data bag for information about an entry in a repository."""
 
     __slots__ = ('name', 'version', 'url', 'source_name', 'binary_name')
 
@@ -84,6 +100,15 @@ class PackageEntry(str):
 
 
 class RepositoryCache:
+    """
+    A cache of packages in a repository.
+
+    This class acts as a cache and abstraction layer for the underlying
+    platform-specific package enumeration function. It exposes progressive
+    methods for testing if a package is present and also enumeration that
+    can be performed multiple times without querying the source multiple
+    times.
+    """
 
     def __init__(self, iterator):
         self._cache = set()
@@ -102,6 +127,13 @@ class RepositoryCache:
         return False
 
     def _enumerate_from_source(self):
+        """
+        Enumerate packages directly from the source function.
+
+        When the source has no more packages to yield, this function will also
+        no longer yield any packages. As this function yields packages, they
+        are added to the cache.
+        """
         while self._source_iterator:
             try:
                 val = next(self._source_iterator)
@@ -111,17 +143,40 @@ class RepositoryCache:
                 self._source_iterator = None
 
     def _enumerate_packages(self):
+        """
+        Enumerate all of the packages in the repository.
+
+        Begin by enumerating any previously enumerated and cached packages, then
+        attempt to enumerate any addition packages directly from the source.
+        """
         yield from self._cache
         yield from self._enumerate_from_source()
 
 
 class RepositoryCacheCollection:
+    """
+    A collection of individual repository caches.
+
+    This class represents a collection of individual repositories for each
+    OS, version, and arch, which are all associated with the same basic URL.
+    It will create repository caches as necessary to meet enumeration
+    requests, and will maintain the caches until the instance is deleted.
+    """
 
     def __init__(self, iterator):
         self._cache = {}
         self._iterator = iterator
 
     def enumerate_packages(self, os_name, os_code_name, os_arch):
+        """
+        Enumerate packages in this repository collection for the given platform.
+
+        :param os_name: the name of the OS associated with the packages.
+        :param os_code_name: the OS version associated with the packages.
+        :param os_arch: the system architecture associated with the packages.
+
+        :returns: An enumerable cache of the packages.
+        """
         cache = self._cache.get((os_name, os_code_name, os_arch))
         if not cache:
             cache = RepositoryCache(self._iterator(os_name, os_code_name, os_arch))
@@ -130,6 +185,13 @@ class RepositoryCacheCollection:
 
 
 def summarize_broken_packages(broken):
+    """
+    Create human-readable summary regarding missing packages.
+
+    :param broken: tuples with information about the broken packages.
+
+    :returns: the human-readable summary.
+    """
     # Group and sort by os, version, arch, key
     grouped = {}
 
@@ -146,6 +208,17 @@ def summarize_broken_packages(broken):
 
 
 def find_package(config, pkg_name, os_name, os_code_name, os_arch):
+    """
+    Find a package by name for the given platform.
+
+    :param config: the parsed YAML configuration.
+    :param pkg_name: the name of the package to be found.
+    :param os_name: the name of the OS associated with the package.
+    :param os_code_name: the OS version associated with the package.
+    :param os_arch: the system architecture associated with the package.
+
+    :returns: the parsed package entry, or None if no package was found.
+    """
     if os_name not in config['package_sources']:
         return
 
@@ -164,6 +237,21 @@ def find_package(config, pkg_name, os_name, os_code_name, os_arch):
 
 
 def get_package_link(config, pkg, os_name, os_code_name, os_arch):
+    """
+    Get an informational link about a package.
+
+    This function uses the package_dashboards configuration to attempt to create
+    a URL to an information page regarding a package. If it is unsuccessful, the
+    URL to the package itself is returned.
+
+    :param config: the parsed YAML configuration.
+    :param pkg: the parsed package entry.
+    :param os_name: the name of the OS associated with the package.
+    :param os_code_name: the OS version associated with the package.
+    :param os_arch: the system architecture associated with the package.
+
+    :returns: a URL to a dashboard or package file.
+    """
     for dashboard in config.get('package_dashboards', ()):
         if dashboard['pattern'].match(pkg.url):
             return dashboard['url'].format_map({

--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -230,7 +230,7 @@ def find_package(config, pkg_name, os_name, os_code_name, os_arch):
         if not sources:
             print('WARNING: No sources for %s %s' % (os_name, os_code_name), file=sys.stderr)
         for source in sources:
-            for p in source.enumerate_packages(os_name, os_code_name, os_arch:
+            for p in source.enumerate_packages(os_name, os_code_name, os_arch):
                 if p == pkg_name:
                     return p
 

--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -71,10 +71,13 @@ def open_gz_url(url, retry=2, retry_period=1, timeout=10):
 
 class PackageEntry(str):
 
-    def __new__(cls, name, version, source_name=None, binary_name=None):
+    __slots__ = ('name', 'version', 'url', 'source_name', 'binary_name')
+
+    def __new__(cls, name, version, url, source_name=None, binary_name=None):
         obj = str.__new__(cls, name)
         obj.name = obj
         obj.version = version
+        obj.url = url
         obj.source_name = obj if source_name is None else source_name
         obj.binary_name = obj if binary_name is None else binary_name
         return obj

--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -161,3 +161,21 @@ def find_package(config, pkg_name, os_name, os_code_name, os_arch):
                     p for p in source.enumerate_packages(os_name, os_code_name, os_arch)
                     if p == pkg_name]:
                 return p
+
+
+def get_package_link(config, pkg, os_name, os_code_name, os_arch):
+    for dashboard in config.get('package_dashboards', ()):
+        if dashboard['pattern'].match(pkg.url):
+            return dashboard['url'].format_map({
+                'binary_name': pkg.binary_name,
+                'name': pkg.name,
+                'os_arch': os_arch,
+                'os_code_name': os_code_name,
+                'os_name': os_name,
+                'source_name': pkg.source_name,
+                'url': pkg.url,
+                'version': pkg.version,
+            })
+
+    # No configured dashboard - fall back to package URL
+    return pkg.url

--- a/test/rosdep_repo_check/__main__.py
+++ b/test/rosdep_repo_check/__main__.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import yaml
+
+from . import summarize_broken_packages
+from .config import load_config
+from .verify import verify_rules
+
+
+def main():
+    config = load_config()
+    broken = set()
+
+    repo_root = os.path.join(os.path.dirname(__file__), '..', '..')
+
+    for path in ('rosdep/base.yaml', 'rosdep/python.yaml'):
+        print("Verify all rosdep keys in '%s'" % path)
+        with open(os.path.join(repo_root, path)) as f:
+            data = yaml.safe_load(f)
+        broken.update(verify_rules(config, data, data))
+
+    if broken:
+        print(summarize_broken_packages(broken), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/rosdep_repo_check/config.py
+++ b/test/rosdep_repo_check/config.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import yaml
+
+from .deb import deb_base_url
+from .rpm import rpm_base_url
+
+
+DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
+
+
+def load_deb_base_url(loader, node):
+    base_url, comp = node.value.rsplit(' ', 1)
+    return deb_base_url(base_url, comp)
+
+
+def load_rpm_base_url(loader, node):
+    return rpm_base_url(node.value)
+
+
+yaml.add_constructor(
+    u'!deb_base_url', load_deb_base_url, Loader=yaml.SafeLoader)
+
+
+yaml.add_constructor(
+    u'!rpm_base_url', load_rpm_base_url, Loader=yaml.SafeLoader)
+
+
+def load_config(path=None):
+    with open(path or DEFAULT_CONFIG_PATH) as f:
+        return yaml.safe_load(f)

--- a/test/rosdep_repo_check/config.py
+++ b/test/rosdep_repo_check/config.py
@@ -26,13 +26,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import re
 import yaml
 
 from .deb import deb_base_url
 from .rpm import rpm_base_url
 
 
-DEFAULT_CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml')
+DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'config.yaml')
 
 
 def load_deb_base_url(loader, node):
@@ -44,12 +47,16 @@ def load_rpm_base_url(loader, node):
     return rpm_base_url(node.value)
 
 
+def load_regex(loader, node):
+    return re.compile(node.value)
+
+
 yaml.add_constructor(
     u'!deb_base_url', load_deb_base_url, Loader=yaml.SafeLoader)
-
-
 yaml.add_constructor(
     u'!rpm_base_url', load_rpm_base_url, Loader=yaml.SafeLoader)
+yaml.add_constructor(
+    u'!regular_expression', load_regex, Loader=yaml.SafeLoader)
 
 
 def load_config(path=None):

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -1,0 +1,59 @@
+---
+package_sources:
+  fedora:
+    - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/releases/$releasever/Everything/$basearch/os/
+    - !rpm_base_url https://dl.fedoraproject.org/pub/$distname/linux/updates/$releasever/Everything/$basearch/
+    - !rpm_base_url https://download1.rpmfusion.org/free/$distname/releases/$releasever/Everything/$basearch/os/
+  rhel:
+    - '7':
+      - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/os/$basearch/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/updates/$basearch/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/sclo/$basearch/rh/
+      '8':
+      - !rpm_base_url https://dl.fedoraproject.org/pub/epel/$releasever/Everything/$basearch/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/BaseOS/$basearch/os/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/AppStream/$basearch/os/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/PowerTools/$basearch/os/
+      - !rpm_base_url http://mirror.centos.org/centos-$releasever/$releasever/extras/$basearch/os/
+    - !rpm_base_url https://download1.rpmfusion.org/free/el/updates/$releasever/$basearch/
+  ubuntu:
+    - !deb_base_url http://archive.ubuntu.com/ubuntu main
+    - !deb_base_url http://archive.ubuntu.com/ubuntu universe
+    - !deb_base_url http://archive.ubuntu.com/ubuntu multiverse
+    - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
+
+supported_versions:
+  fedora:
+    - '32'
+    - '33'
+  rhel:
+    - '7'
+    - '8'
+  ubuntu:
+    - xenial
+    - bionic
+    - focal
+
+supported_arches:
+  fedora:
+    - x86_64
+  rhel:
+    - x86_64
+  ubuntu:
+    - amd64
+
+name_replacements:
+  fedora:
+    '32':
+      '%{__isa_name}': 'x86'
+    '33':
+      '%{__isa_name}': 'x86'
+  rhel:
+    '7':
+      '%{__isa_name}': 'x86'
+      '%{python3_pkgversion}': '36'
+    '8':
+      '%{__isa_name}': 'x86'
+      '%{python3_pkgversion}': '3'

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -32,13 +32,12 @@ package_dashboards:
 
 supported_versions:
   fedora:
-    - '32'
     - '33'
+    - '34'
   rhel:
     - '7'
     - '8'
   ubuntu:
-    - xenial
     - bionic
     - focal
 

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -24,6 +24,12 @@ package_sources:
     - !deb_base_url http://archive.ubuntu.com/ubuntu multiverse
     - !deb_base_url http://repos.ros.org/repos/ros_bootstrap main
 
+package_dashboards:
+  - pattern: !regular_expression .*//dl.fedoraproject.org/pub/.*
+    url: https://src.fedoraproject.org/rpms/{source_name}#bodhi_updates
+  - pattern: !regular_expression .*//archive.ubuntu.com/ubuntu/.*
+    url: https://packages.ubuntu.com/{os_code_name}/{binary_name}
+
 supported_versions:
   fedora:
     - '32'

--- a/test/rosdep_repo_check/deb.py
+++ b/test/rosdep_repo_check/deb.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+from . import open_gz_url
+from . import PackageEntry
+from . import RepositoryCacheCollection
+
+
+def enumerate_blocks(url):
+    block = {}
+    key = None
+    with open_gz_url(url) as f:
+        while True:
+            line = f.readline().decode('utf-8')
+            if not len(line):
+                break
+            elif line[0] in ['\r', '\n']:
+                yield block
+                block = {}
+                key = None
+                continue
+            elif line[0] in [' ', '\t']:
+                # This is a list element
+                if not key:
+                    raise ValueError('list element at block beginning')
+                if not isinstance(block[key], list):
+                    block[key] = [block[key]] if block[key] else []
+                block[key].append(line.strip())
+                continue
+            key, val = line.split(':', 1)
+            key = key.strip()
+            val = val.strip()
+            if not key:
+                raise ValueError('empty key')
+            block[key] = val
+    if block:
+        yield block
+
+
+def enumerate_deb_packages(base_url, comp, os_code_name, os_arch):
+    pkgs_url = os.path.join(base_url, 'dists', os_code_name,
+                            comp, 'binary-' + os_arch, 'Packages.gz')
+    print('Reading debian package metadata from ' + pkgs_url)
+    for block in enumerate_blocks(pkgs_url):
+        yield PackageEntry(block['Package'], block['Version'],
+                           block.get('Source', block['Package']))
+
+
+def deb_base_url(base_url, comp):
+    return RepositoryCacheCollection(
+        lambda os_name, os_code_name, os_arch:
+            enumerate_deb_packages(base_url, comp, os_code_name, os_arch))

--- a/test/rosdep_repo_check/deb.py
+++ b/test/rosdep_repo_check/deb.py
@@ -33,6 +33,13 @@ from . import RepositoryCacheCollection
 
 
 def enumerate_blocks(url):
+    """
+    Enumerate blocks of mapped data from a URL to a text file.
+
+    :param url: the URL of the text file.
+
+    :returns: an enumeration of mappings.
+    """
     block = {}
     key = None
     with open_gz_url(url) as f:
@@ -64,6 +71,16 @@ def enumerate_blocks(url):
 
 
 def enumerate_deb_packages(base_url, comp, os_code_name, os_arch):
+    """
+    Enumerate debian packages in a repository.
+
+    :param base_url: the debian repository base URL.
+    :param comp: the component of the repository to enumerate.
+    :param os_code_name: the OS version associated with the repository.
+    :param os_arch: the system architecture associated with the repository.
+
+    :returns: an enumeration of package entries.
+    """
     pkgs_url = os.path.join(base_url, 'dists', os_code_name,
                             comp, 'binary-' + os_arch, 'Packages.gz')
     print('Reading debian package metadata from ' + pkgs_url)
@@ -74,6 +91,13 @@ def enumerate_deb_packages(base_url, comp, os_code_name, os_arch):
 
 
 def deb_base_url(base_url, comp):
+    """
+    Create an enumerable cache for a debian repository.
+
+    :param base_url: the URL of the debian repository.
+
+    :returns: an enumerable repository cache instance.
+    """
     return RepositoryCacheCollection(
         lambda os_name, os_code_name, os_arch:
             enumerate_deb_packages(base_url, comp, os_code_name, os_arch))

--- a/test/rosdep_repo_check/deb.py
+++ b/test/rosdep_repo_check/deb.py
@@ -68,7 +68,8 @@ def enumerate_deb_packages(base_url, comp, os_code_name, os_arch):
                             comp, 'binary-' + os_arch, 'Packages.gz')
     print('Reading debian package metadata from ' + pkgs_url)
     for block in enumerate_blocks(pkgs_url):
-        yield PackageEntry(block['Package'], block['Version'],
+        pkg_url = os.path.join(base_url, block['Filename'])
+        yield PackageEntry(block['Package'], block['Version'], pkg_url,
                            block.get('Source', block['Package']))
 
 

--- a/test/rosdep_repo_check/rpm.py
+++ b/test/rosdep_repo_check/rpm.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from xml.etree import ElementTree
+
+from . import open_gz_url
+from . import PackageEntry
+from . import RepositoryCacheCollection
+
+
+def replace_tokens(string, os_name, os_code_name, os_arch):
+    for key, value in {
+        '$basearch': os_arch,
+        '$distname': os_name,
+        '$releasever': os_code_name,
+    }.items():
+        string = string.replace(key, value)
+    return string
+
+
+def get_primary_name(repomd_url):
+    print('Reading RPM repository metadata from ' + repomd_url)
+    with open_gz_url(repomd_url) as f:
+        tree = iter(ElementTree.iterparse(f, events=('start', 'end')))
+        event, root = next(tree)
+        if root.tag != '{http://linux.duke.edu/metadata/repo}repomd':
+            raise RuntimeError('Invalid root element in repository metadata: ' + root.tag)
+        for event, root_child in tree:
+            if (
+                root_child.tag != '{http://linux.duke.edu/metadata/repo}data' or
+                root_child.attrib.get('type', '') != 'primary'
+            ):
+                root.clear()
+                continue
+            for data_child in root_child:
+                if (
+                    data_child.tag != '{http://linux.duke.edu/metadata/repo}location' or
+                    'href' not in data_child.attrib
+                ):
+                    root.clear()
+                    continue
+                return data_child.attrib['href']
+            root.clear()
+    raise RuntimeError('Failed to determine primary data file name')
+
+
+def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
+    base_url = replace_tokens(base_url, os_name, os_code_name, os_arch)
+    repomd_url = os.path.join(base_url, 'repodata', 'repomd.xml')
+    primary_xml_name = get_primary_name(repomd_url)
+    primary_xml_url = os.path.join(base_url, primary_xml_name)
+    print('Reading RPM primary metadata from ' + primary_xml_url)
+    with open_gz_url(primary_xml_url) as f:
+        tree = iter(ElementTree.iterparse(f, events=('start', 'end')))
+        event, root = next(tree)
+        if root.tag != '{http://linux.duke.edu/metadata/common}metadata':
+            raise RuntimeError('Invalid root element in primary metadata: ' + root.tag)
+        for event, pkg in tree:
+            if (
+                pkg.tag != '{http://linux.duke.edu/metadata/common}package' or
+                pkg.attrib.get('type', '') != 'rpm'
+            ):
+                root.clear()
+                continue
+            pkg_name = None
+            pkg_version = None
+            pkg_src_name = None
+            for pkg_child in pkg:
+                if pkg_child.tag == '{http://linux.duke.edu/metadata/common}name':
+                    pkg_name = pkg_child.text
+                elif pkg_child.tag == '{http://linux.duke.edu/metadata/common}version':
+                    pkg_version = pkg_child.attrib.get('ver')
+                    if pkg_version:
+                        pkg_epoch = pkg_child.attrib.get('epoch', '0')
+                        if pkg_epoch != '0':
+                            pkg_version = pkg_epoch + ':' + pkg_version
+                        pkg_rel = pkg_child.attrib.get('rel')
+                        if pkg_rel:
+                            pkg_version = pkg_version + '-' + pkg_rel
+                elif pkg_child.tag == '{http://linux.duke.edu/metadata/common}format':
+                    for format_child in pkg_child:
+                        if format_child.tag == '{http://linux.duke.edu/metadata/rpm}sourcerpm':
+                            pkg_src_name = format_child.text
+                        if format_child.tag != '{http://linux.duke.edu/metadata/rpm}provides':
+                            continue
+                        for provides in format_child:
+                            if (
+                                provides.tag != '{http://linux.duke.edu/metadata/rpm}entry' or
+                                'name' not in provides.attrib
+                            ):
+                                continue
+                            prov_version = None
+                            if provides.attrib.get('flags', '') == 'EQ':
+                                prov_version = provides.attrib.get('ver')
+                                if prov_version:
+                                    prov_epoch = provides.attrib.get('epoch', '0')
+                                    if prov_epoch != '0':
+                                        prov_version = prov_epoch + ':' + prov_version
+                                    prov_rel = provides.attrib.get('rel')
+                                    if prov_rel:
+                                        prov_version = prov_version + '-' + prov_rel
+                            yield PackageEntry(
+                                provides.attrib['name'], prov_version, pkg_src_name, pkg_name)
+            if pkg_name:
+                yield PackageEntry(pkg_name, pkg_version, pkg_src_name)
+            root.clear()
+
+
+def rpm_base_url(base_url):
+    return RepositoryCacheCollection(
+        lambda os_name, os_code_name, os_arch:
+            enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch))

--- a/test/rosdep_repo_check/rpm.py
+++ b/test/rosdep_repo_check/rpm.py
@@ -86,6 +86,7 @@ def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
             pkg_name = None
             pkg_version = None
             pkg_src_name = None
+            pkg_url = None
             pkg_provs = []
             for pkg_child in element:
                 if pkg_child.tag == '{http://linux.duke.edu/metadata/common}name':
@@ -99,6 +100,10 @@ def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
                         pkg_rel = pkg_child.attrib.get('rel')
                         if pkg_rel:
                             pkg_version = pkg_version + '-' + pkg_rel
+                elif pkg_child.tag == '{http://linux.duke.edu/metadata/common}location':
+                    pkg_href = pkg_child.attrib.get('href')
+                    if pkg_href:
+                        pkg_url = os.path.join(base_url, pkg_href)
                 elif pkg_child.tag == '{http://linux.duke.edu/metadata/common}format':
                     for format_child in pkg_child:
                         if format_child.tag == '{http://linux.duke.edu/metadata/rpm}sourcerpm':
@@ -123,9 +128,9 @@ def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
                                     if prov_rel:
                                         prov_version = prov_version + '-' + prov_rel
                             pkg_provs.append((provides.attrib['name'], prov_version))
-            yield PackageEntry(pkg_name, pkg_version, pkg_src_name)
+            yield PackageEntry(pkg_name, pkg_version, pkg_url, pkg_src_name)
             for prov_name, prov_version in pkg_provs:
-                yield PackageEntry(prov_name, prov_version, pkg_src_name, pkg_name)
+                yield PackageEntry(prov_name, prov_version, pkg_url, pkg_src_name, pkg_name)
             element.clear()
 
 

--- a/test/rosdep_repo_check/rpm.py
+++ b/test/rosdep_repo_check/rpm.py
@@ -34,6 +34,7 @@ from . import RepositoryCacheCollection
 
 
 def replace_tokens(string, os_name, os_code_name, os_arch):
+    """Replace RPM-specific tokens in the repository base URL."""
     for key, value in {
         '$basearch': os_arch,
         '$distname': os_name,
@@ -44,6 +45,7 @@ def replace_tokens(string, os_name, os_code_name, os_arch):
 
 
 def get_primary_name(repomd_url):
+    """Get the URL of the 'primary' metadata from the 'repo' metadata."""
     print('Reading RPM repository metadata from ' + repomd_url)
     with open_gz_url(repomd_url) as f:
         tree = iter(ElementTree.iterparse(f, events=('start', 'end')))
@@ -70,6 +72,16 @@ def get_primary_name(repomd_url):
 
 
 def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
+    """
+    Enumerate packages in an RPM repository.
+
+    :param base_url: the RPM repository base URL.
+    :param os_name: the name of the OS associated with the repository.
+    :param os_code_name: the OS version associated with the repository.
+    :param os_arch: the system architecture associated with the repository.
+
+    :returns: an enumeration of package entries.
+    """
     base_url = replace_tokens(base_url, os_name, os_code_name, os_arch)
     repomd_url = os.path.join(base_url, 'repodata', 'repomd.xml')
     primary_xml_name = get_primary_name(repomd_url)
@@ -135,6 +147,13 @@ def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
 
 
 def rpm_base_url(base_url):
+    """
+    Create an enumerable cache for an RPM repository.
+
+    :param base_url: the URL of the RPM repository.
+
+    :returns: an enumerable repository cache instance.
+    """
     return RepositoryCacheCollection(
         lambda os_name, os_code_name, os_arch:
             enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch))

--- a/test/rosdep_repo_check/suggest.py
+++ b/test/rosdep_repo_check/suggest.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from . import find_package
+
+
+def make_suggestion(config, key, os_name):
+    os_version = config['supported_versions'][os_name][-1]
+    os_arch = config['supported_arches'][os_name][0]
+    # 1) Check for verbatim key
+    suggestion = find_package(config, key, os_name, os_version, os_arch)
+    if suggestion:
+        print("Suggesting '%s' package for %s" % (suggestion.binary_name, os_name))
+        return suggestion
+    else:
+        print("No '%s' package for %s %s (%s). Looking for variants..." % (
+            key, os_name, os_version, os_arch))
+    # 2) Try -devel in place of -dev
+    if key.endswith('-dev'):
+        suggestion = make_suggestion(config, key[:-4] + '-devel', os_name)
+        if suggestion:
+            return suggestion
+    # 3) Try with 'lib' prefix
+    if key.startswith('lib'):
+        suggestion = make_suggestion(config, key[3:], os_name)
+        if suggestion:
+            return suggestion
+    # 4) Try cmake(foo) and pkgconfig(foo)
+    if key.endswith('-devel'):
+        suggestion = make_suggestion(config, 'cmake(' + key[:-6] + ')', os_name)
+        if suggestion:
+            return suggestion
+        suggestion = make_suggestion(config, 'pkgconfig(' + key[:-6] + ')', os_name)
+        if suggestion:
+            return suggestion

--- a/test/rosdep_repo_check/suggest.py
+++ b/test/rosdep_repo_check/suggest.py
@@ -29,6 +29,16 @@ from . import find_package
 
 
 def make_suggestion(config, key, os_name):
+    """
+    Attempt to find packages which may satisfy a key based on the name.
+
+    This function uses heuristics to suggest OS packages which may satisfy a
+    key. Many of the heuristics do not apply to all platforms.
+
+    :param config: the parsed YAML configuration.
+    :param key: the name of the unsatisifed key.
+    :param os_name: the name of the OS associated with the package.
+    """
     os_version = config['supported_versions'][os_name][-1]
     os_arch = config['supported_arches'][os_name][0]
     # 1) Check for verbatim key

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from io import StringIO
+import os
+import pprint
+import subprocess
+import sys
+import unidiff
+import unittest
+import yaml
+
+from .config import load_config
+from .suggest import make_suggestion
+from .verify import verify_rules
+from .yaml import AnnotatedSafeLoader
+from .yaml import isolate_yaml_snippets_from_line_numbers
+
+
+def detect_lines(diffstr):
+    """Take a diff string and return a dict of
+    files with line numbers changed"""
+    resultant_lines = {}
+    # diffstr is already decoded
+    io = StringIO(diffstr)
+    udiff = unidiff.PatchSet(io)
+    for file in udiff:
+        target_lines = []
+        # if file.path in TARGET_FILES:
+        for hunk in file:
+            target_lines += range(hunk.target_start,
+                                  hunk.target_start + hunk.target_length)
+        resultant_lines[file.path] = target_lines
+    return resultant_lines
+
+
+def get_changed_line_numbers():
+    base_ref = 'HEAD^'
+    GITHUB_BASE_REF = os.environ.get('GITHUB_BASE_REF')
+    if GITHUB_BASE_REF:
+        base_ref = 'remotes/origin/' + GITHUB_BASE_REF
+    cmd = ('git diff --unified=0 %s...' % (base_ref,)).split()
+    diff = subprocess.check_output(cmd).decode('utf-8')
+    return detect_lines(diff)
+
+
+class TestRosdepRepositoryCheck(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._changed_lines = get_changed_line_numbers()
+        cls._config = load_config()
+        cls._full_data = {}
+        cls._isolated_data = {}
+        cls._repo_root = os.path.join(os.path.dirname(__file__), '..', '..')
+
+        for path in ('rosdep/base.yaml', 'rosdep/python.yaml'):
+            if path not in cls._changed_lines:
+                continue
+            with open(os.path.join(cls._repo_root, path)) as f:
+                cls._full_data[path] = yaml.load(f, Loader=AnnotatedSafeLoader)
+            isolated_data = isolate_yaml_snippets_from_line_numbers(
+                cls._full_data[path], cls._changed_lines[path])
+            if not isolated_data:
+                continue
+            cls._isolated_data[path] = isolated_data
+            pprint.pprint(isolated_data)
+
+    def test_rosdep_repo_check(self):
+        broken = False
+
+        for path, data in self._isolated_data.items():
+            print("Verifying the following rosdep rules in '%s':" % path)
+            results = verify_rules(self._config, data, self._full_data[path])
+            for os_name, os_ver, os_arch, key, package in results:
+                broken = True
+                print(
+                    '\n::error file=%s,line=%d::'
+                    "Package '%s' could not be found for %s %s on %s" % (
+                        path, getattr(os_ver, '__line__', os_name.__line__),
+                        package, os_name, os_ver, os_arch),
+                    file=sys.stderr)
+
+        assert not broken, 'New rules contain packages not present in repositories'
+
+    def test_eol_versions(self):
+        excess = False
+
+        for path, data in self._isolated_data.items():
+            print("Checking for EOL rules in '%s':" % path)
+            for key, rules in data.items():
+                for os_name, os_rules in rules.items():
+                    if os_name not in self._config['supported_versions'] or os_name == 'ubuntu':
+                        continue
+                    if not isinstance(os_rules, dict):
+                        continue
+                    if 'pip' in os_rules:
+                        continue
+                    versions = set(v for v in os_rules.keys() if v != '*')
+                    versions.difference_update(self._config['supported_versions'][os_name])
+                    for version in versions:
+                        excess = True
+                        print(
+                            '\n::error file=%s,line=%d::'
+                            "New rules contain unsupported %s version '%s'" % (
+                                path, version.__line__, os_name, version), file=sys.stderr)
+
+        assert not excess, 'New rules contain unsupported OS versions'
+
+    def test_suggest_by_name(self):
+        for path, data in self._isolated_data.items():
+            print("Looking for name-based suggestions in '%s':" % path)
+            for key in data.keys():
+                if key.endswith('-pip'):
+                    # Ignore pip stuff to save time
+                    continue
+                if getattr(key, '__line__', None) not in self._changed_lines[path]:
+                    continue
+                rules = self._full_data[path][key]
+                missing_os_names = set(
+                    self._config['supported_versions'].keys()).difference(rules.keys())
+                for missing_os in missing_os_names:
+                    print('Looking for suggestions for %s on %s' % (key, missing_os))
+                    suggestion = make_suggestion(self._config, key, missing_os)
+                    if suggestion:
+                        print(
+                            '\n::warning file=%s,line=%d::'
+                            "Key '%s' might be satisifed by %s package named '%s'" % (
+                                path, key.__line__, key, missing_os, suggestion.binary_name),
+                            file=sys.stderr)

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -118,30 +118,6 @@ class TestRosdepRepositoryCheck(unittest.TestCase):
 
         assert not broken, 'New rules contain packages not present in repositories'
 
-    def test_eol_versions(self):
-        excess = False
-
-        for path, data in self._isolated_data.items():
-            print("Checking for EOL rules in '%s':" % path)
-            for key, rules in data.items():
-                for os_name, os_rules in rules.items():
-                    if os_name not in self._config['supported_versions'] or os_name == 'ubuntu':
-                        continue
-                    if not isinstance(os_rules, dict):
-                        continue
-                    if 'pip' in os_rules:
-                        continue
-                    versions = set(v for v in os_rules.keys() if v != '*')
-                    versions.difference_update(self._config['supported_versions'][os_name])
-                    for version in versions:
-                        excess = True
-                        print(
-                            '\n::error file=%s,line=%d::'
-                            "New rules contain unsupported %s version '%s'" % (
-                                path, version.__line__, os_name, version), file=sys.stderr)
-
-        assert not excess, 'New rules contain unsupported OS versions'
-
     def test_suggest_by_name(self):
         for path, data in self._isolated_data.items():
             print("Looking for name-based suggestions in '%s':" % path)

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -43,8 +43,7 @@ from .yaml import isolate_yaml_snippets_from_line_numbers
 
 
 def detect_lines(diffstr):
-    """Take a diff string and return a dict of
-    files with line numbers changed"""
+    """Take a diff string and return a dict of files with line numbers changed."""
     resultant_lines = {}
     # diffstr is already decoded
     io = StringIO(diffstr)

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -96,7 +96,7 @@ class TestRosdepRepositoryCheck(unittest.TestCase):
         for path, data in self._isolated_data.items():
             print("Verifying the following rosdep rules in '%s':" % path)
             results = verify_rules(self._config, data, self._full_data[path])
-            for os_name, os_ver, os_arch, key, package in results:
+            for os_name, os_ver, os_arch, key, package, _ in results:
                 broken = True
                 print(
                     '\n::error file=%s,line=%d::'

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -63,8 +63,9 @@ def get_changed_line_numbers():
     GITHUB_BASE_REF = os.environ.get('GITHUB_BASE_REF')
     if GITHUB_BASE_REF:
         base_ref = 'remotes/origin/' + GITHUB_BASE_REF
-    cmd = ('git diff --unified=0 %s...' % (base_ref,)).split()
-    diff = subprocess.check_output(cmd).decode('utf-8')
+    cmd = 'git diff --unified=0 %s... -- rosdep' % (base_ref,)
+    print("Detecting changed rules with '%s'" % (cmd,))
+    diff = subprocess.check_output(cmd.split()).decode('utf-8')
     return detect_lines(diff)
 
 

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -45,12 +45,10 @@ from .yaml import isolate_yaml_snippets_from_line_numbers
 def detect_lines(diffstr):
     """Take a diff string and return a dict of files with line numbers changed."""
     resultant_lines = {}
-    # diffstr is already decoded
     io = StringIO(diffstr)
     udiff = unidiff.PatchSet(io)
     for file in udiff:
         target_lines = []
-        # if file.path in TARGET_FILES:
         for hunk in file:
             target_lines += range(hunk.target_start,
                                   hunk.target_start + hunk.target_length)

--- a/test/rosdep_repo_check/verify.py
+++ b/test/rosdep_repo_check/verify.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from . import find_package
+
+
+def verify_rules(config, rules_to_check, all_rules):
+    for key, rules in rules_to_check.items():
+        if key == '__line__':
+            continue
+        # print("Verifying rosdep key '%s'" % key)
+        for os_name, os_rules in rules.items():
+            if os_name not in config['package_sources']:
+                continue
+            packages_to_check = {}
+            if not isinstance(os_rules, dict):
+                for os_ver in config['supported_versions'].get(os_name, ()):
+                    packages_to_check[os_ver] = os_rules
+            else:
+                packages_to_check = os_rules
+                if '*' in os_rules:
+                    for os_ver in config['supported_versions'].get(os_name, ()):
+                        if os_ver not in all_rules[key][os_name]:
+                            packages_to_check.setdefault(os_ver, os_rules.get('*') or [])
+            for os_ver, packages in packages_to_check.items():
+                if os_ver == '__line__' or os_ver == '*':
+                    continue
+                if os_ver not in config['supported_versions'].get(os_name, ()):
+                    continue
+                for package in packages or []:
+                    for needle, haystack in config['name_replacements'].get(
+                            os_name, {}).get(os_ver, {}).items():
+                        package = package.replace(needle, haystack)
+                    for os_arch in config['supported_arches'][os_name]:
+                        res = find_package(config, package, os_name, os_ver, os_arch)
+                        if not res:
+                            yield (os_name, os_ver, os_arch, key, package)

--- a/test/rosdep_repo_check/verify.py
+++ b/test/rosdep_repo_check/verify.py
@@ -29,6 +29,25 @@ from . import find_package
 
 
 def verify_rules(config, rules_to_check, all_rules, include_found=False):
+    """
+    Verify rosdep rules for supported platforms.
+
+    For all platforms supported in the YAML configuration, verify that the
+    repositories contain the packages listed in the rosdep rules.
+
+    :param config: the parsed YAML configuration.
+    :param rules_to_check: rosdep rules to be checked.
+    :param all_rules: full rosdep rules to check for individual version rules.
+    :param include_found: in addition to missing rules, also yield those found.
+
+    :returns: a tuple of:
+        - OS name
+        - OS version
+        - OS architecture
+        - rosdep key
+        - package name
+        - corresponding package entry, if found
+    """
     for key, rules in rules_to_check.items():
         for os_name, os_rules in rules.items():
             if os_name not in config['package_sources']:

--- a/test/rosdep_repo_check/yaml.py
+++ b/test/rosdep_repo_check/yaml.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2021, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import yaml
+
+
+class AnnotatedSafeLoader(yaml.SafeLoader):
+
+    class AnnotatedDict(dict):
+
+        __slots__ = ('__line__',)
+
+        def __init__(self, *args, **kwargs):
+            return super().__init__(*args, **kwargs)
+
+    class AnnotatedList(list):
+
+        __slots__ = ('__line__',)
+
+        def __init__(self, *args, **kwargs):
+            return super().__init__(*args, **kwargs)
+
+    class AnnotatedStr(str):
+
+        __slots__ = ('__line__',)
+
+        def __new__(cls, *args, **kwargs):
+            return str.__new__(cls, *args, **kwargs)
+
+    def compose_node(self, parent, index):
+        line = self.line
+        node = super().compose_node(parent, index)
+        node.__line__ = line + 1
+        return node
+
+    def construct_annotated_map(self, node):
+        data = AnnotatedSafeLoader.AnnotatedDict()
+        data.__line__ = node.__line__
+        yield data
+        value = self.construct_mapping(node)
+        data.update(value)
+
+    def construct_annotated_seq(self, node):
+        data = AnnotatedSafeLoader.AnnotatedList()
+        data.__line__ = node.__line__
+        yield data
+        data.extend(self.construct_sequence(node))
+
+    def construct_annotated_str(self, node):
+        data = self.construct_yaml_str(node)
+        data = AnnotatedSafeLoader.AnnotatedStr(data)
+        data.__line__ = node.__line__
+        return data
+
+
+AnnotatedSafeLoader.add_constructor(
+    'tag:yaml.org,2002:map', AnnotatedSafeLoader.construct_annotated_map)
+AnnotatedSafeLoader.add_constructor(
+    'tag:yaml.org,2002:seq', AnnotatedSafeLoader.construct_annotated_seq)
+AnnotatedSafeLoader.add_constructor(
+    'tag:yaml.org,2002:str', AnnotatedSafeLoader.construct_annotated_str)
+
+
+def merge_dict(base, to_add):
+    for k, v in to_add.items():
+        if isinstance(v, dict) and isinstance(base.get(k), dict):
+            merge_dict(base[k], v)
+        else:
+            base[k] = v
+
+
+def isolate_yaml_snippets_from_line_numbers(yaml_dict, line_numbers):
+    matches = {}
+
+    for dl in line_numbers:
+        for name, values in reversed(yaml_dict.items()):
+            if name == '__line__':
+                continue
+            if isinstance(values, AnnotatedSafeLoader.AnnotatedDict):
+                if values.__line__ <= dl:
+                    merge_dict(matches,
+                               {name: isolate_yaml_snippets_from_line_numbers(values, [dl])})
+                    break
+            elif isinstance(values, AnnotatedSafeLoader.AnnotatedList):
+                if values.__line__ <= dl:
+                    matches[name] = values
+                    break
+    return matches


### PR DESCRIPTION
This change adds a small system for checking rosdep rules against the current package repositories for supported platforms.

It currently supports three platforms:
- Ubuntu
- Fedora
- RHEL

During a typical rosdep test invocation, it uses a similar mechanism as the one which verifies URLs to detect which lines were added or modified by the latest change, and reviews only those rules.

The algorithm is optimized such that the sources are listed in the order they are checked for the package, and parsing of the repository metadata begins before the download is even completed. This means that presence in the platform repositories can be determined very quickly.

If multiple package names were added or modified, the algorithm first checks the data that has already been parsed and then continues parsing metadata until the package is found or the repository list is exhausted.

To review the entire rosdep database and not only the rules that were changed in the most recent commit, it is also possible to invoke the test as a python module. For example:

`PYTHONPATH=test python3 -m rosdep_repo_check`

This system is currently identifying many missing packages throughout rosdep. We should review these issues at some point, but this system should help to prevent more problematic rules from being added.
