### PR TITLE
rqt_graph: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2311,7 +2311,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.2.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.1.1-1`

## rqt_graph

```
* Make topics that have qos incompatibilities red in the graph, add information to the node tooltip (#61 <https://github.com/ros-visualization/rqt_graph/issues/61>)
* Add node name, topic name, and endpoint kind to the qos edge tooltip (#60 <https://github.com/ros-visualization/rqt_graph/issues/60>)
* Contributors: Ivan Santiago Paunovic
```
