### PR TITLE
picovoice-ros 0.0.2-1

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4783,6 +4783,24 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: noetic
     status: developed
+  picovoice-ros:
+    doc:
+      type: git
+      url: https://github.com/reinzor/picovoice_ros.git
+      version: main
+    release:
+      packages:
+      - picovoice_driver
+      - picovoice_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/reinzor/picovoice_ros-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/reinzor/picovoice_ros.git
+      version: main
+    status: maintained
   pid:
     doc:
       type: git


### PR DESCRIPTION
## Picovoice ROS wrappers

- Rhino speech to intent node
- Porcupine speech to keyword node (hot word detection)

upstream repository: https://github.com/reinzor/picovoice_ros.git
release repository: https://github.com/reinzor/picovoice_ros-release.git