### PR TITLE
kinetic: index abb_robot_driver_interfaces

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -58,6 +58,10 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
       version: master
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
+      version: master
     status: developed
   abseil_cpp:
     doc:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -53,6 +53,12 @@ repositories:
       url: https://github.com/ros-industrial/abb_experimental.git
       version: kinetic-devel
     status: developed
+  abb_robot_driver_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
+      version: master
+    status: developed
   abseil_cpp:
     doc:
       type: git


### PR DESCRIPTION
Enable indexing of `ros-industrial/abb_robot_driver_interfaces` for Kinetic.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
