### PR TITLE
melodic: index abb_robot_driver_interfaces

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -39,6 +39,12 @@ repositories:
       url: https://github.com/ros-industrial/abb_driver.git
       version: kinetic-devel
     status: maintained
+  abb_robot_driver_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
+      version: master
+    status: developed
   abseil_cpp:
     doc:
       type: git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -44,6 +44,10 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
       version: master
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
+      version: master
     status: developed
   abseil_cpp:
     doc:


### PR DESCRIPTION
Enable indexing of `ros-industrial/abb_robot_driver_interfaces` for Melodic.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
