### PR TITLE
noetic: index abb_robot_driver_interfaces

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10,6 +10,12 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  abb_robot_driver_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
+      version: master
+    status: developed
   ackermann_msgs:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -15,6 +15,10 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
       version: master
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
+      version: master
     status: developed
   ackermann_msgs:
     doc:


### PR DESCRIPTION
Enable indexing of `ros-industrial/abb_robot_driver_interfaces` for Noetic.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
