### PR TITLE
[dep] Add ack

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3,6 +3,11 @@ ace:
   debian: [libace-dev]
   gentoo: [dev-libs/ace]
   ubuntu: [libace-dev]
+ack:
+  debian: [ack]
+  ubuntu:
+    '*': [ack]
+    xenial: null
 ack-grep:
   arch: [ack]
   debian: [ack-grep]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`ack`

## Links to Distribution Packages

-    Arch https://www.archlinux.org/packages/community/any/ack/
-    Debian https://packages.debian.org/search?keywords=ack
-    Fedora http://rpmfind.net/linux/rpm2html/search.php?query=ack
-    Gentoo https://packages.gentoo.org/packages/sys-apps/ack
-    Ubuntu https://packages.ubuntu.com/search?keywords=ack

## Purpose of using this:

shell command util to make shell scripting easier.

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

## Problem
There's already `ack-grep` added in https://github.com/ros/rosdistro/pull/19272, where the key points to `ack` for some distros. With that, the state of this commit/PR opens up the follwing questions/concerns:
- Removing `ack-grep` rosdep key would break some downstream usecases.
- For some distros, rosdep key `ack-grep` references to `ack`, but rosdep key `ack` does not.
