### PR TITLE
oroca_rqt_command: 0.6.0-3 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -2153,6 +2153,21 @@ repositories:
       type: git
       url: https://github.com/alvaro0308/optic.git
       version: foxy-devel
+  oroca_rqt_command:
+    doc:
+      type: git
+      url: https://github.com/oroca/oroca-rqt-command.git
+      version: foxy
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/oroca-release/oroca_rqt_command-release.git
+      version: 0.6.0-3
+    source:
+      type: git
+      url: https://github.com/oroca/oroca-rqt-command.git
+      version: foxy
+    status: developed
   orocos_kinematics_dynamics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oroca_rqt_command` to `0.6.0-3`:

- upstream repository: https://github.com/oroca/oroca-rqt-command.git
- release repository: https://github.com/oroca-release/oroca_rqt_command-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## oroca_rqt_command

```
* Modified pkg name to binary release
* Contributors: Pyo
```
