### PR TITLE
denso_robot_ros: 3.1.1-2 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2159,7 +2159,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DENSORobot/denso_robot_ros-release.git
-      version: 3.1.1-1
+      version: 3.1.1-2
     source:
       type: git
       url: https://github.com/DENSORobot/denso_robot_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `denso_robot_ros` to `3.1.1-2`:

- upstream repository: https://github.com/DENSORobot/denso_robot_ros.git
- release repository: https://github.com/DENSORobot/denso_robot_ros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `3.1.1-1`

## bcap_core

```
* Change the symbolic link to the directory of include/bcap_core
* Fix the install section in CMakeLists.txt for build.ros.org failure
```

## bcap_service

- No changes

## bcap_service_test

- No changes

## denso_robot_bringup

- No changes

## denso_robot_control

```
* Add ros::spinOnce() for the callbacks.
```

## denso_robot_core

- No changes

## denso_robot_core_test

- No changes

## denso_robot_descriptions

```
* Fix Controller ABORTED ([#5](https://github.com/DENSORobot/denso_robot_ros/issues/5))
```

## denso_robot_gazebo

- No changes

## denso_robot_moveit_config

- No changes

## denso_robot_ros

- No changes
