### PR TITLE
urg_node: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2974,7 +2974,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node-release.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `1.1.0-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros2-gbp/urg_node-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.2-1`

## urg_node

```
* Merge pull request #86 <https://github.com/ros-drivers/urg_node/issues/86> from ros-drivers/clalancette/galactic-fixes
  Fixes for ROS 2 Galactic
* Don't error out on unknown parameter names.
  In general, parameter callbacks should not error out on unknown
  parameter names.  That's because a) the callbacks may be
  chained, and b) there may be internal parameters that are used.
  Just ignore anything we don't know about.
* Switch to PRIu32 for printing a uint32_t.
  This just ensures that it works on all platforms, and
  removes a warning on Galactic.
* Fix rclcpp::Duration construction.
  As of Galactic, initializing an rclcpp::Duration with just
  a number is deprecated.  We now have to explicitly tell it
  the units of the number, generally done through std::chrono.
* Remove unused reconfigure method.
* Contributors: Chris Lalancette, Michael Ferguson
```
