### PR TITLE
urg_node: 1.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4717,7 +4717,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node-release.git
-      version: 1.0.1-1
+      version: 1.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `1.0.3-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros2-gbp/urg_node-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.0.1-1`

## urg_node

```
* Use Python 3 specifically in helper script (#85 <https://github.com/ros-drivers/urg_node/issues/85>)
  ROS 2 only targets Python 3. Making the shebang specific will ensure it
  isn't accidentally executed using the Python 2 interpreter.
* travis-ci doesn't work
  But ros build farm is giving us coverage
* depend only on parts of boost needed by the package (#75 <https://github.com/ros-drivers/urg_node/issues/75>)
* Contributors: Michael Ferguson, Mikael Arguedas, Scott K Logan
```
