### PR TITLE
ros2_tracing: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1887,7 +1887,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/ros-tracing/ros2_tracing-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `2.3.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/ros2_tracing.git
- release repository: https://gitlab.com/ros-tracing/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.2.0-1`

## tracetools

```
* Update QD to be more specific about public API
* Namespace tracetools C++ functions and macros and deprecate current ones
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Update after namespacing C++ tracetools functions and macros
* Contributors: Christophe Bedard
```
