### PR TITLE
rclcpp: 8.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1601,7 +1601,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 8.1.0-1
+      version: 8.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `8.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `8.1.0-1`

## rclcpp

```
* Initialize integers in test_parameter_event_handler.cpp to avoid undefined behavior (#1609 <https://github.com/ros2/rclcpp/issues/1609>)
* Namespace tracetools C++ functions (#1608 <https://github.com/ros2/rclcpp/issues/1608>)
* Revert "Namespace tracetools C++ functions (#1603 <https://github.com/ros2/rclcpp/issues/1603>)" (#1607 <https://github.com/ros2/rclcpp/issues/1607>)
* Namespace tracetools C++ functions (#1603 <https://github.com/ros2/rclcpp/issues/1603>)
* Clock subscription callback group spins in its own thread (#1556 <https://github.com/ros2/rclcpp/issues/1556>)
* Contributors: Chris Lalancette, Christophe Bedard, Ivan Santiago Paunovic, anaelle-sw
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Fix flaky lifecycle node tests (#1606 <https://github.com/ros2/rclcpp/issues/1606>)
* Clock subscription callback group spins in its own thread (#1556 <https://github.com/ros2/rclcpp/issues/1556>)
* Delete debug messages (#1602 <https://github.com/ros2/rclcpp/issues/1602>)
* add automatically_add_executor_with_node option (#1594 <https://github.com/ros2/rclcpp/issues/1594>)
* Contributors: BriceRenaudeau, Ivan Santiago Paunovic, Jacob Perron, anaelle-sw
```
