### PR TITLE
franka_ros: 0.7.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2053,14 +2053,16 @@ repositories:
       packages:
       - franka_control
       - franka_description
+      - franka_example_controllers
       - franka_gripper
       - franka_hw
       - franka_msgs
+      - franka_ros
       - franka_visualization
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/frankaemika/franka_ros-release.git
-      version: 0.7.1-1
+      version: 0.7.1-2
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros` to `0.7.1-2`:

- upstream repository: https://github.com/frankaemika/franka_ros.git
- release repository: https://github.com/frankaemika/franka_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.7.1-1`
