### PR TITLE
tracetools_analysis: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2768,7 +2768,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
-      version: 1.0.2-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `2.0.0-1`:

- upstream repository: https://gitlab.com/ros-tracing/tracetools_analysis.git
- release repository: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.0.2-2`

## tracetools_analysis

```
* Set callback_instances' timestamp & duration cols to datetime/timedelta
* Improve performance by using lists of dicts as intermediate storage & converting to dataframes at the end
* Update callback_duration notebook and pingpong sample data
* Support instrumentation for linking a timer to a node
* Disable kernel tracing for pingpong example launchfile
* Support lifecycle node state transition instrumentation
* Contributors: Christophe Bedard
```
