### PR TITLE
[dep] Add python3-colcon-common-extensions

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5750,6 +5750,11 @@ python3-click:
   openembedded: [python3-click@meta-python]
   rhel: ['python%{python3_pkgversion}-click']
   ubuntu: [python3-click]
+python3-colcon-common-extensions:
+  debian: [python3-colcon-common-extensions]
+  fedora: [python3-colcon-common-extensions]
+  rhel: ['python%{python3_pkgversion}-colcon-common-extensions']
+  ubuntu: [python3-colcon-common-extensions]
 python3-collada:
   debian:
     '*': [python3-collada]


### PR DESCRIPTION
## Package name:

`python3-colcon-common-extensions`

## Purpose of using this:

Allow `rosdep install` to install `colcon`. 

## Links to Distribution Packages

- debian e.g. buster http://packages.ros.org/ros/ubuntu/dists/buster/main/binary-amd64/Packages
- fedora https://src.fedoraproject.org/rpms/python-colcon-common-extensions#bodhi_updates
- ubuntu e.g. xenial http://packages.ros.org/ros/ubuntu/dists/xenial/main/binary-amd64/Packages

## Problem

- I have no idea if this is the right way to achieve installing `colcon` via `rosdep. As asked at [answers.ros.org#q374424](https://answers.ros.org/question/374424/install-colcon-via-rosdep-install/), I can't find a way to achieve that.
- Choice of the package is from [colcon.readthedocs.io](https://colcon.readthedocs.io/en/released/user/installation.html) that recommends installing this pkg to use `colcon`.
