### PR TITLE
add ubjson

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5113,6 +5113,13 @@ python-tzlocal-pip:
   ubuntu:
     pip:
       packages: [tzlocal]
+python-ubjson:
+  debian: [python-ubjson]
+  ubuntu:
+    '*': [python-ubjson]
+    xenial:
+      pip:
+        packages: [py-ubjson]
 python-ujson:
   debian:
     buster: [python-ujson]
@@ -7341,6 +7348,11 @@ python3-twisted:
     '*': ['python%{python3_pkgversion}-twisted']
     '7': null
   ubuntu: [python3-twisted]
+python3-ubjson:
+  debian: [python3-ubjson]
+  ubuntu:
+    '*': [python3-ubjson]
+    xenial: null
 python3-urllib3:
   debian: [python3-urllib3]
   fedora: [python3-urllib3]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-ubjson / python3-ubjson

## Package Upstream Source:
https://pypi.org/project/py-ubjson/

## Purpose of using this:

We use it to serialize ros messages over mqtt

Distro packaging links:


- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-ubjson
  - https://packages.debian.org/buster/python-ubjson
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/bionic/python-ubjson
   - https://packages.ubuntu.com/bionic/python3-ubjson
