### PR TITLE
add python3-paho-mqtt/python-paho-mqtt

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2941,6 +2941,11 @@ python-packaging:
   debian: [python-packaging]
   fedora: [python-packaging]
   ubuntu: [python-packaging]
+python-paho-mqtt:
+  debian:
+    buster: [python-paho-mqtt]
+  ubuntu:
+    bionic: [python-paho-mqtt]
 python-paho-mqtt-pip:
   ubuntu:
     pip:
@@ -6445,6 +6450,11 @@ python3-packaging:
   openembedded: [python3-packaging@openembedded-core]
   rhel: ['python%{python3_pkgversion}-packaging']
   ubuntu: [python3-packaging]
+python3-paho-mqtt:
+  debian: [python3-paho-mqtt]
+  ubuntu:
+    '*': [python3-paho-mqtt]
+    xenial: null
 python3-pandas:
   debian: [python3-pandas]
   fedora: [python3-pandas]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python-paho-mqtt

## Package Upstream Source:

https://www.eclipse.org/paho/

## Purpose of using this:

Used e.g. by mqtt bridge. There is an existing pip python2 packages. I kept it to not break existing code but added the system dependencies, I also added the python3 package, since it does not exist ye.

Distro packaging links:

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-paho-mqtt
  - https://packages.debian.org/buster/python-paho-mqtt
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/bionic/python3-paho-mqtt
   - https://packages.ubuntu.com/bionic/python-paho-mqtt




