### PR TITLE
iceoryx: 0.99.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -812,6 +812,22 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: devel
     status: maintained
+  iceoryx:
+    release:
+      packages:
+      - cpptoml_vendor
+      - iceoryx_binding_c
+      - iceoryx_posh
+      - iceoryx_utils
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ApexAI/iceoryx-release.git
+      version: 0.99.0-1
+    source:
+      type: git
+      url: https://github.com/eclipse-iceoryx/iceoryx.git
+      version: master
+    status: developed
   ifm3d_core:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `iceoryx` to `0.99.0-1`:

- upstream repository: https://github.com/eclipse-iceoryx/iceoryx.git
- release repository: https://github.com/ApexAI/iceoryx-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`
