### PR TITLE
ros2_socketcan: 1.0.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3306,6 +3306,21 @@ repositories:
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
       version: foxy-devel
     status: developed
+  ros2_socketcan:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/ros2_socketcan.git
+      version: main
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/autowarefoundation/ros2_socketcan-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/ros2_socketcan.git
+      version: main
+    status: developed
   ros2_tracing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_socketcan` to `1.0.0-1`:

- upstream repository: https://github.com/autowarefoundation/ros2_socketcan.git
- release repository: https://github.com/autowarefoundation/ros2_socketcan-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## ros2_socketcan

```
* Initial release
* Initial port from Autoware.Auto
* Initial commit
* Contributors: Joshua Whitley, Kenji Miyake, wep21
```
