### PR TITLE
rosserial: 0.9.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6352,7 +6352,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rosserial-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosserial` to `0.9.2-1`:

- upstream repository: https://github.com/ros-drivers/rosserial.git
- release repository: https://github.com/ros-gbp/rosserial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.9.1-1`

## rosserial

- No changes

## rosserial_arduino

```
* Fix CMP0038 warning in arduino-cmake (#553 <https://github.com/ros-drivers/rosserial/issues/553>)
* Python3 import fix for rosserial_arduino (#554 <https://github.com/ros-drivers/rosserial/issues/554>)
* Contributors: Marco Camurri, Vasily Fedotov
```

## rosserial_chibios

- No changes

## rosserial_client

```
* Use shutil.copyfile() instead of shutil.copy() (#530 <https://github.com/ros-drivers/rosserial/issues/530>)
* Changed C++ STL include and code into original C versions (#525 <https://github.com/ros-drivers/rosserial/issues/525>)
* Contributors: Ben Wolsieffer, Rafael Oliveira
```

## rosserial_embeddedlinux

- No changes

## rosserial_mbed

- No changes

## rosserial_msgs

- No changes

## rosserial_python

```
* Adds a shutdown hook for sending txStopRequest (#551 <https://github.com/ros-drivers/rosserial/issues/551>)
* Gracefully handle socket server end. (#550 <https://github.com/ros-drivers/rosserial/issues/550>)
* Contributors: Can Altineller, Karl Kangur
```

## rosserial_server

```
* Add python3-dev as build depend (#544 <https://github.com/ros-drivers/rosserial/issues/544>)
* Contributors: Tobias Fischer
```

## rosserial_tivac

- No changes

## rosserial_vex_cortex

```
* Fix header mismatch in changelog.
* Contributors: Mike Purvis
```

## rosserial_vex_v5

- No changes

## rosserial_windows

- No changes

## rosserial_xbee

- No changes
