### PR TITLE
tracetools_analysis: 1.0.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4469,7 +4469,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
-      version: 1.0.1-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://gitlab.com/ros-tracing/tracetools_analysis.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `1.0.3-1`:

- upstream repository: https://gitlab.com/ros-tracing/tracetools_analysis.git
- release repository: https://gitlab.com/ros-tracing/tracetools_analysis-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.0.1-1`

## tracetools_analysis

```
* Improve performance by using lists of dicts as intermediate storage & converting to dataframes at the end
* Contributors: Christophe Bedard
```
