### PR TITLE
fanuc: 0.5.1-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -3506,7 +3506,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/fanuc-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros-industrial/fanuc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.5.1-1`:

- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.5.0-1`

## fanuc_cr35ia_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_cr7ia_support

```
* correct joint limits (#310 <https://github.com/ros-industrial/fanuc/issues/310>).
* add note on correctness of joint limits (collaborative controller).
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_driver

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* mark all IKFast plugins as deprecated (#302 <https://github.com/ros-industrial/fanuc/issues/302>).
* disable gitattributes temporarily (#299 <https://github.com/ros-industrial/fanuc/issues/299>).
* add note to readme about performance (#295 <https://github.com/ros-industrial/fanuc/issues/295>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* add note to readme about limitations (#283 <https://github.com/ros-industrial/fanuc/issues/283>).
* add comments to movesm TP program (#280 <https://github.com/ros-industrial/fanuc/issues/280>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_lrmate200i_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_lrmate200ib_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* specify OPW joint offsets in degrees (#293 <https://github.com/ros-industrial/fanuc/issues/293>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* add OPW kinematics parameter files (#284 <https://github.com/ros-industrial/fanuc/issues/284>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
* contributors: Jeroen de Maeyer, gavanderhoorn
```

## fanuc_lrmate200ic_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* specify OPW joint offsets in degrees (#293 <https://github.com/ros-industrial/fanuc/issues/293>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* add OPW kinematics parameter files (#284 <https://github.com/ros-industrial/fanuc/issues/284>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
* contributors: Jeroen de Maeyer, gavanderhoorn
```

## fanuc_m10ia_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* specify OPW joint offsets in degrees (#293 <https://github.com/ros-industrial/fanuc/issues/293>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* add OPW kinematics parameter files (#284 <https://github.com/ros-industrial/fanuc/issues/284>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
* contributors: Jeroen de Maeyer, gavanderhoorn
```

## fanuc_m16ib_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* specify OPW joint offsets in degrees (#293 <https://github.com/ros-industrial/fanuc/issues/293>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* add OPW kinematics parameter files (#284 <https://github.com/ros-industrial/fanuc/issues/284>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
* contributors: Jeroen de Maeyer, gavanderhoorn
```

## fanuc_m20ia_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* specify OPW joint offsets in degrees (#293 <https://github.com/ros-industrial/fanuc/issues/293>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* add OPW kinematics parameter files (#284 <https://github.com/ros-industrial/fanuc/issues/284>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
* contributors: Jeroen de Maeyer, gavanderhoorn
```

## fanuc_m20ib_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_m430ia_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_m6ib_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* specify OPW joint offsets in degrees (#293 <https://github.com/ros-industrial/fanuc/issues/293>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* add OPW kinematics parameter files (#284 <https://github.com/ros-industrial/fanuc/issues/284>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* add M-6iB/6S variant support (#277 <https://github.com/ros-industrial/fanuc/issues/277>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
* contributors: Jeroen de Maeyer, Joao Santos, gavanderhoorn
```

## fanuc_m710ic_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* correct joint limits of the ``/45M`` variant (#291 <https://github.com/ros-industrial/fanuc/issues/291>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_m900ia_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_m900ib_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_r1000ia_support

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* correct missing dependency on ``industrial_robot_client`` (RViz cfg) (#306 <https://github.com/ros-industrial/fanuc/issues/306>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* remove roslaunch version requirements as they're no longer needed (#278 <https://github.com/ros-industrial/fanuc/issues/278>).
* migrate to JSP GUI (was split out of JSP).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```

## fanuc_resources

```
* bump min CMake version (#309 <https://github.com/ros-industrial/fanuc/issues/309>).
* point to manifest for info on package contents (#292 <https://github.com/ros-industrial/fanuc/issues/292>).
* for a complete list of changes see the commit log for 0.5.1 <https://github.com/ros-industrial/fanuc/compare/0.5.0...0.5.1>.
```
