### PR TITLE
abb_robot_driver_interfaces: 0.5.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -44,6 +44,16 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
       version: master
+    release:
+      packages:
+      - abb_egm_msgs
+      - abb_rapid_msgs
+      - abb_rapid_sm_addin_msgs
+      - abb_robot_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb_robot_driver_interfaces-release.git
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb_robot_driver_interfaces` to `0.5.2-1`:

- upstream repository: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
- release repository: https://github.com/ros-industrial-release/abb_robot_driver_interfaces-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## abb_egm_msgs

```
* Install readme and license (#12 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/12>)
* Contributors: gavanderhoorn
```

## abb_rapid_msgs

```
* Install readme and license (#12 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/12>)
* Contributors: gavanderhoorn
```

## abb_rapid_sm_addin_msgs

```
* Install readme and license (#12 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/12>)
* Contributors: gavanderhoorn
```

## abb_robot_msgs

```
* Install readme and license (#12 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/12>)
* Contributors: gavanderhoorn
```
