### PR TITLE
rcpputils: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1649,7 +1649,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.1.0-1`

## rcpputils

```
* Update quality declaration links (#130 <https://github.com/ros2/rcpputils/issues/130>)
* Add functions for getting library path and filename (#128 <https://github.com/ros2/rcpputils/issues/128>)
* Contributors: Nikolai Morin, Simon Honigmann
```
