### PR TITLE
[rosdep] Adding setpriv for Ubuntu Bionic and Debian Stretch.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6772,11 +6772,6 @@ sdl2-ttf:
   gentoo: [media-libs/sdl2-ttf]
   nixos: [SDL2_ttf]
   ubuntu: [libsdl2-ttf-dev]
-setpriv:
-  debian:
-    stretch: [setpriv]
-  ubuntu:
-    bionic: [setpriv]
 setserial:
   debian: [setserial]
   fedora: [setserial]
@@ -7327,12 +7322,16 @@ usbutils:
   ubuntu: [usbutils]
 util-linux:
   arch: [util-linux]
-  debian: [util-linux]
+  debian:
+    '*': util-linux
+    stretch: [setpriv, util-linux]
   fedora: [util-linux]
   gentoo: [util-linux]
   macports: [util-linux]
   nixos: [util-linux]
-  ubuntu: [util-linux]
+  ubuntu:
+    '*': util-linux
+    bionic: [setpriv, util-linux]
 uuid:
   arch: [util-linux]
   debian: [uuid-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7323,14 +7323,14 @@ usbutils:
 util-linux:
   arch: [util-linux]
   debian:
-    '*': util-linux
+    '*': [util-linux]
     stretch: [setpriv, util-linux]
   fedora: [util-linux]
   gentoo: [util-linux]
   macports: [util-linux]
   nixos: [util-linux]
   ubuntu:
-    '*': util-linux
+    '*': [util-linux]
     bionic: [setpriv, util-linux]
 uuid:
   arch: [util-linux]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6773,6 +6773,8 @@ sdl2-ttf:
   nixos: [SDL2_ttf]
   ubuntu: [libsdl2-ttf-dev]
 setpriv:
+  debian:
+    stretch: [setpriv]
   ubuntu:
     bionic: [setpriv]
 setserial:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6772,6 +6772,9 @@ sdl2-ttf:
   gentoo: [media-libs/sdl2-ttf]
   nixos: [SDL2_ttf]
   ubuntu: [libsdl2-ttf-dev]
+setpriv:
+  ubuntu:
+    bionic: [setpriv]
 setserial:
   debian: [setserial]
   fedora: [setserial]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

setpriv

## Package Upstream Source:

https://github.com/karelzak/util-linux/blob/master/sys-utils/setpriv.c

## Purpose of using this:

This allows packages is a tool to run a program with different Linux privilege settings.  Used in robot_upstart.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?searchon=names&keywords=setpriv
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?suite=bionic&searchon=names&keywords=setpriv


