### PR TITLE
abb_robot_driver_interfaces: 0.5.3-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -67,7 +67,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-industrial-release/abb_robot_driver_interfaces-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/ros-industrial/abb_robot_driver_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb_robot_driver_interfaces` to `0.5.3-1`:

- upstream repository: https://github.com/ros-industrial/abb_robot_driver_interfaces.git
- release repository: https://github.com/ros-industrial-release/abb_robot_driver_interfaces-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.5.2-1`

## abb_egm_msgs

```
* Lower minimum required CMake version to solve build error on Kinetic (#14 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/14>)
* Contributors: gavanderhoorn
```

## abb_rapid_msgs

```
* Lower minimum required CMake version to solve build error on Kinetic (#14 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/14>)
* Contributors: gavanderhoorn
```

## abb_rapid_sm_addin_msgs

```
* Lower minimum required CMake version to solve build error on Kinetic (#14 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/14>)
* Contributors: gavanderhoorn
```

## abb_robot_msgs

```
* Lower minimum required CMake version to solve build error on Kinetic (#14 <https://github.com/ros-industrial/abb_robot_driver_interfaces/issues/14>)
* Contributors: gavanderhoorn
```
