### PR TITLE
Add 'acl' rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -19,6 +19,7 @@ acl:
   debian: [acl, libacl1-dev]
   fedora: [acl]
   gentoo: [sys-apps/acl]
+  rhel: [acl]
   ubuntu: [acl, libacl1-dev]
 acpi:
   debian: [acpi]


### PR DESCRIPTION
This package is part of the base repository for RHEL 7 and 8:

https://mirrors.edge.kernel.org/centos/7.9.2009/os/x86_64/Packages/acl-2.2.51-15.el7.x86_64.rpm
https://mirrors.edge.kernel.org/centos/8.3.2011/BaseOS/x86_64/os/Packages/acl-2.2.53-1.el8.x86_64.rpm

Evidently this was missing when #28944 was bloomed.