### PR TITLE
mavros: 1.7.0-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6021,7 +6021,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.6.0-1
+      version: 1.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.7.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.6.0-1`

## libmavconn

- No changes

## mavros

```
* lib: re-generate the code
* plugins: mission: re-generate the code
* MissionBase: correction to file information
* MissionBase: add copyright from origional waypoint.cpp
* uncrustify
* whitespace
* add rallypoint and geofence plugins to mavros plugins xml
* add rallypoint and geofence plugins to CMakeList
* Geofence: add geofence plugin
* Rallypoint: add rallypoint plugin
* Waypoint: inherit MissionBase class for mission protocol
* MissionBase: breakout mission protocol from waypoint.cpp
* README: Update PX4 Autopilot references
  Much needed fixes to clarify the project is named correctly throughout the README
  for the PX4 Autopilot, QGroundControl, and MAVLink
* Fix https://github.com/mavlink/mavros/issues/849
* Contributors: Charlie-Burge, Ramon Roche, Tobias Fischer, Vladimir Ermakov
```

## mavros_extras

- No changes

## mavros_msgs

```
* msgs: re-generate the code
* Contributors: Vladimir Ermakov
```

## test_mavros

- No changes
