### PR TITLE
[rosdep] Added util-linux.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6578,6 +6578,13 @@ usbutils:
     homebrew:
       packages: [mikhailai/misc/usbutils]
   ubuntu: [usbutils]
+util-linux:
+  arch: [util-linux]
+  debian: [util-linux]
+  fedora: [util-linux]
+  gentoo: [util-linux]
+  macports: [util-linux]
+  ubuntu: [util-linux]
 uuid:
   arch: [util-linux]
   debian: [uuid-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:
util-linux

## Package Upstream Source:

https://github.com/karelzak/util-linux

## Purpose of using this:

Use for setpriv for robot_upstart.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=util-linux&searchon=names&suite=stable&section=all
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/search?keywords=util-linux&searchon=names&suite=focal&section=all
- Fedora: https://apps.fedoraproject.org/packages/
  - https://src.fedoraproject.org/rpms/util-linux
- Arch: https://archlinux.org/packages/core/x86_64/util-linux/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/
  - https://packages.gentoo.org/packages/sys-apps/util-linux
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/util-linux#default


