### PR TITLE
psen_scan_v2: 0.2.0-1 in 'noetic/distribution.yaml'

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5142,7 +5142,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan_v2-release.git
-      version: 0.1.6-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan_v2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psen_scan_v2` to `0.2.0-1`:

- upstream repository: https://github.com/PilzDE/psen_scan_v2.git
- release repository: https://github.com/PilzDE/psen_scan_v2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.1.6-1`

## psen_scan_v2

```
* Combine multiple monitoring frames into one scan (#173 <https://github.com/PilzDE/psen_scan_v2/issues/173>)
* API change: Driver waits for scan round to complete before sending measurement data by default
* Contributors: Pilz GmbH and Co. KG
```
