### PR TITLE
mavros: 1.7.1-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -6021,7 +6021,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.7.0-1
+      version: 1.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.7.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.7.0-1`

## libmavconn

- No changes

## mavros

```
* re-generate all pymavlink enums
* Contributors: Vladimir Ermakov
```

## mavros_extras

- No changes

## mavros_msgs

```
* re-generate all pymavlink enums
* Contributors: Vladimir Ermakov
```

## test_mavros

- No changes
