### PR TITLE
navigation2: 0.4.6-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1952,6 +1952,7 @@ repositories:
       - nav2_navfn_planner
       - nav2_planner
       - nav2_recoveries
+      - nav2_regulated_pure_pursuit_controller
       - nav2_rviz_plugins
       - nav2_system_tests
       - nav2_util
@@ -1964,7 +1965,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.4.5-1
+      version: 0.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `0.4.6-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.4.5-1`
