### PR TITLE
domain_bridge: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -497,6 +497,22 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: ros2-devel
     status: maintained
+  domain_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/domain_bridge.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/domain_bridge-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/domain_bridge.git
+      version: main
+    status: developed
   eigen3_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `domain_bridge` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/domain_bridge.git
- release repository: https://github.com/ros2-gbp/domain_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## domain_bridge

```
* Change default value of deadline and lifespan (#15 <https://github.com/ros2/domain_bridge/issues/15>)
* Include rclcpp from-source in CI
* Add missing test dependency
* Add QoS overriding
* Add launch file (#9 <https://github.com/ros2/domain_bridge/issues/9>)
* Ignore generated Python files (#12 <https://github.com/ros2/domain_bridge/issues/12>)
* Add '--from' and '--to' options to executable + add tests (#7 <https://github.com/ros2/domain_bridge/issues/7>)
* Automatically match QoS settings across the bridge (#5 <https://github.com/ros2/domain_bridge/issues/5>)
* Refactor YAML parsing and allow default domain IDs (#6 <https://github.com/ros2/domain_bridge/issues/6>)
* Support for configuring domain bridge with YAML (#4 <https://github.com/ros2/domain_bridge/issues/4>)
* Fix topic bridge less operator (#3 <https://github.com/ros2/domain_bridge/issues/3>)
* Add GitHub workflow for CI
* Add unit tests
* Add domain bridge library (#1 <https://github.com/ros2/domain_bridge/issues/1>)
* Contributors: Jacob Perron
```
