### PR TITLE
Update libcoin80-dev debian buster system dependency

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2297,7 +2297,7 @@ libcoin60-dev:
   ubuntu: [libcoin60-dev]
 libcoin80-dev:
   debian:
-    buster: [libcoin80-dev]
+    '*': [libcoin-dev]
     jessie: [libcoin80-dev]
     stretch: [libcoin80-dev]
   fedora: [Coin2-devel]


### PR DESCRIPTION
Since debian buster, libcoin80-dev package was renamed in libcoin-dev

See: https://packages.debian.org/buster/libcoin-dev