### PR TITLE
apex_test_tools: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -186,6 +186,24 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_test_tools:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: rolling
+    release:
+      packages:
+      - apex_test_tools
+      - test_apex_test_tools
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_test_tools-release.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: rolling
+    status: developed     
   apriltag:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository apex_test_tools to  0.0.2-1:

upstream repository: https://gitlab.com/ApexAI/apex_test_tools.git
release repository: https://gitlab.com/ApexAI/apex_test_tools-release.git
distro file: rolling/distribution.yaml
bloom version: `0.10.3`
previous version for package: `null`