### PR TITLE
rosidl_typesupport_fastrtps: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2223,7 +2223,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `1.2.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.2.0-1`

## fastrtps_cmake_module

```
* updating quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#69 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/69>)
* Contributors: shonigmann
```

## rosidl_typesupport_fastrtps_c

```
* updating quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#69 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/69>)
* Contributors: shonigmann
```

## rosidl_typesupport_fastrtps_cpp

```
* updating quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#69 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/69>)
* Contributors: shonigmann
```
