### PR TITLE
rcl_logging: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1591,7 +1591,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `2.1.2-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `2.1.1-1`

## rcl_logging_interface

- No changes

## rcl_logging_log4cxx

- No changes

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* updating quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#73 <https://github.com/ros2/rcl_logging/issues/73>)
* Contributors: shonigmann
```
