### PR TITLE
launch: 0.17.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1038,7 +1038,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.16.0-1
+      version: 0.17.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `0.17.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.16.0-1`

## launch

```
* Only try to wrap the fd in a socket on Windows (#498 <https://github.com/ros2/launch/issues/498>)
* Close the socket pair used for signal management (#497 <https://github.com/ros2/launch/issues/497>)
* Remove is_winsock_handle() and instead test if wrapping the handle in a socket.socket() works (#494 <https://github.com/ros2/launch/issues/494>)
* Add frontend substitution for logging directory (#490 <https://github.com/ros2/launch/issues/490>)
* Contributors: Ivan Santiago Paunovic, Jacob Perron
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
