### PR TITLE
cob_control: 0.7.13-2 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -1754,7 +1754,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipa320/cob_control-release.git
-      version: 0.7.12-1
+      version: 0.7.13-2
     source:
       type: git
       url: https://github.com/ipa320/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.7.13-2`:

- upstream repository: https://github.com/ipa320/cob_control.git
- release repository: https://github.com/ipa320/cob_control-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.7.12-1`

## cob_base_controller_utils

```
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_base_velocity_smoother

```
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

```
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_control

- No changes

## cob_control_mode_adapter

```
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_control_msgs

- No changes

## cob_footprint_observer

```
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_frame_tracker

- No changes

## cob_hardware_emulation

```
* Merge pull request #252 <https://github.com/ipa320/cob_control/issues/252> from floweisshardt/feature/emulator_move_base_kinetic
  kinetic: add optional move_base interface to base emulator
* add optional move_base interface to base emulator
* Merge pull request #248 <https://github.com/ipa320/cob_control/issues/248> from fmessmer/fix/fjt_emulation_kinetic
  [kinetic] fix fjt emulation
* use timer for joint_states
* skip trajectory points faster than sample_rate
* introduce sample_rate_hz parameter
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, Florian Weisshardt, floweisshardt, fmessmer
```

## cob_mecanum_controller

- No changes

## cob_model_identifier

```
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_obstacle_distance

- No changes

## cob_omni_drive_controller

```
* Merge pull request #250 <https://github.com/ipa320/cob_control/issues/250> from fmessmer/kinetic/TF_REPEATED_DATA
  [kinetic] add check and logs for TF_REPEATED_DATA
* add check and logs for TF_REPEATED_DATA
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_trajectory_controller

```
* Merge pull request #246 <https://github.com/ipa320/cob_control/issues/246> from fmessmer/fix_catkin_lint_kinetic
  [kinetic] fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
