### PR TITLE
cob_driver: 0.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -763,7 +763,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/cob_driver-release.git
-      version: 0.7.4-1
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/ipa320/cob_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.5-1`:

- upstream repository: https://github.com/ipa320/cob_driver.git
- release repository: https://github.com/ipa320/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.7.4-1`

## cob_base_drive_chain

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_bms_driver

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_canopen_motor

- No changes

## cob_driver

- No changes

## cob_elmo_homing

- No changes

## cob_generic_can

- No changes

## cob_light

```
* Merge pull request #419 <https://github.com/ipa320/cob_driver/issues/419> from benmaidel/fix/topic_multi_color
  [cob_light] fix topic multicolor support
* fix topic multicolor support
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Benjamin Maidel, Felix Messmer, fmessmer
```

## cob_mimic

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_phidget_em_state

- No changes

## cob_phidget_power_state

- No changes

## cob_phidgets

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_relayboard

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_scan_unifier

```
* Merge pull request #420 <https://github.com/ipa320/cob_driver/issues/420> from lindemeier/feature/improve_performance
  performance boost
* performance boost
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer, tsl
```

## cob_sick_lms1xx

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_sick_s300

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_sound

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_undercarriage_ctrl

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## cob_utilities

- No changes

## cob_voltage_control

```
* Merge pull request #418 <https://github.com/ipa320/cob_driver/issues/418> from fmessmer/fix_catkin_lint
  fix catkin_lint
* fix catkin_lint
* Contributors: Felix Messmer, fmessmer
```

## laser_scan_densifier

- No changes
