### PR TITLE
pincher_arm: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4874,7 +4874,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/pincher_arm-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/fictionlab/pincher_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pincher_arm` to `0.2.0-1`:

- upstream repository: https://github.com/fictionlab/pincher_arm.git
- release repository: https://github.com/fictionlab-gbp/pincher_arm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.1.1-1`

## pincher_arm

- No changes

## pincher_arm_bringup

```
* Add driver.launch file
* Add license to fake_joint_pub script
```

## pincher_arm_description

```
* Add license content to the URDF files
* Don't add base_link to URDF
```

## pincher_arm_ikfast_plugin

- No changes

## pincher_arm_moveit_config

```
* Don't add base_link to URDF
* Load robot description in moveit package only for simulation
```

## pincher_arm_moveit_demos

- No changes
