### PR TITLE
rmw_connextdds: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1757,7 +1757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.5.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.4.0-1`

## rmw_connextdds

```
* Merge pull request #13 <https://github.com/rticommunity/rmw_connextdds/issues/13> from Ericsson/unique_network_flows
* Refactor common API
* Update branch master to support Rolling only (#15 <https://github.com/rticommunity/rmw_connextdds/issues/15>)
* Contributors: Ananya Muddukrishna, Andrea Sorbini, William Woodall
```

## rmw_connextdds_common

```
* Merge pull request #13 <https://github.com/rticommunity/rmw_connextdds/issues/13> from Ericsson/unique_network_flows
* Remove superfluous header inclusion
* Remove conflicting linkage
* Further remove feature-based exclusion
* Remove feature-based exclusion
* Uncrustify
* Refactor common API
* Include required headers if feature is enabled
* Add conditional compilation support
* Prefer more generic file name
* Restrict unique flow endpoint check to versions beyond Foxy
* Indicate missing support for unique network flows
* Update branch master to support Rolling only (#15 <https://github.com/rticommunity/rmw_connextdds/issues/15>)
* Contributors: Ananya Muddukrishna, Andrea Sorbini, William Woodall
```

## rti_connext_dds_cmake_module

- No changes
