### PR TITLE
ros_comm: 1.15.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5809,7 +5809,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.15.10-1
+      version: 1.15.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.15.11-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.15.10-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

```
* Handle SIGINT in rosbag play (#2150 <https://github.com/ros/ros_comm/issues/2150>)
* Catch all exceptions in record thread (#2151 <https://github.com/ros/ros_comm/issues/2151>)
* raw_input does not exist in python 3 (#2143 <https://github.com/ros/ros_comm/issues/2143>)
* Contributors: Martin Pecka, Sebastian Scherer, pseyfert
```

## rosbag_storage

- No changes

## roscpp

- No changes

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

- No changes

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

- No changes
