### PR TITLE
picovoice-ros: 0.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4817,7 +4817,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/reinzor/picovoice_ros-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/reinzor/picovoice_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `picovoice-ros` to `0.0.3-1`:

- upstream repository: https://github.com/reinzor/picovoice_ros.git
- release repository: https://github.com/reinzor/picovoice_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.0.2-1`

## picovoice_driver

```
* chore: Remove trailing libs
* Merge pull request #2 <https://github.com/reinzor/picovoice_ros/issues/2> from reinzor/feat/arm-build
  feat: ARM support
* feat: ARM support
* Contributors: Rein Appeldoorn
```

## picovoice_msgs

- No changes
