### PR TITLE
[dep] rocker

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6965,6 +6965,9 @@ python3-retrying:
     pip:
       packages: [retrying]
   ubuntu: [python3-retrying]
+python3-rocker:
+  debian: [python3-rocker]
+  ubuntu: [python3-rocker]
 python3-rosdep:
   alpine: [rosdep]
   debian: [python3-rosdep]


### PR DESCRIPTION
## Package name:

rocker https://github.com/osrf/rocker

## Purpose of using this:

Convenient `docker` CLI wrapper IINM.

## Links to Distribution Packages

- Debian: buster http://packages.ros.org/ros/ubuntu/dists/buster/main/binary-amd64/Packages
- Ubuntu: xenial http://packages.ros.org/ros/ubuntu/dists/xenial/main/binary-amd64/Packages
- Fedora: https://apps.fedoraproject.org/packages/ --> None? Also `apps.fedoraproject.org/packages` leads me to useless webpage for searching a pkg.
- Arch: https://www.archlinux.org/packages/ --> None
- Gentoo: https://packages.gentoo.org/packages/ --> None. Also `https://packages.gentoo.org/packages/` not found.
- macOS: https://formulae.brew.sh/ --> None
