### PR TITLE
Adding python3-junitparser as a rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6231,8 +6231,8 @@ python3-jsonschema:
   ubuntu: [python3-jsonschema]
 python3-junitparser:
   debian:
-    bullseye: [python3-junitparser]
-    buster: [python3-junitparser]
+    '*': [python3-junitparser]
+    stretch: null
   ubuntu:
     '*': [python3-junitparser]
     bionic: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6230,10 +6230,13 @@ python3-jsonschema:
   gentoo: [dev-python/jsonschema]
   ubuntu: [python3-jsonschema]
 python3-junitparser:
-  debian: [python3-junitparser]
-  fedora: [python3-junitparser]
-  gentoo: [dev-python/junitparser]
-  ubuntu: [python3-junitparser]
+  debian:
+    bullseye: [python3-junitparser]
+    buster: [python3-junitparser]
+  ubuntu:
+    '*': [python3-junitparser]
+    bionic: null
+    xenial: null
 python3-kitchen:
   arch: [python-kitchen]
   debian: [python3-kitchen]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6229,6 +6229,11 @@ python3-jsonschema:
   fedora: [python3-jsonschema]
   gentoo: [dev-python/jsonschema]
   ubuntu: [python3-jsonschema]
+python3-junitparser:
+  debian: [python3-junitparser]
+  fedora: [python3-junitparser]
+  gentoo: [dev-python/junitparser]
+  ubuntu: [python3-junitparser]
 python3-kitchen:
   arch: [python-kitchen]
   debian: [python3-kitchen]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-junitparser

## Package Upstream Source:

https://github.com/weiwei/junitparser

## Purpose of using this:

The dependency is used as part of a testing pipeline, and it would be nice to have support for parsing results from this common unit testing framework.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-junitparser
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/focal/python3-junitparser
- Fedora: https://apps.fedoraproject.org/packages/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE

Distro A, OPSEC #4584