### PR TITLE
rqt_moveit: 0.5.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -11362,7 +11362,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_moveit-release.git
-      version: 0.5.7-0
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_moveit` to `0.5.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_moveit.git
- release repository: https://github.com/ros-gbp/rqt_moveit-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.5.7-0`

## rqt_moveit

```
* fixed renaming of xmlrpc in python 3
```
