### PR TITLE
rqt_moveit: 0.5.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6556,7 +6556,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_moveit-release.git
-      version: 0.5.9-3
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_moveit` to `0.5.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_moveit.git
- release repository: https://github.com/ros-gbp/rqt_moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.5.9-3`

## rqt_moveit

```
* fixed renaming of xmlrpc in python 3
```
