### PR TITLE
apex_containers: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -186,6 +186,21 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_containers:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_containers-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: rolling
+    status: developed
   apex_test_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apex_containers` to `0.0.4-1`:

- upstream repository: https://gitlab.com/ApexAI/apex_containers.git
- release repository: https://gitlab.com/ApexAI/apex_containers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`
