### PR TITLE
Fixup links to indexes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ Distro packaging links:
   - REQUIRED
 - Ubuntu: https://packages.ubuntu.com/
    - REQUIRED
-- Fedora: https://src.fedoraproject.org/
+- Fedora: https://src.fedoraproject.org/browse/projects/
   - IF AVAILABLE
 - Arch: https://www.archlinux.org/packages/
   - IF AVAILABLE

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,13 +31,15 @@ Distro packaging links:
   - REQUIRED
 - Ubuntu: https://packages.ubuntu.com/
    - REQUIRED
-- Fedora: https://apps.fedoraproject.org/packages/
+- Fedora: https://src.fedoraproject.org/
   - IF AVAILABLE
 - Arch: https://www.archlinux.org/packages/
   - IF AVAILABLE
-- Gentoo: https://packages.gentoo.org/packages/
+- Gentoo: https://packages.gentoo.org/
   - IF AVAILABLE
 - macOS: https://formulae.brew.sh/
+  - IF AVAILABLE
+- Alpine: https://pkgs.alpinelinux.org/packages
   - IF AVAILABLE
 
 


### PR DESCRIPTION
Fedora new url
Gentoo, url to index is higher now
Add alpine index too


Followup to comments in #29017 