### PR TITLE
rqt_dep: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6463,7 +6463,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_dep-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_dep.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_dep` to `0.4.11-1`:        

- upstream repository: https://github.com/ros-visualization/rqt_dep.git
- release repository: https://github.com/ros-gbp/rqt_dep-release.git
- distro file: `noetic/distribution.yaml`       
- bloom version: `0.10.6`
- previous version for package: `0.4.10-1`                                     
               
## rqt_dep                       
                                              
```                                                                                                  
* Update maintainers (#13 <https://github.com/ros-visualization/rqt_dep/issues/13>)   
* Fix shebang line for python3 (#12 <https://github.com/ros-visualization/rqt_dep/issues/12>)                                     
* Bump CMake minimum version to avoid CMP0048 warning                                  
* Contributors: Dirk Thomas, Ivan Santiago Paunovic, Mikael Arguedas
```  