### PR TITLE
qt_gui_core: 2.0.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1493,7 +1493,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.0.0-3
+      version: 2.0.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.0.0-4`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.0.0-3`

## qt_dotgraph

- No changes

## qt_gui

```
* Fix 'dict_keys' object not subscriptable (#243 <https://github.com/ros-visualization/qt_gui_core/issues/243>)
* Contributors: Michael Jeronimo
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Fix duplicated QMap to QMultiMap (#244 <https://github.com/ros-visualization/qt_gui_core/issues/244>)
* Switch to using the filesystem implementation in rcpputils. (#239 <https://github.com/ros-visualization/qt_gui_core/issues/239>)
* Contributors: Chris Lalancette, Homalozoa X
```

## qt_gui_py_common

- No changes
