### PR TITLE
Add rosdep rule for 'libatomic'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1853,6 +1853,12 @@ libasound2-dev:
   gentoo: [media-libs/alsa-lib]
   openembedded: [alsa-lib@openembedded-core]
   ubuntu: [libasound2-dev]
+libatomic:
+  arch: [gcc-libs]
+  debian: [libatomic1]
+  fedora: [libatomic]
+  rhel: [libatomic]
+  ubuntu: [libatomic1]
 libav:
   arch: [libav-git]
   debian: [libav-tools]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libatomic

## Package Upstream Source:

https://gcc.gnu.org/

## Purpose of using this:

libatomic seems to be implicitly available on Ubuntu, but needs to be called out as a dependency for RHEL.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/libatomic1
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.debian.org/buster/libatomic1
- Fedora: https://apps.fedoraproject.org/packages/
  - https://src.fedoraproject.org/rpms/gcc/blob/rawhide/f/gcc.spec#_577
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/core/x86_64/gcc-libs/
- Gentoo: https://packages.gentoo.org/packages/
  - UNKNOWN
- macOS: https://formulae.brew.sh/
  - UNKNOWN
- RHEL:
  - https://mirrors.edge.kernel.org/centos/7.9.2009/os/x86_64/Packages/libatomic-4.8.5-44.el7.x86_64.rpm
  - https://mirrors.edge.kernel.org/centos/8.3.2011/BaseOS/x86_64/os/Packages/libatomic-8.3.1-5.1.el8.x86_64.rpm

Since this is a subcomponent of gcc, it's difficult to track down which Gentoo or macOS rule would be appropriate. I'm open to suggestions.