### PR TITLE
urg_stamped: 0.0.10-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -13613,7 +13613,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.9-1
+      version: 0.0.10-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_stamped` to `0.0.10-1`:

- upstream repository: https://github.com/seqsense/urg_stamped.git
- release repository: https://github.com/seqsense/urg_stamped-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.0.9-1`

## urg_stamped

```
* Add codecov.yml (#96 <https://github.com/seqsense/urg_stamped/issues/96>)
* Fix error handling during delay estimation (#92 <https://github.com/seqsense/urg_stamped/issues/92>)
* Add option to enable debug log output at launch (#93 <https://github.com/seqsense/urg_stamped/issues/93>)
* Send TM command after receiving QT response (#91 <https://github.com/seqsense/urg_stamped/issues/91>)
* Refactor directory and namespace (#90 <https://github.com/seqsense/urg_stamped/issues/90>)
* Contributors: Atsushi Watanabe
```
