### PR TITLE
ros2_control: 0.4.0-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -3210,7 +3210,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `0.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.0-1`

## controller_interface

```
* Replace controller_interface return type SUCCESS by OK and mark SUCCESS as deprecated (#374 <https://github.com/ros-controls/ros2_control/issues/374>)
* Contributors: Mateus Amarante
```

## controller_manager

```
* Fix deprecation warnings: SUCCESS -> OK (#375 <https://github.com/ros-controls/ros2_control/issues/375>)
* Don't use FileType for param-file (#351 <https://github.com/ros-controls/ros2_control/issues/351>)
* Remodel ros2controlcli, refactor spawner/unspawner and fix test (#349 <https://github.com/ros-controls/ros2_control/issues/349>)
* Add spawner and unspawner scripts (#310 <https://github.com/ros-controls/ros2_control/issues/310>)
* Contributors: Bence Magyar, Jordan Palacios, Karsten Knese, Victor Lopez
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [ros2_control_test_assets] Fix typo (#371 <https://github.com/ros-controls/ros2_control/issues/371>)
* uint -> size_t, 0u and auto (#346 <https://github.com/ros-controls/ros2_control/issues/346>)
* Contributors: Karsten Knese, Yutaka Kondo
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* [ros2_control_test_assets] Fix typo (#371 <https://github.com/ros-controls/ros2_control/issues/371>)
* Contributors: Yutaka Kondo
```

## ros2controlcli

```
* Remodel ros2controlcli, refactor spawner/unspawner and fix test (#349 <https://github.com/ros-controls/ros2_control/issues/349>)
* Contributors: Karsten Knese
```

## transmission_interface

- No changes
