### PR TITLE
Split libuv-dev into libuv-dev and libuv1-dev. Fix #28399

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4528,11 +4528,7 @@ libusb-dev:
   ubuntu: [libusb-dev]
 libuv-dev:
   debian:
-    buster: [libuv1-dev]
     jessie: [libuv0.10-dev]
-    stretch: [libuv1-dev]
-  fedora: [libuv-devel]
-  gentoo: [dev-libs/libuv]
   ubuntu:
     bionic: [libuv0.10-dev]
     precise: [libuv-dev]
@@ -4544,6 +4540,14 @@ libuv-dev:
     xenial: [libuv0.10-dev]
     yakkety: [libuv0.10-dev]
     zesty: [libuv0.10-dev]
+libuv1-dev:
+  arch: [libuv]
+  debian:
+    '*': [libuv1-dev]
+    jessie: null
+  fedora: [libuv-devel]
+  gentoo: [dev-libs/libuv]
+  ubuntu: [libuv1-dev]
 libuvc-dev:
   debian:
     '*': [libuvc-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add/modify the following dependency to the rosdep database.

## Package names:

- libuv-dev
- libuv1-dev

## Package Upstream Source:

https://libuv.org/

## Purpose of using this:

See https://github.com/ros/rosdistro/issues/28399.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/search?suite=all&searchon=names&keywords=libuv
- Ubuntu: https://packages.ubuntu.com/search?searchon=names&suite=all&section=all&keywords=libuv
- Fedora: https://src.fedoraproject.org/rpms/libuv
- Arch: https://archlinux.org/packages/extra/x86_64/libuv/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/libuv
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
