### PR TITLE
iceoryx: 0.99.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -870,7 +870,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ApexAI/iceoryx-release.git
-      version: 0.99.4-1
+      version: 0.99.5-1
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iceoryx` to `0.99.5-1`:

- upstream repository: https://github.com/eclipse-iceoryx/iceoryx.git
- release repository: https://github.com/ApexAI/iceoryx-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.99.4-1`


adding libatomic to package.xml in iceoryx_utils for RHEL, thanks to @cottsay 