### PR TITLE
(contributing) Add guidelines for anchoring and aliasing of pip entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ python3-foobar-pip:
       packages: [foobar]
 ```
 
-In constrast to normal python entries, which are often different for python 2 and 3, pip entries for python 2 and 3 are almost always identical.
+In contrast to normal python entries, which are often different for python 2 and 3, pip entries for python 2 and 3 are almost always identical.
 Hence no new entry would be needed. Though this would leave us with a mess of `python3-*`, `python-*-pip` and `python3-*-pip` entries.
 To prevent this, the `python3-*-pip` entry should be mapped to the legacy `python-*-pip` entry by using yaml anchors and aliases.
 (Preferably this was the other way around. So the `python3-*-pip` entry containing the contents and the anchor and the legacy `python-*-pip` entry being aliased to it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,8 @@ python3-foobar-pip: *migrate_eol_2025_04_30_python3_foobar_pip # Alias
 
 The anchor/alias should be formatted as `migrate_eol_<YYYY>_<MM>_<DD>_<NEW_KEY_UNDERSCORED>`.
 
+The EOL date of the entry should match the EOL date of the longest supported current platform.
+
 Some existing rules do not have `python-` or `python3-` prefixes, but this is no longer recommended.
 If the package ever becomes available in Debian or Ubuntu, the `python3-` prefix ensures that the `pip` key is next to it alphabetically.
 The `-pip` key should be removed when the package becomes available on all platforms, and all existing users of the `-pip` key should migrate to the new key.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ python3-foobar-pip:
 In constrast to normal python entries, which are often different for python 2 and 3, pip entries for python 2 and 3 are almost always identical.
 Hence no new entry would be needed. Though this would leave us with a mess of `python3-*`, `python-*-pip` and `python3-*-pip` entries.
 To prevent this, the `python3-*-pip` entry should be mapped to the legacy `python-*-pip` entry by using yaml anchors and aliases.
-(Prerabbly this was the other way around. So the `python3-*-pip` entry containing the contents and the anchor and the legacy `python-*-pip` entry being aliased to it.
+(Preferably this was the other way around. So the `python3-*-pip` entry containing the contents and the anchor and the legacy `python-*-pip` entry being aliased to it.
 Though the anchor should be defined before the anchor is used and `python3-` entries come after `python-` entries in alphabetical order.)
 
 For example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,24 @@ python3-foobar-pip:
       packages: [foobar]
 ```
 
+In constrast to normal python entries, which are often different for python 2 and 3, pip entries for python 2 and 3 are almost always identical.
+Hence no new entry would be needed. Though this would leave us with a mess of `python3-*`, `python-*-pip` and `python3-*-pip` entries.
+To prevent this, the `python3-*-pip` entry should be mapped to the legacy `python-*-pip` entry by using yaml anchors and aliases.
+(Prerabbly this was the other way around. So the `python3-*-pip` entry containing the contents and the anchor and the legacy `python-*-pip` entry being aliased to it.
+Though the anchor should be defined before the anchor is used and `python3-` entries come after `python-` entries in alphabetical order.)
+
+For example:
+
+```yaml
+python-foobar-pip: &migrate_eol_2025_04_30_python3_foobar_pip # Anchor
+  ubuntu:
+    pip:
+      packages: [foobar]
+python3-foobar-pip: *migrate_eol_2025_04_30_python3_foobar_pip # Alias
+```
+
+The anchor/alias should be formatted as `migrate_eol_<YYYY>_<MM>_<DD>_<NEW_KEY_UNDERSCORED>`.
+
 Some existing rules do not have `python-` or `python3-` prefixes, but this is no longer recommended.
 If the package ever becomes available in Debian or Ubuntu, the `python3-` prefix ensures that the `pip` key is next to it alphabetically.
 The `-pip` key should be removed when the package becomes available on all platforms, and all existing users of the `-pip` key should migrate to the new key.


### PR DESCRIPTION
As discussed in #28891

Fixes #28891 
