### PR TITLE
system_modes: 0.6.0-2 in 'dashing/distribution.yaml' [bloom]

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -3522,7 +3522,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.5.0-1
+      version: 0.6.0-2
     source:
       type: git
       url: https://github.com/micro-ROS/system_modes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_modes` to `0.6.0-2`:

- upstream repository: https://github.com/micro-ROS/system_modes.git
- release repository: https://github.com/microROS/system_modes-release.git
- distro file: `dashing/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.5.0-1`
