### PR TITLE
audio_common: 0.3.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -801,7 +801,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.10-1
+      version: 0.3.11-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.11-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.3.10-1`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

- No changes

## sound_play

```
* Merge pull request #167 <https://github.com/ros-drivers/audio_common/issues/167> from k-okada/fix_155
* Use rospy.myargv() instead of sys.argv to support remapping
* Contributors: Kei Okada, Shingo Kitagawa
```
