### PR TITLE
hector_slam: 0.5.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2575,7 +2575,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.5.1-1
+      version: 0.5.2-2
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2575,7 +2575,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release.git
-      version: 0.5.2-2
+      version: 0.5.2-4
     source:
       type: git
       url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git


### PR DESCRIPTION
Creating the PR with bloom didn't finish correctly.
So here's the last step manually.

I'm using an oauth token and the first time it complained about needing the workflow permission.
After adding that it failed with:
```
To https://github.com/StefanFabian/rosdistro.git
 * [new branch]          bloom-hector_slam-3 -> bloom-hector_slam-3
Failed to open pull request: GithubException - HTTP Error 404: Not Found (https://api.github.com/repos/ros/rosdistro/pulls): None
````