### PR TITLE
depthimage_to_laserscan: 2.3.1-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -675,7 +675,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthimage_to_laserscan` to `2.3.1-1`:

- upstream repository: https://github.com/ros-perception/depthimage_to_laserscan.git
- release repository: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.3.0-1`

## depthimage_to_laserscan

```
* Cleanup the CMakeLists.txt (#51 <https://github.com/ros-perception/depthimage_to_laserscan/issues/51>)
* Contributors: Chris Lalancette
```
