### PR TITLE
unique_identifier_msgs: 2.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4650,7 +4650,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.1.3-1`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `2.1.2-1`

## unique_identifier_msgs

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#20 <https://github.com/ros2/unique_identifier_msgs/issues/20>)
* Update QD to QL 1 (#18 <https://github.com/ros2/unique_identifier_msgs/issues/18>)
* Add Security Vulnerability Policy pointing to REP-2006. (#11 <https://github.com/ros2/unique_identifier_msgs/issues/11>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Michel Hidalgo, Simon Honigmann, Stephen Brawner
```
