### PR TITLE
spdlog_vendor: 1.1.3-1 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -4251,7 +4251,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       test_abi: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.1.3-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `1.1.2-1`

## spdlog_vendor

```
* Update quality declaration links (re: ros2/docs.ros2.org#52 <https://github.com/ros2/docs.ros2.org/issues/52>) (#25 <https://github.com/ros2/spdlog_vendor/issues/25>)
* Updated QD links to foxy
* Updated QD to 1 (#16 <https://github.com/ros2/spdlog_vendor/issues/16>)
* Add Security Vulnerability Policy pointing to REP-2006. (#13 <https://github.com/ros2/spdlog_vendor/issues/13>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Simon Honigmann
```
