### PR TITLE
darknet_ros: 1.1.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1249,6 +1249,7 @@ repositories:
       version: master
     release:
       packages:
+      - darknet_ros
       - darknet_ros_msgs
       tags:
         release: release/noetic/{package}/{version}

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1242,6 +1242,24 @@ repositories:
       url: https://github.com/OTL/cv_camera.git
       version: master
     status: maintained
+  darknet_ros:
+    doc:
+      type: git
+      url: https://github.com/leggedrobotics/darknet_ros.git
+      version: master
+    release:
+      packages:
+      - darknet_ros_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/leggedrobotics/darknet_ros-release.git
+      version: 1.1.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/leggedrobotics/darknet_ros.git
+      version: master
+    status: maintained
   dataspeed_can:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `darknet_ros` to `1.1.5-1`:

- upstream repository: https://github.com/leggedrobotics/darknet_ros
- release repository: https://github.com/leggedrobotics/darknet_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.4-0`

## darknet_ros

```
* Merge pull request `#308 <https://github.com/leggedrobotics/darknet_ros/issues/308>`_ from leggedrobotics/noetic
  Noetic
* Minor fix in CMake.
* Minor fix in test.
* Updated readme.
* Updated to newest darknet and fixed opencv on Ubuntu 20.04.
* First changes in CMakeLists.
* Merge pull request `#287 <https://github.com/leggedrobotics/darknet_ros/issues/287>`_ from leggedrobotics/feature/nodeletize
  Feature/nodeletize
* Small adjustments
* Added pointer deletion in destructor and minor formatting
* Minor formatting
* Adding option to use nodelet
* Add libxext
* Add libxt-dev
* Retrieve binaries from Github releases
* Merge pull request `#232 <https://github.com/leggedrobotics/darknet_ros/issues/232>`_ from leggedrobotics/add-required-deps
  Update package.xml dependencies
* Don't require cmake-clang-tools
* Update package.xml dependencies
* Added clang tooling.
* Merge pull request `#207 <https://github.com/leggedrobotics/darknet_ros/issues/207>`_ from umdlife/install_weights
  Add install targets for configuration files
* Add install targets for configuration files
  Adds the `launch`, `config`, and `yolo_network_config` folders to the
  install target for `darknet_ros` so they are available in the catkin
  install directory.
* Fixed linking of cuda libraries.
* Merge branch 'kunaltyagi-cleanup'
* Cleaned up CMakeLists.txt, used OpenCV C++ API for cpp file
* Merge pull request `#189 <https://github.com/leggedrobotics/darknet_ros/issues/189>`_ from martinspedro/master
  /darknet_ros/found_object uses custom msg with Header for improving synchronization
* YOLO publishes Object Count with Time stamp using custom msg with Header
* Merge pull request `#183 <https://github.com/leggedrobotics/darknet_ros/issues/183>`_ from kunaltyagi/id_num
  Add numerical ID and launch param for image
* Adding numerical ID and launch param for image
* Merge pull request `#182 <https://github.com/leggedrobotics/darknet_ros/issues/182>`_ from leggedrobotics/fix/image_publisher
  Fixed copy of image publisher.
* Fixed copy of image publisher.
* Merge branch 'kjbilton-master'
* Increased scope of image acquisition mutex to prevent image overwriting
* Merge branch 'utra-robosoccer-master'
* Removed warnings caused by catkin builds
* Added test_depend of wget to accomodate Jenkins.
* Contributors: Jason Wang, Kunal Tyagi, Kyle Bilton, Marko Bjelonic, Pedro Martins, Tom Lankhorst, Tomas Gareau, timonh
```

## darknet_ros_msgs

```
* Merge pull request `#189 <https://github.com/leggedrobotics/darknet_ros/issues/189>`_ from martinspedro/master
  /darknet_ros/found_object uses custom msg with Header for improving synchronization
* std_msgs::Int8 with Header for Object Count
* Merge pull request `#183 <https://github.com/leggedrobotics/darknet_ros/issues/183>`_ from kunaltyagi/id_num
  Add numerical ID and launch param for image
* Adding numerical ID and launch param for image
* Contributors: Kunal Tyagi, Marko Bjelonic, Pedro Martins
```
