### PR TITLE
Add rosdep 'sdl2-image'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6066,6 +6066,9 @@ sdl2:
   openembedded: [libsdl2@openembedded-core]
   rhel: [SDL2-devel]
   ubuntu: [libsdl2-dev]
+sdl2-image:
+  debian: [libsdl2-image-dev]
+  ubuntu: [libsdl2-image-dev]
 sdl2-mixer:
   debian: [libsdl2-mixer-dev]
   fedora: [SDL2_mixer-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6068,9 +6068,9 @@ sdl2:
   ubuntu: [libsdl2-dev]
 sdl2-image:
   debian: [libsdl2-image-dev]
-  fedora: [SDL2_Image-devel]
+  fedora: [SDL2_image-devel]
   rhel:
-    '7': [SDL2_Image-devel]
+    '7': [SDL2_image-devel]
   ubuntu: [libsdl2-image-dev]
 sdl2-mixer:
   debian: [libsdl2-mixer-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6068,6 +6068,9 @@ sdl2:
   ubuntu: [libsdl2-dev]
 sdl2-image:
   debian: [libsdl2-image-dev]
+  fedora: [SDL2_Image-devel]
+  rhel:
+    '7': [SDL2_Image-devel]
   ubuntu: [libsdl2-image-dev]
 sdl2-mixer:
   debian: [libsdl2-mixer-dev]


### PR DESCRIPTION
Signed-off-by: Caio Amaral <caioaamaral@gmail.com>

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

sdl2-image

## Package Upstream Source:

https://www.libsdl.org/projects/SDL_image/

## Purpose of using this:

SDL_image is an image file loading library.
It loads images as SDL surfaces and textures, and supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, SVG, TGA, TIFF, WEBP, XCF, XPM, XV

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://debian.pkgs.org/sid/debian-main-amd64/libsdl2-image-dev_2.0.5+dfsg1-2_amd64.deb.html
- Ubuntu: https://packages.ubuntu.com/
   - https://ubuntu.pkgs.org/20.04/ubuntu-universe-amd64/libsdl2-image-dev_2.0.5+dfsg1-2_amd64.deb.html
