### PR TITLE
domain_bridge: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -539,7 +539,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/domain_bridge-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `domain_bridge` to `0.2.0-1`:

- upstream repository: https://github.com/ros2/domain_bridge.git
- release repository: https://github.com/ros2-gbp/domain_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.6`
- previous version for package: `0.1.0-1`

## domain_bridge

```
* Stop installing test resources (#17 <https://github.com/ros2/domain_bridge/issues/17>)
* Add explicit link against stdc++fs (#16 <https://github.com/ros2/domain_bridge/issues/16>)
* Contributors: Scott K Logan
```
