### PR TITLE
moveit_msgs: 0.11.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3935,7 +3935,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_msgs-release.git
-      version: 0.11.1-1
+      version: 0.11.2-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `0.11.2-1`:

- upstream repository: https://github.com/ros-planning/moveit_msgs.git
- release repository: https://github.com/ros-gbp/moveit_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.2`
- previous version for package: `0.11.1-1`

## moveit_msgs

```
* Migrate to GitHub actions (#100 <https://github.com/ros-planning/moveit_msgs/issues/100>)
* Support specifying pipeline ids with planning requests (#95 <https://github.com/ros-planning/moveit_msgs/issues/95>)
* Add parameterization type to orientation constraints (#96 <https://github.com/ros-planning/moveit_msgs/issues/96>)
* Contributors: Henning Kayser, Jeroen, Robert Haschke, Tyler Weaver
```
