### PR TITLE
visp: 3.4.0-7 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8081,7 +8081,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.4.0-6
+      version: 3.4.0-7
     source:
       type: git
       url: https://github.com/lagadic/visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.4.0-7`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/lagadic/visp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `3.4.0-6`
