### PR TITLE
phidgets_drivers: 0.7.11-1 in 'kinetic/distribution.yaml' [bloom]

### DIFF
--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -10266,7 +10266,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 0.7.10-1
+      version: 0.7.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `0.7.11-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `kinetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.7.10-1`

## libphidget21

- No changes

## phidgets_api

- No changes

## phidgets_drivers

- No changes

## phidgets_high_speed_encoder

```
* high_speed_encoder: Use private node handle for params (#79 <https://github.com/ros-drivers/phidgets_drivers/issues/79>)
  Co-authored-by: Martin Günther <mailto:martin.guenther@dfki.de>
* Contributors: Evan Davies
```

## phidgets_ik

```
* Fix success flag of phidgets_ik set_digital_output service
  Fixes #81 <https://github.com/ros-drivers/phidgets_drivers/issues/81>
* Contributors: Martin Günther
```

## phidgets_imu

- No changes

## phidgets_msgs

- No changes
