### PR TITLE
imu_tools: 1.2.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2759,7 +2759,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.3-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `1.2.2-1`

## imu_complementary_filter

```
* Fix "non standard content" warning in imu_tools metapackage
  Fixes #135 <https://github.com/ccny-ros-pkg/imu_tools/issues/135>.
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## imu_filter_madgwick

```
* Fix "non standard content" warning in imu_tools metapackage
  Fixes #135 <https://github.com/ccny-ros-pkg/imu_tools/issues/135>.
* Add example launch file for imu_filter_madgwick (#132 <https://github.com/ccny-ros-pkg/imu_tools/issues/132>)
* Update maintainers in package.xml
* Fix warnings: reordering and unused vars
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther, pietrocolombo
```

## imu_tools

```
* Fix "non standard content" warning in imu_tools metapackage
  Fixes #135 <https://github.com/ccny-ros-pkg/imu_tools/issues/135>.
* Update maintainers in package.xml
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```

## rviz_imu_plugin

```
* Fix "non standard content" warning in imu_tools metapackage
  Fixes #135 <https://github.com/ccny-ros-pkg/imu_tools/issues/135>.
* Update maintainers in package.xml
* Set cmake_policy CMP0048 to fix warning
* Contributors: Martin Günther
```
