### PR TITLE
adding python3-bidict as rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5601,6 +5601,10 @@ python3-backoff-pip:
   ubuntu:
     pip:
       packages: [backoff]
+python3-bidict:
+  debian: [python3-bidict]
+  fedora: [python3-bidict]
+  ubuntu: [python3-bidict]
 python3-bitarray:
   debian: [python3-bitarray]
   fedora: [python3-bitarray]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically.
If you've already run the release bloom has a `--pull-request-only` option you can use.-->


<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-bidict

## Package Upstream Source:

https://github.com/jab/bidict

## Purpose of using this:

The bidirectional mapping library for Python.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas and state not available for IF AVAILABLE -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-bidict
- Ubuntu: https://packages.ubuntu.com/
   - https://packages.ubuntu.com/groovy/python3-bidict

