### PR TITLE
ros_industrial_cmake_boilerplate: 0.2.9-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5969,7 +5969,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
-      version: 0.2.8-1
+      version: 0.2.9-2
     source:
       type: git
       url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.2.9-2`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `0.2.8-1`

## ros_industrial_cmake_boilerplate

```
* Add ENABLE functionality to initialize_code_coverage
* Improve cpack package naming
* Add cpack archive package
* Add CPACK to build debian and nuget package
* Extract description from package.xml
* Contributors: Levi Armstrong
```
