### PR TITLE
Update marti_messages release repository for ROS 2 distributions.

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -1581,7 +1581,7 @@ repositories:
       - marti_visualization_msgs
       tags:
         release: release/dashing/{package}/{version}
-      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      url: https://github.com/ros2-gbp/marti_messages-release.git
       version: 1.2.0-1
     source:
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -1759,7 +1759,7 @@ repositories:
       - marti_visualization_msgs
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      url: https://github.com/ros2-gbp/marti_messages-release.git
       version: 1.2.0-1
     source:
       test_pull_requests: true


### PR DESCRIPTION
In order to take advantage of Rolling release features we've
incorporated all changes from the swri-robotics-gbp repository into the
ros2-gbp one and granted access to the requested maintainers.