### PR TITLE
tesseract: 0.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7503,6 +7503,31 @@ repositories:
       url: https://github.com/ros-teleop/teleop_twist_keyboard.git
       version: master
     status: maintained
+  tesseract:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial-consortium/tesseract.git
+      version: master
+    release:
+      packages:
+      - tesseract_collision
+      - tesseract_common
+      - tesseract_environment
+      - tesseract_geometry
+      - tesseract_kinematics
+      - tesseract_scene_graph
+      - tesseract_support
+      - tesseract_urdf
+      - tesseract_visualization
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/tesseract-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial-consortium/tesseract.git
+      version: master
+    status: developed
   tf2_web_republisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tesseract` to `0.3.0-1`:

- upstream repository: https://github.com/ros-industrial-consortium/tesseract.git
- release repository: https://github.com/ros-industrial-release/tesseract-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.3`
- previous version for package: `null`

## tesseract_collision

```
* Only enable code coverage if compiler definition is set
* Fix issue in trajectory player setCurrentDuration not handling finished bool
* Fix bullet broadphase when new links are added
* Debug unit test
* Fix conversion warnings
  - Use size_t everywhere we expect to index a vector
  - Cast the result of rand unsigned
* Update benchmarks to use collision margin data
* Make compatible with fcl version 0.6
* Add cmake format
* Add support for defining collision margin data in SRDF (#573 <https://github.com/ros-industrial-consortium/tesseract/issues/573>)
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Add logic to how a provided collision margin data can be applied
* Fix method for updating max margin in CollisionMarginData
* Add libomp-dev as test_depend to tesseract_environment and tesseract_collision
* Fix method for changing bullet extern gDbvtMargin
* Contributors: Hervé Audren, Levi Armstrong, Matthew Powelson, david.hooks
```

## tesseract_common

```
* Only enable code coverage if compiler definition is set
* Move serialize implementation to cpp based on boost documentation for shared libraries
* Rename Any method cast() and cast_const() to as()
* Remove NullAny structure
* Cleanup equal operator
* Fix satisfiesPositionLimits to use relative equal and calculation of redundant solutions to include all permutations
* Split loading plugins into two classes ClassLoader and PluginLoader
* Remove dependency on class_loader and leverage Boost DLL
* Add PluginLoader class to tesseract_common
* Fixup enforceJointLimits
  Up to now, it would incorrectly apply the upper limit to any position
  that's outside the range. For example, a position that's slightly under
  the lower limit would get assigned the upper limit. Fix this by using
  Eigen's min and max functions, resulting in a proper clamp.
* Add satisfy and enforce position limits utility functions (#576 <https://github.com/ros-industrial-consortium/tesseract/issues/576>)
* Add QueryIntAttributeRequired utility function
* Add cmake format
* Add support for defining collision margin data in SRDF (#573 <https://github.com/ros-industrial-consortium/tesseract/issues/573>)
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Add serializable any type erasure (#555 <https://github.com/ros-industrial-consortium/tesseract/issues/555>)
* Add ToolCenterPoint unit tests
* Start to adding boost serialization support
* Contributors: Hervé Audren, Levi Armstrong
```

## tesseract_environment

```
* Only enable code coverage if compiler definition is set
* Fix issue in trajectory player setCurrentDuration not handling finished bool
* Fix bullet broadphase when new links are added
* Debug unit test
* Add cmake format
* Add support for defining collision margin data in SRDF (#573 <https://github.com/ros-industrial-consortium/tesseract/issues/573>)
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Add libomp-dev as test_depend to tesseract_environment and tesseract_collision
* Add multithreaded environment unit test
* Fix mutex locking bug in environment applyCommands
* Add ability to construct ROP and REP kinematic solver with different solver names
* Contributors: Hervé Audren, Levi Armstrong, Matthew Powelson
```

## tesseract_geometry

```
* Only enable code coverage if compiler definition is set
* Add cmake format
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Contributors: Hervé Audren, Levi Armstrong
```

## tesseract_kinematics

```
* Only enable code coverage if compiler definition is set
* Fix satisfiesPositionLimits to use relative equal and calculation of redundant solutions to include all permutations
* Fix inv kinematics to only return solution within limits and add redundant solutions for kdl ik solvers
* Add cmake format
* Add kinematics utility function for calculating manipulability (#571 <https://github.com/ros-industrial-consortium/tesseract/issues/571>)
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Add kinematics utility function isNearSingularity (#569 <https://github.com/ros-industrial-consortium/tesseract/issues/569>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Fix checkJoints in UR Kinematics
* Add universal robot inverse kinematics
* Fix kinematics checkJoints not returning false when outside limits (#564 <https://github.com/ros-industrial-consortium/tesseract/issues/564>)
* Add ability to construct ROP and REP kinematic solver with different solver names
* Fix IKFast inverse kinematics wrapper
* Update forward kinematics interface to return solutions versus out parameters
* Update inverse kinematics interface to return solutions versus out parameters
* Contributors: Hervé Audren, Levi Armstrong
```

## tesseract_scene_graph

```
* Only enable code coverage if compiler definition is set
* Add cmake format
* Add support for defining collision margin data in SRDF (#573 <https://github.com/ros-industrial-consortium/tesseract/issues/573>)
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Add ability to construct ROP and REP kinematic solver with different solver names
* Contributors: Hervé Audren, Levi Armstrong
```

## tesseract_support

```
* Add cmake format
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Contributors: Levi Armstrong
```

## tesseract_urdf

```
* Only enable code coverage if compiler definition is set
* Add cmake format
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Contributors: Hervé Audren, Levi Armstrong
```

## tesseract_visualization

```
* Only enable code coverage if compiler definition is set
* Fix issue in trajectory player setCurrentDuration not handling finished bool
* Move serialize implementation to cpp based on boost documentation for shared libraries
* Rename Any method cast() and cast_const() to as()
* Split loading plugins into two classes ClassLoader and PluginLoader
* Remove dependency on class_loader and leverage Boost DLL
* Add cmake format
* Add support for defining collision margin data in SRDF (#573 <https://github.com/ros-industrial-consortium/tesseract/issues/573>)
* Use boost targets, add cpack and license file (#572 <https://github.com/ros-industrial-consortium/tesseract/issues/572>)
* Fix the way in which Eigen is included (#570 <https://github.com/ros-industrial-consortium/tesseract/issues/570>)
* Add scale to tool path marker
* Modify trajectory interpolator to visualize trajectories w/o time
* Start to adding boost serialization support
* Contributors: Hervé Audren, Levi Armstrong, Matthew Powelson
```
